### PR TITLE
fix: resolve hi3516av100 module issues for hardware deployment

### DIFF
--- a/kernel/init/hi3516av100/base_init.c
+++ b/kernel/init/hi3516av100/base_init.c
@@ -77,7 +77,8 @@ DECLARE_BLOB_FUNC(VB_CopySupplement);		EXPORT_SYMBOL(VB_CopySupplement);
 DECLARE_BLOB_FUNC(VB_AddBlkToPool);		EXPORT_SYMBOL(VB_AddBlkToPool);
 DECLARE_BLOB_FUNC(VbGetSupplementConf);		EXPORT_SYMBOL(VbGetSupplementConf);
 
-extern unsigned int vb_force_exit;
+unsigned int vb_force_exit;
+EXPORT_SYMBOL(vb_force_exit);
 module_param(vb_force_exit, uint, S_IRUGO);
 
 /******* create node  /proc/sys/dev/debug/proc_message_enable ************/

--- a/kernel/init/hi3516av100/sys_init.c
+++ b/kernel/init/hi3516av100/sys_init.c
@@ -29,8 +29,9 @@ DECLARE_BLOB_SYM(coefficient8_lanczos2_8tap);	EXPORT_SYMBOL(coefficient8_lanczos
 
 DECLARE_BLOB_SYM(g_benchmark_list);		EXPORT_SYMBOL(g_benchmark_list);
 DECLARE_BLOB_SYM(g_u32FuncId);			EXPORT_SYMBOL(g_u32FuncId);
-DECLARE_BLOB_SYM(mem_total);			EXPORT_SYMBOL(mem_total);
-DECLARE_BLOB_SYM(vi_vpss_online);		EXPORT_SYMBOL(vi_vpss_online);
+/* These are module_param'd inside the blob — use matching types */
+extern unsigned int mem_total;			EXPORT_SYMBOL(mem_total);
+extern unsigned int vi_vpss_online;		EXPORT_SYMBOL(vi_vpss_online);
 
 static int __init sys_mod_init(void)
 {


### PR DESCRIPTION
## Summary

Same fixes as CV200 (#45) and CV100 (#47), applied to AV100 (V2A generation):

1. **`vb_force_exit`** — extern → definition + EXPORT_SYMBOL
2. **`vi_vpss_online` / `mem_total`** — char[] → unsigned int (match blob's module_param types)

## Test plan

- [ ] CI build passes (`hi3516av100_lite`)
- [ ] depmod shows no warnings for `open_base.ko`
- [ ] Hardware test (if AV100 board available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)