### PR TITLE
fix: resolve hi3516cv200 module issues for hardware deployment

### DIFF
--- a/kernel/hi3516cv200.kbuild
+++ b/kernel/hi3516cv200.kbuild
@@ -169,13 +169,17 @@ ccflags-y += -I$(src)/mmz/hi3516cv200
 # Cipher needs porting from kernel 3.4 to 4.9 (asm/system.h removal, etc.)
 # obj-m += $(PREFIX)cipher.o
 
-# --- ISP module (full source) ---
+# --- ISP module (full source, ENABLE_JPEGEDCF needed for ISP_GetDCFInfo) ---
+ccflags-y += -DENABLE_JPEGEDCF
 CV200_ISP_DIR = isp/arch/hi3516cv200/firmware/drv
+CV200_ISP_VREG_DIR = isp/arch/hi3516cv200/firmware/vreg
 $(PREFIX)isp-objs := \
 	$(CV200_ISP_DIR)/isp.o \
 	$(CV200_ISP_DIR)/isp_st.o \
 	$(CV200_ISP_DIR)/mkp_acm.o \
-	$(CV200_ISP_DIR)/isp_acm_lut.o
+	$(CV200_ISP_DIR)/isp_acm_lut.o \
+	$(CV200_ISP_VREG_DIR)/hi_vreg.o \
+	$(CV200_ISP_VREG_DIR)/hi_drv_vreg.o
 ifndef DISABLE_ISP
     obj-m += $(PREFIX)isp.o
 endif

--- a/kernel/init/hi3516cv200/base_init.c
+++ b/kernel/init/hi3516cv200/base_init.c
@@ -88,7 +88,8 @@ DECLARE_BLOB_FUNC(VB_CopySupplement);		EXPORT_SYMBOL(VB_CopySupplement);
 DECLARE_BLOB_FUNC(VB_AddBlkToPool);		EXPORT_SYMBOL(VB_AddBlkToPool);
 DECLARE_BLOB_FUNC(VbGetSupplementConf);		EXPORT_SYMBOL(VbGetSupplementConf);
 
-extern unsigned int vb_force_exit;
+unsigned int vb_force_exit;
+EXPORT_SYMBOL(vb_force_exit);
 module_param(vb_force_exit, uint, S_IRUGO);
 
 /******* create node  /proc/sys/dev/debug/proc_message_enable ************/

--- a/kernel/init/hi3516cv200/sys_init.c
+++ b/kernel/init/hi3516cv200/sys_init.c
@@ -24,8 +24,10 @@ DECLARE_BLOB_SYM(coefficient8_lanczos2_8tap);	EXPORT_SYMBOL(coefficient8_lanczos
 
 DECLARE_BLOB_SYM(g_benchmark_list);		EXPORT_SYMBOL(g_benchmark_list);
 DECLARE_BLOB_SYM(g_u32FuncId);			EXPORT_SYMBOL(g_u32FuncId);
-DECLARE_BLOB_SYM(mem_total);			EXPORT_SYMBOL(mem_total);
-DECLARE_BLOB_SYM(vi_vpss_online);		EXPORT_SYMBOL(vi_vpss_online);
+
+/* These are module_param'd inside the blob — use matching types */
+extern unsigned int mem_total;			EXPORT_SYMBOL(mem_total);
+extern unsigned int vi_vpss_online;		EXPORT_SYMBOL(vi_vpss_online);
 
 static int __init sys_mod_init(void)
 {

--- a/kernel/isp/arch/hi3516cv200/firmware/drv/isp.c
+++ b/kernel/isp/arch/hi3516cv200/firmware/drv/isp.c
@@ -118,8 +118,8 @@ int isp_irq = -1;
  ****************************************************************************/
 ISP_DRV_CTX_S           g_astIspDrvCtx[1] = {{0}};
 
-ISP_EXPORT_FUNC_S       g_stIspExpFunc = {0};
-ISP_PIRIS_EXPORT_FUNC_S  g_stIspPirisExpFunc = {0};
+ISP_EXPORT_FUNC_S       g_stIspExpFunc __attribute__((section(".data"))) = {0};
+ISP_PIRIS_EXPORT_FUNC_S  g_stIspPirisExpFunc __attribute__((section(".data"))) = {0};
 static ISP_VERSION_S    gs_stIspLibInfo;
 void __iomem            *reg_vicap_base_va = HI_NULL;
 void __iomem            *reg_isp_base_va = HI_NULL;
@@ -3255,9 +3255,7 @@ module_param(lsc_update_mode, uint, S_IRUGO);
 EXPORT_SYMBOL(g_stIspExpFunc);
 EXPORT_SYMBOL(g_stIspPirisExpFunc);
 
-#ifdef ENABLE_JPEGEDCF
 EXPORT_SYMBOL(ISP_GetDCFInfo);
-#endif
 MODULE_AUTHOR(MPP_AUTHOR);
 MODULE_LICENSE(MPP_LICENSE);
 MODULE_VERSION(MPP_VERSION);

--- a/kernel/sys_config/hi3516cv200/sys_config.c
+++ b/kernel/sys_config/hi3516cv200/sys_config.c
@@ -578,6 +578,22 @@ static void insert_sns(void)
 
 		sys_write_reg(0x2003002c, 0xc4001);			// sensor unreset, clk 24MHz, VI 99MHz
 	}
+    else if (!strcmp(sensor, "jxf22"))
+	{
+		sys_write_reg(0x200f0040, 0x2);    			// I2C0_SCL
+		sys_write_reg(0x200f0044, 0x2);    			// I2C0_SDA
+
+		//cmos pinmux
+		sys_write_reg(0x200f007c, 0x1);    			// VI_DATA13
+		sys_write_reg(0x200f0080, 0x1);    			// VI_DATA10
+		sys_write_reg(0x200f0084, 0x1);    			// VI_DATA12
+		sys_write_reg(0x200f0088, 0x1);    			// VI_DATA11
+		sys_write_reg(0x200f008c, 0x2);    			// VI_VS
+		sys_write_reg(0x200f0090, 0x2);    			// VI_HS
+		sys_write_reg(0x200f0094, 0x1);    			// VI_DATA9
+
+		sys_write_reg(0x2003002c, 0xc4001);			// sensor unreset, clk 24MHz, VI 99MHz
+	}
     else if (!strcmp(sensor, "ov2718"))
 	{
 		sys_write_reg(0x200f0040, 0x2);    			// I2C0_SCL


### PR DESCRIPTION
## Summary

- Fix 5 issues preventing open_ modules from loading on real hi3518ev200 hardware
- Add JXF22 sensor support to sys_config pin mux/clock configuration
- All 29 modules load successfully, video pipeline verified streaming H264+MJPEG at 1920x1080

### Issues fixed

| Issue | Root cause | Fix |
|-------|-----------|-----|
| ISP missing IO_READ/WRITE/VREG symbols | vreg source files not compiled into ISP module | Added `hi_vreg.o`, `hi_drv_vreg.o` to kbuild |
| `ISP_GetDCFInfo` unresolved (VI/VPSS need it) | Export gated by `#ifdef ENABLE_JPEGEDCF` | Added `-DENABLE_JPEGEDCF` to ccflags, removed ifdef |
| `g_stIspExpFunc` invisible in kallsyms | BSS-section EXPORT_SYMBOLs not registered | Forced to `.data` section via `__attribute__` |
| `vb_force_exit` undefined in base module | Declared extern but not in blob | Changed to definition + EXPORT_SYMBOL |
| `vi_vpss_online` module param ignored | Opaque `char[]` type conflicted with blob's `uint` param | Changed to `extern unsigned int` |

## Test plan

- [x] Built with `make BOARD=hi3516cv200_lite br-hisilicon-opensdk`
- [x] All 29 modules load on hi3518ev200 (64MB RAM, JXF22 sensor)
- [x] Majestic streams H264 1920x1080@20fps + MJPEG 1080p@5fps
- [x] JPEG snapshots captured successfully
- [x] Survives reboot — modules auto-load via `load_hisilicon`
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)