### PR TITLE
sensor/hi3516cv200/ov2710: enable DVP output pads in DVP branch

### DIFF
--- a/libraries/sensor/hi3516cv200/omnivision_ov2710/ov2710_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv200/omnivision_ov2710/ov2710_sensor_ctl.c
@@ -318,7 +318,16 @@ void sensor_linear_1080p30_init()
     {
         int parallel = ov2710_is_parallel_mode();
         if (parallel) {
-            /* DVP/parallel output (cv100 V1 reference register values) */
+            /* DVP/parallel output (cv100 V1 reference register values).
+             * Override the common 0x3017=0x00, 0x3018=0x00 written above —
+             * those leave every DVP pad as input (high-Z), correct for MIPI
+             * but lethal for DVP. Per OV2710 datasheet table 7-1 sheet 3:
+             *   0x3017 PAD OUTPUT ENABLE01: bit6=VSYNC OEN, bit5=HREF OEN,
+             *                               bit4=PCLK OEN, bit[3:0]=D[9:6] OEN
+             *   0x3018 PAD OUTPUT ENABLE02: bit[7:2]=D[5:0] OEN
+             * 0x7F enables VSYNC/HREF/PCLK/D[9:6]; 0xFC enables D[5:0]. */
+            sensor_write_register(0x3017, 0x7f);
+            sensor_write_register(0x3018, 0xfc);
             sensor_write_register(0x3011, 0x28);
             sensor_write_register(0x300f, 0x88);
 


### PR DESCRIPTION
**Draft** — pending hardware confirmation from @0xPIT on issue #70 (test build attached to that thread).

## Symptom

Sensor lib dlopens cleanly, prints \`(DVP/parallel port) init success\`, but no frame ever reaches VI:

\`\`\`
HI_MPI_ISP_QueryExposureInfo: Get Active Stat Buffer Err
ERR_ISP_? (HiSilicon error code 0xA01C8046)
Timeout from venc channel 0
\`\`\`

## Decoded the error

\`0xA01C8046\` = \`HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_NO_INT)\`:
- module \`0x1C\` = \`HI_ID_ISP\` (kernel/include/\<chiparch\>/hi_common.h)
- errid \`0x46\` = \`ERR_ISP_NO_INT\` (libraries/isp/arch/hi3519v101/include/hi_comm_isp.h:112)

**\"No interrupt\"** = ISP never received a frame-end interrupt from VI = sensor's HSYNC/VSYNC/PCLK never reached the SoC's VI receiver.

## Root cause

The OV2710 source we imported in #71 was authored for **MIPI port** mode. In that mode DVP pads should stay high-Z, so the common init sequence writes \`0x3017=0x00\` and \`0x3018=0x00\`. Per OV2710 datasheet table 7-1 sheet 3:

| Reg | Name | Bit usage |
|---|---|---|
| \`0x3017\` | PAD OUTPUT ENABLE01 | bit6=VSYNC OEN, bit5=HREF OEN, bit4=PCLK OEN, bit[3:0]=D[9:6] OEN |
| \`0x3018\` | PAD OUTPUT ENABLE02 | bit[7:2]=D[5:0] OEN |

Header note: *\"0: input; 1: output\"*. With both held at zero, every DVP pad is disabled — the chip's internal pipeline runs (I2C writes are honored, \`ipctool\` happily reads back chip ID + mode), but no signal ever leaves the package.

## Fix

Override the common writes in the dladdr-detected DVP branch:

\`\`\`c
sensor_write_register(0x3017, 0x7f);  /* VSYNC + HREF + PCLK + D[9:6] OEN */
sensor_write_register(0x3018, 0xfc);  /* D[5:0] OEN */
\`\`\`

Values match the **cv100 V1 reference \`libsns_ov2710.so\`** init sequence (extracted by \`arm-openipc-linux-musleabi-objdump -d\` on \`general/package/hisilicon-osdrv-hi3516cv100/files/sensor/libsns_ov2710.so\` in OpenIPC/firmware) — that binary has been the known-good DVP path for OV2710 since the original openipc fork.

The MIPI branch is **untouched** — the common 0x00/0x00 writes remain correct there.

## Test plan

- [x] Cross-compiled with the OpenIPC v5TE toolchain (\`-marm -march=armv5te -mtune=arm926ej-s -mfloat-abi=soft\`); ELF size 20716 B matches the canonical CI build's 20620 B; ARM A32 encoding verified by \`objdump\`; same \`DT_NEEDED: [libc.so]\` as the working firmware .so.
- [x] All four DVP-branch register writes (\`0x3017=0x7F\`, \`0x3018=0xFC\`, \`0x3011=0x28\`, \`0x300F=0x88\`) present in \`sensor_linear_1080p30_init\`.
- [ ] Hardware verification on @0xPIT's hi3518ev200 + OV2710 PTZ camera (test .so attached to OpenIPC/openhisilicon#70). Expecting: no more \`Get Active Stat Buffer Err\`, frames flow on RTSP, AE settles to a sane exposure (not 82ms@max-gain).

Will undraft after the hardware verdict.

Refs: #70