### PR TITLE
ci: fail QEMU smoke test on silent module-load regressions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -482,13 +482,32 @@ jobs:
 
           echo
           echo "=== Checking for successful boot ==="
-          if grep -qE "Starting crond: OK" qemu-output.txt; then
-              echo "PASS: ${{ matrix.machine }} kernel booted to userspace"
-          else
-              echo "--- last 30 lines ---"
-              tail -30 qemu-output.txt
-              echo "FAIL: no 'Starting crond: OK' in QEMU output" >&2
+
+          fail_with() {
+              echo "--- last 50 lines of QEMU output ---"
+              tail -50 qemu-output.txt
+              echo "FAIL (${{ matrix.machine }}): $1" >&2
               exit 1
+          }
+
+          # Module-load regression checks — see OpenIPC/openhisilicon#62.
+          # A silent insmod/rmmod failure used to slip through because the only
+          # assertion was that crond reached userspace; load_hisilicon can exit
+          # mid-sequence and still get there.
+          if grep -q "insmod: can't insert" qemu-output.txt; then
+              fail_with "'insmod: can't insert' detected — module failed to load"
+          fi
+          if grep -qF "Error: There's something wrong, please check!" qemu-output.txt; then
+              fail_with "load_hisilicon report_error exit"
+          fi
+          if grep -q "Cannot get chip id" qemu-output.txt; then
+              fail_with "majestic 'Cannot get chip id' — sys module not active"
+          fi
+
+          if grep -qE "Starting crond: OK" qemu-output.txt; then
+              echo "PASS: ${{ matrix.machine }} kernel booted to userspace, no module-load regressions"
+          else
+              fail_with "no 'Starting crond: OK' in QEMU output"
           fi
 
       - name: Upload QEMU output

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -491,11 +491,14 @@ jobs:
           }
 
           # Module-load regression checks — see OpenIPC/openhisilicon#62.
-          # A silent insmod/rmmod failure used to slip through because the only
-          # assertion was that crond reached userspace; load_hisilicon can exit
-          # mid-sequence and still get there.
-          if grep -q "insmod: can't insert" qemu-output.txt; then
-              fail_with "'insmod: can't insert' detected — module failed to load"
+          # The bug: load_hisilicon's remove_detect() rmmods modules by vendor
+          # name (mmz, hi_media, sys_config, hi_sensor_i2c, ...) but openhisilicon
+          # source-built modules announce themselves as open_* internally, so
+          # those rmmods fail silently. The previous QEMU assertion (just "crond
+          # reached userspace") missed it because the script exits cleanly when
+          # SENSOR=unknown and crond starts regardless.
+          if grep -qE "^rmmod: can't unload" qemu-output.txt; then
+              fail_with "rmmod failure during boot — vendor name does not match loaded module name (#62)"
           fi
           if grep -qF "Error: There's something wrong, please check!" qemu-output.txt; then
               fail_with "load_hisilicon report_error exit"


### PR DESCRIPTION
## Summary

The `qemu-boot` matrix's only pass criterion was `Starting crond: OK`. That misses silent module-load failures — `load_hisilicon` can `report_error`-exit mid-sequence and init still reaches crond.

The cv200 QEMU job has been printing this in every recent run, marked green:

```
insmod: can't insert 'hi3518e_sys.ko': Operation not permitted
```

Add three negative checks alongside the existing positive one:

- `insmod: can't insert` — direct module-load failure.
- `Error: There's something wrong, please check!` — `load_hisilicon`'s `report_error` exit.
- `Cannot get chip id` — majestic's downstream symptom when sys is inactive.

Each failure path tails 50 lines of `qemu-output.txt` and names which signal hit, so the matrix tells us which platforms are affected without downloading the artifact.

## Why this isn't a fix

This PR is diagnostic only. It will turn red on platforms where #62 is biting today (expected: cv200; likely cv100, av100, cv300, 3519v101, cv500 — all platforms whose load script `rmmod`s by vendor name while openhisilicon ships `open_*` source modules) and stay green on ev200/gk7205v200 (which already align). The actual fix — making source-built modules announce vendor module names — is tracked in #62.

## Test plan

- [ ] `qemu-boot (hi3516ev200)` and `qemu-boot (gk7205v200)` stay green (no false-positives on already-aligned platforms).
- [ ] `qemu-boot (hi3516cv200)` turns red with `FAIL (hi3516cv200): 'insmod: can't insert' detected`.
- [ ] Note which of `hi3516cv100`, `hi3516av100`, `hi3516cv300`, `hi3519v101`, `hi3516cv500` go red and on which signal — this scopes the #62 fix per-platform.
- [ ] Existing artifact upload (`qemu-boot-<platform>`) still works for deep-dive triage.

Refs #62.