### PR TITLE
mmz: fail allocator init when every configured zone is rejected

### DIFF
--- a/kernel/mmz/hi3516av100/media-mem.c
+++ b/kernel/mmz/hi3516av100/media-mem.c
@@ -1026,6 +1026,7 @@ static int media_mem_parse_cmdline(char *s)
 	hil_mmz_t *zone = NULL;
 	char *line;
     unsigned long phys_end = 0;
+	int attempted = 0, registered = 0;
 
 	while( (line = strsep(&s,":")) !=NULL) {
 		int i;
@@ -1063,10 +1064,14 @@ static int media_mem_parse_cmdline(char *s)
 		}
 		mmz_info_phys_start = zone->phys_start + zone->nbytes - 0x2000;
 
+		attempted++;
 		if (hil_mmz_register(zone)) {
 			printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n", hil_mmz_fmt_arg(zone));
 			hil_mmz_destroy(zone);
+			zone = NULL;
+			continue;
 		}
+		registered++;
 
         // if phys_end is 0xFFFFFFFF (32bit)
         phys_end = (zone->phys_start + zone->nbytes);
@@ -1085,6 +1090,12 @@ static int media_mem_parse_cmdline(char *s)
         }
 
 		zone = NULL;
+	}
+
+	if (attempted > 0 && registered == 0) {
+		printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
+				attempted);
+		return -ENODEV;
 	}
 
 	return 0;

--- a/kernel/mmz/hi3516cv100/media-mem.c
+++ b/kernel/mmz/hi3516cv100/media-mem.c
@@ -957,6 +957,7 @@ static int media_mem_parse_cmdline(char *s)
 {
 	hil_mmz_t *zone = NULL;
 	char *line;
+	int attempted = 0, registered = 0;
 
 	while( (line = strsep(&s,":")) !=NULL) {
 		int i;
@@ -992,12 +993,21 @@ static int media_mem_parse_cmdline(char *s)
 			printk(KERN_ERR "MMZ: your parameter num is not correct!\n");	
 			continue;
 		}
-		mmz_info_phys_start = zone->phys_start + zone->nbytes - 0x2000;	
+		mmz_info_phys_start = zone->phys_start + zone->nbytes - 0x2000;
+		attempted++;
 		if (hil_mmz_register(zone)) {
 			printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n", hil_mmz_fmt_arg(zone));
 			hil_mmz_destroy(zone);
+		} else {
+			registered++;
 		}
 		zone = NULL;
+	}
+
+	if (attempted > 0 && registered == 0) {
+		printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
+				attempted);
+		return -ENODEV;
 	}
 
 	return 0;
@@ -1150,11 +1160,15 @@ MODULE_PARM_DESC(mmz,"mmz=name,0,start,size,type,eqsize:[others]");
 
 static int __init media_mem_init(void)
 {
+	int ret;
+
 	printk(KERN_INFO "Hisilicon Media Memory Zone Manager\n");
 
 	media_mem_proc_init();
 
-	media_mem_parse_cmdline(setup_zones);
+	ret = media_mem_parse_cmdline(setup_zones);
+	if (ret)
+		return ret;
 
 	//kcom_mmz_register();
 

--- a/kernel/mmz/hi3516cv200/media-mem.c
+++ b/kernel/mmz/hi3516cv200/media-mem.c
@@ -1028,6 +1028,7 @@ static int media_mem_parse_cmdline(char *s)
 	hil_mmz_t *zone = NULL;
 	char *line;
     unsigned long phys_end = 0;
+	int attempted = 0, registered = 0;
 
 	while( (line = strsep(&s,":")) !=NULL) {
 		int i;
@@ -1065,10 +1066,14 @@ static int media_mem_parse_cmdline(char *s)
 		}
 		mmz_info_phys_start = zone->phys_start + zone->nbytes - 0x2000;
 
+		attempted++;
 		if (hil_mmz_register(zone)) {
 			printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n", hil_mmz_fmt_arg(zone));
 			hil_mmz_destroy(zone);
+			zone = NULL;
+			continue;
 		}
+		registered++;
 
         // if phys_end is 0xFFFFFFFF (32bit)
         phys_end = (zone->phys_start + zone->nbytes);
@@ -1087,6 +1092,12 @@ static int media_mem_parse_cmdline(char *s)
         }
 
 		zone = NULL;
+	}
+
+	if (attempted > 0 && registered == 0) {
+		printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
+				attempted);
+		return -ENODEV;
 	}
 
 	return 0;

--- a/kernel/osal/hi3516cv300/mmz/cma_allocator.c
+++ b/kernel/osal/hi3516cv300/mmz/cma_allocator.c
@@ -542,10 +542,11 @@ static void __mmf_unmap(void *virt)
 
 static int __allocator_init(char *s)
 {
-    #ifdef CONFIG_CMA 
+    #ifdef CONFIG_CMA
 	hil_mmz_t *zone = NULL;
 	char *line;
 	struct cma_zone *cma_zone = NULL;
+	int attempted = 0, registered = 0;
 
 	while ((line = strsep(&s, ":")) != NULL) {
 		int i;
@@ -601,12 +602,21 @@ static int __allocator_init(char *s)
 			continue;
 		}
 
+		attempted++;
 		if (hil_mmz_register(zone)) {
 			printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n", hil_mmz_fmt_arg(zone));
 			hil_mmz_destroy(zone);
+		} else {
+			registered++;
 		}
 
 		zone = NULL;
+	}
+
+	if (attempted > 0 && registered == 0) {
+		printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
+				attempted);
+		return -ENODEV;
 	}
     #endif
 	return 0;

--- a/kernel/osal/hi3516cv300/mmz/hisi_allocator.c
+++ b/kernel/osal/hi3516cv300/mmz/hisi_allocator.c
@@ -484,6 +484,7 @@ static int __allocator_init(char *s)
 {
 	hil_mmz_t *zone = NULL;
 	char *line;
+	int attempted = 0, registered = 0;
 
 	while ((line = strsep(&s, ":")) != NULL) {
 		int i;
@@ -519,11 +520,20 @@ static int __allocator_init(char *s)
 
 		//mmz_info_phys_start = zone->phys_start + zone->nbytes - 0x2000;
 
+		attempted++;
 		if (hil_mmz_register(zone)) {
 			printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n", hil_mmz_fmt_arg(zone));
 			hil_mmz_destroy(zone);
+		} else {
+			registered++;
 		}
 		zone = NULL;
+	}
+
+	if (attempted > 0 && registered == 0) {
+		printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
+				attempted);
+		return -ENODEV;
 	}
 
 	return 0;

--- a/kernel/osal/hi3516cv300/osal.c
+++ b/kernel/osal/hi3516cv300/osal.c
@@ -16,6 +16,7 @@ extern int mem_check_module_param(void);
 extern void osal_device_init(void);
 
 static int __init osal_init(void){
+    int ret;
 
    if (-1 == mem_check_module_param())
    {
@@ -25,7 +26,12 @@ static int __init osal_init(void){
     osal_device_init();
     osal_proc_init();
     himedia_init();
-    media_mem_init();
+    ret = media_mem_init();
+    if (ret) {
+        himedia_exit();
+        osal_proc_exit();
+        return ret;
+    }
     osal_printk("hi_osal %s init success!\n", HI_OSAL_VERSION);
     return 0;
 }

--- a/kernel/osal/hi3516cv500/mmz/cma_allocator.c
+++ b/kernel/osal/hi3516cv500/mmz/cma_allocator.c
@@ -489,6 +489,7 @@ static int __allocator_init(char *s)
     hil_mmz_t *zone = NULL;
     char *line = NULL;
     struct cma_zone *cma_zone = NULL;
+    int attempted = 0, registered = 0;
 
     while ((line = strsep(&s, ":")) != NULL) {
         int i;
@@ -554,13 +555,22 @@ static int __allocator_init(char *s)
             continue;
         }
 
+        attempted++;
         if (hil_mmz_register(zone)) {
             printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n",
                    hil_mmz_fmt_arg(zone));
             hil_mmz_destroy(zone);
+        } else {
+            registered++;
         }
 
         zone = NULL;
+    }
+
+    if (attempted > 0 && registered == 0) {
+        printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
+                attempted);
+        return -ENODEV;
     }
 #endif
 

--- a/kernel/osal/hi3516cv500/osal.c
+++ b/kernel/osal/hi3516cv500/osal.c
@@ -15,6 +15,8 @@
 
 static int __init osal_init(void)
 {
+    int ret;
+
     if (mem_check_module_param() == -1) {
         return -1;
     }
@@ -22,7 +24,12 @@ static int __init osal_init(void)
     osal_device_init();
     osal_proc_init();
     himedia_init();
-    media_mem_init();
+    ret = media_mem_init();
+    if (ret) {
+        himedia_exit();
+        osal_proc_exit();
+        return ret;
+    }
     osal_printk("hi_osal %s init success!\n", HI_OSAL_VERSION);
     return 0;
 }

--- a/kernel/osal/hi3519v101/mmz/cma_allocator.c
+++ b/kernel/osal/hi3519v101/mmz/cma_allocator.c
@@ -542,10 +542,11 @@ static void __mmf_unmap(void *virt)
 
 static int __allocator_init(char *s)
 {
-    #ifdef CONFIG_CMA 
+    #ifdef CONFIG_CMA
 	hil_mmz_t *zone = NULL;
 	char *line;
 	struct cma_zone *cma_zone = NULL;
+	int attempted = 0, registered = 0;
 
 	while ((line = strsep(&s, ":")) != NULL) {
 		int i;
@@ -601,12 +602,21 @@ static int __allocator_init(char *s)
 			continue;
 		}
 
+		attempted++;
 		if (hil_mmz_register(zone)) {
 			printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n", hil_mmz_fmt_arg(zone));
 			hil_mmz_destroy(zone);
+		} else {
+			registered++;
 		}
 
 		zone = NULL;
+	}
+
+	if (attempted > 0 && registered == 0) {
+		printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
+				attempted);
+		return -ENODEV;
 	}
     #endif
 	return 0;

--- a/kernel/osal/hi3519v101/mmz/hisi_allocator.c
+++ b/kernel/osal/hi3519v101/mmz/hisi_allocator.c
@@ -484,6 +484,7 @@ static int __allocator_init(char *s)
 {
 	hil_mmz_t *zone = NULL;
 	char *line;
+	int attempted = 0, registered = 0;
 
 	while ((line = strsep(&s, ":")) != NULL) {
 		int i;
@@ -519,11 +520,20 @@ static int __allocator_init(char *s)
 
 		//mmz_info_phys_start = zone->phys_start + zone->nbytes - 0x2000;
 
+		attempted++;
 		if (hil_mmz_register(zone)) {
 			printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n", hil_mmz_fmt_arg(zone));
 			hil_mmz_destroy(zone);
+		} else {
+			registered++;
 		}
 		zone = NULL;
+	}
+
+	if (attempted > 0 && registered == 0) {
+		printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
+				attempted);
+		return -ENODEV;
 	}
 
 	return 0;

--- a/kernel/osal/hi3519v101/osal.c
+++ b/kernel/osal/hi3519v101/osal.c
@@ -16,6 +16,7 @@ extern int mem_check_module_param(void);
 extern void osal_device_init(void);
 
 static int __init osal_init(void){
+    int ret;
 
    if (-1 == mem_check_module_param())
    {
@@ -25,7 +26,12 @@ static int __init osal_init(void){
     osal_device_init();
     osal_proc_init();
     himedia_init();
-    media_mem_init();
+    ret = media_mem_init();
+    if (ret) {
+        himedia_exit();
+        osal_proc_exit();
+        return ret;
+    }
     osal_printk("hi_osal %s init success!\n", HI_OSAL_VERSION);
     return 0;
 }

--- a/kernel/osal/linux/kernel/mmz/cma_allocator.c
+++ b/kernel/osal/linux/kernel/mmz/cma_allocator.c
@@ -543,6 +543,7 @@ static int __allocator_init(char *s)
 	mmz_mmz_t *zone = NULL;
 	char *line = NULL;
 	struct cma_zone *cma_zone = NULL;
+	int attempted = 0, registered = 0;
 
 	while ((line = strsep(&s, ":")) != NULL) {
 		int i;
@@ -592,13 +593,22 @@ static int __allocator_init(char *s)
 			continue;
 		}
 
+		attempted++;
 		if (mmz_mmz_register(zone)) {
 			printk(KERN_WARNING "Add MMZ failed: " MMZ_MMZ_FMT_S "\n",
 			       mmz_mmz_fmt_arg(zone));
 			mmz_mmz_destroy(zone);
+		} else {
+			registered++;
 		}
 
 		zone = NULL;
+	}
+
+	if (attempted > 0 && registered == 0) {
+		printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
+				attempted);
+		return -ENODEV;
 	}
 
 	return 0;


### PR DESCRIPTION
## Summary

- When the `mmz=` range conflicts with kernel memory (e.g. observed on an `hi3516av200`/V3 camera booted with `mem=256M` while `load_hisilicon` derives `mmz_start=0x88000000,size=384M` from `osmem`/`totalmem` env), `_check_mmz` correctly rejects every zone — but the per-zone loop in `__allocator_init` / `media_mem_parse_cmdline` swallowed the failure and returned 0. `insmod hi_osal.ko` looked successful, the load script's `|| report_error` never fired, every dependent vendor blob loaded on top of an empty MMZ list, and the only symptom was majestic crashing later with no obvious link to the original conflict.
- Track `attempted` vs. `registered` and return `-ENODEV` when the input string was non-empty but no zone survived, so the OSAL/MMZ insmod now fails loudly with the existing `MMZ conflict to kernel memory ...` / `Add MMZ failed: ...` lines still in `dmesg` right above the failure.
- Applied across every allocator that swallowed register failures: V1/V2/V2A legacy MMZ, V3 (`cv300`, `3519v101`) `hisi`+`cma`, V3.5 `cv500` `cma`, and V4 shared pre-5.16 `cma`. V3.5 `hisi`, V4 `allocator.c`, and V4 post-5.16 `cma` already fail fast on register error and were left alone.
- Drive-by in V2/V2A (`cv200`, `av100`): the post-register wraparound check dereferenced `zone` after `hil_mmz_destroy` on the failure path. Restructured to `continue` on register failure (also enables the new counter).
- V1 (`cv100`) `media_mem_init` was discarding the parser return value; capture and propagate it so the new `-ENODEV` actually fails insmod.

## Test plan
- [ ] CI: 8 SDK builds + 8 QEMU smoke tests pass (silent module-load regression already covered by #63).
- [ ] On the affected `hi3516av200`/V3 camera with the conflicting `mem=256M` cmdline + `osmem=128M` U-Boot env: `insmod hi_osal.ko mmz=anonymous,0,0x88000000,384M anony=1` now exits non-zero, `load_hisilicon`'s `|| report_error` fires, and downstream `hi3519v101_*` blobs no longer load on top of an empty MMZ list.
- [ ] Happy-path regression: a correctly-configured camera (e.g. `hi3516ev200` with `mem=32M mmz_allocator=hisi`) still loads `open_osal.ko` and brings up the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)