### PR TITLE
mipi_rx/hi3519v101: ioremap MIPI registers + wire up module_init

### DIFF
--- a/kernel/mipi_rx/hi3519v101/mipi.c
+++ b/kernel/mipi_rx/hi3519v101/mipi.c
@@ -19,11 +19,15 @@
  *      2013.04.03 create this file <zengwen@huawei.com>
  */
 
+#include <linux/module.h>
+
 #include "hi_osal.h"
 #include "hi_mipi.h"
 #include "mipi_reg.h"
 #include "mipi_hal.h"
 #include "hi_type.h"
+
+extern void mipi_drv_exit_reg(void);
 
 /****************************************************************************
  * MACRO DEFINITION                                                         *
@@ -2507,8 +2511,14 @@ void mipi_exit(void)
     osal_destroydev(s_pstHiMipiDevice);
     s_pstHiMipiDevice = NULL;
 
+    mipi_drv_exit_reg();
+
     osal_mutex_destory(&hi_mipi_lock);
-	
+
 	osal_printk("unload hi_mipi driver successful!\n");
 }
+
+module_init(mipi_init);
+module_exit(mipi_exit);
+MODULE_LICENSE("GPL");
 

--- a/kernel/mipi_rx/hi3519v101/mipi_hal.c
+++ b/kernel/mipi_rx/hi3519v101/mipi_hal.c
@@ -81,8 +81,10 @@ unsigned int mipi_drv_init_reg(void)
 
     if (!gpMipiAllReg)
     {
-        gpMipiAllReg = (MIPI_REGS_TYPE_S*)OSAL_IO_ADDRESS(MIPI_BASE_ADDR);    
-
+        /* OSAL_IO_ADDRESS panics on Linux >= 3.18 (osal_ioaddress in
+         * kernel/osal/hi3519v101/osal_addr.c); v101 ships kernel 3.18.20,
+         * so map the MIPI register region with osal_ioremap_nocache. */
+        gpMipiAllReg = (MIPI_REGS_TYPE_S*)osal_ioremap_nocache(MIPI_BASE_ADDR, sizeof(MIPI_REGS_TYPE_S));
         if(NULL == gpMipiAllReg)
         {
             ret = HI_FAILURE;
@@ -109,6 +111,14 @@ unsigned int mipi_drv_init_reg(void)
     return ret;
 }
 
+void mipi_drv_exit_reg(void)
+{
+    if (gpMipiAllReg)
+    {
+        osal_iounmap(gpMipiAllReg);
+        gpMipiAllReg = NULL;
+    }
+}
 
 void mipi_drv_reset_sensor(COMBO_DEV dev)
 {


### PR DESCRIPTION
## Same shape as #68, but for V3 (`hi3519v101`) instead of V3.5 (`cv300`)

`hi3519v101/mipi.c` already had functional `mipi_init` / `mipi_exit` but they were never registered via `module_init` / `module_exit`. So insmod-loading `hi_mipi.ko` (renamed `open_mipi_rx`) on a real `hi3519v101` board (and its `hi3516av200` sibling) loaded inert code: `/dev/hi_mipi` was never created and majestic failed sensor init with:

```
warning: open hi_mipi dev failed
Cannot set VI Mipi attr
Cannot init sensor / Cannot start SDK
```

Wiring up `module_init(mipi_init)` alone would **panic the kernel**: `mipi_drv_init_reg()` calls `OSAL_IO_ADDRESS(MIPI_BASE_ADDR)`, which expands to `osal_ioaddress()` in `kernel/osal/hi3519v101/osal_addr.c` — and that function is a hard panic on Linux ≥ 3.18:

```c
void *osal_ioaddress(int addr) {
#if LINUX_VERSION_CODE < KERNEL_VERSION(3,18,0)
    return (void *)IO_ADDRESS(addr);
#else
    panic("ASSERT: linux kernel not support IO_ADDRESS now.");
#endif
}
```

v101 ships kernel 3.18.20, so the panic branch is always taken.

## Two-part fix

1. **`mipi_hal.c`** — replace the live `OSAL_IO_ADDRESS(MIPI_BASE_ADDR)` in `mipi_drv_init_reg()` with `osal_ioremap_nocache(MIPI_BASE_ADDR, sizeof(MIPI_REGS_TYPE_S))`. Add a matching `mipi_drv_exit_reg()` that `iounmap()`s on module unload. The other `OSAL_IO_ADDRESS` occurrences in this file (`sensor_reset` / `mipi_reset` / `misc_reg` lines) are all inside `#ifdef HI_FPGA` blocks and not compiled on real cameras — the active ASIC paths use the existing `reg_crg_base_va` and are unchanged.

2. **`mipi.c`** — wire up `module_init(mipi_init)` / `module_exit(mipi_exit)` with `MODULE_LICENSE("GPL")`. Update `mipi_exit()` to call `mipi_drv_exit_reg()` after destroying the device, mirroring init order in reverse.

## Verified end-to-end on `hi3516av200`

Camera kernel 3.18.20, `imx385` sensor over MIPI, with the load script's MMZ misconfig corrected separately ([firmware#2039](https://github.com/OpenIPC/firmware/pull/2039)):

```
$ ls /dev/ | grep mipi          # before: empty
hi_mipi                          # after
$ dmesg | tail -1                # after
load hi_mipi driver successful!

$ SENSOR=imx385_i2c_1080p majestic
...
-------Sony IMX385 Sensor 1080p30 Initial OK!-------
h264 1920x1080@20fps 4096kbit 20gop
MJPEG 1920x1080@5fps 50q
HiSilicon SDK started
RTSP server started on port 554
```

`mipi_init`'s `request_irq` for IRQ 60/61 succeeded on this kernel — both free per `/proc/interrupts` (ethernet is on 57, ISP/VIU on 62/63) — so the ethernet-IRQ-collision path that the cv300 commit had to tolerate isn't even exercised here.

Refs OpenIPC/openhisilicon#68.

## Test plan
- [x] Live test on `hi3516av200` — `/dev/hi_mipi` created, majestic reaches sensor init, RTSP serves.
- [ ] CI: build all 8 SDK targets (no other platform's mipi_rx is touched).
- [ ] CI: QEMU smoke test for `hi3519v101` boots clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)