### PR TITLE
fix: export ssp_drv symbols from CV300 sensor_spi

### DIFF
--- a/kernel/sensor_spi/hi3516cv300/ssp_drv.c
+++ b/kernel/sensor_spi/hi3516cv300/ssp_drv.c
@@ -497,3 +497,7 @@ HI_VOID ssp_drv_exit(HI_U32 u32BusNum)
 
     iounmap((void*)reg_ssp_base_va[u32BusNum]);
 }
+
+EXPORT_SYMBOL(ssp_drv_init);
+EXPORT_SYMBOL(ssp_drv_exit);
+EXPORT_SYMBOL(ssp_get_ops);


### PR DESCRIPTION
## Summary

Add EXPORT_SYMBOL for `ssp_drv_init`, `ssp_drv_exit`, `ssp_get_ops` in CV300 sensor_spi driver.

The vendor shipped a combined `hi3516cv300_sensor.ko` with both I2C and SPI linked together. OpenHisilicon splits them into `open_sensor_i2c.ko` and `open_sensor_spi.ko`, but sensor_i2c depends on these SSP functions. Without the exports, `insmod open_sensor_i2c.ko` fails with unknown symbol errors.

## Test plan

- [x] Sysupgrade to hi3516cv300 hardware (IMX291 sensor)
- [x] All modules load on boot, SDK starts
- [x] JPEG snapshot captured (105KB)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)