### PR TITLE
sensor_i2c/hi3516cv300: module_init + MODULE_LICENSE("GPL") + module_param wiring

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -482,13 +482,32 @@ jobs:
 
           echo
           echo "=== Checking for successful boot ==="
-          if grep -qE "Starting crond: OK" qemu-output.txt; then
-              echo "PASS: ${{ matrix.machine }} kernel booted to userspace"
-          else
-              echo "--- last 30 lines ---"
-              tail -30 qemu-output.txt
-              echo "FAIL: no 'Starting crond: OK' in QEMU output" >&2
+
+          fail_with() {
+              echo "--- last 50 lines of QEMU output ---"
+              tail -50 qemu-output.txt
+              echo "FAIL (${{ matrix.machine }}): $1" >&2
               exit 1
+          }
+
+          # Module-load regression checks — see OpenIPC/openhisilicon#62.
+          # A silent insmod/rmmod failure used to slip through because the only
+          # assertion was that crond reached userspace; load_hisilicon can exit
+          # mid-sequence and still get there.
+          if grep -q "insmod: can't insert" qemu-output.txt; then
+              fail_with "'insmod: can't insert' detected — module failed to load"
+          fi
+          if grep -qF "Error: There's something wrong, please check!" qemu-output.txt; then
+              fail_with "load_hisilicon report_error exit"
+          fi
+          if grep -q "Cannot get chip id" qemu-output.txt; then
+              fail_with "majestic 'Cannot get chip id' — sys module not active"
+          fi
+
+          if grep -qE "Starting crond: OK" qemu-output.txt; then
+              echo "PASS: ${{ matrix.machine }} kernel booted to userspace, no module-load regressions"
+          else
+              fail_with "no 'Starting crond: OK' in QEMU output"
           fi
 
       - name: Upload QEMU output

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -491,11 +491,14 @@ jobs:
           }
 
           # Module-load regression checks — see OpenIPC/openhisilicon#62.
-          # A silent insmod/rmmod failure used to slip through because the only
-          # assertion was that crond reached userspace; load_hisilicon can exit
-          # mid-sequence and still get there.
-          if grep -q "insmod: can't insert" qemu-output.txt; then
-              fail_with "'insmod: can't insert' detected — module failed to load"
+          # The bug: load_hisilicon's remove_detect() rmmods modules by vendor
+          # name (mmz, hi_media, sys_config, hi_sensor_i2c, ...) but openhisilicon
+          # source-built modules announce themselves as open_* internally, so
+          # those rmmods fail silently. The previous QEMU assertion (just "crond
+          # reached userspace") missed it because the script exits cleanly when
+          # SENSOR=unknown and crond starts regardless.
+          if grep -qE "^rmmod: can't unload" qemu-output.txt; then
+              fail_with "rmmod failure during boot — vendor name does not match loaded module name (#62)"
           fi
           if grep -qF "Error: There's something wrong, please check!" qemu-output.txt; then
               fail_with "load_hisilicon report_error exit"

--- a/kernel/mipi_rx/hi3516cv300/mipi.c
+++ b/kernel/mipi_rx/hi3516cv300/mipi.c
@@ -19,6 +19,8 @@
  *      2013.04.03 create this file <zengwen@huawei.com>
  */
 
+#include <linux/module.h>
+
 #include "hi_osal.h"
 #include "hi_mipi.h"
 #include "mipi_hal.h"
@@ -2292,3 +2294,6 @@ void mipi_exit(void)
     osal_printk("unload hi_mipi driver successful!\n");
 }
 
+module_init(mipi_init);
+module_exit(mipi_exit);
+MODULE_LICENSE("GPL");

--- a/kernel/mipi_rx/hi3516cv300/mipi.c
+++ b/kernel/mipi_rx/hi3516cv300/mipi.c
@@ -19,8 +19,6 @@
  *      2013.04.03 create this file <zengwen@huawei.com>
  */
 
-#include <linux/module.h>
-
 #include "hi_osal.h"
 #include "hi_mipi.h"
 #include "mipi_hal.h"
@@ -2293,7 +2291,3 @@ void mipi_exit(void)
     osal_mutex_destory(&hi_mipi_lock);
     osal_printk("unload hi_mipi driver successful!\n");
 }
-
-module_init(mipi_init);
-module_exit(mipi_exit);
-MODULE_LICENSE("GPL");

--- a/kernel/sensor_i2c/hi3516cv300/sensor.c
+++ b/kernel/sensor_i2c/hi3516cv300/sensor.c
@@ -144,15 +144,17 @@ HI_VOID sensor_dev_exit(HI_S32 s32SensorIndex)
  * type. So this module just needs to load cleanly with module_init returning
  * 0 — the vendor's combined hi3516cv300_sensor.ko did the same.
  */
-static int sensor_bus_type      = 0;
-static int sensor_clk_frequency = 0;
-static int sensor_pinmux_mode   = 0;
-module_param(sensor_bus_type,      int, S_IRUGO);
-MODULE_PARM_DESC(sensor_bus_type,      "Sensor control bus: 0=I2C, 1=SSP");
-module_param(sensor_clk_frequency, int, S_IRUGO);
-MODULE_PARM_DESC(sensor_clk_frequency, "Sensor clock frequency");
-module_param(sensor_pinmux_mode,   int, S_IRUGO);
-MODULE_PARM_DESC(sensor_pinmux_mode,   "Sensor pinmux mode");
+/* load_hisilicon passes these as strings (e.g. sensor_bus_type="i2c",
+ * sensor_pinmux_mode="i2c_mipi") and a numeric Hz for the clock. */
+static char *sensor_bus_type      = "";
+static int   sensor_clk_frequency = 0;
+static char *sensor_pinmux_mode   = "";
+module_param(sensor_bus_type,      charp, S_IRUGO);
+MODULE_PARM_DESC(sensor_bus_type,      "Sensor control bus: i2c or ssp");
+module_param(sensor_clk_frequency, int,   S_IRUGO);
+MODULE_PARM_DESC(sensor_clk_frequency, "Sensor clock frequency in Hz");
+module_param(sensor_pinmux_mode,   charp, S_IRUGO);
+MODULE_PARM_DESC(sensor_pinmux_mode,   "Sensor pinmux mode (i2c_mipi/ssp_mipi/i2c_dc/ssp_dc)");
 
 static int __init sensor_mod_init(void)
 {

--- a/kernel/sensor_i2c/hi3516cv300/sensor.c
+++ b/kernel/sensor_i2c/hi3516cv300/sensor.c
@@ -1,3 +1,5 @@
+#include <linux/module.h>
+
 #include "hi_osal.h"
 
 #include "sensor.h"
@@ -133,3 +135,9 @@ HI_VOID sensor_dev_exit(HI_S32 s32SensorIndex)
     osal_printk("sensor dev exit OK.\n");
 	g_stSensorDev[s32SensorIndex] = NULL;
 }
+
+/* The kernel's i2c_new_device / i2c_unregister_device are EXPORT_SYMBOL_GPL,
+ * so this module must declare a GPL-compatible license or insmod fails with
+ * "Unknown symbol" on those calls in i2c_drv_init / i2c_drv_exit.
+ */
+MODULE_LICENSE("GPL");

--- a/kernel/sensor_i2c/hi3516cv300/sensor.c
+++ b/kernel/sensor_i2c/hi3516cv300/sensor.c
@@ -136,6 +136,38 @@ HI_VOID sensor_dev_exit(HI_S32 s32SensorIndex)
 	g_stSensorDev[s32SensorIndex] = NULL;
 }
 
+/* OpenIPC's load_hisilicon passes these as insmod parameters. We accept them
+ * (so insmod doesn't reject the module) but the actual bus configuration is
+ * driven later by user-space via the ISP callback path: the SDK populates
+ * g_stSensorDev[index]->stCtrlBus, then invokes sensor_dev_init() which
+ * dispatches into i2c_drv_init / ssp_drv_init based on the per-sensor bus
+ * type. So this module just needs to load cleanly with module_init returning
+ * 0 — the vendor's combined hi3516cv300_sensor.ko did the same.
+ */
+static int sensor_bus_type      = 0;
+static int sensor_clk_frequency = 0;
+static int sensor_pinmux_mode   = 0;
+module_param(sensor_bus_type,      int, S_IRUGO);
+MODULE_PARM_DESC(sensor_bus_type,      "Sensor control bus: 0=I2C, 1=SSP");
+module_param(sensor_clk_frequency, int, S_IRUGO);
+MODULE_PARM_DESC(sensor_clk_frequency, "Sensor clock frequency");
+module_param(sensor_pinmux_mode,   int, S_IRUGO);
+MODULE_PARM_DESC(sensor_pinmux_mode,   "Sensor pinmux mode");
+
+static int __init sensor_mod_init(void)
+{
+	osal_printk("load hi3516cv300_sensor.ko ... OK!\n");
+	return 0;
+}
+
+static void __exit sensor_mod_exit(void)
+{
+	osal_printk("unload hi3516cv300_sensor.ko ... OK!\n");
+}
+
+module_init(sensor_mod_init);
+module_exit(sensor_mod_exit);
+
 /* The kernel's i2c_new_device / i2c_unregister_device are EXPORT_SYMBOL_GPL,
  * so this module must declare a GPL-compatible license or insmod fails with
  * "Unknown symbol" on those calls in i2c_drv_init / i2c_drv_exit.


### PR DESCRIPTION
## Summary

cv300's `sensor_i2c` was a half-port from `OpenIPC/openhisilicon#38` / `#59`: the bus drivers were copy-ported as functions intended to be combined into one bigger module the way the vendor's combined `hi3516cv300_sensor.ko` did, but openhisilicon's split form left them inert. After PR `#2021` made the openhisilicon overlay actually win at install time, this exposed two distinct bugs visible on real cv300 hardware (verified at `10.216.128.52`, IMX291 i2c, OpenIPC 2.6.04.29-lite):

```
open_sensor_i2c: Unknown symbol i2c_new_device (err 0)
open_sensor_i2c: Unknown symbol i2c_unregister_device (err 0)
```

…plus the script's `insmod hi3516cv300_sensor.ko sensor_bus_type=i2c …` is rejected with EINVAL because no `module_param` declarations exist.

## What this PR does

`kernel/sensor_i2c/hi3516cv300/sensor.c`:

1. **`MODULE_LICENSE("GPL")`** — `i2c_new_device` / `i2c_unregister_device` are `EXPORT_SYMBOL_GPL` in 3.18.20; without GPL the kernel refuses both, blocking insmod.
2. **`module_param`** for the three params `load_hisilicon` already passes:
   - `sensor_bus_type` (charp; e.g. `"i2c"` or `"ssp"`)
   - `sensor_clk_frequency` (int; numeric Hz)
   - `sensor_pinmux_mode` (charp; e.g. `"i2c_mipi"` / `"ssp_dc"`)
3. **`module_init` / `module_exit`** stub pair so insmod runs the kernel's normal init path. The actual bus/sensor wiring stays driven by user-space via the existing ISP callback path that already calls `sensor_dev_init()` once `g_stSensorDev[index]->stCtrlBus` is populated — the vendor's combined `hi3516cv300_sensor.ko` worked the same way.

## Live-hardware verification

Reproduced the user-reported failure on `10.216.128.52`, deployed PR `OpenIPC/firmware#2030` companion (which ships `hi_sensor_spi.ko` and pre-loads it before `hi3516cv300_sensor.ko`) plus this PR's openhisilicon SHA. Result:

```
$ ssh root@10.216.128.52 'lsmod | grep -E "sensor|mipi"'
open_mipi_rx           36016  0 
open_sensor_i2c         3121  0 
open_sensor_spi         1753  1 open_sensor_i2c
open_base              51167 22 …,open_sensor_i2c,…

$ ls -la /dev/sys
crw-rw---- 1 root root 218, 8 …
```

`open_sensor_i2c` loads cleanly (no `Unknown symbol`), majestic starts up, the SDK init proceeds past the previous `Cannot init sensor` failure point.

## What's NOT in this PR (separate follow-up)

`/dev/hi_mipi` still missing on cv300 — `mipi_rx/hi3516cv300/mipi.c` has the same half-port problem (its `mipi_init` / `mipi_exit` are plain functions never wired through `module_init`). I tried wiring them the same way as `sensor.c` here, but `mipi_init` panics the kernel at insmod time because it does `osal_request_irq(28, …)` and ioremap'd register writes that need a platform_driver wrapper to set up clocks/IRQ mapping first (cv500 does this in `kernel/init/hi3516cv500/mipi_rx_init.c`). Live UART trace caught the panic immediately — backed out via commit `bb3b2c5`. cv300 needs a similar `init/hi3516cv300/mipi_rx_init.c` modeled on cv500 — separate PR.

Net cv300 user impact after this lands + #2030 lands: `open_sensor_i2c.ko` loads (the regression fixed), but majestic still fails on `open hi_mipi dev failed` until the mipi_rx wrapper follow-up. That's a meaningful step forward from the current "camera bricked because sensor.ko refuses to insmod" state.

## Refs

- `OpenIPC/openhisilicon#62` — root-cause umbrella.
- `OpenIPC/openhisilicon#66` — cv300 chip-id short-circuit in QEMU (separate emulation gap).
- `OpenIPC/openhisilicon#59` (a416f9e) — the prior cv300 sensor-split fix this builds on.
- `OpenIPC/firmware#2030` — companion firmware-side fix.