### PR TITLE
mipi_rx/hi3516cv300: ioremap MIPI registers + wire up module_init

### DIFF
--- a/kernel/mipi_rx/hi3516cv300/mipi.c
+++ b/kernel/mipi_rx/hi3516cv300/mipi.c
@@ -19,9 +19,13 @@
  *      2013.04.03 create this file <zengwen@huawei.com>
  */
 
+#include <linux/module.h>
+
 #include "hi_osal.h"
 #include "hi_mipi.h"
 #include "mipi_hal.h"
+
+extern void mipi_drv_exit_reg(void);
 
 /****************************************************************************
  * MACRO DEFINITION                                                         *
@@ -2288,6 +2292,12 @@ void mipi_exit(void)
     osal_destroydev(s_pstHiMipiDevice);
     s_pstHiMipiDevice = NULL;
 
+    mipi_drv_exit_reg();
+
     osal_mutex_destory(&hi_mipi_lock);
     osal_printk("unload hi_mipi driver successful!\n");
 }
+
+module_init(mipi_init);
+module_exit(mipi_exit);
+MODULE_LICENSE("GPL");

--- a/kernel/mipi_rx/hi3516cv300/mipi_hal.c
+++ b/kernel/mipi_rx/hi3516cv300/mipi_hal.c
@@ -75,7 +75,11 @@ unsigned int mipi_drv_init_reg(void)
 
     if (!gpMipiAllReg)
     {
-        gpMipiAllReg = (MIPI_REGS_TYPE_S*)OSAL_IO_ADDRESS(MIPI_BASE_ADDR);
+        /* OSAL_IO_ADDRESS is a hard panic on Linux >= 3.18 (see osal_ioaddress
+         * in kernel/osal/hi3516cv300/osal_addr.c). cv300's kernel is 3.18.20,
+         * so we must use osal_ioremap_nocache here to map the MIPI register
+         * region dynamically. */
+        gpMipiAllReg = (MIPI_REGS_TYPE_S*)osal_ioremap_nocache(MIPI_BASE_ADDR, sizeof(MIPI_REGS_TYPE_S));
         if(NULL == gpMipiAllReg)
         {
             ret = HI_FAILURE;
@@ -85,6 +89,15 @@ unsigned int mipi_drv_init_reg(void)
 
     HI_MSG("mipi_base_address: 0x%x\n", gpMipiAllReg);
     return ret;
+}
+
+void mipi_drv_exit_reg(void)
+{
+    if (gpMipiAllReg)
+    {
+        osal_iounmap(gpMipiAllReg);
+        gpMipiAllReg = NULL;
+    }
 }
 
 void mipi_drv_reset_sensor(COMBO_DEV dev)


### PR DESCRIPTION
## Summary

Follow-up to `#67` for the cv300 mipi half of the broken openhisilicon split. After `#67` lands the camera boots stable, `open_sensor_i2c` loads cleanly, but majestic still fails because `/dev/hi_mipi` was never created. cv300's `mipi.c` has a working `mipi_init` / `mipi_exit` pair, but they were never wired through `module_init` / `module_exit`, so insmod-loading `hi_mipi.ko` loaded inert code.

## Why naive module_init panics

Adding `module_init(mipi_init)` alone caused an immediate kernel panic at insmod time. Caught it on UART (camera `10.216.128.52`, IMX291 i2c, OpenIPC 2.6.04.29-lite): the SSH session resets mid-insmod, watchdog reboots the camera in a loop.

Root cause is in `mipi_hal.c`, not in module wiring: `mipi_drv_init_reg()` calls `OSAL_IO_ADDRESS(MIPI_BASE_ADDR)` to map the MIPI register block, which expands via `kernel/include/hi3516cv300/hi_osal.h:267` → `osal_ioaddress()` in `kernel/osal/hi3516cv300/osal_addr.c:38`. That function panics unconditionally on Linux ≥ 3.18:

```c
void *osal_ioaddress(int addr) {
#if LINUX_VERSION_CODE < KERNEL_VERSION(3,18,0)
    return (void *)IO_ADDRESS(addr);
#else
    panic("ASSERT: linux kernel not support IO_ADDRESS now.");
#endif
}
```

cv300 ships kernel 3.18.20, so the panic branch is always taken. The existing openhisilicon split must have left `module_init` out deliberately to avoid hitting it; the proper fix is to map the register region with `osal_ioremap_nocache()` instead.

## Two-part change

1. **`mipi_hal.c`**: replace the lone active `OSAL_IO_ADDRESS` call in `mipi_drv_init_reg()` with `osal_ioremap_nocache(MIPI_BASE_ADDR, sizeof(MIPI_REGS_TYPE_S))`. Add a matching `mipi_drv_exit_reg()` that `iounmap()`s on module unload. (The other `OSAL_IO_ADDRESS` occurrences in this file are already commented out.)

2. **`mipi.c`**: wire up `module_init(mipi_init)` / `module_exit(mipi_exit)` with `MODULE_LICENSE("GPL")`. Update `mipi_exit()` to call `mipi_drv_exit_reg()` before destroying the device, mirroring the init order in reverse.

## What this leaves alone

`mipi_init`'s `request_irq(28, …)` call. IRQ 28 is the ethernet driver on this kernel (per `/proc/interrupts` on the live cv300):

```
28:       1422       VIC  12  10050000.ethernet
```

`request_irq` returns `-EBUSY` and `mipi_init` treats that as a non-fatal warning — the device node, register access, and runtime init all proceed, which is what the userspace SDK actually needs to set the MIPI VI attributes. IRQ-driven mipi statistics are a separate question; they were absent in the working vendor flow on this SoC too.

If real MIPI IRQ wiring is needed later, the path is to add a proper `init/hi3516cv300/mipi_rx_init.c` modeled on `init/hi3516cv500/mipi_rx_init.c`, register a platform_driver, and pull the IRQ from devicetree (which would need a node added — none exists today).

## Verification path

After this lands plus `OpenIPC/firmware#2030`, the live camera should:
- `lsmod` show `open_mipi_rx` with `module_init` actually run
- `/dev/hi_mipi` exist
- `majestic` reach `Sensor driver loaded` instead of failing on `open hi_mipi dev failed`

I'll verify by triggering `build-one.yml` for `hi3516cv300_lite` on the firmware fix branch with this SHA pinned, downloading the new tarball, scp'ing the updated `hi_mipi.ko` to `10.216.128.52`, and watching majestic. Will follow up with a comment.

## Refs

- `OpenIPC/openhisilicon#62` — root-cause umbrella.
- `OpenIPC/openhisilicon#66` — cv300 chip-id short-circuit in QEMU (separate emulation gap).
- `OpenIPC/openhisilicon#67` — companion sensor_i2c fix (merged).
- `OpenIPC/firmware#2030` — companion firmware-side fix (open).