### PR TITLE
sys_config/hi3516cv200: register OV2710 (MIPI + DVP) in sensor whitelist

### DIFF
--- a/kernel/sys_config/hi3516cv200/sys_config.c
+++ b/kernel/sys_config/hi3516cv200/sys_config.c
@@ -601,6 +601,30 @@ static void insert_sns(void)
 
 		sys_write_reg(0x2003002c, 0xc4001);			// sensor unreset, clk 24MHz, VI 99MHz
 	}
+    else if (!strcmp(sensor, "ov2710_mipi"))
+	{
+		// MIPI variant — uses libsns_ov2710_mipi.so via ov2710_mipi_1080p.ini
+		sys_write_reg(0x200f0040, 0x2);    			// I2C0_SCL
+		sys_write_reg(0x200f0044, 0x2);    			// I2C0_SDA
+
+		sys_write_reg(0x2003002c, 0xc4001);			// sensor unreset, clk 24MHz, VI 99MHz
+	}
+    else if (!strcmp(sensor, "ov2710_dc"))
+	{
+		// DVP/parallel variant — uses libsns_ov2710_dc.so via ov2710_dc_1080p.ini
+		sys_write_reg(0x200f0040, 0x2);    			// I2C0_SCL
+		sys_write_reg(0x200f0044, 0x2);    			// I2C0_SDA
+
+		sys_write_reg(0x200f007c, 0x1);    			// VI_DATA13
+		sys_write_reg(0x200f0080, 0x1);    			// VI_DATA10
+		sys_write_reg(0x200f0084, 0x1);    			// VI_DATA12
+		sys_write_reg(0x200f0088, 0x1);    			// VI_DATA11
+		sys_write_reg(0x200f008c, 0x2);    			// VI_VS
+		sys_write_reg(0x200f0090, 0x2);    			// VI_HS
+		sys_write_reg(0x200f0094, 0x1);    			// VI_DATA9
+
+		sys_write_reg(0x2003002c, 0xc4001);			// sensor unreset, clk 24MHz, VI 99MHz
+	}
     else if (!strcmp(sensor, "bt1120"))
     {
         sys_write_reg( 0x200f0008, 0x4 );    			// VI_VS


### PR DESCRIPTION
Follow-up to #71. The sensor library landed but the kernel-side `sys_config.ko` per-sensor pinmux table was untouched, so users get a noisy:

\`\`\`
kern.emerg kernel: sensor_type 'ov2710' is error!!!
\`\`\`

at boot before \`load_hisilicon\` patches things up via userspace devmem. Caught in the wild on the issue thread (#70) — @0xPIT's hi3518ev200 board flashed the test firmware and saw this print.

Adds two cases to `insert_sns()`:

| Case | Wiring | Pinmux |
|---|---|---|
| `ov2710` | MIPI | I2C0 SCL/SDA + 24 MHz mclk only (modeled on existing `ov2718`) |
| `ov2710_dc` | DVP/parallel | same I2C + clock + VI_DATA9..13 + VS/HS pinmux (modeled on existing `ov9732`) |

Both at 24 MHz mclk to match the cv100 V1 reference and OV2710 datasheet's typical input clock. Mirrors the per-sensor branches I added to `load_hisilicon` in OpenIPC/firmware#2035.

Refs: #70