### PR TITLE
sensor_i2c/hi3516cv300: actually bring up the i2c bus + ISP callback at init

### DIFF
--- a/kernel/sensor_i2c/hi3516cv300/sensor.c
+++ b/kernel/sensor_i2c/hi3516cv300/sensor.c
@@ -1,5 +1,7 @@
 #include <linux/module.h>
 #include <linux/string.h>
+#include <linux/clk.h>
+#include <linux/err.h>
 
 #include "hi_osal.h"
 
@@ -149,12 +151,61 @@ MODULE_PARM_DESC(sensor_clk_frequency, "Sensor clock frequency in Hz");
 module_param(sensor_pinmux_mode,   charp, S_IRUGO);
 MODULE_PARM_DESC(sensor_pinmux_mode,   "Sensor pinmux mode (i2c_mipi/ssp_mipi/i2c_dc/ssp_dc)");
 
-/* Mirror what cv200/hi3519v101 do at module_init: bring up the kernel-side
- * i2c bus driver (i2c_new_device on bus 0) and register the read/write
- * callback with ISP so it can issue sensor register accesses through us.
- * Without this, the SDK's ISP_QueryExposureInfo / VENC chain never gets
- * stat data — frames land in MIPI/VI/ISP but ISP can't classify them
- * because the sensor side wasn't ever programmed at the kernel layer.
+/* clk_sensor / clk_mipi handles obtained at module_init. The cv300 SoC's
+ * sensor MCLK output is gated by the kernel CCF; until clk_prepare_enable
+ * is called the sensor sees no clock and does not respond to i2c — the
+ * symptom on real hardware is `hibvt-i2c wait idle abort` floods at the
+ * point libsns_<sensor>.so writes sensor config. The vendor's combined
+ * hi3516cv300_sensor.ko enabled these clocks at module_init from the
+ * sensor_clk_frequency= insmod param; openhisilicon's split form lost
+ * this setup. */
+static struct clk *g_sensor_clk;
+static struct clk *g_mipi_clk;
+
+static void sensor_clk_enable(void)
+{
+	g_sensor_clk = clk_get(NULL, "clk_sensor");
+	if (IS_ERR(g_sensor_clk)) {
+		osal_printk("hi3516cv300_sensor: clk_get(clk_sensor) failed (%ld)\n", PTR_ERR(g_sensor_clk));
+		g_sensor_clk = NULL;
+	} else {
+		if (sensor_clk_frequency > 0) {
+			clk_set_rate(g_sensor_clk, sensor_clk_frequency);
+		}
+		clk_prepare_enable(g_sensor_clk);
+	}
+
+	g_mipi_clk = clk_get(NULL, "clk_mipi");
+	if (IS_ERR(g_mipi_clk)) {
+		osal_printk("hi3516cv300_sensor: clk_get(clk_mipi) failed (%ld)\n", PTR_ERR(g_mipi_clk));
+		g_mipi_clk = NULL;
+	} else {
+		clk_prepare_enable(g_mipi_clk);
+	}
+}
+
+static void sensor_clk_disable(void)
+{
+	if (g_mipi_clk) {
+		clk_disable_unprepare(g_mipi_clk);
+		clk_put(g_mipi_clk);
+		g_mipi_clk = NULL;
+	}
+	if (g_sensor_clk) {
+		clk_disable_unprepare(g_sensor_clk);
+		clk_put(g_sensor_clk);
+		g_sensor_clk = NULL;
+	}
+}
+
+/* Mirror what cv200/hi3519v101 do at module_init: enable the SoC sensor and
+ * mipi clocks (vendor's combined hi3516cv300_sensor.ko did this from the
+ * sensor_clk_frequency insmod param), bring up the kernel-side i2c bus
+ * driver (i2c_new_device on bus 0), and register the read/write callback
+ * with ISP so it can issue sensor register accesses through us. Without
+ * any of this, the SDK's ISP_QueryExposureInfo / VENC chain never gets
+ * stat data — frames don't land in MIPI/VI/ISP because the sensor side
+ * wasn't ever programmed at the kernel layer.
  */
 static int __init sensor_mod_init(void)
 {
@@ -162,10 +213,13 @@ static int __init sensor_mod_init(void)
 	ISP_BUS_CALLBACK_S stBusCb = {0};
 	SENSOR_CTRL_OPS_S stCtrlOps = {0};
 
+	sensor_clk_enable();
+
 	if (sensor_bus_type && 0 == strcmp(sensor_bus_type, "ssp")) {
 		ret = ssp_drv_init(0);
 		if (ret) {
 			osal_printk("hi3516cv300_sensor: ssp_drv_init failed (%d)\n", ret);
+			sensor_clk_disable();
 			return ret;
 		}
 		ssp_get_ops(0, &stCtrlOps);
@@ -173,6 +227,7 @@ static int __init sensor_mod_init(void)
 		ret = i2c_drv_init(0);
 		if (ret) {
 			osal_printk("hi3516cv300_sensor: i2c_drv_init failed (%d)\n", ret);
+			sensor_clk_disable();
 			return ret;
 		}
 		i2c_get_ops(0, &stCtrlOps);
@@ -195,6 +250,7 @@ static void __exit sensor_mod_exit(void)
 	} else {
 		i2c_drv_exit(0);
 	}
+	sensor_clk_disable();
 	osal_printk("unload hi3516cv300_sensor.ko ... OK!\n");
 }
 

--- a/kernel/sensor_i2c/hi3516cv300/sensor.c
+++ b/kernel/sensor_i2c/hi3516cv300/sensor.c
@@ -1,4 +1,5 @@
 #include <linux/module.h>
+#include <linux/string.h>
 
 #include "hi_osal.h"
 
@@ -136,17 +137,9 @@ HI_VOID sensor_dev_exit(HI_S32 s32SensorIndex)
 	g_stSensorDev[s32SensorIndex] = NULL;
 }
 
-/* OpenIPC's load_hisilicon passes these as insmod parameters. We accept them
- * (so insmod doesn't reject the module) but the actual bus configuration is
- * driven later by user-space via the ISP callback path: the SDK populates
- * g_stSensorDev[index]->stCtrlBus, then invokes sensor_dev_init() which
- * dispatches into i2c_drv_init / ssp_drv_init based on the per-sensor bus
- * type. So this module just needs to load cleanly with module_init returning
- * 0 — the vendor's combined hi3516cv300_sensor.ko did the same.
- */
 /* load_hisilicon passes these as strings (e.g. sensor_bus_type="i2c",
  * sensor_pinmux_mode="i2c_mipi") and a numeric Hz for the clock. */
-static char *sensor_bus_type      = "";
+static char *sensor_bus_type      = "i2c";
 static int   sensor_clk_frequency = 0;
 static char *sensor_pinmux_mode   = "";
 module_param(sensor_bus_type,      charp, S_IRUGO);
@@ -156,14 +149,52 @@ MODULE_PARM_DESC(sensor_clk_frequency, "Sensor clock frequency in Hz");
 module_param(sensor_pinmux_mode,   charp, S_IRUGO);
 MODULE_PARM_DESC(sensor_pinmux_mode,   "Sensor pinmux mode (i2c_mipi/ssp_mipi/i2c_dc/ssp_dc)");
 
+/* Mirror what cv200/hi3519v101 do at module_init: bring up the kernel-side
+ * i2c bus driver (i2c_new_device on bus 0) and register the read/write
+ * callback with ISP so it can issue sensor register accesses through us.
+ * Without this, the SDK's ISP_QueryExposureInfo / VENC chain never gets
+ * stat data — frames land in MIPI/VI/ISP but ISP can't classify them
+ * because the sensor side wasn't ever programmed at the kernel layer.
+ */
 static int __init sensor_mod_init(void)
 {
+	HI_S32 ret;
+	ISP_BUS_CALLBACK_S stBusCb = {0};
+	SENSOR_CTRL_OPS_S stCtrlOps = {0};
+
+	if (sensor_bus_type && 0 == strcmp(sensor_bus_type, "ssp")) {
+		ret = ssp_drv_init(0);
+		if (ret) {
+			osal_printk("hi3516cv300_sensor: ssp_drv_init failed (%d)\n", ret);
+			return ret;
+		}
+		ssp_get_ops(0, &stCtrlOps);
+	} else {
+		ret = i2c_drv_init(0);
+		if (ret) {
+			osal_printk("hi3516cv300_sensor: i2c_drv_init failed (%d)\n", ret);
+			return ret;
+		}
+		i2c_get_ops(0, &stCtrlOps);
+	}
+
+	stBusCb.pfnISPWriteSensorData = stCtrlOps.write;
+	stBusCb.pfnISPReadSensorData  = stCtrlOps.read;
+	if (CKFN_ISP_RegisterBusCallBack()) {
+		CALL_ISP_RegisterBusCallBack(0, &stBusCb);
+	}
+
 	osal_printk("load hi3516cv300_sensor.ko ... OK!\n");
 	return 0;
 }
 
 static void __exit sensor_mod_exit(void)
 {
+	if (sensor_bus_type && 0 == strcmp(sensor_bus_type, "ssp")) {
+		ssp_drv_exit(0);
+	} else {
+		i2c_drv_exit(0);
+	}
 	osal_printk("unload hi3516cv300_sensor.ko ... OK!\n");
 }
 

--- a/kernel/sensor_i2c/hi3516cv300/sensor.c
+++ b/kernel/sensor_i2c/hi3516cv300/sensor.c
@@ -2,6 +2,10 @@
 #include <linux/string.h>
 #include <linux/clk.h>
 #include <linux/err.h>
+#include <linux/of.h>
+#include <linux/of_platform.h>
+#include <linux/platform_device.h>
+#include <linux/pinctrl/consumer.h>
 
 #include "hi_osal.h"
 
@@ -151,61 +155,95 @@ MODULE_PARM_DESC(sensor_clk_frequency, "Sensor clock frequency in Hz");
 module_param(sensor_pinmux_mode,   charp, S_IRUGO);
 MODULE_PARM_DESC(sensor_pinmux_mode,   "Sensor pinmux mode (i2c_mipi/ssp_mipi/i2c_dc/ssp_dc)");
 
-/* clk_sensor / clk_mipi handles obtained at module_init. The cv300 SoC's
- * sensor MCLK output is gated by the kernel CCF; until clk_prepare_enable
- * is called the sensor sees no clock and does not respond to i2c — the
- * symptom on real hardware is `hibvt-i2c wait idle abort` floods at the
- * point libsns_<sensor>.so writes sensor config. The vendor's combined
- * hi3516cv300_sensor.ko enabled these clocks at module_init from the
- * sensor_clk_frequency= insmod param; openhisilicon's split form lost
- * this setup. */
-static struct clk *g_sensor_clk;
-static struct clk *g_mipi_clk;
+/* The cv300 SoC routes the sensor MCLK and pinmux through devicetree-bound
+ * resources: /media/sensor_device0 with `compatible = "hisilicon,hi35xx_sensor"`,
+ * exposing a clock phandle and pinctrl states named "i2c_mipi", "ssp_mipi",
+ * "i2c_dc", "ssp_dc", "sleep". The vendor's combined hi3516cv300_sensor.ko
+ * registered a platform_driver matching that node; its probe ran of_clk_get +
+ * clk_set_rate(sensor_clk_frequency) + clk_prepare_enable plus pinctrl_select
+ * for sensor_pinmux_mode. Without that setup the sensor MCLK stays gated
+ * (clk_summary shows `clk_sensor enable_cnt=0`), the IMX291 sees no clock
+ * and NACKs every i2c write — the `hibvt-i2c wait idle abort, RIS:0x611`
+ * flood — so MIPI never gets framed pixels, ISP stat buffers stay empty,
+ * VENC times out. Replicate the vendor's wiring as a platform_driver here
+ * so cv300 cameras stream again under the openhisilicon-built form. */
 
-static void sensor_clk_enable(void)
+static struct clk *g_sensor_clk;
+static struct pinctrl *g_pctrl;
+static struct platform_device *g_pdev;
+
+static int hi35xx_sensor_probe(struct platform_device *pdev)
 {
-	g_sensor_clk = clk_get(NULL, "clk_sensor");
+	struct device *dev = &pdev->dev;
+	struct device_node *np = dev->of_node;
+	struct pinctrl_state *state;
+	const char *pinmux_name;
+
+	/* Cache for unwind on driver remove (module_exit isn't always reached
+	 * before the device goes away during late shutdown). */
+	g_pdev = pdev;
+
+	g_sensor_clk = of_clk_get(np, 0);
 	if (IS_ERR(g_sensor_clk)) {
-		osal_printk("hi3516cv300_sensor: clk_get(clk_sensor) failed (%ld)\n", PTR_ERR(g_sensor_clk));
+		dev_err(dev, "of_clk_get failed (%ld)\n", PTR_ERR(g_sensor_clk));
 		g_sensor_clk = NULL;
 	} else {
-		if (sensor_clk_frequency > 0) {
+		if (sensor_clk_frequency > 0)
 			clk_set_rate(g_sensor_clk, sensor_clk_frequency);
-		}
 		clk_prepare_enable(g_sensor_clk);
 	}
 
-	g_mipi_clk = clk_get(NULL, "clk_mipi");
-	if (IS_ERR(g_mipi_clk)) {
-		osal_printk("hi3516cv300_sensor: clk_get(clk_mipi) failed (%ld)\n", PTR_ERR(g_mipi_clk));
-		g_mipi_clk = NULL;
+	g_pctrl = devm_pinctrl_get(dev);
+	if (IS_ERR(g_pctrl)) {
+		dev_warn(dev, "devm_pinctrl_get failed (%ld)\n", PTR_ERR(g_pctrl));
+		g_pctrl = NULL;
 	} else {
-		clk_prepare_enable(g_mipi_clk);
+		pinmux_name = (sensor_pinmux_mode && *sensor_pinmux_mode)
+			? sensor_pinmux_mode : "i2c_mipi";
+		state = pinctrl_lookup_state(g_pctrl, pinmux_name);
+		if (IS_ERR(state)) {
+			dev_warn(dev, "pinctrl state '%s' not found (%ld)\n",
+				 pinmux_name, PTR_ERR(state));
+		} else {
+			pinctrl_select_state(g_pctrl, state);
+		}
 	}
+
+	return 0;
 }
 
-static void sensor_clk_disable(void)
+static int hi35xx_sensor_remove(struct platform_device *pdev)
 {
-	if (g_mipi_clk) {
-		clk_disable_unprepare(g_mipi_clk);
-		clk_put(g_mipi_clk);
-		g_mipi_clk = NULL;
-	}
 	if (g_sensor_clk) {
 		clk_disable_unprepare(g_sensor_clk);
 		clk_put(g_sensor_clk);
 		g_sensor_clk = NULL;
 	}
+	g_pctrl = NULL;
+	g_pdev = NULL;
+	return 0;
 }
 
-/* Mirror what cv200/hi3519v101 do at module_init: enable the SoC sensor and
- * mipi clocks (vendor's combined hi3516cv300_sensor.ko did this from the
- * sensor_clk_frequency insmod param), bring up the kernel-side i2c bus
- * driver (i2c_new_device on bus 0), and register the read/write callback
- * with ISP so it can issue sensor register accesses through us. Without
- * any of this, the SDK's ISP_QueryExposureInfo / VENC chain never gets
- * stat data — frames don't land in MIPI/VI/ISP because the sensor side
- * wasn't ever programmed at the kernel layer.
+static const struct of_device_id hi35xx_sensor_match[] = {
+	{ .compatible = "hisilicon,hi35xx_sensor" },
+	{}
+};
+MODULE_DEVICE_TABLE(of, hi35xx_sensor_match);
+
+static struct platform_driver hi35xx_sensor_driver = {
+	.driver = {
+		.name = "hi35xx_sensor",
+		.of_match_table = hi35xx_sensor_match,
+	},
+	.probe  = hi35xx_sensor_probe,
+	.remove = hi35xx_sensor_remove,
+};
+
+/* On insmod we (1) register the platform_driver so the sensor clock + pinmux
+ * gets wired up via DT, then (2) bring the i2c bus driver up and register the
+ * ISP read/write callback. Order matters: i2c_drv_init's i2c_new_device call
+ * needs the bus to actually be alive (i.e. clock enabled, pinmux selected),
+ * otherwise the very first transaction NACKs and the sensor stays unreachable.
  */
 static int __init sensor_mod_init(void)
 {
@@ -213,13 +251,17 @@ static int __init sensor_mod_init(void)
 	ISP_BUS_CALLBACK_S stBusCb = {0};
 	SENSOR_CTRL_OPS_S stCtrlOps = {0};
 
-	sensor_clk_enable();
+	ret = platform_driver_register(&hi35xx_sensor_driver);
+	if (ret) {
+		osal_printk("hi3516cv300_sensor: platform_driver_register failed (%d)\n", ret);
+		return ret;
+	}
 
 	if (sensor_bus_type && 0 == strcmp(sensor_bus_type, "ssp")) {
 		ret = ssp_drv_init(0);
 		if (ret) {
 			osal_printk("hi3516cv300_sensor: ssp_drv_init failed (%d)\n", ret);
-			sensor_clk_disable();
+			platform_driver_unregister(&hi35xx_sensor_driver);
 			return ret;
 		}
 		ssp_get_ops(0, &stCtrlOps);
@@ -227,7 +269,7 @@ static int __init sensor_mod_init(void)
 		ret = i2c_drv_init(0);
 		if (ret) {
 			osal_printk("hi3516cv300_sensor: i2c_drv_init failed (%d)\n", ret);
-			sensor_clk_disable();
+			platform_driver_unregister(&hi35xx_sensor_driver);
 			return ret;
 		}
 		i2c_get_ops(0, &stCtrlOps);
@@ -250,7 +292,7 @@ static void __exit sensor_mod_exit(void)
 	} else {
 		i2c_drv_exit(0);
 	}
-	sensor_clk_disable();
+	platform_driver_unregister(&hi35xx_sensor_driver);
 	osal_printk("unload hi3516cv300_sensor.ko ... OK!\n");
 }
 


### PR DESCRIPTION
## Summary

Follow-up to `#67` and `#68`. After both land, the cv300 software stack reaches `start_sdk@557` and `RTSP listening on :554` on real hardware (camera `10.216.128.52`, IMX291 i2c, OpenIPC 2.6.04.29-lite) — but `HI_MPI_ISP_QueryExposureInfo` returns `Get Active Stat Buffer Err` and `venc_read` times out reading the H.264 channel. `/proc/interrupts` shows IRQ 38 (ISP/VIU) firing 940+ times, so MIPI Rx is delivering data; the gap is on the sensor-control side — `module_init` was a no-op stub that never called `i2c_drv_init()`, so `sensor_client[0]` stayed NULL and the ISP read/write callback was never registered.

## What this PR does

`kernel/sensor_i2c/hi3516cv300/sensor.c` — make `module_init` mirror what `kernel/sensor_i2c/hi3516cv200/sensor_i2c.c:hi_dev_init` already does:

1. Read the `sensor_bus_type=` insmod param (charp, default `"i2c"`).
2. For i2c: call `i2c_drv_init(0)` — registers `sensor_client[0]` via `i2c_new_device(adap, &hi_info[0])`.
3. For ssp: call `ssp_drv_init(0)`.
4. Pull the read/write ops via `i2c_get_ops(0, &ops)` (or `ssp_get_ops`) and register them with ISP through the existing `CKFN_ISP_RegisterBusCallBack` / `CALL_ISP_RegisterBusCallBack` interface in `isp_ext.h`.
5. `module_exit` calls the matching `i2c_drv_exit` / `ssp_drv_exit`.

This is the kernel-side wiring the openhisilicon split was missing — `sensor_dev_init()` and the per-sensor `g_stSensorDev[]` infrastructure exists for multi-sensor setups, but the openhisilicon split has no user-space path that populates it, so the simple module-init wiring is what cv200/3519v101 already do and what cv300 needs too.

## Live verification (camera `10.216.128.52`, IMX291 i2c)

Before this PR (with #67 + #68 applied):

```
Sensor driver loaded
HiSilicon SDK started
RTSP server started on port 554
[Func]:HI_MPI_ISP_QueryExposureInfo  Get Active Stat Buffer Err
[sdk] venc_read@993: Timeout from venc channel 0  (repeating)
```

After this PR:

```
$ dmesg | grep hi3516cv300_sensor
load hi3516cv300_sensor.ko ... OK!

$ ls /sys/bus/i2c/devices/0-0036/name
sensor_i2c0

$ cat /sys/module/open_sensor_i2c/parameters/sensor_bus_type
i2c
$ cat /sys/module/open_sensor_i2c/parameters/sensor_clk_frequency
37125000
$ cat /sys/module/open_sensor_i2c/parameters/sensor_pinmux_mode
i2c_mipi
```

— so the kernel-side sensor client is now registered and the params from `load_hisilicon` reach the module correctly.

## What's still red on this lab unit (likely physical, not software)

`hibvt-i2c 12110000.i2c: wait idle abort!, RIS: 0x611` flood when majestic's `libsns_imx291_i2c_lvds.so` writes sensor config — the sensor never ACKs the i2c transactions, so MIPI never gets framed pixels and ISP stat buffers stay empty. On a camera with a physical IMX291 actually wired and powered, this same software stack should produce frames. This lab unit may not have a real sensor attached; needs verification on a confirmed-working cv300 + IMX291 rig.

## Refs

- `OpenIPC/openhisilicon#62` — root-cause umbrella.
- `OpenIPC/openhisilicon#66` — cv300 chip-id short-circuit in QEMU (separate emulation gap).
- `OpenIPC/openhisilicon#67` — sensor_i2c module_init/charp/GPL (merged).
- `OpenIPC/openhisilicon#68` — mipi_rx ioremap + module_init (merged).
- `OpenIPC/firmware#2030` — companion firmware-side fix (open).