### PR TITLE
ssp_sony: fix IMX sensor cold boot failure on hi3516cv100

### DIFF
--- a/kernel/ssp_sony/hi3516cv100/ssp_sony.c
+++ b/kernel/ssp_sony/hi3516cv100/ssp_sony.c
@@ -790,9 +790,20 @@ static int __init hi_ssp_init(void)
 	}
 
     SSP_SPIN_LOCK_INIT;
-	
+
+	/*
+	 * Sony IMX sensors (IMX122, IMX222, IMX322, IMX323) power up with
+	 * TESTEN=0 in the STANDBY register (addr 0x00), which prevents all
+	 * subsequent SPI register writes from taking effect.  Write 0x30
+	 * (STANDBY=0, TESTEN=3) to prime the sensor before userspace runs.
+	 *
+	 * devaddr=0x02, addr=0x00, data=0x30 — values are bit-reversed for
+	 * the LSB-first SPI wire format: 0x02→0x40, 0x00→0x00, 0x30→0x0C.
+	 */
+	hi_ssp_write_alt(0x40, 0x00, 0x0C);
+
 	printk("Kernel: ssp initial ok!\n");
-    
+
     return 0;
 #endif
 }


### PR DESCRIPTION
## Problem

Sony IMX122/222/322/323 SPI sensors fail to produce video on the **first boot after a power cycle** on hi3516cv100 boards. The streamer application reports "Sensor Initial OK!" but the VI subsystem receives zero interrupts — no frames are captured. Killing and restarting the application immediately fixes it, and video works on every subsequent restart until the next power cycle.

This affects all userspace applications (Majestic, vendor Sofia, SDK samples) that use these sensors via the `ssp_sony` SPI driver.

## Root cause

These sensors power up with register `0x00` (STANDBY) = `0x01`:
- **STANDBY = 1** (sensor in standby — expected)
- **TESTEN = 0** (bits [5:4] = 0 — register writes **disabled**)

The TESTEN field gates whether SPI register writes are accepted by the sensor silicon. When TESTEN=0, **all SPI writes are silently ignored** — the sensor acknowledges the SPI transaction but does not latch the data.

The sensor driver's init sequence begins by writing `0x31` to register `0x00` (STANDBY=1, TESTEN=3) to enable register programming. But this write is itself blocked because TESTEN=0. Every subsequent register write in the init sequence also fails silently. The sensor never gets configured and never starts outputting frames.

On the second application run, TESTEN=3 is retained in the sensor's registers from the first attempt's partial initialization (SPI register state persists across application restarts since the sensor remains powered). All writes now succeed, and the sensor works.

### Why STANDBY=0 fixes it

The STANDBY bit (bit [0] of register `0x00`) has a dedicated hardware path in the sensor — it can always be toggled regardless of TESTEN state. Per the datasheet (IMX122LQJ-C, p.67): *"Register communication is executed even in standby mode."* and *"The standby cancel is immediately reflected from the communication."*

Writing `0x30` (STANDBY=0, TESTEN=3) works because the STANDBY transition is processed through this hardware path, and in doing so, the TESTEN bits are also latched. After this single write, all subsequent SPI register writes are accepted normally.

## Verification

Tested on hi3516cv100 + IMX122 (board_num=8) with repeated power-cycle tests:

| Scenario | VI IntCnt after 8s | Result |
|---|---|---|
| Cold boot, stock `ssp_sony.ko` | 0 | ❌ No frames |
| Cold boot, patched `ssp_sony.ko` | 120+ | ✅ 20fps |
| Warm restart, stock `ssp_sony.ko` | 130+ | ✅ (always worked) |
| Warm restart, patched `ssp_sony.ko` | 190+ | ✅ |

The fix was also verified by running the equivalent SPI write (`0x30` to register `0x200`) from a standalone userspace tool before the streamer — confirming the root cause is specifically the TESTEN state, not a timing or GPIO issue.

## Fix

Add a single `hi_ssp_write_alt()` call to `hi_ssp_init()` that writes `0x30` to the sensor's STANDBY register immediately after SSP hardware initialization. This primes TESTEN before any userspace application runs.

The write is harmless on warm restarts (sensor is already in operating mode with TESTEN=3) and on boards with non-Sony sensors (the SPI write targets Sony-specific chip ID 0x02 and has no effect on other sensor types).

## References

- IMX122LQJ-C datasheet, "Power-on Sequence" (p.86)
- IMX122LQJ-C datasheet, "Standby mode" / STANDBY register (p.67)
- IMX122LQJ-C datasheet, "Register Map" — TESTEN bits [5:4] of register 0x00 (p.34)