### PR TITLE
sensor: upgrade hi3516cv100 to mpp2 (T1+) + add JXH42, IMX327

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ sensor driver found online came from — see
 | | IMX307 | | | | x | | x | x |
 | | IMX323 | | | | x | | | |
 | | IMX326 | | | | | x | | |
-| | IMX327 | | | | | | x | x |
+| | IMX327 | | | | | x | x | x |
 | | IMX335 | | | | | | x | x |
 | | IMX385 | | | | x | x | | |
 | | IMX390 | | | | | | x | |
@@ -224,6 +224,11 @@ sensor driver found online came from — see
 | | MN34041 | x | | | | | | |
 | | MN34220 | | | x | | | x | |
 | | MN34222 | | x | | | | | |
+| **Silicon Optronics (JX)** | JXH22 | x | | | | | | |
+| | JXH42 | x | | | | | | |
+| | JXH63 | | | | | | | x |
+| | JXF22 | | | | x | | | |
+| | JXF37 | | | | | | | x |
 | **GalaxyCore** | GC2053 | | | | | | x | x |
 
 Each sensor has `.so` (shared) and `.a` (static) library builds. The goal is to eventually unify sensor drivers across platforms where the same sensor model is used.

--- a/docs/sensor-driver-api.md
+++ b/docs/sensor-driver-api.md
@@ -28,7 +28,8 @@ across platforms with only a `#include` path change.
 
 | Tier | Platforms | Headline shape |
 |---|---|---|
-| **T1 / V1** | `hi3516cv100` | `int sensor_register_callback(void)` — **one** MPI call, no AE/AWB lib |
+| **T1 / V1** | *(historical mpp/ flavour — not used in this repo, see §3.1)* | `int sensor_register_callback(void)` — **one** MPI call, no AE/AWB lib |
+| **T1+ / V1** | `hi3516cv100` | `int sensor_register_callback(void)` — **three** MPI calls (ISP/AE/AWB) but **no `IspDev`** arg in any of them; CV100 has only one ISP. From the mpp2 flavour SDK. |
 | **T2 / V2** | `hi3516cv200`, `hi3516av100`, `hi3516cv300` | `int sensor_register_callback(void)` — **three** MPI calls (ISP/AE/AWB), `IspDev` is a local `0`, internal `ALG_LIB_S stLib` |
 | **T3 / V3A** | `hi3519v101`, `hi3516av200`† | `static int sensor_register_callback(ISP_DEV IspDev, ALG_LIB_S *pstAeLib, ALG_LIB_S *pstAwbLib)` — caller passes lib handles, first tier to export `ISP_SNS_OBJ_S stSns<X>Obj` |
 | **T4 / V4-HI** | `hi3516cv500` | `static HI_S32 sensor_register_callback(VI_PIPE vi_pipe, ALG_LIB_S *pstAeLib, ALG_LIB_S *pstAwbLib)` — `VI_PIPE` not `ISP_DEV`, `ISP_SNS_ATTR_INFO_S` carries the sensor ID, ISP params split into `<sensor>_cmos_ex.h` |
@@ -36,21 +37,27 @@ across platforms with only a `#include` path change.
 
 Verified anchor points (one driver per tier):
 
-- T1 — `libraries/sensor/hi3516cv100/sony_imx236/imx236_cmos.c:951`
+- T1+ — `libraries/sensor/hi3516cv100/sony_imx236/imx236_cmos.c:902`
+- T1+ — `libraries/sensor/hi3516cv100/soi_jxh42/jxh42_cmos.c:507`
 - T2 — `libraries/sensor/hi3516cv200/aptina_9m034/m034_cmos.c:1335`
 - T2 — `libraries/sensor/hi3516cv300/sony_imx290/imx290_cmos.c:2030`
 - T2 — `libraries/sensor/hi3516av100/aptina_ar0230/ar0230_cmos.c:1329`
 - T3 — `libraries/sensor/hi3519v101/sony_imx226/imx226_cmos.c:1458` (`stSnsImx226Obj` at `:1533`)
+- T3 — `libraries/sensor/hi3519v101/sony_imx327/imx327_cmos.c:1874`
 - T4 — `libraries/sensor/hi3516cv500/sony_imx307/imx307_cmos.c:1238` (`stSnsImx307Obj` at `:1348`)
 - T5 — `libraries/sensor/hi3516ev200/galaxycore_gc2053/gc2053_cmos.c:1120` (`stSnsGc2053Obj` at `:1236`)
 - T5 — `libraries/sensor/gk7205v200/galaxycore_gc2053/gc2053_cmos.c:1120` (identical to EV200)
 
-† **`hi3516av200`** is a T3-shape platform observed in the wild (e.g. all 7
-sensors under OpenIPC's `sensors/hisilicon/` that target `hi3516av200_rev1`)
-but **not** currently buildable in this repo — the kernel-side
-`mipi_rx`/`sys_config`/OSAL variants for `hi3516av200` are absent. The
-*sensor source* format is identical to V101, so the .so would compile against
-a future `hi3516av200` kernel addition without source changes.
+Note: the legacy T1 (single-call, no AE/AWB) form lives only in the older mpp/ SDK flavour; this repo's `hi3516cv100/` was upgraded to mpp2 (T1+) so every sensor under it now uses the three-call shape — there are no T1 anchors in-repo to cite. See §3.1 for the mpp/mpp2 split.
+
+† **`hi3516av200`** is a sibling chip within the V3A generation; per the
+README's "Supported hardware" table, both `hi3519v101` and `hi3516av200`
+silicon are built via `CHIPARCH=hi3519v101` (same kernel-side machinery —
+`mipi_rx`, `sys_config`, OSAL — and same MPI surface). When OpenIPC's
+`sensors/hisilicon/` names a driver `<sensor>_hi3516av200_rev1`, that
+source belongs under `libraries/sensor/hi3519v101/` and the resulting
+`.so` runs on both chips. Seven of those drivers exist upstream; one
+(IMX327) has been ported into `libraries/sensor/hi3519v101/sony_imx327/`.
 
 ## 2. Identification flowchart
 
@@ -93,7 +100,7 @@ Secondary fingerprints, in case the registration function is missing or stripped
 | If you see... | It's probably... |
 |---|---|
 | `sensor_register_callback(pRegSnsRegCb, pAeSnsRegCb, pAwbSnsRegCb, pSnsRegsCfg)` (typedef-pointer params) | wrapped driver — see §7.1 to identify the underlying tier |
-| `#include "hi_comm_isp.h"` *and not* `mpi_ae.h` | T1 |
+| `#include "hi_comm_isp.h"` *and not* `mpi_ae.h` | T1 (historical, not in this repo) |
 | `mpi_isp.h` + `mpi_ae.h` + `mpi_awb.h` + `#define <X>_ID <num>` + `ISP_DEV IspDev = 0;` in `sensor_register_callback` | T2 |
 | `g_pastImx226[ISP_MAX_DEV_NUM]` (or any state array indexed by `ISP_MAX_DEV_NUM`) | T3 |
 | `g_pastImx307[ISP_MAX_PIPE_NUM]` + `ISP_SNS_ATTR_INFO_S stSnsAttrInfo` + `ISP_SNS_OBJ_S stSns<X>Obj` | T4 |
@@ -102,87 +109,63 @@ Secondary fingerprints, in case the registration function is missing or stripped
 
 ## 3. Per-tier details
 
-### 3.1 T1 — CV100
+### 3.1 T1 / T1+ — CV100
 
-Single-call ISP-only registration. Everything else (AE curves, exposure math, gain
-tables) lives inline as static structs in `*_cmos.c`. There is no `ALG_LIB_S`,
-no `ISP_SNS_OBJ_S`, and no AE/AWB MPI surface.
+CV100 has two userspace API surfaces in the wild — old (T1, mpp/) and new
+(T1+, mpp2/). Both run on the same kernel modules. **This repo's
+`hi3516cv100/` is the T1+ (mpp2) flavour**; the older T1 form lives only in
+historical SDK trees and isn't built here.
 
-Headers (`imx236_cmos.c:1–11`):
+#### T1 — historical mpp/ surface (not in this repo)
+
+Single-call ISP-only registration. No `ALG_LIB_S`, no `ISP_SNS_OBJ_S`, no
+AE/AWB MPI surface — exposure math and AE/AWB tables live inline as static
+structs in `*_cmos.c`.
+
+Header set:
 
 ```c
-#include <stdio.h>
-#include <unistd.h>
-#include <string.h>
-#include <assert.h>
 #include "hi_comm_sns.h"
 #include "hi_comm_isp.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
 ```
 
-Registration (`imx236_cmos.c:951–962`):
+Registration:
 
 ```c
 int sensor_register_callback(void)
 {
     int ret;
     ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-    if (ret) {
-        printf("sensor register callback function failed!\n");
-        return ret;
-    }
-    return 0;
+    /* ... */
 }
 ```
 
-Makefile (`hi3516cv100/sony_imx236/Makefile`):
+Where it lives: HiSilicon Hi3518 SDK V1.0.B.0's `mpp/component/isp/sensor/`
+tree. Not built in this repo (the OpenIPC firmware that consumes this repo
+runs on the T1+ MPI runtime, so building T1 sensors here would produce
+ABI-incompatible artifacts).
 
-```makefile
-LIB_NAME := libsns_imx236
-override CFLAGS += -fPIC \
-    -I$(CURDIR)/../../../../kernel/include/hi3516cv100
-```
+#### T1+ — mpp2 surface (this repo's hi3516cv100)
 
-**T1+ variant — newer CV100 SDK revisions with AE/AWB.** The `imx236` driver
-above is the earliest CV100 form, when there was no AE/AWB MPI surface at all.
-A *later* userspace SDK rev for the same chip adds the three-call ISP/AE/AWB
-pattern — but **without** an `IspDev` argument, since CV100 has only one ISP.
+Three-call ISP/AE/AWB registration — but **no `IspDev`** argument in any
+of them, because CV100 has only one ISP. Function signature stays
+`int sensor_register_callback(void)`; the body looks like T2 with `IspDev`
+removed.
 
-This is not just a sensor convention; the underlying MPI library prototype is
-genuinely different. From a real Hi3518 SDK:
-
-- **HiSilicon Hi3518 SDK V1.0.B.0** (the canonical source) ships **two parallel
-  MPP userspace trees side-by-side under one kernel**:
-  - `mpp/component/isp/sensor/` — T1 surface
-  - `mpp2/component/isp2/sensor/` — T1+ surface
-- The `ko/` directory is **identical** between the two trees (same `hi3518_isp.ko`,
-  `hi3518_base.ko`, `mmz.ko`, etc.) — T1 vs T1+ is purely a userspace MPP swap,
-  not a kernel ABI change.
-- `mpp2/include/` adds these headers absent from `mpp/include/`:
-  `hi_ae_comm.h`, `hi_af_comm.h`, `hi_awb_comm.h`, `hi_comm_3a.h`,
-  `hi_vreg.h`, `mpi_ae.h`, `mpi_af.h`, `mpi_awb.h`.
-- The `HI_MPI_ISP_SensorRegCallBack` prototype itself changes:
+Header set (in `kernel/include/hi3516cv100/`):
 
 ```c
-/* mpp/include/mpi_isp.h (T1):    one arg, opaque function-pointer struct */
-HI_S32 HI_MPI_ISP_SensorRegCallBack(SENSOR_EXP_FUNC_S *pstSensorExpFuncs);
-
-/* mpp2/include/mpi_isp.h (T1+):  two args, sensor ID added */
-HI_S32 HI_MPI_ISP_SensorRegCallBack(SENSOR_ID SensorId,
-                                    ISP_SENSOR_REGISTER_S *pstRegister);
-HI_S32 HI_MPI_ISP_SensorUnRegCallBack(SENSOR_ID SensorId);
-
-/* mpp2/include/mpi_ae.h (T1+):   3 args, no IspDev — same in mpi_awb.h */
-HI_S32 HI_MPI_AE_SensorRegCallBack(ALG_LIB_S *pstAeLib, SENSOR_ID SensorId,
-                                   AE_SENSOR_REGISTER_S *pstRegister);
-HI_S32 HI_MPI_AE_SensorUnRegCallBack(ALG_LIB_S *pstAeLib, SENSOR_ID SensorId);
+#include "hi_comm_sns.h"
+#include "hi_sns_ctrl.h"
+#include "mpi_isp.h"
+#include "mpi_ae.h"      /* T1+ adds these three */
+#include "mpi_awb.h"
+#include "mpi_af.h"
 ```
 
-The same sensor ships in **both** trees with a completely different
-`sensor_register_callback` body. Compare `sony_imx236/imx236_cmos.c` in the
-two trees — the T1 (`mpp/`) form is the single-call shape shown above; the
-T1+ (`mpp2/`) form looks like:
+Registration body (anchor: `libraries/sensor/hi3516cv100/sony_imx236/imx236_cmos.c:902`):
 
 ```c
 int sensor_register_callback(void)
@@ -210,16 +193,45 @@ int sensor_register_callback(void)
 }
 ```
 
-OpenIPC's `sensors/hisilicon/jxh42_i2c_hi3516cv100_rev1/jxh42_cmos.c:507`
-follows this same T1+ shape, confirming it as the form running in the wild.
+A second in-repo anchor showing the same shape:
+`libraries/sensor/hi3516cv100/soi_jxh42/jxh42_cmos.c:507`.
 
-Compare to T2: T1+ is structurally T2 with `IspDev` removed from every call —
-because CV100 only has one ISP, there's nothing to index. The flowchart's
-T1↔T2 split ("does the body call HI_MPI_AE_SensorRegCallBack?") will land T1+
-in the T2 branch; to disambiguate, check whether the first arg of
-`HI_MPI_ISP_SensorRegCallBack` is `IspDev` (T2) or the sensor ID directly (T1+).
-Equivalently, look at the headers: T1+ has `hi_comm_3a.h` / `hi_ae_comm.h`
-available; T2 has those plus `hi_comm_video.h` and uses `ISP_DEV` types.
+#### Why the surfaces are genuinely different
+
+The MPI library prototype itself changed between mpp and mpp2 — this isn't
+a sensor-side convention difference, it's an ABI break:
+
+```c
+/* mpp/include/mpi_isp.h (T1):    one arg, opaque function-pointer struct */
+HI_S32 HI_MPI_ISP_SensorRegCallBack(SENSOR_EXP_FUNC_S *pstSensorExpFuncs);
+
+/* kernel/include/hi3516cv100/mpi_isp.h (T1+, mpp2): two args, sensor ID added */
+HI_S32 HI_MPI_ISP_SensorRegCallBack(SENSOR_ID SensorId,
+                                    ISP_SENSOR_REGISTER_S *pstRegister);
+HI_S32 HI_MPI_ISP_SensorUnRegCallBack(SENSOR_ID SensorId);
+
+/* kernel/include/hi3516cv100/mpi_ae.h (T1+, mpp2): 3 args, no IspDev — same in mpi_awb.h */
+HI_S32 HI_MPI_AE_SensorRegCallBack(ALG_LIB_S *pstAeLib, SENSOR_ID SensorId,
+                                   AE_SENSOR_REGISTER_S *pstRegister);
+HI_S32 HI_MPI_AE_SensorUnRegCallBack(ALG_LIB_S *pstAeLib, SENSOR_ID SensorId);
+```
+
+`mpp2/include/` adds eight headers absent from `mpp/include/`:
+`hi_ae_comm.h`, `hi_af_comm.h`, `hi_awb_comm.h`, `hi_comm_3a.h`,
+`hi_vreg.h`, `mpi_ae.h`, `mpi_af.h`, `mpi_awb.h` — these now live
+under this repo's `kernel/include/hi3516cv100/` after the mpp2 upgrade.
+
+The `ko/` directory is **identical** between mpp and mpp2 — the T1↔T1+
+swap is purely userspace MPP, not a kernel ABI change.
+
+#### Telling T1+ from T2 in found-online source
+
+Both have function signature `int sensor_register_callback(void)` and three
+MPI calls. Disambiguate by checking the first arg of
+`HI_MPI_ISP_SensorRegCallBack`: T2 has `IspDev`, T1+ has the sensor ID
+directly. Equivalently: T2 includes `hi_comm_video.h` and uses `ISP_DEV`
+types; T1+ has the new `hi_comm_3a.h` / `hi_ae_comm.h` available but no
+`ISP_DEV` references.
 
 ### 3.2 T2 — CV200 / AV100 / CV300
 
@@ -1038,13 +1050,13 @@ in §1 and §3.
 
 | Platform | Tier | Reg sig | Type prefix | Pipe abstraction | Bus-info pattern | Makefile -I flavour | Output |
 |---|---|---|---|---|---|---|---|
-| `hi3516cv100` | T1 | `(void)`, 1 MPI call | `HI_*` | none | static globals | `kernel/include/<chiparch>` | `libsns_<x>.{so,a}` |
-| `hi3516cv100` *(T1+ rev)* | T1+ | `(void)`, 3 MPI calls **without `IspDev`** | `HI_*` | none | static globals | varies | `libsns_<x>.{so,a}` |
+| *(historical mpp/, not in repo)* | T1 | `(void)`, 1 MPI call | `HI_*` | none | static globals | varies | `libsns_<x>.{so,a}` |
+| `hi3516cv100` | T1+ | `(void)`, 3 MPI calls **without `IspDev`** | `HI_*` | none | static globals | `kernel/include/hi3516cv100` (mpp2 flavour) | `libsns_<x>.{so,a}` |
 | `hi3516cv200` | T2 | `(void)`, 3 MPI calls | `HI_*` | `ISP_DEV` (=0) | static globals | `kernel/include/<chiparch>` + `kernel/isp/arch/<chiparch>/include` | `libsns_<x>.{so,a}` |
 | `hi3516av100` | T2 | same as CV200 | `HI_*` | `ISP_DEV` (=0) | static globals | same shape, different platform | `libsns_<x>.{so,a}` |
 | `hi3516cv300` | T2 | same as CV200 | `HI_*` | `ISP_DEV` (=0) | static globals | same shape, different platform | `libsns_<x>.{so,a}` |
 | `hi3519v101` | T3 | `(ISP_DEV, AE*, AWB*)`, 3 MPI calls | `HI_*` | `ISP_DEV` (0–1) | `g_aun<X>BusInfo[ISP_MAX_DEV_NUM]` + `set_bus_info` | `kernel/include/<chiparch>` + `kernel/isp/arch/<chiparch>/include` | `libsns_<x>.{so,a}` |
-| `hi3516av200` *(†, src-compat only)* | T3 | same as V101 | `HI_*` | `ISP_DEV` | same as V101 | n/a (kernel-side absent in this repo) | `libsns_<x>.{so,a}` |
+| `hi3516av200` *(†, built via `CHIPARCH=hi3519v101`)* | T3 | same as V101 | `HI_*` | `ISP_DEV` | same as V101 | same as V101 | `libsns_<x>.{so,a}` |
 | `hi3516cv500` | T4 | `(VI_PIPE, AE*, AWB*)`, 3 MPI calls + `ISP_SNS_ATTR_INFO_S` | `HI_*` | `VI_PIPE` | `g_aun<X>BusInfo[ISP_MAX_PIPE_NUM]` + `set_bus_info` | `libraries/isp/include/hi3516cv500/3a` + `libraries/isp/include/hi3516cv500` + `kernel/include/hi3516cv500/adapt` | `libsns_<x>.{so,a}` |
 | `hi3516ev200` | T5 | same as CV500 | `GK_*` | `VI_PIPE` | same as CV500 | `-DSDK_CODE=$(SDK_CODE) -I$(CURDIR)/../../../../include` (unified) | `libsns_<x>.{so,a}` |
 | `gk7205v200` | T5 | same as CV500 | `GK_*` | `VI_PIPE` | same as CV500 | same as EV200 (sources are identical) | `libsns_<x>.{so,a}` |

--- a/kernel/include/hi3516cv100/hi_ae_comm.h
+++ b/kernel/include/hi3516cv100/hi_ae_comm.h
@@ -1,0 +1,221 @@
+/******************************************************************************
+
+  Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : hi_ae_comm.h
+  Version       : Initial Draft
+  Author        : Hisilicon multimedia software group
+  Created       : 2012/12/18
+  Description   : 
+  History       :
+  1.Date        : 2012/12/18
+    Author      : n00168968
+    Modification: Created file
+
+******************************************************************************/
+#ifndef __HI_AE_COMM_H__
+#define __HI_AE_COMM_H__
+
+#include "hi_type.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#define HI_AE_LIB_NAME "hisi_ae_lib"
+
+/************************** ae ctrl cmd **************************************/
+typedef enum hiAE_CTRL_CMD_E
+{
+    AE_DEBUG_ATTR_SET,
+    AE_DEBUG_ATTR_GET, 
+
+    AE_CTRL_BUTT,
+} AE_CTRL_CMD_E;
+
+typedef struct hiAE_DBG_ATTR_S
+{
+    HI_U32  u32FrameEndUpdateMode;
+    HI_U32  u32MaxIntTime;
+    HI_U32  u32MinIntTime;
+    HI_U32  u32MaxAgain;
+    HI_U32  u32MinAgain;
+    HI_U32  u32MaxDgain;
+    HI_U32  u32MinDgain;
+    HI_U32  u32MaxIspDgain;
+    HI_U32  u32MinIspDgain;
+    HI_U32  u32MaxSysGain;
+    HI_U32  u32MinSysGain;
+    HI_U32  u32Compensation;
+    HI_U32  u32EVBias;
+    HI_BOOL bManualExposureEn;
+    HI_BOOL bManualTimeEn;
+    HI_BOOL bManualAgainEn;
+    HI_BOOL bManualDgainEn;
+    HI_BOOL bManualIspDgainEn;
+    HI_U32  u32ManualExposureLines;
+    HI_U32  u32ManualAgain;
+    HI_U32  u32ManualDgain;
+    HI_U32  u32ManualIspDgain;
+    HI_U32  au32AeWeights[255];  
+}AE_DBG_ATTR_S;
+
+typedef struct hiAE_DBG_STATUS_S
+{
+    HI_U32  u32FrmNumBgn;
+    HI_U32  u32FullLines;
+    HI_U32  u32IntTime;
+    HI_U32  u32Again;
+    HI_U32  u32Dgain;
+    HI_U32  u32IspDgain;
+    HI_U32  u32Exposure;
+    HI_U32  u32Increment;
+    HI_S32  s32HistError;
+    HI_S32  s32HistOriAverage;
+    HI_S32  s32LumaOffset;
+}AE_DBG_STATUS_S;
+
+/************************** sensor's interface to ae *********************/
+
+/* eg: 0.35db, enAccuType=AE_ACCURACY_DB, f32Accuracy=0.35 
+*  and the multiply of 0.35db is power(10, (0.35/20))
+*  eg: 1/16, 2/16, 3/16 multiplies, enAccuType=AE_ACCURACY_LINEAR, f32Accuracy=0.0625
+*  eg: 1,2,4,8,16 multiplies, enAccuType=AE_ACCURACY_DB, f32Accuracy=6
+*/
+typedef enum hiAE_ACCURACY_E
+{
+    AE_ACCURACY_DB = 0,
+    AE_ACCURACY_LINEAR,
+    AE_ACCURACY_TABLE,
+    
+    AE_ACCURACY_BUTT,
+} AE_ACCURACY_E;
+
+typedef struct hiAE_ACCURACY_S
+{
+    AE_ACCURACY_E enAccuType;
+    float   f32Accuracy;
+} AE_ACCURACY_S;
+
+typedef struct hiAE_SENSOR_DEFAULT_S
+{
+    HI_U8   au8HistThresh[4];
+    HI_U8   u8AeCompensation;
+
+    HI_U32  u32LinesPer500ms;
+    HI_U32  u32FlickerFreq;
+
+    HI_U32  u32FullLinesStd;
+    HI_U32  u32MaxIntTime;     /* unit is line */
+    HI_U32  u32MinIntTime;
+    HI_U32  u32MaxIntTimeTarget;
+    HI_U32  u32MinIntTimeTarget;
+    AE_ACCURACY_S stIntTimeAccu;
+    
+    HI_U32  u32MaxAgain;
+    HI_U32  u32MinAgain;
+    HI_U32  u32MaxAgainTarget;
+    HI_U32  u32MinAgainTarget;
+    AE_ACCURACY_S stAgainAccu;
+
+    HI_U32  u32MaxDgain;
+    HI_U32  u32MinDgain;
+    HI_U32  u32MaxDgainTarget;
+    HI_U32  u32MinDgainTarget;
+    AE_ACCURACY_S stDgainAccu;
+
+    HI_U32  u32MaxISPDgainTarget;
+    HI_U32  u32MinISPDgainTarget;
+    HI_U32  u32ISPDgainShift;
+} AE_SENSOR_DEFAULT_S;
+
+typedef struct hiAE_SENSOR_GAININFO_S
+{
+    HI_U32  u32SnsTimes;  //10bit precision
+    HI_U32  u32GainDb;    // gain step in db
+    
+} AE_SENSOR_GAININFO_S;
+
+
+typedef struct hiAE_SENSOR_EXP_FUNC_S
+{
+    HI_S32(*pfn_cmos_get_ae_default)(AE_SENSOR_DEFAULT_S *pstAeSnsDft);
+
+    /* the function of sensor set fps */
+    HI_VOID(*pfn_cmos_fps_set)(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft);
+    HI_VOID(*pfn_cmos_slow_framerate_set)(HI_U16 u16FullLines, AE_SENSOR_DEFAULT_S *pstAeSnsDft);
+
+    /* while isp notify ae to update sensor regs, ae call these funcs. */
+    HI_VOID(*pfn_cmos_inttime_update)(HI_U32 u32IntTime);
+    HI_VOID(*pfn_cmos_gains_update)(HI_U32 u32Again, HI_U32 u32Dgain);
+
+    HI_VOID (*pfn_cmos_again_calc_table)(HI_U32 u32InTimes, AE_SENSOR_GAININFO_S *pstAeSnsGainInfo);
+    HI_VOID (*pfn_cmos_dgain_calc_table)(HI_U32 u32InTimes, AE_SENSOR_GAININFO_S *pstAeSnsGainInfo);
+    
+} AE_SENSOR_EXP_FUNC_S;
+
+typedef struct hiAE_SENSOR_REGISTER_S
+{
+    AE_SENSOR_EXP_FUNC_S stSnsExp;
+} AE_SENSOR_REGISTER_S;
+
+#if 0
+/************************** lens's interface to ae ********************/
+typedef enum hiAE_MOTOR_IRIS_E
+{
+    AE_DC_MOTOR_IRIS = 0,
+    AE_STEP_MOTOR_IRIS,
+    
+    AE_MOTOR_IRIS_BUTT,
+} AE_MOTOR_IRIS_E;
+
+typedef struct hiAE_DC_MOTOR_IRIS_PARAM_S
+{
+    HI_U32 u32MinPwmValue;
+    HI_U32 u32MaxPwmValue;
+    HI_U32 u32PwmOpenValue;
+    HI_U32 u32PwmCloseValue;
+    HI_U32 u32PwmHoldValue;
+} AE_DC_MOTOR_IRIS_S;
+
+typedef struct hiAE_STEP_MOTOR_IRIS_PARAM_S
+{
+    HI_S32 s32Rsv;
+} AE_STEP_MOTOR_IRIS_S;
+
+typedef struct hiAE_IRIS_DEFAULT_S
+{
+    HI_BOOL bUpdate;
+    
+    AE_MOTOR_IRIS_E enMotorIrisType;
+    union
+    {
+        AE_DC_MOTOR_IRIS_S stDcMotorIris;
+        AE_STEP_MOTOR_IRIS_S stStepMotorIris;
+    };    
+} AE_IRIS_DEFAULT_S;
+
+typedef struct hiAE_LENS_EXP_FUNC_S
+{
+    HI_U32(*pfn_lens_get_iris_default)(AE_IRIS_DEFAULT_S *pstIrisDft);
+} AE_LENS_EXP_FUNC_S;
+
+typedef struct hiAE_LENS_REGISTER_S
+{
+    AE_LENS_EXP_FUNC_S stLensExpFunc;
+} AE_LENS_REGISTER_S;
+
+HI_S32 AE_RegisterLens(SENSOR_ID SensorId,
+        AE_LENS_REGISTER_S *pstRegister);
+#endif
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#endif

--- a/kernel/include/hi3516cv100/hi_af_comm.h
+++ b/kernel/include/hi3516cv100/hi_af_comm.h
@@ -1,0 +1,36 @@
+/******************************************************************************
+
+  Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : hi_af_comm.h
+  Version       : Initial Draft
+  Author        : Hisilicon multimedia software group
+  Created       : 2012/12/20
+  Description   : 
+  History       :
+  1.Date        : 2012/12/20
+    Author      : n00168968
+    Modification: Created file
+
+******************************************************************************/
+#ifndef __HI_AF_COMM_H__
+#define __HI_AF_COMM_H__
+
+#include "hi_type.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#define HI_AF_LIB_NAME "hisi_af_lib"
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#endif

--- a/kernel/include/hi3516cv100/hi_awb_comm.h
+++ b/kernel/include/hi3516cv100/hi_awb_comm.h
@@ -1,0 +1,144 @@
+/******************************************************************************
+
+  Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : hi_awb_comm.h
+  Version       : Initial Draft
+  Author        : Hisilicon multimedia software group
+  Created       : 2012/12/19
+  Description   : 
+  History       :
+  1.Date        : 2012/12/19
+    Author      : n00168968
+    Modification: Created file
+
+******************************************************************************/
+#ifndef __HI_AWB_COMM_H__
+#define __HI_AWB_COMM_H__
+
+#include "hi_type.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#define HI_AWB_LIB_NAME "hisi_awb_lib"
+
+/************************** isp ctrl cmd *************************************/
+typedef enum hiAWB_CTRL_CMD_E
+{
+    AWB_SATURATION_SET,
+    AWB_SATURATION_GET,
+    
+    AWB_DEBUG_ATTR_SET,
+    AWB_DEBUG_ATTR_GET,
+
+    AWB_CTRL_BUTT,
+} AWB_CTRL_CMD_E;
+
+typedef struct hiAWB_DBG_ATTR_S
+{
+    HI_U16 u16Enable;
+    HI_U16 u16ManualEnable;
+    HI_U32 u32HighTemp;
+    HI_U32 u32LowTemp;
+    HI_U32 u32RefTemp;
+    HI_U32 u32Zone;
+    HI_U32 u32DevEnable;
+    HI_U32 u32ShiftLimit;
+    HI_U32 u32WhiteLevel;
+    HI_U32 u32BlackLevel;
+    HI_U32 u32CrMax;
+    HI_U32 u32CrMin;
+    HI_U32 u32CbMax;
+    HI_U32 u32CbMin;
+    HI_U32 u32RgainBase;
+    HI_U32 u32GgainBase;
+    HI_U32 u32BgainBase;
+    HI_S32 s32p1;
+    HI_S32 s32p2;
+    HI_S32 s32q;
+    HI_S32 s32a;
+    HI_S32 s32c;
+    
+    HI_U16 u16ManSatEnable;
+    HI_U16 u16SatTarget;
+} AWB_DBG_ATTR_S;
+
+typedef struct hiAWB_ZONE_DBG_S
+{
+    HI_U16 u16Num;
+    HI_U32 u32Sum;
+    HI_U16 u16Rg;
+    HI_U16 u16Bg;
+    HI_U32 u32TK;
+    HI_S32 s32Shift;
+    HI_U32 u32Weight;
+    HI_S32 s32Dev;    
+}AWB_ZONE_DBG_S;
+
+typedef struct hiAWB_DBG_STATUS_S
+{
+    HI_U32 u32FrmNumBgn;
+    HI_U32 u32GlobalSum;
+    HI_U32 u32GlobalRgSta;
+    HI_U32 u32GlobalBgSta;
+    HI_U32 u32TK;
+    HI_U16 u16Rgain;
+    HI_U16 u16Ggain;
+    HI_U16 u16Bgain;
+    HI_U16 au16CCM[9];
+    
+    AWB_ZONE_DBG_S astZoneDebug[255];
+
+    HI_U32 u32FrmNumEnd;    
+} AWB_DBG_STATUS_S;
+
+/************************** sensor's interface to awb *********************/
+typedef struct hiAWB_CCM_S
+{    
+    HI_U16 u16HighColorTemp;    /* D50 lighting source is  recommended */
+    HI_U16 au16HighCCM[9];
+    HI_U16 u16MidColorTemp;     /* D32 lighting source is  recommended */
+    HI_U16 au16MidCCM[9];       
+    HI_U16 u16LowColorTemp;     /* A lighting source is  recommended */
+    HI_U16 au16LowCCM[9];
+}AWB_CCM_S;
+
+typedef struct hiAWB_AGC_TABLE_S
+{
+    HI_BOOL bValid;
+    
+    HI_U8   au8Saturation[8];   /* adjust saturation, different iso with different saturation */
+} AWB_AGC_TABLE_S;
+
+typedef struct hiAWB_SENSOR_DEFAULT_S
+{
+    HI_U16  u16WbRefTemp;       /* reference color temperature for WB  */    
+    HI_U16  au16GainOffset[4];  /* gain offset for white balance */
+    HI_S32  as32WbPara[6];      /* parameter for wb curve,p1,p2,q1,a1,b1,c1 */
+
+    AWB_AGC_TABLE_S stAgcTbl;
+    AWB_CCM_S stCcm;
+} AWB_SENSOR_DEFAULT_S;
+
+typedef struct hiAWB_SENSOR_EXP_FUNC_S
+{
+    HI_S32(*pfn_cmos_get_awb_default)(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft);
+} AWB_SENSOR_EXP_FUNC_S;
+
+typedef struct hiAWB_SENSOR_REGISTER_S
+{
+    AWB_SENSOR_EXP_FUNC_S stSnsExp;
+} AWB_SENSOR_REGISTER_S;
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#endif

--- a/kernel/include/hi3516cv100/hi_comm_3a.h
+++ b/kernel/include/hi3516cv100/hi_comm_3a.h
@@ -1,0 +1,301 @@
+/******************************************************************************
+
+  Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : hi_comm_3a.h
+  Version       : Initial Draft
+  Author        : Hisilicon multimedia software group
+  Created       : 2012/12/18
+  Description   : 
+  History       :
+  1.Date        : 2012/12/18
+    Author      : n00168968
+    Modification: Created file
+
+******************************************************************************/
+
+#ifndef __HI_COMM_3A_H__
+#define __HI_COMM_3A_H__
+
+#include "hi_common.h"
+#include "hi_comm_isp.h"
+
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#define MAX_REGISTER_ALG_LIB_NUM 2
+
+typedef enum hiISP_ALG_MOD_E
+{
+    ISP_ALG_AE = 0,
+    ISP_ALG_AF,
+    ISP_ALG_AWB,
+    ISP_ALG_ANTIFOG,
+    ISP_ALG_BLC,
+    ISP_ALG_DP,
+    ISP_ALG_DRC,
+    ISP_ALG_DEMOSAIC,
+    ISP_ALG_GAMMA,
+    ISP_ALG_GAMMAFE,
+    ISP_ALG_GE,
+    ISP_ALG_NEW_ANTIFOG,
+    ISP_ALG_NR,
+    ISP_ALG_SHARPEN,
+    ISP_ALG_SHADING,
+    
+    ISP_ALG_BUTT,
+} ISP_ALG_MOD_E;
+
+typedef enum hiISP_CTRL_CMD_E
+{
+    ISP_WDR_MODE_SET = 8000,
+    ISP_PROC_WRITE,
+    
+    ISP_AE_FPS_BASE_SET,
+    ISP_AWB_ISO_SET,  /* set iso, change saturation when iso change */
+    ISP_AE_INTTIME_GET,
+    ISP_AWB_INTTIME_SET,
+
+    ISP_CHANGE_IMAGE_MODE_SET,
+    ISP_CTRL_CMD_BUTT,
+} ISP_CTRL_CMD_E;
+
+typedef struct hiISP_CTRL_PROC_WRITE_S
+{
+    HI_CHAR *pcProcBuff;
+    HI_U32   u32BuffLen;
+    HI_U32   u32WriteLen;   /* The len count should contain '\0'. */
+} ISP_CTRL_PROC_WRITE_S;
+
+/********************************  AE  *************************************/
+/* the init param of ae alg */
+typedef struct hiISP_AE_PARAM_S
+{
+    SENSOR_ID SensorId;
+    
+    HI_U32 u32MaxIspDgain;
+    HI_U32 u32MinIspDgain;
+    HI_U32 u32IspDgainShift;
+} ISP_AE_PARAM_S;
+
+/* the statistics of ae alg */
+typedef struct hiISP_AE_STAT_1_S
+{
+    HI_U8   au8MeteringHistThresh[4];
+    HI_U16  au16MeteringHist[4];
+} ISP_AE_STAT_1_S;
+
+typedef struct hiISP_AE_STAT_2_S
+{
+    HI_U8   au8MeteringHistThresh[4];
+    HI_U16  au16MeteringMemArrary[WEIGHT_ZONE_ROW][WEIGHT_ZONE_COLUMN][5];
+} ISP_AE_STAT_2_S;
+
+typedef struct hiISP_AE_STAT_3_S
+{    
+    HI_U16  au16HistogramMemArray[256];
+} ISP_AE_STAT_3_S;
+
+typedef struct hiISP_AE_INFO_S
+{
+    HI_U32  u32FrameCnt;    /* the counting of frame */
+
+    ISP_AE_STAT_1_S *pstAeStat1;
+    ISP_AE_STAT_2_S *pstAeStat2;
+    ISP_AE_STAT_3_S *pstAeStat3;
+} ISP_AE_INFO_S;
+
+typedef struct hiISP_AE_STAT_ATTR_S
+{
+    HI_BOOL bChange;
+
+    HI_U8   au8MeteringHistThresh[4];
+    HI_U8   au8WeightTable[15][17];
+} ISP_AE_STAT_ATTR_S;
+
+/* the final calculate of ae alg */
+typedef struct hiISP_AE_RESULT_S
+{
+    HI_U32  u32IspDgain;
+    HI_U32  u32IspDgainShift;
+    HI_U32  u32Iso;
+    
+    ISP_AE_STAT_ATTR_S stStatAttr;
+} ISP_AE_RESULT_S;
+
+typedef struct hiISP_AE_EXP_FUNC_S
+{
+    HI_S32 (*pfn_ae_init)(HI_S32 s32Handle, const ISP_AE_PARAM_S *pstAeParam);
+    HI_S32 (*pfn_ae_run)(HI_S32 s32Handle,
+        const ISP_AE_INFO_S *pstAeInfo,
+        ISP_AE_RESULT_S *pstAeResult,
+        HI_S32 s32Rsv
+        );
+    HI_S32 (*pfn_ae_ctrl)(HI_S32 s32Handle, HI_U32 u32Cmd, HI_VOID *pValue);
+    HI_S32 (*pfn_ae_exit)(HI_S32 s32Handle);
+} ISP_AE_EXP_FUNC_S;
+
+typedef struct hiISP_AE_REGISTER_S
+{
+    ISP_AE_EXP_FUNC_S stAeExpFunc;
+} ISP_AE_REGISTER_S;
+
+/********************************  AWB  *************************************/
+
+/* the init param of awb alg */
+typedef struct hiISP_AWB_PARAM_S
+{
+    SENSOR_ID SensorId;
+    HI_S32 s32Rsv;
+} ISP_AWB_PARAM_S;
+
+/* the statistics of awb alg */
+typedef struct hiISP_AWB_STAT_1_S
+{
+    HI_U16  u16MeteringAwbRg;
+    HI_U16  u16MeteringAwbBg;
+    HI_U32  u32MeteringAwbSum;
+} ISP_AWB_STAT_1_S;
+
+typedef struct hiISP_AWB_STAT_2_S
+{
+    HI_U16  au16MeteringMemArrayRg[255];
+    HI_U16  au16MeteringMemArrayBg[255];
+    HI_U16  au16MeteringMemArraySum[255];
+} ISP_AWB_STAT_2_S;
+
+typedef struct hiISP_AWB_INFO_S
+{
+    HI_U32  u32FrameCnt;
+
+    ISP_AWB_STAT_1_S *pstAwbStat1;
+    ISP_AWB_STAT_2_S *pstAwbStat2;
+} ISP_AWB_INFO_S;
+
+/* the statistics's attr of awb alg */
+typedef struct hiISP_AWB_STAT_ATTR_S
+{
+    HI_BOOL bChange;
+
+    HI_U16  u16MeteringWhiteLevelAwb;
+    HI_U16  u16MeteringBlackLevelAwb;
+    HI_U16  u16MeteringCrRefMaxAwb;
+    HI_U16  u16MeteringCbRefMaxAwb;
+    HI_U16  u16MeteringCrRefMinAwb;
+    HI_U16  u16MeteringCbRefMinAwb;
+} ISP_AWB_STAT_ATTR_S;
+
+/* the final calculate of awb alg */
+typedef struct hiISP_AWB_RESULT_S
+{
+    HI_U32  au32WhiteBalanceGain[4];
+    HI_U16  au16ColorMatrix[9];
+    
+    ISP_AWB_STAT_ATTR_S stStatAttr;
+} ISP_AWB_RESULT_S;
+
+typedef struct hiISP_AWB_EXP_FUNC_S
+{
+    HI_S32 (*pfn_awb_init)(HI_S32 s32Handle, const ISP_AWB_PARAM_S *pstAwbParam);
+    HI_S32 (*pfn_awb_run)(HI_S32 s32Handle,
+        const ISP_AWB_INFO_S *pstAwbInfo,
+        ISP_AWB_RESULT_S *pstAwbResult,
+        HI_S32 s32Rsv
+        );
+    HI_S32 (*pfn_awb_ctrl)(HI_S32 s32Handle, HI_U32 u32Cmd, HI_VOID *pValue);
+    HI_S32 (*pfn_awb_exit)(HI_S32 s32Handle);
+} ISP_AWB_EXP_FUNC_S;
+
+typedef struct hiISP_AWB_REGISTER_S
+{    
+    ISP_AWB_EXP_FUNC_S stAwbExpFunc;
+} ISP_AWB_REGISTER_S;
+
+/********************************  AF  *************************************/
+
+/* the init param of af alg */
+typedef struct hiISP_AF_PARAM_S
+{
+    SENSOR_ID SensorId;
+    HI_S32 s32Rsv;
+} ISP_AF_PARAM_S;
+
+/* the statistics of af alg */
+typedef struct hiISP_AF_STAT_S
+{
+    HI_U16 u16FocusMetrics;     /* The integrated and normalized measure of contrast*/
+    HI_U16 u16ThresholdRead;    /* The ISP recommend value of AF threshold*/
+    HI_U16 u16ThresholdWrite;   /* The user defined value of AF threshold (or 0 to use threshold from previous frame)*/
+    HI_U16 u16FocusIntensity;   /* The average brightness*/
+    HI_U8  u8MetricsShift;      /* Metrics scaling factor:the bigger value for this register means all zones metrics go higher,0x03 is the default, Range: [0x0, 0xF] */
+    HI_U8  u8NpOffset;          /* The AF noise profile offset, Range: [0x0, 0xFF] */
+    HI_U16 au16ZoneMetrics[WEIGHT_ZONE_ROW][WEIGHT_ZONE_COLUMN]; /* The zoned measure of contrast*/ 
+} ISP_AF_STAT_S;
+
+typedef struct hiISP_AF_INFO_S
+{
+    HI_U32  u32FrameCnt;
+    
+    ISP_AF_STAT_S   *pstStatistics;
+} ISP_AF_INFO_S;
+
+typedef struct hiISP_AF_STAT_ATTR_S
+{
+    HI_BOOL bChange;
+
+    HI_U16 u16ThresholdWrite;
+    HI_U8  u8MetricsShift;
+    HI_U8  u8NpOffset;
+} ISP_AF_STAT_ATTR_S;
+
+/* the final calculate of af alg */
+typedef struct hiISP_AF_RESULT_S
+{
+    ISP_AF_STAT_ATTR_S stStatAttr;
+    HI_S32 s32Rsv;
+} ISP_AF_RESULT_S;
+
+typedef struct hiISP_AF_EXP_FUNC_S
+{
+    HI_S32 (*pfn_af_init)(HI_S32 s32Handle, const ISP_AF_PARAM_S *pstAfParam);
+    HI_S32 (*pfn_af_run)(HI_S32 s32Handle,
+        const ISP_AF_INFO_S *pstAfInfo,
+        ISP_AF_RESULT_S *pstAfResult,
+        HI_S32 s32Rsv
+        );
+    HI_S32 (*pfn_af_ctrl)(HI_S32 s32Handle, HI_U32 u32Cmd, HI_VOID *pValue);
+    HI_S32 (*pfn_af_exit)(HI_S32 s32Handle);
+} ISP_AF_EXP_FUNC_S;
+
+typedef struct hiISP_AF_REGISTER_S
+{    
+    ISP_AF_EXP_FUNC_S stAfExpFunc;
+} ISP_AF_REGISTER_S;
+
+typedef struct hiALG_LIB_S
+{
+    HI_S32  s32Id;
+    HI_CHAR acLibName[20];
+} ALG_LIB_S;
+
+typedef struct hiISP_BIND_ATTR_S
+{
+    SENSOR_ID   SensorId;
+    ALG_LIB_S   stAeLib;
+    ALG_LIB_S   stAfLib;
+    ALG_LIB_S   stAwbLib;
+} ISP_BIND_ATTR_S;
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#endif /*__HI_COMM_SNS_H__ */
+

--- a/kernel/include/hi3516cv100/hi_comm_isp.h
+++ b/kernel/include/hi3516cv100/hi_comm_isp.h
@@ -21,6 +21,7 @@
 #include "hi_type.h"
 #include "hi_errno.h"
 #include "hi_common.h"
+#include "hi_isp_debug.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -28,35 +29,34 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
+
 /****************************************************************************
  * MACRO DEFINITION                                                         *
  ****************************************************************************/
+    
+#define VREG_MAX_NUM        16
 
-#define WEIGHT_ZONE_ROW			15
-#define WEIGHT_ZONE_COLUMN		17
-#define LIGHTSOURCE_NUM          4
-#define NP_LUT_SIZE            128
-
-#define LUT_FACTOR (8)
-#define GAMMA_FE_LUT_SIZE ((1<<LUT_FACTOR)+1)
-#define GAMMA_NODE_NUMBER  257
-
-#define ISP_REG_BASE		0x205A0000
-#define ISP_REG_SIZE		0x7fff
-
-#define ISP_WINDOW0_START	0x205A010C
-#define ISP_WINDOW0_SIZE	0x205A0110
-#define ISP_WINDOW2_START	0x205A0120
-#define ISP_WINDOW2_SIZE	0x205A0124
-
-#define ISP_BYPASS_BASE		0x205A0040
-
+#define WEIGHT_ZONE_ROW     15
+#define WEIGHT_ZONE_COLUMN  17
+#define LUT_FACTOR          (8)
+#define GAMMA_FE_LUT_SIZE   ((1<<LUT_FACTOR)+1)
+#define GAMMA_NODE_NUMBER   257
 #define SHADING_TABLE_NODE_NUMBER_MAX (129)
-#define EXPOSURE_GAIN_SHIFT (10)
-#define MAX_ISP_DGAIN_LINEAR (4)
-#define MAX_ISP_DGAIN_WDR (32)
+#define LIGHTSOURCE_NUM          4
+#define NP_LUT_SIZE             128
 
+#define ISP_REG_BASE        0x205A0000
+#define ISP_REG_SIZE        0x7fff
 
+#define ISP_WINDOW0_START   0x205A010C
+#define ISP_WINDOW0_SIZE    0x205A0110
+#define ISP_WINDOW2_START   0x205A0120
+#define ISP_WINDOW2_SIZE    0x205A0124
+
+#define ISP_BYPASS_BASE     0x205A0040
+
+#define ISP_MAX_SNS_REGS    16
+#define ISP_MAX_DEV_NUM     1
 
 /****************************************************************************
  * GENERAL STRUCTURES                                                       *
@@ -64,49 +64,61 @@ extern "C"{
 
 typedef enum hiISP_ERR_CODE_E
 {
-    ERR_ISP_NOT_INIT				= 0x40,
-    ERR_ISP_TM_NOT_CFG				= 0x41,
-    ERR_ISP_ATTR_NOT_CFG			= 0x42,
-    ERR_ISP_SNS_UNREGISTER			= 0x43,
-    ERR_ISP_INVALID_ADDR			= 0x44,
-    
+    ERR_ISP_NOT_INIT                = 0x40,
+    ERR_ISP_TM_NOT_CFG              = 0x41,
+    ERR_ISP_ATTR_NOT_CFG            = 0x42,
+    ERR_ISP_SNS_UNREGISTER          = 0x43,
+    ERR_ISP_INVALID_ADDR            = 0x44,
+    ERR_ISP_NOMEM                   = 0x45,
 } ISP_ERR_CODE_E;
 
 
-#define HI_ERR_ISP_NULL_PTR							HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, EN_ERR_NULL_PTR)
-#define HI_ERR_ISP_ILLEGAL_PARAM         			HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, EN_ERR_ILLEGAL_PARAM)
+#define HI_ERR_ISP_NULL_PTR             HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, EN_ERR_NULL_PTR)
+#define HI_ERR_ISP_ILLEGAL_PARAM        HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, EN_ERR_ILLEGAL_PARAM)
 
-#define HI_ERR_ISP_NOT_INIT         				HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_NOT_INIT)
-#define HI_ERR_ISP_TM_NOT_CFG         				HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_TM_NOT_CFG)
-#define HI_ERR_ISP_ATTR_NOT_CFG         			HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_ATTR_NOT_CFG)
-#define HI_ERR_ISP_SNS_UNREGISTER  	       			HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_SNS_UNREGISTER)
-#define HI_ERR_ISP_INVALID_ADDR	   		   			HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_INVALID_ADDR)
+#define HI_ERR_ISP_NOT_INIT             HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_NOT_INIT)
+#define HI_ERR_ISP_TM_NOT_CFG           HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_TM_NOT_CFG)
+#define HI_ERR_ISP_ATTR_NOT_CFG         HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_ATTR_NOT_CFG)
+#define HI_ERR_ISP_SNS_UNREGISTER       HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_SNS_UNREGISTER)
+#define HI_ERR_ISP_INVALID_ADDR         HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_INVALID_ADDR)
+#define HI_ERR_ISP_NOMEM                HI_DEF_ERR(HI_ID_ISP, EN_ERR_LEVEL_ERROR, ERR_ISP_NOMEM)
 
 
 typedef enum hiISP_BAYER_FORMAT_E
 {
-	BAYER_RGGB	= 0,
-	BAYER_GRBG	= 1,
-	BAYER_GBRG	= 2,
-	BAYER_BGGR	= 3,
-	BAYER_BUTT	
-    
+    BAYER_RGGB    = 0,
+    BAYER_GRBG    = 1,
+    BAYER_GBRG    = 2,
+    BAYER_BGGR    = 3,
+    BAYER_BUTT    
 } ISP_BAYER_FORMAT_E;
 
 typedef enum hiISP_OP_TYPE_E
 {
-	OP_TYPE_AUTO	= 0,
-	OP_TYPE_MANUAL	= 1,
-	OP_TYPE_BUTT
-    
+    OP_TYPE_AUTO    = 0,
+    OP_TYPE_MANUAL  = 1,
+    OP_TYPE_BUTT
 } ISP_OP_TYPE_E;
+
+#define ISP_AE_ROUTE_MAX_NODES 8
+typedef struct hiISP_AE_ROUTE_NODE_S
+{
+    HI_U32  u32IntTime;
+    HI_U32  u32SysGain;     /* shift is in the ISP_AE_ATTR_S's stSysGainRange. */
+    HI_U32  u32ApePercent;  /* the percent of the iris's aperture, range is [0~100], dc-iris not support in auto mode. */
+} ISP_AE_ROUTE_NODE_S;
+
+typedef struct hiISP_AE_ROUTE_S
+{
+    HI_U32 u32TotalNum;    
+    ISP_AE_ROUTE_NODE_S astRouteNode[ISP_AE_ROUTE_MAX_NODES];
+} ISP_AE_ROUTE_S;
 
 typedef enum hiISP_AE_MODE_E
 {
-    AE_MODE_LOW_NOISE		= 0,
-    AE_MODE_FRAME_RATE		= 1,
+    AE_MODE_LOW_NOISE   = 0,
+    AE_MODE_FRAME_RATE  = 1,
     AE_MODE_BUTT
-    
 } ISP_AE_MODE_E;
 
 typedef enum hiISP_AWB_ALG_TYPE_E
@@ -116,128 +128,143 @@ typedef enum hiISP_AWB_ALG_TYPE_E
 	AWB_ALG_BUTT
     
 } ISP_AWB_ALG_TYPE_E;
+
 typedef enum hiISP_WB_MODE_E
 {
     /* all auto*/
     WB_AUTO = 0,
     
-    /* half auto */		
-    WB_FLUORESCENT,		/*fluorescent*/
-    WB_LAMP,				/*lamp*/
-    WB_DAYLIGHT,			/*daylight*/
-    WB_FLASH,				/*flash light*/
-    WB_CLOUDY,				/*cloudy*/
-    WB_SHADOW,				/*shadow*/
+    /* half auto */        
+    WB_FLUORESCENT,        /*fluorescent*/
+    WB_LAMP,                /*lamp*/
+    WB_DAYLIGHT,            /*daylight*/
+    WB_FLASH,                /*flash light*/
+    WB_CLOUDY,                /*cloudy*/
+    WB_SHADOW,                /*shadow*/
     WB_BUTT
-    
 } ISP_WB_MODE_E;
 
 typedef struct hiISP_WINDOW_S
 {
-	HI_U16 u16Start;
-	HI_U16 u16Length;
-    
+    HI_U16 u16Start;
+    HI_U16 u16Length;
 } ISP_WINDOW_S;
 
 typedef enum hiISP_WIND_MODE_E
 {
-	ISP_WIND_NONE		= 0,
-	ISP_WIND_HOR		= 1,
-	ISP_WIND_VER		= 2,
-	ISP_WIND_ALL		= 3,
-	ISP_WIND_BUTT
-    
+    ISP_WIND_NONE        = 0,
+    ISP_WIND_HOR        = 1,
+    ISP_WIND_VER        = 2,
+    ISP_WIND_ALL        = 3,
+    ISP_WIND_BUTT
 } ISP_WIND_MODE_E;
 
 typedef enum hiISP_IRIS_STATUS_E
 {
-	ISP_IRIS_KEEP  = 0,       /* Do nothing to Iris */
-	ISP_IRIS_OPEN  = 1,       /* Open Iris to the max */
-	ISP_IRIS_CLOSE = 2,       /* Close Iris to the min */
-	ISP_IRIS_BUTT
-
+    ISP_IRIS_KEEP  = 0,       /* Do nothing to Iris */
+    ISP_IRIS_OPEN  = 1,       /* Open Iris to the max */
+    ISP_IRIS_CLOSE = 2,       /* Close Iris to the min */
+    ISP_IRIS_BUTT
 } ISP_IRIS_STATUS_E;
 
 typedef enum hiISP_TRIGGER_STATUS_E
 {
-	ISP_TRIGGER_INIT     = 0,  /* Initial status, before trigger */
-	ISP_TRIGGER_SUCCESS  = 1,  /* Trigger finished successfully */
-	ISP_TRIGGER_TIMEOUT  = 2,  /* Trigger finished because of time out */
-	ISP_TRIGGER_BUTT
-
+    ISP_TRIGGER_INIT     = 0,  /* Initial status, before trigger */
+    ISP_TRIGGER_SUCCESS  = 1,  /* Trigger finished successfully */
+    ISP_TRIGGER_TIMEOUT  = 2,  /* Trigger finished because of time out */
+    ISP_TRIGGER_BUTT
 } ISP_TRIGGER_STATUS_E;
+
+typedef enum hiISP_WDR_MODE_E
+{
+    ISP_SENSOR_LINEAR_MODE = 0,
+    ISP_SENSOR_WDR_MODE,
+
+    ISP_WDR_BUTT,
+} ISP_WDR_MODE_E;
+
+typedef struct hiISP_WDR_ATTR_S
+{
+    ISP_WDR_MODE_E  enWdrMode;
+} ISP_WDR_ATTR_S;
 
 typedef struct hiISP_INPUT_TIMING_S
 {
-	ISP_WIND_MODE_E enWndMode;
-	HI_U16 u16HorWndStart;    /*RW, Range: [0x0, 0x780]*/
-	HI_U16 u16HorWndLength;   /*RW, Range: [0x0, 0x780]*/
-	HI_U16 u16VerWndStart;    /*RW, Range: [0x0, 0x4B0]*/
-	HI_U16 u16VerWndLength;   /*RW, Range: [0x0, 0x4B0]*/
-    
+    ISP_WIND_MODE_E enWndMode;
+    HI_U16 u16HorWndStart;    /*RW, Range: [0x0, 0x780]*/
+    HI_U16 u16HorWndLength;   /*RW, Range: [0x0, 0x780]*/
+    HI_U16 u16VerWndStart;    /*RW, Range: [0x0, 0x4B0]*/
+    HI_U16 u16VerWndLength;   /*RW, Range: [0x0, 0x4B0]*/
 } ISP_INPUT_TIMING_S;
 
-typedef struct hiISP_IMAGE_ATTR_S		// sensor information: list?
+typedef struct hiISP_IMAGE_ATTR_S
 {
-	HI_U16 u16Width;   /*RW, Range: [0x0, 0x780]*/
-	HI_U16 u16Height;  /*RW, Range: [0x0, 0x4B0]*/
-	HI_U16 u16FrameRate;	/*RW, Range: [0x0, 0xFF]*/		
-	ISP_BAYER_FORMAT_E  enBayer;
-    
+    HI_U16 u16Width;        /*RW, Range: [0x0, 0x780]*/
+    HI_U16 u16Height;       /*RW, Range: [0x0, 0x4B0]*/
+    HI_U16 u16FrameRate;    /*RW, Range: [0x0, 0xFF]*/        
+    ISP_BAYER_FORMAT_E  enBayer;    
 } ISP_IMAGE_ATTR_S;
 
 typedef enum hiISP_MOD_BYPASS_E
 {
-	ISP_MOD_SHARPEN		= 0x8000,
-	ISP_MOD_GAMMARGB	= 0x4000,
-	ISP_MOD_COLORMATRIX	= 0x2000,
-	ISP_MOD_DEMOSAIC	= 0x1000,
+    ISP_MOD_SHARPEN     = 0x8000,
+    ISP_MOD_GAMMARGB    = 0x4000,
+    ISP_MOD_COLORMATRIX = 0x2000,
+    ISP_MOD_DEMOSAIC    = 0x1000,
+    
+    ISP_MOD_GAMMAPOST   = 0x0800,
+    ISP_MOD_GAMMAPRE    = 0x0200,
+    ISP_MOD_SHADING     = 0x0100,
 
-	ISP_MOD_GAMMAPOST	= 0x0800,
-	ISP_MOD_GAMMAPRE	= 0x0200,
-	ISP_MOD_SHADING		= 0x0100,
-
-	ISP_MOD_IRIDIX		= 0x0080,
-	ISP_MOD_GAIN		= 0x0040,
-	ISP_MOD_SINTER		= 0x0008,
-	ISP_MOD_HOTPIXEL	= 0x0004,
-	ISP_MOD_GAMMAFE		= 0x0002,	
-	ISP_MOD_BALANCEFE	= 0x0001,		
-	ISP_MOD_BUTT
+    ISP_MOD_DRC         = 0x0080,
+    ISP_MOD_GAIN        = 0x0040,
+    ISP_MOD_SINTER      = 0x0008,
+    ISP_MOD_HOTPIXEL    = 0x0004,
+    ISP_MOD_GAMMAFE     = 0x0002,
+    ISP_MOD_BALANCEFE   = 0x0001,
+    ISP_MOD_BUTT
     
 } ISP_MOD_BYPASS_E;
 
 
 typedef enum hiISP_AE_FRAME_END_UPDATE_E
 {
-        ISP_AE_FRAME_END_UPDATE_0  = 0x0, //isp update gain and exposure  in the  same frame
-        ISP_AE_FRAME_END_UPDATE_1  = 0x1, //isp update exposure one frame before  gain
-        ISP_AE_FRAME_END_UPDATE_2  = 0x2, //isp update exposure one frame before  gain, interrupt config
-       
-        ISP_AE_FRAME_END_BUTT
-
+    ISP_AE_FRAME_END_UPDATE_0  = 0x0, //isp update gain and exposure  in the  same frame
+    ISP_AE_FRAME_END_UPDATE_1  = 0x1, //isp update exposure one frame before  gain
+    ISP_AE_FRAME_END_UPDATE_2  = 0x2, //isp update exposure one frame before  gain, isr config
+    ISP_AE_FRAME_END_BUTT,
 }ISP_AE_FRAME_END_UPDATE_E;
+
 /* 4A settings                                                              */
 typedef struct hiISP_AE_ATTR_S
 {
     /* base parameter */
-    ISP_AE_MODE_E enAEMode;		/*AE mode(lownoise/framerate)(onvif)*/
+    ISP_AE_MODE_E enAEMode;     /*AE mode(lownoise/framerate)(onvif)*/
     HI_U16 u16ExpTimeMax;       /*RW, the exposure time's max and min value .(unit :line),Range:[0, 0xFFFF], it's related to specific sensor, usually the range max value is 1125  for 1080p sensor,and 750 for 720p sensor*/
     HI_U16 u16ExpTimeMin;       /*RW, Range: [0, u16ExpTimeMax]*/
     HI_U16 u16DGainMax;         /*RW,  the Dgain's  max value, Range : [0x1, 0xFF],it's related to specific sensor*/
     HI_U16 u16DGainMin;         /*RW, Range: [0x1, u16DainMax]*/
-    HI_U16 u16AGainMax;			/*RW,  the Again's  max value, Range : [0x1, 0xFF],it's related to specific sensor*/
+    HI_U16 u16AGainMax;         /*RW,  the Again's  max value, Range : [0x1, 0xFF],it's related to specific sensor*/
     HI_U16 u16AGainMin;         /*RW, Range: [0x1, u16AainMax]*/
     
-    HI_U8  u8ExpStep;			/*RW, AE adjust step, Range: [0x0, 0xFF]*/
-    HI_S16 s16ExpTolerance;		/*RW, AE adjust tolerance, Range: [0x0, 0xFF]*/
-    HI_U8  u8ExpCompensation;	/*RW, AE compensation, Range: [0x0, 0xFF]*/ 
+    HI_U8  u8ExpStep;           /*RW, AE adjust step, Range: [0x0, 0xFF]*/
+    HI_S16 s16ExpTolerance;     /*RW, AE adjust tolerance, Range: [0x0, 0xFF]*/
+    HI_U8  u8ExpCompensation;   /*RW, AE compensation, Range: [0x0, 0xFF]*/ 
     ISP_AE_FRAME_END_UPDATE_E  enFrameEndUpdateMode;
     HI_BOOL bByPassAE;
     /*AE weighting table*/
     HI_U8 u8Weight[WEIGHT_ZONE_ROW][WEIGHT_ZONE_COLUMN]; /*Range :  [0, 0xF]*/
-    
+    /* ae route strategy */
+    //ISP_AE_ROUTE_S stRoute;     /* */
 } ISP_AE_ATTR_S;
+
+typedef enum hiISP_AE_STRATEGY_E
+{
+    AE_EXP_HIGHLIGHT_PRIOR = 0,
+    AE_EXP_LOWLIGHT_PRIOR  = 1,
+    AE_STRATEGY_MODE_BUTT
+} ISP_AE_STRATEGY_E;
+
 
 typedef struct hiISP_AE_ATTR_EX_S
 {
@@ -253,79 +280,88 @@ typedef struct hiISP_AE_ATTR_EX_S
     HI_U32 u32SystemGainMax;    /*RW, the maximum gain of the system, Range: [0x400, 0xFFFFFFFF],it's related to specific sensor*/
 	HI_U32 u32SystemGainMin;    /*RW, the minmum gain of the system, Range: [0x400, u32SystemGainMax],it's related to specific sensor*/
     HI_U32 u32GainThreshold;    /*RW, the setting of the system gain threshold  for low nosie mode */
-    
+
     HI_U8  u8ExpStep;			/*RW, AE adjust step, Range: [0x0, 0xFF]*/
     HI_S16 s16ExpTolerance;		/*RW, AE adjust tolerance, Range: [0x0, 0xFF]*/
     HI_U8  u8ExpCompensation;	/*RW, AE compensation, Range: [0x0, 0xFF]*/ 
+	HI_U16  u16EVBias;          /*RW, AE EV bias, Range: [0x100, 0x1000]*/
+    ISP_AE_STRATEGY_E enAEStrategyMode;  /*RW, Support Highlight prior or Lowlight prior*/
+    HI_U16  u16HistRatioSlope;       /*RW, Range: [0x0, 0xFFFF], AE hist ratio slope*/
+    HI_U8   u8MaxHistOffset;         /*RW, Range: [0x0, 0xFF], Max hist offset*/
     ISP_AE_FRAME_END_UPDATE_E  enFrameEndUpdateMode;
     HI_BOOL bByPassAE;
     /*AE weighting table*/
     HI_U8 u8Weight[WEIGHT_ZONE_ROW][WEIGHT_ZONE_COLUMN]; /*Range :  [0, 0xF]*/
+    /* ae route strategy */
+    //ISP_AE_ROUTE_S stRoute;     /* */
 } ISP_AE_ATTR_EX_S;
+
+
+typedef struct hiISP_AE_DELAY_S
+{
+    HI_U16 u16BlackDelayFrame;    /*RW, AE black delay frame count, Range: [0x0, 0xFFFF]*/
+    HI_U16 u16WhiteDelayFrame;    /*RW, AE white delay frame count, Range: [0x0, 0xFFFF]*/
+} ISP_AE_DELAY_S;
+
 
 typedef struct hiISP_EXP_STA_INFO_S
 {
-    HI_U8  u8ExpHistThresh[4];				/*RW, Histogram threshold for bin 0/1 1/2 2/3 3/4 boundary, Range: [0x0, 0xFF]*/
-    HI_U16 u16ExpStatistic[WEIGHT_ZONE_ROW ][WEIGHT_ZONE_COLUMN][5];	/*RO, zone exposure statistics,Range: [0x0, 0xFFFF]*/
-    HI_U16 u16Exp_Hist256Value[256];		/*RO, 256 bins histogram,Range: [0x0, 0xFFFF]*/
-    HI_U16 u16Exp_Hist5Value[5];			/*RO, 5 bins histogram, Range: [0x0, 0xFFFF]*/
-    HI_U8  u8AveLum;						/*RO, average lum,Range: [0x0, 0xFF]*/
+    HI_U8  u8ExpHistThresh[4];              /*RW, Histogram threshold for bin 0/1 1/2 2/3 3/4 boundary, Range: [0x0, 0xFF]*/
+    HI_U16 u16ExpStatistic[WEIGHT_ZONE_ROW ][WEIGHT_ZONE_COLUMN][5];    /*RO, zone exposure statistics,Range: [0x0, 0xFFFF]*/
+    HI_U16 u16Exp_Hist256Value[256];        /*RO, 256 bins histogram,Range: [0x0, 0xFFFF]*/
+    HI_U16 u16Exp_Hist5Value[5];            /*RO, 5 bins histogram, Range: [0x0, 0xFFFF]*/
+    HI_U8  u8AveLum;                        /*RO, average lum,Range: [0x0, 0xFF]*/
     HI_U8  u8ExpHistTarget[5];              /*RW, Histogram target for bin 0/1/2/3/4 */
-    HI_S16 s16HistError;                    /*RO, hist error, indicates the difference between ae compensation and hist balance*/
+    HI_S16 s16HistError;   
 }ISP_EXP_STA_INFO_S;
 
 typedef struct hiISP_ME_ATTR_S
 {
-	HI_S32 s32AGain;       		/*RW,  sensor analog gain (unit: times), Range: [0x0, 0xFF],it's related to the specific sensor */
-	HI_S32 s32DGain;       		/*RW,  sensor digital gain (unit: times), Range: [0x0, 0xFF],it's related to the specific sensor */
-	HI_U32 u32ExpLine;			/*RW,  sensor exposure time (unit: line ), Range: [0x0, 0xFFFF],it's related to the specific sensor */
+    HI_S32 s32AGain;            /*RW,  sensor analog gain (unit: times), Range: [0x0, 0xFF],it's related to the specific sensor */
+    HI_S32 s32DGain;            /*RW,  sensor digital gain (unit: times), Range: [0x0, 0xFF],it's related to the specific sensor */
+    HI_U32 u32ExpLine;          /*RW,  sensor exposure time (unit: line ), Range: [0x0, 0xFFFF],it's related to the specific sensor */
 
-	HI_BOOL bManualExpLineEnable;
-	HI_BOOL bManualAGainEnable;
-	HI_BOOL bManualDGainEnable;
-
+    HI_BOOL bManualExpLineEnable;
+    HI_BOOL bManualAGainEnable;
+    HI_BOOL bManualDGainEnable;
 } ISP_ME_ATTR_S;
 
 typedef struct hiISP_ME_ATTR_EX_S
 {
-	HI_S32 s32AGain;       		/*RW,  sensor analog gain (unit: times), Range: [0x400, 0xFFFFFFFF],it's related to the specific sensor */
-	HI_S32 s32DGain;       		/*RW,  sensor digital gain (unit: times), Range: [0x400, 0xFFFFFFFF],it's related to the specific sensor */
-    HI_U32 u32ISPDGain;         /*RW,  isp digital gain(unit: times), Range: [0x100, 0xFFFF],it's related to the specific ISP*/
-	HI_U32 u32ExpLine;			/*RW,  sensor exposure time (unit: line ), Range: [0x0, 0xFFFF],it's related to the specific sensor */
-    
-	HI_BOOL bManualExpLineEnable;
-	HI_BOOL bManualAGainEnable;
-	HI_BOOL bManualDGainEnable;
-    HI_BOOL bManualISPDGainEnable;
+    HI_S32 s32AGain;            /*RW,  sensor analog gain (unit: times), Range: [0x0, 0xFF],it's related to the specific sensor */
+    HI_S32 s32DGain;            /*RW,  sensor digital gain (unit: times), Range: [0x0, 0xFF],it's related to the specific sensor */
+    HI_U32 u32ISPDGain;         /*RW,  sensor digital gain (unit: times), Range: [0x0, 0xFF],it's related to the specific isp   */
+    HI_U32 u32ExpLine;          /*RW,  sensor exposure time (unit: line ), Range: [0x0, 0xFFFF],it's related to the specific sensor */
 
+    HI_BOOL bManualExpLineEnable;
+    HI_BOOL bManualAGainEnable;
+    HI_BOOL bManualDGainEnable;
+    HI_BOOL bManualISPGainEnable;
 } ISP_ME_ATTR_EX_S;
 
 typedef struct hiISP_AF_ATTR_S
 {
-    HI_S32 s32FocusDistanceMax;		/* the focuse range*/
+    HI_S32 s32FocusDistanceMax; /* the focuse range */
     HI_S32 s32FocusDistanceMin;
 
-    /*weighting table*/
-    HI_U8 u8Weight[WEIGHT_ZONE_ROW][WEIGHT_ZONE_COLUMN];
-    
+    /* weighting table */
+    HI_U8 u8Weight[WEIGHT_ZONE_ROW][WEIGHT_ZONE_COLUMN];    
 } ISP_AF_ATTR_S;
 
 typedef struct hiISP_FOUCS_STA_INFO_S
 {
-	HI_U16 u16FocusMetrics;      /*RO, The integrated and normalized measure of contrast*/
-	HI_U16 u16ThresholdRead;     /*RO, The ISP recommend value of AF threshold*/
-	HI_U16 u16ThresholdWrite;    /*RW, The user defined value of AF threshold (or 0 to use threshold from previous frame)*/
-	HI_U16 u16FocusIntensity;    /*RO, The average brightness*/
-    HI_U8  u8MetricsShift;       /*RW, Metrics scaling factor:the bigger value for this register means all zones metrics go higher,0x03 is the default, Range: [0x0, 0xF]*/
-    HI_U8  u8NpOffset;           /*RW, The AF noise profile offset, Range: [0x0, 0xFF]*/
-	HI_U16 u16ZoneMetrics[WEIGHT_ZONE_ROW][WEIGHT_ZONE_COLUMN]; /*RO, The zoned measure of contrast*/
-    
+    HI_U16 u16FocusMetrics;     /*RO, The integrated and normalized measure of contrast*/
+    HI_U16 u16ThresholdRead;    /*RO, The ISP recommend value of AF threshold*/
+    HI_U16 u16ThresholdWrite;   /*RW, The user defined value of AF threshold (or 0 to use threshold from previous frame)*/
+    HI_U16 u16FocusIntensity;   /*RO, The average brightness*/
+    HI_U8  u8MetricsShift;      /*RW, Metrics scaling factor:the bigger value for this register means all zones metrics go higher,0x03 is the default, Range: [0x0, 0xF]*/
+    HI_U8  u8NpOffset;          /*RW, The AF noise profile offset, Range: [0x0, 0xFF]*/
+	HI_U16 u16ZoneMetrics[WEIGHT_ZONE_ROW][WEIGHT_ZONE_COLUMN]; /*RO, The zoned measure of contrast*/    
 } ISP_FOCUS_STA_INFO_S;
 
 typedef struct hiISP_MF_ATTR_S
 {
-    HI_S32 s32DefaultSpeed;		/*1,default speed(unit:m/s).(onvif)*/		
-    
+    HI_S32 s32DefaultSpeed;     /* 1,default speed(unit:m/s).(onvif)*/    
 } ISP_MF_ATTR_S;
 
 typedef struct hiISP_AWB_CALIBRATION_S 
@@ -345,7 +381,7 @@ typedef struct hiISP_AWB_ATTR_S
     HI_U8 u8ZoneSel;           /*RW,  A value of 0 or 0x3F means global AWB, A value between 0 and 0x3F means zoned AWB */
     HI_U8 u8HighColorTemp;     /*RW, AWB max temperature in K/100, Range: [0x0, 0xFF], Recommended: [85, 100] */
     HI_U8 u8LowColorTemp;      /*RW, AWB min temperature in K/100, Range: [0x0, u8HighColorTemp), Recommended: [20, 25] */
-    /* weighting table*/
+    /* weighting table */
     HI_U8 u8Weight[WEIGHT_ZONE_ROW][WEIGHT_ZONE_COLUMN];  /*RW, Range :  [0, 0xF]*/
     
 } ISP_AWB_ATTR_S;
@@ -403,50 +439,47 @@ typedef struct hiISP_AWB_ADD_LIGHTSOURCE_S
 
 typedef struct hiISP_WB_ZONE_STA_INFO_S
 {
-    HI_U16 u16Rg;         /*RO, Zoned WB output G/R, Range : [0x0, 0xFFF]*/
-    HI_U16 u16Bg;         /*RO, Zoned WB output G/B, Range : [0x0, 0xFFF]*/
-    HI_U32 u32Sum;        /*RO, Zoned WB output population,Range: [0x0, 0xFFFFFFFF]*/
-  
+    HI_U16 u16Rg;               /*RO, Zoned WB output G/R, Range : [0x0, 0xFFF]*/
+    HI_U16 u16Bg;               /*RO, Zoned WB output G/B, Range : [0x0, 0xFFF]*/
+    HI_U32 u32Sum;              /*RO, Zoned WB output population,Range: [0x0, 0xFFFFFFFF]*/  
 } ISP_WB_ZONE_STA_INFO_S;
 
 typedef struct hiISP_WB_STA_INFO_S
 {
-    HI_U16 u16WhiteLevel;  /*RW, Upper limit of valid data for white region, Range: [0x0, 0xFFFF]*/
-    HI_U16 u16BlackLevel;  /*RW, Lower limit of valid data for white region, Range: [0x0, u16WhiteLevel)*/
-    HI_U16 u16CbMax;       /*RW, Maximum value of B/G for white region, Range: [0x0,0xFFF]*/
-    HI_U16 u16CbMin;       /*RW, Minimum value of B/G for white region, Range: [0x0, u16CbMax)*/
-    HI_U16 u16CrMax;       /*RW, Maximum value of R/G for white region, Range: [0x0, 0xFFF]*/
-    HI_U16 u16CrMin;       /*RW, Minimum value of R/G for white region, Range: [0x0, u16CrMax)*/
+    HI_U16 u16WhiteLevel;       /*RW, Upper limit of valid data for white region, Range: [0x0, 0xFFFF]*/
+    HI_U16 u16BlackLevel;       /*RW, Lower limit of valid data for white region, Range: [0x0, u16WhiteLevel)*/
+    HI_U16 u16CbMax;            /*RW, Maximum value of B/G for white region, Range: [0x0,0xFFF]*/
+    HI_U16 u16CbMin;            /*RW, Minimum value of B/G for white region, Range: [0x0, u16CbMax)*/
+    HI_U16 u16CrMax;            /*RW, Maximum value of R/G for white region, Range: [0x0, 0xFFF]*/
+    HI_U16 u16CrMin;            /*RW, Minimum value of R/G for white region, Range: [0x0, u16CrMax)*/
     
-    HI_U16 u16GRgain;      /*RO, Global WB output G/R, Range: [0x0, 0xFFFF]*/
-    HI_U16 u16GBgain;      /*RO, Global WB output G/B, Range: [0x0, 0xFFFF]*/
-    HI_U32 u32GSum;        /*RO, Global WB output population, Range: [0x0, 0xFFFF]*/
+    HI_U16 u16GRgain;           /*RO, Global WB output G/R, Range: [0x0, 0xFFFF]*/
+    HI_U16 u16GBgain;           /*RO, Global WB output G/B, Range: [0x0, 0xFFFF]*/
+    HI_U32 u32GSum;             /*RO, Global WB output population, Range: [0x0, 0xFFFF]*/
 
-    HI_U32 u32Rgain;      /*RO,  gain value of R channel for AWB , Range: [0x0, 0xFFF]*/
-    HI_U32 u32Ggain;      /*RO,  gain value of G channel for AWB , Range: [0x0, 0xFFF]*/
-    HI_U32 u32Bgain;      /*RO,  gain value of B channel for AWB , Range: [0x0, 0xFFF]*/
- 
+    HI_U32 u32Rgain;            /*RO, gain value of R channel for AWB, Range: [0x0, 0xFFF]*/
+    HI_U32 u32Ggain;            /*RO, gain value of G channel for AWB, Range: [0x0, 0xFFF]*/
+    HI_U32 u32Bgain;            /*RO, gain value of B channel for AWB, Range: [0x0, 0xFFF]*/
+    
     ISP_WB_ZONE_STA_INFO_S stZoneSta[WEIGHT_ZONE_ROW][WEIGHT_ZONE_COLUMN];  /*RO, Zoned WB statistics*/
-  
 } ISP_WB_STA_INFO_S;
 
-typedef struct hiISP_MWB_ATTR_S		
+typedef struct hiISP_MWB_ATTR_S        
 {
-    HI_U16 u16Rgain;      /*RW, Multiplier for R color channel, Range: [0x0, 0xFFF]*/
-    HI_U16 u16Ggain;      /*RW, Multiplier for G color channel, Range: [0x0, 0xFFF]*/
-    HI_U16 u16Bgain;      /*RW, Multiplier for B color channel, Range: [0x0, 0xFFF]*/
+    HI_U16 u16Rgain;            /*RW, Multiplier for R color channel, Range: [0x0, 0xFFF]*/
+    HI_U16 u16Ggain;            /*RW, Multiplier for G color channel, Range: [0x0, 0xFFF]*/
+    HI_U16 u16Bgain;            /*RW, Multiplier for B color channel, Range: [0x0, 0xFFF]*/
     
 } ISP_MWB_ATTR_S;
 
 typedef struct hiISP_COLORMATRIX_S
-{   HI_U16 u16HighColorTemp; /*RW,  Range: [u16MidColorTemp + 400,  10000]*/
-    HI_U16 au16HighCCM[9];  /*RW,  Range: [0x0,  0xFFFF]*/
-    HI_U16 u16MidColorTemp; /*RW,  the MidColorTemp should be at least 400 smaller than HighColorTemp, Range: [u16LowColorTemp + 400,  u16HighColorTemp-400]*/
-    HI_U16 au16MidCCM[9];   /*RW,  Range: [0x0,  0xFFFF]*/
-    HI_U16 u16LowColorTemp;  /*RW,  the LowColorTemp should be at least 400 smaller than HighColorTemp, Range: [0,  u16MidColorTemp-400]*/
-    HI_U16 au16LowCCM[9];  /*RW,  Range: [0x0,  0xFFFF]*/
+{   HI_U16 u16HighColorTemp;    /*RW,  Range: [u16MidColorTemp + 400,  10000]*/
+    HI_U16 au16HighCCM[9];      /*RW,  Range: [0x0,  0xFFFF]*/
+    HI_U16 u16MidColorTemp;     /*RW,  the MidColorTemp should be at least 400 smaller than HighColorTemp, Range: [u16LowColorTemp + 400,  u16HighColorTemp-400]*/
+    HI_U16 au16MidCCM[9];       /*RW,  Range: [0x0,  0xFFFF]*/
+    HI_U16 u16LowColorTemp;     /*RW,  the LowColorTemp should be at least 400 smaller than HighColorTemp, Range: [0,  u16MidColorTemp-400]*/
+    HI_U16 au16LowCCM[9];       /*RW,  Range: [0x0,  0xFFFF]*/
 } ISP_COLORMATRIX_S;
-
 
 typedef struct hiISP_COLORTONE_S
 {
@@ -456,101 +489,131 @@ typedef struct hiISP_COLORTONE_S
   
 }ISP_COLORTONE_S;
 
+typedef struct hiISP_SATURATION_ATTR_S
+{
+    HI_BOOL bSatManualEnable;
+    HI_U8   u8SatTarget;        /*RW,  Range: [0, 0xFF] */
+    HI_U8   au8Sat[8];           /*RW,  Range: [0, 0xFF] */ 
+}ISP_SATURATION_ATTR_S;
+
+typedef enum hiISP_IRIS_TYPE_E
+{
+    ISP_IRIS_DC_TYPE = 0,
+    ISP_IRIS_P_TYPE,
+    
+    ISP_IRIS_TYPE_BUTT,
+} ISP_IRIS_TYPE_E;
+
 typedef struct hiISP_AI_ATTR_S
 {
-	HI_BOOL bIrisEnable;			/*Auto iris  on/off*/
-	HI_BOOL bIrisCalEnable;			/*iris calibration on/off*/
-	HI_BOOL bIrisCalExit;           /*iris calibration exit, exit the calibration*/
-	HI_U32  u32IrisHoldValue;       /*RW, iris hold value, Range: [0x0, 0x3E8]*/
+    HI_BOOL bIrisEnable;        /*Auto iris  on/off*/
+    HI_BOOL bIrisCalEnable;     /*iris calibration on/off*/
+	HI_BOOL bIrisCalExit;       /*iris calibration exit, exit the calibration*/
+    HI_U32  u32IrisHoldValue;   /*RW, iris hold value, Range: [0x0, 0x3E8]*/
 
-	ISP_IRIS_STATUS_E enIrisStatus;         /*RW, status of Iris*/
-	ISP_TRIGGER_STATUS_E enTriggerStatus;   /*RW, status of trigger*/
-	HI_U16 u16IrisStopValue;                /*RW, the initial stop value for AI trigger, Range: [0x0,0x3E8]*/
-	HI_U16 u16IrisCloseDrive;               /*RW, the drive value to close Iris, Range: [0x0,0x3E8], Recommended value: [700, 900]. A larger value means faster.*/
-	HI_U16 u16IrisTriggerTime;              /*RW, frame numbers of AI trigger lasting time. > 600, [0x0, 0xFFF]*/
-    HI_U8  u8IrisInertiaValue;              /*RW, frame numbers of  AI moment of inertia, Range: [0x0, 0xFF],the recommended value is between[0x3, 0xa]*/
-    
+    ISP_IRIS_STATUS_E enIrisStatus;         /*RW, status of Iris*/
+    ISP_TRIGGER_STATUS_E enTriggerStatus;   /*RW, status of trigger*/
+    HI_U16 u16IrisStopValue;    /*RW, the initial stop value for AI trigger, Range: [0x0,0x3E8]*/
+    HI_U16 u16IrisCloseDrive;   /*RW, the drive value to close Iris, Range: [0x0,0x3E8], Recommended value: [700, 900]. A larger value means faster.*/
+    HI_U16 u16IrisTriggerTime;  /*RW, frame numbers of AI trigger lasting time. > 600, [0x0, 0xFFF]*/
+    HI_U8  u8IrisInertiaValue;  /*RW, frame numbers of  AI moment of inertia, Range: [0x0, 0xFF],the recommended value is between[0x3, 0xa]*/
 } ISP_AI_ATTR_S;
 
 typedef struct hiISP_MI_ATTR_S
 {
-    HI_S32 s32FixAttenuation;		
-    
+    HI_BOOL bEnable;            /* manual iris  on/off*/
+    HI_U32  u32IrisHoldValue;   /*RW, iris hold value, Range: [0x0, 0x3E8]*/
+    HI_U16  u16ApePercent;      /* the percent of the iris's aperture, range is [0~100]. */
 } ISP_MI_ATTR_S;
-
 
 typedef struct hiISP_DRC_ATTR_S
 {
     HI_BOOL bDRCEnable;        
     HI_BOOL bDRCManualEnable;        
     HI_U32  u32StrengthTarget;  /*RW,  Range: [0, 0xFF]. It is not the final strength used by ISP. 
-                                         * It will be clipped to reasonable value when image is noisy. */
+                                     * It will be clipped to reasonable value when image is noisy. */
     HI_U32  u32SlopeMax;        /*RW,  Range: [0, 0xFF]. Not recommended to change. */
-    HI_U32  u32SlopeMin;          /*RW,  Range: [0, 0xFF]. Not recommended to change. */
-    HI_U32  u32WhiteLevel;        /*RW,  Range: [0, 0xFFFF]. Not recommended to change. */
-    HI_U32  u32BlackLevel;        /*RW,  Range: [0, 0xFFF]. Not recommended to change. */
+    HI_U32  u32SlopeMin;        /*RW,  Range: [0, 0xFF]. Not recommended to change. */
+    HI_U32  u32WhiteLevel;      /*RW,  Range: [0, 0xFFF]. Not recommended to change. */
+    HI_U32  u32BlackLevel;      /*RW,  Range: [0, 0xFFF]. Not recommended to change. */
     HI_U32  u32VarianceSpace;     /*RW,  Range: [0, 0xF]. Not recommended to change*/
     HI_U32  u32VarianceIntensity; /*RW,  Range: [0, 0xF].Not recommended to change*/
 } ISP_DRC_ATTR_S;
 
 typedef enum hiISP_ANTIFLICKER_MODE_E
 {
-      ISP_ANTIFLICKER_MODE_0 = 0x0,    /*The exposure time is fixed at several values. The minimum exposure time is 1/120 sec. (60 Hz) or 1/100 sec. (50 Hz). Since the exposure time is synchronized with the fluorescent lighting,
-                                                                   rolling bar noise can be suppressed. In high-luminance environments, however, the exposure time is fixed to the minimum exposure time, it may lead to over exposure*/
+    /* The exposure time is fixed at several values. The minimum exposure time is 1/120 sec.
+     * (60 Hz) or 1/100 sec. (50 Hz). Since the exposure time is synchronized with the fluorescent lighting,
+     * rolling bar noise can be suppressed. In high-luminance environments, however, 
+     * the exposure time is fixed to the minimum exposure time, it may lead to over exposure
+     */
+    ISP_ANTIFLICKER_MODE_0 = 0x0,
 
-      ISP_ANTIFLICKER_MODE_1 = 0x1,    /*In this mode, the exposure time is not fixed in high-luminance environments and the exposure time can be reduced  to the minimum . Use it when the exposure is to be controlled in high-luminance environments.
-                                                                  in low lumiance enviroment, the effect is the same as the above one*/
-      
-      ISP_ANTIFLICKER_MODE_BUTT
-      
+    /* In this mode, the exposure time is not fixed in high-luminance environments and the 
+     * exposure time can be reduced  to the minimum . Use it when the exposure is to be controlled
+     * in high-luminance environments. in low lumiance enviroment, the effect is the same as the above one
+     */
+    ISP_ANTIFLICKER_MODE_1 = 0x1,
+
+    ISP_ANTIFLICKER_MODE_BUTT      
 }ISP_ANTIFLICKER_MODE_E;
 
 typedef struct hiISP_ANTIFLICKER_S
 {
-	HI_BOOL bEnable;
-       
-	HI_U8 u8Frequency;                /*RW, Range: usually this value is 50 or 60  which is the frequency of the AC power supply*/
+    HI_BOOL bEnable;
+    HI_U8   u8Frequency;          /*RW, Range: usually this value is 50 or 60  which is the frequency of the AC power supply*/
 
-   ISP_ANTIFLICKER_MODE_E  enMode;
-    
+    ISP_ANTIFLICKER_MODE_E  enMode;
 } ISP_ANTIFLICKER_S;
 
-typedef struct hiISP_SATURATION_ATTR_S
+typedef struct hiISP_SUBFLICKER_S
 {
-    HI_BOOL bSatManualEnable;
-    HI_U8   u8SatTarget;    /*RW,  Range: [0, 0xFF] */
-    HI_U8   au8Sat[8];       /*RW,  Range: [0, 0xFF] */
- 
-}ISP_SATURATION_ATTR_S;
+    HI_BOOL bEnable;
+
+    /* RW, Range: [0x0, 0x64], if subflicker mode enable, current luma is less than AE compensation plus LumaDiff, 
+      AE will keep min antiflicker shutter time(for example: 1/100s or 1/120s) to avoid flicker. while current luma is 
+      larger than AE compensation plus the LumaDiff, AE will reduce shutter time to avoid over-exposure and introduce 
+      flicker in the pircture */
+    HI_U8   u8LumaDiff;          
+} ISP_SUBFLICKER_S;
+
+typedef struct hiISP_DCIRIS_ATTR_S
+{
+    HI_S32 s32Para1;                 /*RW, Range: usually this value is larger than 1000 */
+    HI_S32 s32Para2;                 /*RW, Range: usually this value is 1 */
+    HI_S32 s32Para3;                 /*RW, Range: usually this value is larger than 1000 */
+    HI_U32 u32MinPwmDuty;            /*RW, Range:[0, 1000], which is the min pwm duty of the dciris control algorithm */
+    HI_U32 u32MaxPwmDuty;            /*RW, Range:[0, 1000], which is the max pwm duty of the dciris control algorithm */
+    HI_U32 u32OpenPwmDuty;           /*RW, Range:[0, 1000], which is the open pwm duty of the dciris control algorithm */
+} ISP_DCIRIS_ATTR_S;
+
 
 typedef struct hiISP_DP_ATTR_S
 {
-	HI_BOOL bEnableDynamic;
-    HI_U16 u16DynamicBadPixelSlope;       /*RW, Range: [0x0, 0xFFF], blending degree of bad pixel*/ 
-    HI_U16 u16DynamicBadPixelThresh;         /*RW, Range: [0x0, 0xFFF], thresh hold in bad pixel detection*/ 
-	HI_BOOL bEnableStatic;
-	HI_BOOL bEnableDetect;
-	ISP_TRIGGER_STATUS_E enTriggerStatus;  /*status of bad pixel trigger*/
-	HI_U8   u8BadPixelStartThresh;         /*RW,  Range: [0, 0xFF] */
-	HI_U8   u8BadPixelFinishThresh;        /*RW,  Range: [0, 0xFF] */
-	HI_U16  u16BadPixelCountMax;           /*RW, limit of max number of bad pixel,  Range: [0, 0x3FF] */
-	HI_U16  u16BadPixelCountMin;            /*RW, limit of min number of bad pixel, Range: [0, 0x3FF]*/
-	HI_U16  u16BadPixelCount;               /*RW, limit of min number of bad pixel, Range: [0, 0x3FF]*/
-	HI_U16  u16BadPixelTriggerTime;     /*RW, time limit for bad pixel trigger, in frame number ,Range: [0x0, 0x640]*/
-	HI_U32  u32BadPixelTable[1024];     /*RW, Range: [0x0, 0x3FFFFF],the first 11 bits represents the X coordinate of the defect pixel, the second 11 bits represent the Y coordinate of the defect pixel*/
-	
+    HI_BOOL bEnableDynamic;
+    HI_U16  u16DynamicBadPixelSlope;       /*RW, Range: [0x0, 0xFFF], blending degree of bad pixel*/ 
+    HI_U16  u16DynamicBadPixelThresh;         /*RW, Range: [0x0, 0xFFF], thresh hold in bad pixel detection*/ 
+    HI_BOOL bEnableStatic;
+    HI_BOOL bEnableDetect;
+    ISP_TRIGGER_STATUS_E enTriggerStatus;   /*status of bad pixel trigger*/
+    HI_U8   u8BadPixelStartThresh;          /*RW,  Range: [0, 0xFF] */
+    HI_U8   u8BadPixelFinishThresh;         /*RW,  Range: [0, 0xFF] */
+    HI_U16  u16BadPixelCountMax;            /*RW, limit of max number of bad pixel,  Range: [0, 0x3FF] */
+    HI_U16  u16BadPixelCountMin;            /*RW, limit of min number of bad pixel, Range: [0, 0x3FF]*/
+    HI_U16  u16BadPixelCount;               /*RW, limit of min number of bad pixel, Range: [0, 0x3FF]*/
+    HI_U16  u16BadPixelTriggerTime;         /*RW, time limit for bad pixel trigger, in frame number ,Range: [0x0, 0x640]*/
+    HI_U32  u32BadPixelTable[1024];         /*RW, Range: [0x0, 0x3FFFFF],the first 11 bits represents the X coordinate of the defect pixel, the second 11 bits represent the Y coordinate of the defect pixel*/
 } ISP_DP_ATTR_S;
 
 typedef struct hiISP_DIS_ATTR_S
 {
     HI_BOOL bEnable;
-    
 } ISP_DIS_ATTR_S;
+
 typedef struct hiISP_DIS_INFO_S
 {
-    HI_S8 s8Xoffset;         /*RO, Range: [0x00, 0x80]*/
-    HI_S8 s8Yoffset;         /*RO, Range: [0x80, 0xFF]*/   
-    
+    HI_S8 s8Xoffset;         /*RW, Range: [0x00, 0x80]*/
+    HI_S8 s8Yoffset;         /*RW, Range: [0x80, 0xFF]*/   
 } ISP_DIS_INFO_S;
 
 
@@ -568,28 +631,25 @@ typedef struct hiISP_SHADINGTAB_S
     HI_U16 u16ShadingCenterB_X;  /*RW, Range: [0x0, 0xFFFF]*/
     HI_U16 u16ShadingCenterB_Y;  /*RW, Range: [0x0, 0xFFFF]*/
 
-	HI_U16 u16ShadingTable_R[SHADING_TABLE_NODE_NUMBER_MAX]; /*RW, Range: [0x0, 0xFFFF]*/
-	HI_U16 u16ShadingTable_G[SHADING_TABLE_NODE_NUMBER_MAX]; /*RW, Range: [0x0, 0xFFFF]*/
-	HI_U16 u16ShadingTable_B[SHADING_TABLE_NODE_NUMBER_MAX]; /*RW, Range: [0x0, 0xFFFF]*/
+    HI_U16 u16ShadingTable_R[SHADING_TABLE_NODE_NUMBER_MAX]; /*RW, Range: [0x0, 0xFFFF]*/
+    HI_U16 u16ShadingTable_G[SHADING_TABLE_NODE_NUMBER_MAX]; /*RW, Range: [0x0, 0xFFFF]*/
+    HI_U16 u16ShadingTable_B[SHADING_TABLE_NODE_NUMBER_MAX]; /*RW, Range: [0x0, 0xFFFF]*/
 
     HI_U16 u16ShadingOffCenter_R;  /*RW, Range: [0x0, 0xFFFF]*/
     HI_U16 u16ShadingOffCenter_G;  /*RW, Range: [0x0, 0xFFFF]*/
     HI_U16 u16ShadingOffCenter_B;  /*RW, Range: [0x0, 0xFFFF]*/
 
     HI_U16 u16ShadingTableNodeNumber;  /*RW, Range: [0x0, SHADING_TABLE_NODE_NUMBER_MAX]*/
-
 } ISP_SHADINGTAB_S;
 
 typedef struct hiISP_DENOISE_ATTR_S
 {
-	HI_BOOL bEnable;
-	HI_BOOL bManualEnable;
-	HI_U8 u8ThreshTarget;	    /*RW,  Noise reduction effect for high spacial frequencies Range: [0x0, u8ThreshTarget]*/
-	HI_U8 u8ThreshMax;			/*RW,  Noise reduction effect for high spacial frequencies, Range: [0x0, 0xFF] */
+    HI_BOOL bEnable;
+    HI_BOOL bManualEnable;
+    HI_U8 u8ThreshTarget;       /*RW,  Noise reduction effect for high spacial frequencies Range: [0x0, u8ThreshTarget]*/
+    HI_U8 u8ThreshMax;          /*RW,  Noise reduction effect for high spacial frequencies, Range: [0x0, 0xFF] */
     HI_U8 u8SnrThresh[8];       /*RW,  Noise reduction target value array for  different iso, Range: [0x0, 0xFF],*/
-
 } ISP_DENOISE_ATTR_S;
-
 typedef struct hiISP_NOISEPROFILE_TABLE_S
 {
 
@@ -599,65 +659,59 @@ typedef struct hiISP_NOISEPROFILE_TABLE_S
 
 typedef struct hiISP_GAMMA_ATTR_S
 {
-	HI_BOOL bEnable;
-    
+    HI_BOOL bEnable;
 } ISP_GAMMA_ATTR_S;
 
 typedef enum hiISP_GAMMA_CURVE_E
 {
-	ISP_GAMMA_CURVE_1_6 = 0x0,           /* 1.6 Gamma curve */
-	ISP_GAMMA_CURVE_1_8 = 0x1,           /* 1.8 Gamma curve */
-	ISP_GAMMA_CURVE_2_0 = 0x2,           /* 2.0 Gamma curve */
-	ISP_GAMMA_CURVE_2_2 = 0x3,           /* 2.2 Gamma curve */
-	ISP_GAMMA_CURVE_DEFAULT = 0x4,       /* default Gamma curve */
-	ISP_GAMMA_CURVE_SRGB = 0x5,
-	ISP_GAMMA_CURVE_USER_DEFINE = 0x6,   /* user defined Gamma curve, Gamma Table must be correct */
-	ISP_GAMMA_CURVE_BUTT
-	
+    ISP_GAMMA_CURVE_1_6 = 0x0,           /* 1.6 Gamma curve */
+    ISP_GAMMA_CURVE_1_8 = 0x1,           /* 1.8 Gamma curve */
+    ISP_GAMMA_CURVE_2_0 = 0x2,           /* 2.0 Gamma curve */
+    ISP_GAMMA_CURVE_2_2 = 0x3,           /* 2.2 Gamma curve */
+    ISP_GAMMA_CURVE_DEFAULT = 0x4,       /* default Gamma curve */
+    ISP_GAMMA_CURVE_SRGB = 0x5,
+    ISP_GAMMA_CURVE_USER_DEFINE = 0x6,   /* user defined Gamma curve, Gamma Table must be correct */
+    ISP_GAMMA_CURVE_BUTT
 } ISP_GAMMA_CURVE_E;
 
 typedef struct hiISP_GAMMA_TABLE_S
 {
-	ISP_GAMMA_CURVE_E enGammaCurve;
-	HI_U16 u16Gamma[GAMMA_NODE_NUMBER];
-	HI_U16 u16Gamma_FE[GAMMA_FE_LUT_SIZE];   /* only for WDR sensor mode */
-   
+    ISP_GAMMA_CURVE_E enGammaCurve;
+    HI_U16 u16Gamma[GAMMA_NODE_NUMBER];
+    HI_U16 u16Gamma_FE[GAMMA_FE_LUT_SIZE];   /* only for WDR sensor mode */
 } ISP_GAMMA_TABLE_S;
 
 typedef struct hiISP_SHARPEN_ATTR_S
 {
-	HI_BOOL bEnable;
-	HI_BOOL bManualEnable;
-	HI_U8 u8StrengthTarget;   /*RW,  Range:[0, 0xFF]. */
-    HI_U8 u8StrengthUdTarget; /*RW,  Range:[0, 0xFF]. */
-	HI_U8 u8StrengthMin;      /*RW,  Range:[0, u32StrengthTarget]. */
-    HI_U8 u8SharpenAltD[8]; /*RW,  Range: [0, 0xFF].  */
-    HI_U8 u8SharpenAltUd[8]; /*RW, Range: [0, 0xFF]. */
+    HI_BOOL bEnable;
+    HI_BOOL bManualEnable;
+    HI_U8 u8StrengthTarget;     /*RW,  Range:[0, 0xFF]. */
+    HI_U8 u8StrengthUdTarget;     /*RW,  Range:[0, 0xFF]. */
+    HI_U8 u8StrengthMin;        /*RW,  Range:[0, u32StrengthTarget]. */
+    HI_U8 u8SharpenAltD[8];     /*RW,  Range: [0, 0xFF].  */
+    HI_U8 u8SharpenAltUd[8];    /*RW, Range: [0, 0xFF]. */
 } ISP_SHARPEN_ATTR_S;
-
-
 
 typedef struct hiISP_PARA_REC_S
 {
-	HI_BOOL bInit;
-	HI_BOOL bTmCfg;
-	HI_BOOL bAttrCfg;
-	
+    HI_BOOL bInit;
+    HI_BOOL bTmCfg;
+    HI_BOOL bAttrCfg;
+    
     ISP_INPUT_TIMING_S stInputTiming;
     ISP_IMAGE_ATTR_S stImageAttr;
 
-	HI_U32 u32ModFlag;
+    HI_U32 u32ModFlag;
 
-	/* Exposure */
-	ISP_OP_TYPE_E enExpType;
-	ISP_AE_ATTR_S stAEAttr;
-	ISP_ME_ATTR_S stMEAttr;
+    /* Exposure */
+    ISP_OP_TYPE_E enExpType;
+    ISP_AE_ATTR_S stAEAttr;
+    ISP_ME_ATTR_S stMEAttr;
 
-	/* White Balance */
-	ISP_OP_TYPE_E enWBType;
-	ISP_AWB_ATTR_S stAWBAttr;
-	ISP_MWB_ATTR_S stMWBAttr;
-    
+    /* White Balance */
+    ISP_OP_TYPE_E enWBType;
+    ISP_AWB_ATTR_S stAWBAttr;
+    ISP_MWB_ATTR_S stMWBAttr;
 } ISP_PARA_REC_S;
 
 /*Crosstalk Removal*/
@@ -667,84 +721,95 @@ typedef struct hiISP_CR_ATTR_S
     HI_U8    u8Strength[8];  /*Range: [0x0, 0xFF] */
     HI_U8    u8Sensitivity; /*Range: [0x0, 0xFF],this register is  not recommended  to change */
     HI_U16   u16Threshold;  /*Range: [0x0, 0xFFFF],this register is  not recommended  to change */
-    HI_U16   u16Slope; /*Range: [0x0, 0xFFFF],this register is  not recommended  to change */
+    HI_U16   u16Slope;      /*Range: [0x0, 0xFFFF],this register is  not recommended  to change */
 }ISP_CR_ATTR_S;
 
 typedef struct hiISP_ANTIFOG_S
 {
-	HI_BOOL bEnable;
-    HI_U8 u8Strength;  /*Range: [0x0, 0xFF]*/
-	// TODO:
+    HI_BOOL bEnable;
+    HI_U8   u8Strength;     /*Range: [0x0, 0xFF]*/
 } ISP_ANTIFOG_S;
 
 typedef struct hiISP_ANTI_FALSECOLOR_S
 {
-	HI_U8  u8Strength;       /*Range: [0x0, 0xFF], the recommended range is [0x0, 0x95], the normal color will gradually be eroded when this register is larger than 0x95.*/
-	// TODO:
+    HI_U8  u8Strength;      /* Range: [0x0, 0xFF], the recommended range is [0x0, 0x95], the normal 
+                                * color will gradually be eroded when this register is larger than 0x95. */
 } ISP_ANTI_FALSECOLOR_S;
 
 /*users query ISP state information*/
 typedef struct hiISP_INNER_STATE_INFO_S
 {
-	HI_U32 u32ExposureTime;  /*RO,  Range: [0x0, 0xFFFF] */
-	HI_U32 u32AnalogGain;	/*RO,Range: [0x0, 0xFFFF] */
-	HI_U32 u32DigitalGain;	/*RO,Range: [0x0, 0xFFFF] */
-	HI_U32 u32Exposure;			/*RO,Range: [0x0, 0xFFFFFFFF] */
-	HI_U16 u16AE_Hist256Value[256];		/*RO, 256 bins histogram  */
-	HI_U16 u16AE_Hist5Value[5];			/*RO, 5 bins histogram   */   
-	HI_U8 u8AveLum;					    /*RO, Range: [0x0, 0xFF]*/	
-	HI_BOOL bExposureIsMAX;
+    HI_U32 u32ExposureTime;         /* RO,  Range: [0x0, 0xFFFF] */                
+    HI_U32 u32AnalogGain;           /* RO,Range: [0x0, 0xFFFF] */                
+    HI_U32 u32DigitalGain;          /* RO,Range: [0x0, 0xFFFF] */            
+    HI_U32 u32Exposure;             /* RO,Range: [0x0, 0xFFFFFFFF] */        
+    HI_U16 u16AE_Hist256Value[256]; /* RO, 256 bins histogram */
+    HI_U16 u16AE_Hist5Value[5];     /* RO, 5 bins histogram */
+    HI_U8  u8AveLum;                /* RO, Range: [0x0, 0xFF] */    
+    HI_BOOL bExposureIsMAX;
 }ISP_INNER_STATE_INFO_S;
 
-/*users query ISP state information*/
 typedef struct hiISP_INNER_STATE_INFO_EX_S
 {
-	HI_U32 u32ExposureTime;  /*RO,  Range: [0x0, 0xFFFF] */
-	HI_U32 u32AnalogGain;	/*RO,Range: [0x0, 0xFFFFFFFF] */
-	HI_U32 u32DigitalGain;	/*RO,Range: [0x0, 0xFFFFFFFF] */
-    HI_U32 u32ISPDigitalGain;	/*RO,Range: [0x0, 0xFFFFFFFF] */
-	HI_U32 u32Exposure;			/*RO,Range: [0x0, 0xFFFFFFFF] */
-	HI_U16 u16AE_Hist256Value[256];		/*RO, 256 bins histogram */
-	HI_U16 u16AE_Hist5Value[5];			/*RO, 5 bins histogram */
-	HI_U8 u8AveLum;					    /*RO, Range: [0x0, 0xFF]*/
-	HI_BOOL bExposureIsMAX;
+    HI_U32 u32ExposureTime;         /*RO,  Range: [0x0, 0xFFFF] */
+    HI_U32 u32AnalogGain;	        /*RO,Range: [0x0, 0xFFFFFFFF] */
+    HI_U32 u32DigitalGain;	        /*RO,Range: [0x0, 0xFFFFFFFF] */
+    HI_U32 u32ISPDigitalGain;	    /*RO,Range: [0x0, 0xFFFFFFFF] */
+    HI_U32 u32Exposure;			    /*RO,Range: [0x0, 0xFFFFFFFF] */
+    HI_U16 u16AE_Hist256Value[256];	/*RO, 256 bins histogram */
+    HI_U16 u16AE_Hist5Value[5];		/*RO, 5 bins histogram */
+    HI_U8  u8AveLum;			    /*RO, Range: [0x0, 0xFF]*/
+    HI_BOOL bExposureIsMAX;
 }ISP_INNER_STATE_INFO_EX_S;
-
-
-/*ISP debug information*/
-typedef struct hiISP_DEBUG_INFO_S
-{
-    HI_BOOL bAEDebugEnable;     /*RW, 1:enable AE debug, 0:disable AE debug*/
-    HI_U32 u32AEAddr;           /*RW, phy address of AE debug*/
-    HI_U32 u32AESize;           /*RO, */
-    
-    HI_BOOL bAWBDebugEnable;
-    HI_U32 u32AWBAddr;
-    HI_U32 u32AWBSize;
-
-    HI_BOOL bSysDebugEnable;
-    HI_U32 u32SysAddr;
-    HI_U32 u32SysSize;
-
-    HI_U32 u32DebugDepth;
-}ISP_DEBUG_INFO_S;
 
 /*Demosaic Attr*/
 typedef struct hiISP_DEMOSAIC_ATTR_S
 {
-    HI_U8   u8VhSlope;    /*RW,Range: [0x0, 0xFF] */
-    HI_U8   u8AaSlope;    /*RW,Range: [0x0, 0xFF] */
-    HI_U8   u8VaSlope;    /*RW,Range: [0x0, 0xFF] */
-    HI_U8   u8UuSlope;    /*RW,Range: [0x0, 0xFF] */
-    HI_U16  u16VhThresh;  /*RW,Range: [0x0, 0xFFFF] */   
-    HI_U16  u16AaThresh;  /*RW,Range: [0x0, 0xFFFF] */
-    HI_U16  u16VaThresh;  /*RW,Range: [0x0, 0xFFFF] */
-    HI_U16  u16UuThresh;  /*RW,Range: [0x0, 0xFFFF] */
-    HI_U8 u8DemosaicConfig; /*RW,Range: [0x0, 0xFF] */
-    HI_U8  u8LumThresh[8]; /*RW, Range:[0x0, 0xFF] */
-    HI_U8  u8NpOffset[8];  /*RW, Range:[0x0, 0xFF] */
-    
+    HI_U8   u8VhSlope;              /*RW,Range: [0x0, 0xFF] */
+    HI_U8   u8AaSlope;              /*RW,Range: [0x0, 0xFF] */
+    HI_U8   u8VaSlope;              /*RW,Range: [0x0, 0xFF] */
+    HI_U8   u8UuSlope;              /*RW,Range: [0x0, 0xFF] */
+    HI_U16  u16VhThresh;            /*RW,Range: [0x0, 0xFFFF] */   
+    HI_U16  u16AaThresh;            /*RW,Range: [0x0, 0xFFFF] */
+    HI_U16  u16VaThresh;            /*RW,Range: [0x0, 0xFFFF] */
+    HI_U16  u16UuThresh;            /*RW,Range: [0x0, 0xFFFF] */
+    HI_U8   u8DemosaicConfig;       /*RW,Range: [0x0, 0xFF] */
+    HI_U8   u8LumThresh[8];         /*RW, Range:[0x0, 0xFF] */
+    HI_U8   u8NpOffset[8];          /*RW, Range:[0x0, 0xFF] */
 }ISP_DEMOSAIC_ATTR_S;
+
+typedef struct hiISP_BLACK_LEVEL_S 
+{ 
+    HI_U16 au16BlackLevel[4]; /*RW, Range: [0x0, 0xFFF]*/ 
+} ISP_BLACK_LEVEL_S; 
+
+/*ISP debug information*/
+typedef struct hiISP_DEBUG_INFO_S
+{
+    HI_BOOL bDebugEn;       /*RW, 1:enable debug, 0:disable debug*/
+    HI_U32  u32PhyAddr;     /*RW, phy address of debug info */
+    HI_U32  u32Depth;       /*RW, depth of debug info */
+} ISP_DEBUG_INFO_S;
+
+typedef struct hiISP_DBG_ATTR_S
+{
+    HI_U32  u32Rsv;         /* need to add member */
+} ISP_DBG_ATTR_S;
+
+typedef struct hiISP_DBG_STATUS_S
+{
+    HI_U32  u32FrmNumBgn;
+    HI_U32  u32Rsv;         /* need to add member */
+    HI_U32  u32FrmNumEnd;
+} ISP_DBG_STATUS_S;
+
+typedef enum hiISP_SNS_TYPE_E
+{
+    ISP_SNS_I2C_TYPE = 0,
+    ISP_SNS_SSP_TYPE,
+    
+    ISP_SNS_TYPE_BUTT,
+} ISP_SNS_TYPE_E;
 
 typedef struct hiISP_I2C_DATA_S
 {
@@ -755,7 +820,6 @@ typedef struct hiISP_I2C_DATA_S
     HI_U32  u32AddrByteNum;
     HI_U32  u32Data;
     HI_U32  u32DataByteNum;
-
 } ISP_I2C_DATA_S;
 
 typedef struct hiISP_SSP_DATA_S
@@ -770,53 +834,36 @@ typedef struct hiISP_SSP_DATA_S
     HI_U32  u32DataByteNum;
 } ISP_SSP_DATA_S;
 
-#define SSP_DATA_REVERSE(value, bytenum)\
-do{\
-    HI_S32 i;\
-    HI_S32 reverse = 0;\
-    for(i=0;i<(bytenum*8);i++)\
-	{\
-		reverse = reverse + ((((value)>>i)&(0x01))<<((bytenum*8-1)-i));\
-	}\
-	value = reverse;\
-}while(0)
+typedef struct hiISP_SNS_REGS_INFO_S
+{
+    ISP_SNS_TYPE_E enSnsType;
+    HI_U32  u32RegNum;
+    HI_BOOL bDelayCfgIspDgain;
 
+    union
+    {
+        ISP_I2C_DATA_S astI2cData[ISP_MAX_SNS_REGS];
+        ISP_SSP_DATA_S astSspData[ISP_MAX_SNS_REGS];
+    };
+} ISP_SNS_REGS_INFO_S;
 
-typedef struct hiISP_BLACK_LEVEL_S 
-{ 
-    HI_U16 au16BlackLevel[4]; /*RW, Range: [0x0, 0xFFF]*/ 
-
-} ISP_BLACK_LEVEL_S; 
 typedef struct hiISP_VD_INFO_S
 {
   HI_U32  u32Reserved;          /*RO, Range: [0x0, 0xFFFFFFFF] */
 }ISP_VD_INFO_S;
 
-typedef struct hiISP_VD_TIMEOUT_S
+
+typedef struct hiISP_REG_ATTR_S
 {
-   ISP_VD_INFO_S stVdInfo;
-   HI_U32  u32MilliSec;   /*RW, Range: [0x0, 0xFFFFFFFF], the number of the */
-   HI_S32  s32IntStatus;   /*RO, when there is ISP interrupt, then the s32IntStatus is 1 */
-}ISP_VD_TIMEOUT_S;
-
-
-#define ISP_CHECK_POINTER(ptr)\
-    do {\
-        if (NULL == ptr)\
-        {\
-        	HI_PRINT("Null Pointer!\n");\
-            return HI_ERR_ISP_NULL_PTR;\
-        }\
-    }while(0)
-    
-#define ISP_CHECK_BOOL(bool)\
-    do {\
-        if (( HI_TRUE != bool)&&( HI_FALSE != bool))\
-        {\
-            HI_PRINT("Invalid Isp Bool Type %d in %s!\n", bool, __FUNCTION__);\
-            return HI_ERR_ISP_ILLEGAL_PARAM;\
-        }\
-    }while(0)  
+    HI_U32 u32IspRegAddr;
+    HI_U32 u32IspRegSize;
+    HI_U32 u32IspExtRegAddr;
+    HI_U32 u32IspExtRegSize;
+    HI_U32 u32AeExtRegAddr;
+    HI_U32 u32AeExtRegSize;
+    HI_U32 u32AwbExtRegAddr;
+    HI_U32 u32AwbExtRegSize;
+} ISP_REG_ATTR_S;
 
 
 #ifdef __cplusplus

--- a/kernel/include/hi3516cv100/hi_comm_sns.h
+++ b/kernel/include/hi3516cv100/hi_comm_sns.h
@@ -7,7 +7,7 @@
   Version       : Initial Draft
   Author        : Hisilicon multimedia software group
   Created       : 2011/01/05
-  Description   :
+  Description   : 
   History       :
   1.Date        : 2011/01/05
     Author      : x00100808
@@ -19,7 +19,7 @@
 #define __HI_COMM_SNS_H__
 
 #include "hi_type.h"
-#include "hi_comm_isp.h"
+#include "hi_common.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -27,282 +27,175 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-#define CMOS_SHADING_TABLE_NODE_NUMBER_MAX (129)
-
-
-typedef struct cmos_inttime_
+typedef struct hiISP_CMOS_BLACK_LEVEL_S
 {
-	/* Public */
-	HI_U16 exp_ratio;
-	HI_U16 vblanking_lines;
-	HI_U32 exposure_ashort;
-	HI_U32 exposure_along;
-	HI_U32 flicker_freq;
-	HI_U8  exposure_shift;
-
-	/* Private */
-	HI_U16 full_lines_std;
-	HI_U16 full_lines_std_30fps;
-	HI_U16 full_lines_std_25fps;
-	HI_U16 full_lines;
-	HI_U16 full_lines_del;
-	HI_U16 full_lines_limit;
-	HI_U16 exp_ratio_target;
-	HI_U16 max_lines_target;
-	HI_U16 max_lines;
-	HI_U16 min_lines_target;
-	HI_U16 min_lines;
-	HI_U16 lines_per_500ms;
-    HI_U16 slow_framerate;
-} cmos_inttime_t;
-
-typedef struct cmos_inttime_ * cmos_inttime_ptr_t;
-typedef struct cmos_inttime_ * cmos_inttime_const_ptr_t;
-
-typedef struct cmos_isp_agc_table_
-{
-    HI_U8 sharpen_alt_d[8];         /* adjust image edge, different ISO with different sharp strength */
-    HI_U8 sharpen_alt_ud[8];        /* adjust image texture, different ISO with different strength */
-    HI_U8 snr_thresh[8];            /* adjust denoise strength, different ISO with different strength */
-    HI_U8 demosaic_lum_thresh[8];
-    HI_U8 demosaic_np_offset[8];
-    HI_U8 ge_strength[8];
-    HI_U8 saturation[8];            /* adjust saturation, different ISO with different saturation */    
-} cmos_isp_agc_table_t;
-
-typedef struct cmos_isp_agc_table_ * cmos_isp_agc_table_ptr_t;
-typedef const struct cmos_isp_agc_table_ * cmos_isp_agc_table_const_ptr_t;
-
-
-typedef struct cmos_isp_noise_table_
-{
-    HI_U8 noise_profile_weight_lut[128];
-    HI_U8 demosaic_weight_lut[128];
-} cmos_isp_noise_table_t;
-
-typedef struct cmos_isp_noise_table_ * cmos_isp_noise_table_ptr_t;
-typedef const struct cmos_isp_noise_table_ * cmos_isp_noise_table_const_ptr_t;
-
-typedef struct cmos_isp_demosaic_
-{
-    HI_U8   vh_slope;
-    HI_U8   aa_slope;
-    HI_U8   va_slope;
-    HI_U8   uu_slope;
-    HI_U8   sat_slope;
-    HI_U8   ac_slope;
-    HI_U16  vh_thresh;
-    HI_U16  aa_thresh;
-    HI_U16  va_thresh;
-    HI_U16  uu_thresh;
-    HI_U16  sat_thresh;
-    HI_U16  ac_thresh;
-}cmos_isp_demosaic_t;
-
-typedef struct cmos_isp_demosaic_ * cmos_isp_demosaic_ptr_t;
-typedef const struct cmos_isp_demosaic_ * cmos_isp_demosaic_const_ptr_t;
-
-
-typedef struct cmos_gains_
-{
-	/* Public */
-	HI_U32 dgain;
-	HI_U32 again;
-	HI_U32 isp_dgain;
-	HI_U32 iso;
-	HI_U32 dgain_db;
-	HI_U32 again_db;
-	HI_U32 dgain_fine;
-	HI_U16 out_offset_1;
-	HI_U16 out_offset_2;
-
-	/* Private */
-    HI_U32 max_system_gain_target;
-    HI_U32 max_system_gain_shift;
-	HI_U32 min_system_gain_target;
-    HI_U32 min_system_gain_shift;
-    HI_U32 low_noise_gain_threshold;
-
-	HI_U32 max_again_target;
-	HI_U32 max_dgain_target;
-	HI_U32 max_isp_dgain_target;
-	HI_U32 max_again;
-	HI_U32 max_dgain;
-    HI_U32 max_ispdgain;
-	HI_U32 min_again_target;
-	HI_U32 min_dgain_target;
-    HI_U32 min_isp_dgain_target;
+    HI_BOOL bUpdate;
     
-	HI_U8  again_shift;
-	HI_U8  dgain_shift;
-	HI_U8  isp_dgain_shift; 
-	HI_U8  dgain_fine_shift;
-    HI_BOOL isp_dgain_delay_cfg;
-	HI_U32 dgain_offset;
-	HI_U32 max_dgain_step;
+    HI_U16  au16BlackLevel[4];
+} ISP_CMOS_BLACK_LEVEL_S;
 
-    HI_U32 max_adgain;
-
-} cmos_gains_t;
-
-typedef struct cmos_gains_ * cmos_gains_ptr_t;
-typedef const struct cmos_gains_ * cmos_gains_const_ptr_t;
-
-typedef struct cmos_isp_ccm_
+typedef struct hiISP_CMOS_AGC_TABLE_S
 {
-    HI_U16 u16HighColorTemp;    /*D50 lighting source is  recommended */
-    HI_U16 au16HighCCM[9];
-    HI_U16 u16MidColorTemp;     /*D32 lighting source is  recommended */
-    HI_U16 au16MidCCM[9];
-    HI_U16 u16LowColorTemp;     /*A lighting source is  recommended */
-    HI_U16 au16LowCCM[9];
-} cmos_isp_ccm_t;
+    HI_BOOL bValid;
+    
+    HI_U8   au8SharpenAltD[8];          /* adjust image edge,different iso with different sharp strength */
+    HI_U8   au8SharpenAltUd[8];         /* adjust image texture, different iso with different strength */
+    HI_U8   au8SnrThresh[8];            /* adjust denoise strength, different iso with different strength */
+    HI_U8   au8DemosaicLumThresh[8];  
+    HI_U8   au8DemosaicNpOffset[8];
+    HI_U8   au8GeStrength[8];
+} ISP_CMOS_AGC_TABLE_S;
 
-typedef struct cmos_isp_ccm_ * cmos_isp_ccm_ptr_t;
-typedef const struct cmos_isp_ccm_ * cmos_isp_ccm_const_ptr_t;
-
-typedef struct cmos_isp_shading_table_
+typedef struct hiISP_CMOS_NOISE_TABLE_S
 {
-    HI_U16 shading_center_r_x;
-    HI_U16 shading_center_r_y;
-    HI_U16 shading_center_g_x;
-    HI_U16 shading_center_g_y;
-    HI_U16 shading_center_b_x;
-    HI_U16 shading_center_b_y;
+    HI_BOOL bValid;
+    
+    HI_U8   au8NoiseProfileWeightLut[128];
+    HI_U8   au8DemosaicWeightLut[128];
+} ISP_CMOS_NOISE_TABLE_S;
 
-	HI_U16 shading_table_r[CMOS_SHADING_TABLE_NODE_NUMBER_MAX];
-	HI_U16 shading_table_g[CMOS_SHADING_TABLE_NODE_NUMBER_MAX];
-	HI_U16 shading_table_b[CMOS_SHADING_TABLE_NODE_NUMBER_MAX];
-
-    HI_U16 shading_off_center_r;
-    HI_U16 shading_off_center_g;
-    HI_U16 shading_off_center_b;
-
-    HI_U16 shading_table_node_number;
-} cmos_isp_shading_table_t;
-
-typedef struct cmos_isp_shading_table_ * cmos_isp_shading_table_ptr_t;
-typedef const struct cmos_isp_shading_table_ * cmos_isp_shading_table_const_ptr_t;
-
-typedef struct cmos_isp_gamma_table_
+typedef struct hiISP_CMOS_DEMOSAIC_S
 {
-    HI_U16 gamma_table[GAMMA_NODE_NUMBER];
-}cmos_isp_gamma_table_t;
+    HI_BOOL bValid;
+    
+    HI_U8   u8VhSlope;
+    HI_U8   u8AaSlope;
+    HI_U8   u8VaSlope;
+    HI_U8   u8UuSlope;
+    HI_U8   u8SatSlope;
+    HI_U8   u8AcSlope;
+    HI_U16  u16VhThresh;
+    HI_U16  u16AaThresh;
+    HI_U16  u16VaThresh;
+    HI_U16  u16UuThresh;
+    HI_U16  u16SatThresh;
+    HI_U16  u16AcThresh;
+} ISP_CMOS_DEMOSAIC_S;
 
-typedef struct cmos_isp_gamma_table_ * cmos_isp_gamma_table_ptr_t;
-typedef const struct cmos_isp_gamma_table_ * cmos_isp_gamma_table_const_ptr_t;
-
-typedef struct cmos_isp_default_
+typedef struct hiISP_CMOS_DRC_S
 {
-	cmos_isp_ccm_t ccm;
+    HI_U8   u8DrcBlack;
+    HI_U8   u8DrcVs;         /* variance space */
+    HI_U8   u8DrcVi;         /* variance intensity */
+    HI_U8   u8DrcSm;         /* slope max */
+    HI_U16  u16DrcWl;        /* white level */
+} ISP_CMOS_DRC_S;
 
-	HI_U16 black_level[4];		// black level
-
-	HI_U16 wb_ref_temp;          //reference color temperature for WB
-
-	HI_U16 gain_offset[4];		// gain offset for white balance
-
-	HI_S32 wb_para[6];          //parameter for wb curve
-
-	HI_U8 hist_thresh[4];		// hist threshold
-
-	HI_U8 iridix_black;
-	HI_U8 rggb;					// rggb start sequence
-
-	HI_U16 again_max;
-	HI_U16 dgain_max;
-
-	HI_U8 iridix_vs;			// variance space
-	HI_U8 iridix_vi;			// variance intensity
-	HI_U8 iridix_sm;			// slope max
-	HI_U16 iridix_wl;			// white level
-
-	HI_U8 balance_fe;
-	HI_U8 ae_compensation;		// ae compensation
-	HI_U8 sinter_thresh;		// sinter threshold
-
-    //add by z54137. We support two methods to generate noise profile lut.
-    //noise_profile = 0 is for original one, noise_profile = 1 is for latest one.
-	HI_U8 noise_profile;        //two different noise profile
-	HI_U16 nr0;		            //nr0 for noise profile 2
-	HI_U16 nr1;		            //nr1 for noise profile 2
-
-    HI_U16 frame_end_update_mode;//enFrameEndUpdateMode
-} cmos_isp_default_t;
-
-typedef struct cmos_isp_default_ * cmos_isp_default_ptr_t;
-
-typedef enum coms_isp_special_alg_
+#define LUT_FACTOR (8)
+#define GAMMA_FE_LUT_SIZE ((1<<LUT_FACTOR)+1)
+typedef struct hiISP_CMOS_GAMMAFE_S
 {
-	isp_special_alg_0 = 0,		// for altasens only
-    isp_special_alg_m034_lin,   // for aptm034 linear only
-	isp_special_alg_m034_wdr,   // for aptm034 wdr only
-	isp_special_alg_ar0331_lin,   // for aptar0331 linear only
-	isp_special_alg_ar0331_wdr,   // for aptar0331 wdr only
-	isp_special_alg_awb,  // for sony only
-    isp_special_alg_imx104_lin,
-    isp_special_alg_imx104_wdr,
-	isp_special_alg_butt
-} coms_isp_special_alg_e;
+    HI_BOOL bValid;         /* wdr sensor should set */
+    
+    HI_U16  au16Gammafe[GAMMA_FE_LUT_SIZE];
+} ISP_CMOS_GAMMAFE_S;
 
-
-
-typedef struct cmos_sensor_max_resolution_
+typedef struct hiISP_CMOS_DENOISE_S
 {
-    HI_U32  u32MaxWidth;
-    HI_U32  u32MaxHeight;
+    HI_U8   u8SinterThresh;     /* sinter threshold */
+    
+    HI_U8   u8NoiseProfile;     /* two different noise profile */ 
+    HI_U16  u16Nr0;             /* nr0 for noise profile 2 */
+    HI_U16  u16Nr1;             /* nr1 for noise profile 2 */
+} ISP_CMOS_DENOISE_S;
 
-}cmos_sensor_max_resolution_t;
-
-typedef struct cmos_sensor_max_resolution_ * cmos_sensor_max_resolution_ptr_t;
-
-
-typedef struct cmos_sensor_image_mode_
+typedef struct hiISP_CMOS_COMM_S
 {
-    HI_U16 u16Width;
-    HI_U16 u16Height;
-    HI_U16 u16Fps;
+    HI_U8   u8Rggb;             /* rggb start sequence */    
+    HI_U8   u8BalanceFe;
+} ISP_CMOS_COMM_S;
 
-}cmos_sensor_image_mode_t;
-
-typedef struct cmos_sensor_image_mode_ * cmos_sensor_image_mode_ptr_t;
-
-
-/* Sensor Control Operation */
-typedef struct hiSENSOR_EXP_FUNC_S
+#define CMOS_SHADING_TABLE_NODE_NUMBER_MAX (129)
+typedef struct hiISP_CMOS_SHADING_S
 {
-    cmos_inttime_const_ptr_t (*pfn_cmos_inttime_initialize)(void);
-    void (*pfn_cmos_inttime_update)				(cmos_inttime_ptr_t p_inttime);
+    HI_BOOL bValid;
+    
+    HI_U16 u16RCenterX;
+    HI_U16 u16RCenterY;
+    HI_U16 u16GCenterX;
+    HI_U16 u16GCenterY;
+    HI_U16 u16BCenterX;
+    HI_U16 u16BCenterY;
 
-    cmos_gains_ptr_t (*pfn_cmos_gains_initialize)(void);
-    void (*pfn_cmos_gains_update)						(cmos_gains_const_ptr_t p_gains);
-    HI_U16 (*pfn_cmos_gains_update2)					(cmos_gains_const_ptr_t p_gains);
-    HI_U32 (*pfn_analog_gain_from_exposure_calculate)	(cmos_gains_ptr_t p_gains, HI_U32 exposure, HI_U32 exposure_max, HI_U32 exposure_shift);
-    HI_U32 (*pfn_digital_gain_from_exposure_calculate)	(cmos_gains_ptr_t p_gains, HI_U32 exposure, HI_U32 exposure_max, HI_U32 exposure_shift);
-    HI_U32 (*pfn_isp_digital_gain_from_exposure_calculate)	(cmos_gains_ptr_t p_gains, HI_U32 exposure, HI_U32 exposure_max, HI_U32 exposure_shift);
+    HI_U16 au16RShadingTbl[CMOS_SHADING_TABLE_NODE_NUMBER_MAX];
+    HI_U16 au16GShadingTbl[CMOS_SHADING_TABLE_NODE_NUMBER_MAX];
+    HI_U16 au16BShadingTbl[CMOS_SHADING_TABLE_NODE_NUMBER_MAX];
 
-    void (*pfn_cmos_fps_set)				(cmos_inttime_ptr_t p_inttime, const HI_U8 fps);
-    HI_U16 (*pfn_vblanking_calculate)		(cmos_inttime_ptr_t p_inttime);
-    void (*pfn_cmos_vblanking_front_update)	(cmos_inttime_const_ptr_t p_inttime);
+    HI_U16 u16ROffCenter;
+    HI_U16 u16GOffCenter;
+    HI_U16 u16BOffCenter;
 
-    void (*pfn_setup_sensor)(int isp_mode);
-    HI_U8 (*pfn_cmos_get_analog_gain)(cmos_gains_ptr_t cmos_gains);
-    HI_U8 (*pfn_cmos_get_digital_gain)(cmos_gains_ptr_t cmos_gains);
-    HI_U8 (*pfn_cmos_get_digital_fine_gain)(cmos_gains_ptr_t cmos_gains);
-    HI_U32 (*pfn_cmos_get_iso)(cmos_gains_ptr_t cmos_gains);
+    HI_U16 u16TblNodeNum;
+} ISP_CMOS_SHADING_S;
 
-    HI_U32 (*pfn_cmos_get_isp_default)(cmos_isp_default_ptr_t p_coms_isp_default);
-    HI_U32 (*pfn_cmos_get_isp_special_alg)(void);
-    HI_U32 (*pfn_cmos_get_isp_agc_table)(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table);
-    HI_U32 (*pfn_cmos_get_isp_noise_table)(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table);
-    HI_U32 (*pfn_cmos_get_isp_demosaic)(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic);
-    HI_U32 (*pfn_cmos_get_isp_shading_table)(cmos_isp_shading_table_ptr_t p_cmos_isp_shading_table);
-    HI_U32 (*pfn_cmos_get_isp_gamma_table)(cmos_isp_gamma_table_ptr_t p_cmos_isp_gamma_table);
-    HI_S32 (*pfn_cmos_get_sensor_max_resolution)(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution);
-    HI_S32 (*pfn_cmos_set_sensor_image_mode)(cmos_sensor_image_mode_ptr_t p_cmos_sensor_image_mode);
-    // ...
+#define GAMMA_NODE_NUMBER   257
+typedef struct hiISP_CMOS_GAMMA_S
+{
+    HI_BOOL bValid;
+    
+    HI_U16  au16Gamma[GAMMA_NODE_NUMBER];
+} ISP_CMOS_GAMMA_S;
 
-} SENSOR_EXP_FUNC_S;
+typedef struct hiISP_CMOS_DEFAULT_S
+{    
+    ISP_CMOS_COMM_S         stComm;
+    ISP_CMOS_DENOISE_S      stDenoise;
+    ISP_CMOS_DRC_S          stDrc;
+    ISP_CMOS_AGC_TABLE_S    stAgcTbl;
+    ISP_CMOS_NOISE_TABLE_S  stNoiseTbl;
+    ISP_CMOS_DEMOSAIC_S     stDemosaic;
+    ISP_CMOS_GAMMAFE_S      stGammafe;
+    ISP_CMOS_GAMMA_S        stGamma;
+    ISP_CMOS_SHADING_S      stShading;
+} ISP_CMOS_DEFAULT_S;
+
+typedef enum hiISP_CMOS_MODE_E
+{
+    ISP_CMOS_MODE_PIXEL_DETECT = 0,
+    ISP_CMOS_MODE_WDR,
+    ISP_CMOS_MODE_RESOLUTION,
+
+    ISP_CMOS_MODE_BUTT,
+} ISP_CMOS_MODE_E;
+
+typedef struct hiISP_CMOS_SENSOR_MAX_RESOLUTION_S
+{
+  HI_U32  u32MaxWidth;
+  HI_U32  u32MaxHeight;
+
+}ISP_CMOS_SENSOR_MAX_RESOLUTION;
+
+
+typedef struct hiISP_CMOS_SENSOR_IMAGE_MODE_S
+{
+  HI_U16 u16Width;
+  HI_U16 u16Height;
+  HI_U16 u16Fps;
+  
+}ISP_CMOS_SENSOR_IMAGE_MODE;
+
+
+typedef struct hiISP_SENSOR_EXP_FUNC_S
+{
+    HI_VOID(*pfn_cmos_sensor_init)(HI_VOID);
+    HI_VOID(*pfn_cmos_sensor_global_init)(HI_VOID);
+    /* the algs get data which is associated with sensor, except 3a */
+    HI_U32(*pfn_cmos_get_isp_default)(ISP_CMOS_DEFAULT_S *pstDef);
+    HI_U32(*pfn_cmos_get_isp_black_level)(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel);
+    HI_S32(*pfn_cmos_get_sensor_max_resolution)(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution);
+
+    /* the function of sensor set pixel detect */
+    HI_VOID(*pfn_cmos_set_pixel_detect)(HI_BOOL bEnable);
+    HI_VOID(*pfn_cmos_set_wdr_mode)(HI_U8 u8Mode);
+    HI_VOID(*pfn_cmos_set_resolution)(HI_U32 u32ResolutionMode);
+    HI_S32(*pfn_cmos_set_image_mode)(ISP_CMOS_SENSOR_IMAGE_MODE *pstSensorImageMode);
+  
+} ISP_SENSOR_EXP_FUNC_S;
+
+typedef struct hiISP_SENSOR_REGISTER_S
+{
+    ISP_SENSOR_EXP_FUNC_S stSnsExp;
+} ISP_SENSOR_REGISTER_S;
 
 
 #ifdef __cplusplus

--- a/kernel/include/hi3516cv100/hi_isp_debug.h
+++ b/kernel/include/hi3516cv100/hi_isp_debug.h
@@ -18,7 +18,6 @@
 #ifndef __HI_ISP_DEBUG_H__
 #define __HI_ISP_DEBUG_H__
 
-#include <stdio.h>
 #include "hi_debug.h"
 
 #if 0
@@ -29,63 +28,14 @@
 #define PRINT_INFO_2FILE
 #endif
 
-#define HI_ID_ISP	10
-
-#define DEBUG_POS	printf("file:%s,line:%d\r\n",__FILE__,__LINE__);
-
 #define ISP_TRACE(level, fmt...)\
     do{ \
             HI_TRACE(level,HI_ID_ISP,"[Func]:%s [Line]:%d [Info]:",__FUNCTION__, __LINE__);\
             HI_TRACE(level,HI_ID_ISP,##fmt);\
     }while(0)
 
-
-#define HI_PRINT	printf
-
 /* To avoid divide-0 exception in code. */
-#define DIV_0_TO_1(a)   ( (0 == a) ? 1 : a )
+#define DIV_0_TO_1(a)   ( (0 == (a)) ? 1 : (a) )
 
-#ifndef MAX
-#define MAX(a, b) (((a) < (b)) ?  (b) : (a))
-#endif
-
-#ifndef MIN
-#define MIN(a, b) (((a) > (b)) ?  (b) : (a))
-#endif
-
-#ifndef ABS
-#define ABS(x) (((x) < 0) ? -(x) : (x))
-#endif
-
-#ifndef POW2
-#define POW2(a) ((a) * (a))
-#endif
-
-
-/* WR_TXT_FILE
- * pStream: start address of write. 
- * size: how long to write, unit may be 8/16/32 according to sizeof(pStream).
- * file_name: must be string.
- * */
-#define WR_TXT_FILE(pStream,size,file_name) \
-    do\
-    {\
-        FILE* pFile;\
-        pFile = fopen(file_name, "wt");\
-        if (HI_NULL == pFile)\
-        {\
-            printf("open file err\n");\
-        }\
-        else\
-        {\
-            int i;\
-            for(i = 0; i < size; i++)\
-            {\
-                fprintf(pFile, "%d\n", pStream[i]);\
-            }\
-            fclose(pFile);\
-        }\
-    }while(0)
-
-#endif 	/* __HI_ISP_DEBUG_H__ */    		
+#endif     /* __HI_ISP_DEBUG_H__ */            
 

--- a/kernel/include/hi3516cv100/hi_sns_ctrl.h
+++ b/kernel/include/hi3516cv100/hi_sns_ctrl.h
@@ -18,6 +18,7 @@
 #ifndef __HI_SNS_CTRL_H__
 #define __HI_SNS_CTRL_H__
 
+#include "hi_type.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -31,7 +32,8 @@ int  sensor_write_register(int addr, int data);
 int  sensor_read_register(int addr);
 int  sensor_write_register_bit(int addr, int data, int mask);
 int  sensor_register_callback(void); 
-int  sensor_mode_set(HI_U8 u8Mode);
+int sensor_unregister_callback(void);
+
 
 #ifdef __cplusplus
 #if __cplusplus

--- a/kernel/include/hi3516cv100/hi_vreg.h
+++ b/kernel/include/hi3516cv100/hi_vreg.h
@@ -1,0 +1,96 @@
+/******************************************************************************
+
+  Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : hi_vreg.h
+  Version       : Initial Draft
+  Author        : Hisilicon multimedia software group
+  Created       : 2013/01/09
+  Description   : 
+  History       :
+  1.Date        : 2013/01/09
+    Author      : n00168968
+    Modification: Created file
+
+******************************************************************************/
+
+#ifndef __HI_VREG_H__
+#define __HI_VREG_H__
+
+#include "hi_type.h"
+#include "hi_comm_isp.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#define REG_ACCESS_WIDTH_1  0
+#define REG_ACCESS_WIDTH    0                /* 1: 16bit   2: 8bit */
+
+/* Vreg is a blok of memory alloced to simulate the regs.
+ * We try to differentiate vregs by baseaddr.  Each vreg
+ * block's size should at least 4k bytes.
+ */
+ /*---------------------------------------------------------------------------------------------------------*
+  *| 0x205A0000 |  0x10000  |  0x20000 |  0x21000 | ... |  0x30000  | ... |  0x40000 | ... |  0x80000 | ...|*
+  *|------------|-----------|----------|----------|-----|-----------|-----|----------|-----|----------|----|*
+  *|   ISP_REG  |  ISP_VREG | AE1_VREG | AE2_VREG | ... | AWB1_VREG | ... | AF1_VREG | ... | VIU_VREG | ...|*
+  *---------------------------------------------------------------------------------------------------------*/
+#define VREG_SIZE_ALIGN 0x1000
+
+#define EXT_REG_BASE    0x10000
+
+#define ISP_VREG_BASE   0x10000
+#define ISP_VREG_SIZE   (VREG_SIZE_ALIGN << 4)
+
+#define AE_LIB_VREG_BASE(id)    (0x20000 + VREG_SIZE_ALIGN * (id))
+#define AWB_LIB_VREG_BASE(id)   (0x30000 + VREG_SIZE_ALIGN * (id))
+#define AF_LIB_VREG_BASE(id)    (0x40000 + VREG_SIZE_ALIGN * (id))
+#define ALG_LIB_VREG_SIZE       (VREG_SIZE_ALIGN)
+#define MAX_ALG_LIB_VREG_NUM    (1 << 4)
+
+#define HISI_AE_LIB_EXTREG_ID_0 0
+#define HISI_AE_LIB_EXTREG_ID_1 1
+
+#define HISI_AWB_LIB_EXTREG_ID_0 0
+#define HISI_AWB_LIB_EXTREG_ID_1 1
+
+#define VIU_VREG_BASE   0x80000
+#define VPP_VREG_BASE   0x90000
+#define VEDU_VREG_BASE  0xa0000
+#define VOU_VREG_BASE   0xb0000
+
+HI_S32 VReg_Init(HI_U32 u32BaseAddr, HI_U32 u32Size);
+HI_S32 VReg_Exit(HI_U32 u32BaseAddr, HI_U32 u32Size);
+HI_U32 VReg_GetVirtAddr(HI_U32 u32BaseAddr);
+HI_VOID VReg_Munmap(HI_VOID);
+HI_U32 IO_READ32(HI_U32 u32Addr);
+HI_S32 IO_WRITE32(HI_U32 u32Addr, HI_U32 u32Value);
+HI_U16 IO_READ16(HI_U32 u32Addr);
+HI_S32 IO_WRITE16(HI_U32 u32Addr, HI_U32 u32Value);
+HI_U8  IO_READ8(HI_U32 u32Addr);
+HI_S32 IO_WRITE8(HI_U32 u32Addr, HI_U32 u32Value);
+
+/* Dynamic bus access functions, 4 byte align access */
+//TODO: allocate dev addr (such as ISP_REG_BASE_ADDR) according to devId.
+#define __IO_CALC_ADDRESS_DYNAMIC(BASE)    (HI_U32)(((BASE >= EXT_REG_BASE) ? 0 : ISP_REG_BASE) + (BASE))
+
+#define IORD_32DIRECT(BASE)             IO_READ32(__IO_CALC_ADDRESS_DYNAMIC(BASE))
+#define IORD_16DIRECT(BASE)             IO_READ16(__IO_CALC_ADDRESS_DYNAMIC(BASE))
+#define IORD_8DIRECT(BASE)              IO_READ8(__IO_CALC_ADDRESS_DYNAMIC(BASE))
+
+#define IOWR_32DIRECT(BASE, DATA)       IO_WRITE32(__IO_CALC_ADDRESS_DYNAMIC(BASE), (DATA))
+#define IOWR_16DIRECT(BASE, DATA)       IO_WRITE16(__IO_CALC_ADDRESS_DYNAMIC(BASE), (DATA))
+#define IOWR_8DIRECT(BASE, DATA)        IO_WRITE8(__IO_CALC_ADDRESS_DYNAMIC(BASE), (DATA))
+
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#endif

--- a/kernel/include/hi3516cv100/mpi_ae.h
+++ b/kernel/include/hi3516cv100/mpi_ae.h
@@ -1,0 +1,97 @@
+/******************************************************************************
+
+  Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : mpi_ae.h
+  Version       : Initial Draft
+  Author        : Hisilicon multimedia software group
+  Created       : 2012/12/19
+  Description   : 
+  History       :
+  1.Date        : 2012/12/19
+    Author      : n00168968
+    Modification: Created file
+
+******************************************************************************/
+#ifndef __MPI_AE_H__
+#define __MPI_AE_H__
+
+#include "hi_comm_isp.h"
+#include "hi_comm_3a.h"
+#include "hi_ae_comm.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+/* The interface of ae lib register to isp. */
+HI_S32 HI_MPI_AE_Register(ALG_LIB_S *pstAeLib);
+HI_S32 HI_MPI_AE_UnRegister(ALG_LIB_S *pstAeLib);
+
+/* The callback function of sensor register to ae lib. */
+HI_S32 HI_MPI_AE_SensorRegCallBack(ALG_LIB_S *pstAeLib, SENSOR_ID SensorId,
+    AE_SENSOR_REGISTER_S *pstRegister);
+HI_S32 HI_MPI_AE_SensorUnRegCallBack(ALG_LIB_S *pstAeLib, SENSOR_ID SensorId);
+
+/* The new ae lib is compatible with the old mpi interface. */
+HI_S32 HI_MPI_ISP_SetExposureType(ISP_OP_TYPE_E enExpType);
+HI_S32 HI_MPI_ISP_GetExposureType(ISP_OP_TYPE_E *penExpType);
+
+HI_S32 HI_MPI_ISP_SetAEAttr(const ISP_AE_ATTR_S *pstAEAttr);
+HI_S32 HI_MPI_ISP_GetAEAttr(ISP_AE_ATTR_S *pstAEAttr);
+
+HI_S32 HI_MPI_ISP_SetAEAttrEx(const ISP_AE_ATTR_EX_S *pstAEAttrEx);
+HI_S32 HI_MPI_ISP_GetAEAttrEx(ISP_AE_ATTR_EX_S *pstAEAttrEx);
+
+HI_S32 HI_MPI_ISP_SetExpStaInfo(ISP_EXP_STA_INFO_S *pstExpStatistic);
+HI_S32 HI_MPI_ISP_GetExpStaInfo(ISP_EXP_STA_INFO_S *pstExpStatistic);
+
+HI_S32 HI_MPI_ISP_SetMEAttr(const ISP_ME_ATTR_S *pstMEAttr);
+HI_S32 HI_MPI_ISP_GetMEAttr(ISP_ME_ATTR_S *pstMEAttr);
+
+HI_S32 HI_MPI_ISP_SetMEAttrEx(const ISP_ME_ATTR_EX_S *pstMEAttrEx);
+HI_S32 HI_MPI_ISP_GetMEAttrEx(ISP_ME_ATTR_EX_S *pstMEAttrEx);
+
+HI_S32 HI_MPI_ISP_SetSlowFrameRate(HI_U8 u8Value);
+HI_S32 HI_MPI_ISP_GetSlowFrameRate(HI_U8 *pu8Value);
+
+HI_S32 HI_MPI_ISP_SetAntiFlickerAttr(const ISP_ANTIFLICKER_S *pstAntiflicker);
+HI_S32 HI_MPI_ISP_GetAntiFlickerAttr(ISP_ANTIFLICKER_S *pstAntiflicker);
+
+HI_S32 HI_MPI_ISP_SetSubFlickerAttr(const ISP_SUBFLICKER_S *pstSubflicker);
+HI_S32 HI_MPI_ISP_GetSubFlickerAttr(ISP_SUBFLICKER_S *pstSubflicker);
+
+HI_S32 HI_MPI_ISP_SetDcirisAttr(const ISP_DCIRIS_ATTR_S *pstDcirisAttr);
+HI_S32 HI_MPI_ISP_GetDcirisAttr(ISP_DCIRIS_ATTR_S *pstDcirisAttr);
+
+HI_S32 HI_MPI_ISP_QueryInnerStateInfo(ISP_INNER_STATE_INFO_S *pstInnerStateInfo);
+HI_S32 HI_MPI_ISP_QueryInnerStateInfoEx(ISP_INNER_STATE_INFO_EX_S *pstInnerStateInfoEx);
+
+HI_S32 HI_MPI_ISP_SetIrisType(ISP_OP_TYPE_E enIrisType);        //not support yet
+HI_S32 HI_MPI_ISP_GetIrisType(ISP_OP_TYPE_E *penIrisType);      //not support yet
+
+HI_S32 HI_MPI_ISP_SetAIAttr(const ISP_AI_ATTR_S *pstAIAttr);
+HI_S32 HI_MPI_ISP_GetAIAttr(ISP_AI_ATTR_S *pstAIAttr);
+
+HI_S32 HI_MPI_ISP_SetMIAttr(const ISP_MI_ATTR_S *pstMIAttr);    //not support yet
+HI_S32 HI_MPI_ISP_GetMIAttr(ISP_MI_ATTR_S *pstMIAttr);          //not support yet
+
+HI_S32 HI_MPI_ISP_SetAERouteAttr(const ISP_AE_ROUTE_S *pstAERouteAttr);
+HI_S32 HI_MPI_ISP_GetAERouteAttr(ISP_AE_ROUTE_S *pstAERouteAttr);
+
+HI_S32 HI_MPI_ISP_SetAEDelayAttr(const ISP_AE_DELAY_S *pstAEDelayAttr);
+HI_S32 HI_MPI_ISP_GetAEDelayAttr(ISP_AE_DELAY_S *pstAEDelayAttr);
+
+
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#endif
+

--- a/kernel/include/hi3516cv100/mpi_af.h
+++ b/kernel/include/hi3516cv100/mpi_af.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+
+  Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : mpi_af.h
+  Version       : Initial Draft
+  Author        : Hisilicon multimedia software group
+  Created       : 2012/12/19
+  Description   : 
+  History       :
+  1.Date        : 2012/12/19
+    Author      : n00168968
+    Modification: Created file
+
+******************************************************************************/
+#ifndef __MPI_AF_H__
+#define __MPI_AF_H__
+
+#include "hi_comm_isp.h"
+#include "hi_comm_3a.h"
+#include "hi_af_comm.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+/* The interface of af lib register to isp. */
+HI_S32 HI_MPI_AF_Register(ALG_LIB_S *pstAfLib);
+HI_S32 HI_MPI_AF_UnRegister(ALG_LIB_S *pstAfLib);
+
+#if 0
+/* The callback function of sensor register to af lib. */
+HI_S32 hi_af_sensor_register_cb(ALG_LIB_S *pstAfLib, SENSOR_ID SensorId,
+    CMOS_ISP_AF_DEFAULT_S *pstSnsDft, SENSOR_AF_EXP_FUNC_S *pstSnsExp);
+#endif
+
+/* The new awb lib is compatible with the old mpi interface. */
+HI_S32 HI_MPI_ISP_SetFocusType(ISP_OP_TYPE_E enFocusType);    //not support yet
+HI_S32 HI_MPI_ISP_GetFocusType(ISP_OP_TYPE_E *penFocusType);  //not support yet
+
+HI_S32 HI_MPI_ISP_SetAFAttr(const ISP_AF_ATTR_S *pstAFAttr);    //not support yet
+HI_S32 HI_MPI_ISP_GetAFAttr(ISP_AF_ATTR_S *pstAFAttr);          //not support yet
+
+HI_S32 HI_MPI_ISP_SetMFAttr(const ISP_MF_ATTR_S *pstMFAttr);    //not support yet
+HI_S32 HI_MPI_ISP_GetMFAttr(ISP_MF_ATTR_S *pstMFAttr);         //not support yet
+
+HI_S32 HI_MPI_ISP_ManualFocusMove(HI_S32 s32MoveSteps);    //not support yet
+
+HI_S32 HI_MPI_ISP_SetFocusStaInfo(const ISP_FOCUS_STA_INFO_S *pstFocusStatistic);
+HI_S32 HI_MPI_ISP_GetFocusStaInfo(ISP_FOCUS_STA_INFO_S *pstFocusStatistic);
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#endif
+

--- a/kernel/include/hi3516cv100/mpi_awb.h
+++ b/kernel/include/hi3516cv100/mpi_awb.h
@@ -1,0 +1,82 @@
+/******************************************************************************
+
+  Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : mpi_awb.h
+  Version       : Initial Draft
+  Author        : Hisilicon multimedia software group
+  Created       : 2012/12/19
+  Description   : 
+  History       :
+  1.Date        : 2012/12/19
+    Author      : n00168968
+    Modification: Created file
+
+******************************************************************************/
+#ifndef __MPI_AWB_H__
+#define __MPI_AWB_H__
+
+#include "hi_comm_isp.h"
+#include "hi_comm_3a.h"
+#include "hi_awb_comm.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+/* The interface of awb lib register to isp. */
+HI_S32 HI_MPI_AWB_Register(ALG_LIB_S *pstAwbLib);
+HI_S32 HI_MPI_AWB_UnRegister(ALG_LIB_S *pstAwbLib);
+
+/* The callback function of sensor register to awb lib. */
+HI_S32 HI_MPI_AWB_SensorRegCallBack(ALG_LIB_S *pstAwbLib, SENSOR_ID SensorId,
+    AWB_SENSOR_REGISTER_S *pstRegister);
+HI_S32 HI_MPI_AWB_SensorUnRegCallBack(ALG_LIB_S *pstAwbLib, SENSOR_ID SensorId);
+
+/* The new awb lib is compatible with the old mpi interface. */
+HI_S32 HI_MPI_ISP_SetWBType(ISP_OP_TYPE_E enWBType);
+HI_S32 HI_MPI_ISP_GetWBType(ISP_OP_TYPE_E *penWBType);
+
+HI_S32 HI_MPI_ISP_SetAWBAttr(const ISP_AWB_ATTR_S *pstAWBAttr);
+HI_S32 HI_MPI_ISP_GetAWBAttr(ISP_AWB_ATTR_S *pstAWBAttr);
+
+HI_S32 HI_MPI_ISP_SetAWBAlgType(ISP_AWB_ALG_TYPE_E enALGType);
+HI_S32 HI_MPI_ISP_GetAWBAlgType(ISP_AWB_ALG_TYPE_E *penALGType);
+
+HI_S32 HI_MPI_ISP_SetAdvAWBAttr(ISP_ADV_AWB_ATTR_S *pstAdvAWBAttr);
+HI_S32 HI_MPI_ISP_GetAdvAWBAttr(ISP_ADV_AWB_ATTR_S *pstAdvAWBAttr);
+
+HI_S32 HI_MPI_ISP_SetLightSource(const ISP_AWB_ADD_LIGHTSOURCE_S *pstLightSource);
+HI_S32 HI_MPI_ISP_GetLightSource(ISP_AWB_ADD_LIGHTSOURCE_S *pstLightSource);
+
+HI_S32 HI_MPI_ISP_SetMWBAttr(const ISP_MWB_ATTR_S *pstMWBAttr);
+HI_S32 HI_MPI_ISP_GetMWBAttr(ISP_MWB_ATTR_S *pstMWBAttr);
+
+HI_S32 HI_MPI_ISP_SetColorTemp(const HI_U16 u16ColorTemp);     //not support yet
+HI_S32 HI_MPI_ISP_GetColorTemp(HI_U16 *pu16ColorTemp);
+
+HI_S32 HI_MPI_ISP_SetColorTone(ISP_COLORTONE_S *pstColorTone);
+HI_S32 HI_MPI_ISP_GetColorTone(ISP_COLORTONE_S *pstColorTone);
+HI_S32 HI_MPI_ISP_SetWBStaInfo(ISP_WB_STA_INFO_S *pstWBStatistic);
+HI_S32 HI_MPI_ISP_GetWBStaInfo(ISP_WB_STA_INFO_S *pstWBStatistic);
+
+HI_S32 HI_MPI_ISP_SetCCM(const ISP_COLORMATRIX_S *pstColorMatrix);
+HI_S32 HI_MPI_ISP_GetCCM(ISP_COLORMATRIX_S *pstColorMatrix);
+
+HI_S32 HI_MPI_ISP_SetSaturation(HI_U32 u32Value);
+HI_S32 HI_MPI_ISP_GetSaturation(HI_U32 *pu32Value);
+
+HI_S32 HI_MPI_ISP_SetSaturationAttr(const ISP_SATURATION_ATTR_S *pstSatAttr);
+HI_S32 HI_MPI_ISP_GetSaturationAttr(ISP_SATURATION_ATTR_S *pstSatAttr);
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#endif
+

--- a/kernel/include/hi3516cv100/mpi_isp.h
+++ b/kernel/include/hi3516cv100/mpi_isp.h
@@ -20,6 +20,7 @@
 
 #include "hi_comm_isp.h"
 #include "hi_comm_sns.h"
+#include "hi_comm_3a.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -27,97 +28,43 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
+/* Firmware Main Operation */
+HI_S32 HI_MPI_ISP_Init(HI_VOID);
+HI_S32 HI_MPI_ISP_Run(HI_VOID);
+HI_S32 HI_MPI_ISP_Exit(HI_VOID);
+HI_S32 HI_MPI_ISP_SensorRegCallBack(SENSOR_ID SensorId, ISP_SENSOR_REGISTER_S *pstRegister);
+HI_S32 HI_MPI_ISP_SensorUnRegCallBack(SENSOR_ID SensorId);
 
+/* if have registered multy libs, set bind attr to appoint the active lib. */
+HI_S32 HI_MPI_ISP_SetBindAttr(const ISP_BIND_ATTR_S *pstBindAttr);
+HI_S32 HI_MPI_ISP_GetBindAttr(ISP_BIND_ATTR_S *pstBindAttr);
+HI_S32 HI_MPI_ISP_AeLibRegCallBack(ALG_LIB_S *pstAeLib,
+        ISP_AE_REGISTER_S *pstRegister);
+HI_S32 HI_MPI_ISP_AwbLibRegCallBack(ALG_LIB_S *pstAwbLib,
+        ISP_AWB_REGISTER_S *pstRegister);
+HI_S32 HI_MPI_ISP_AfLibRegCallBack(ALG_LIB_S *pstAfLib,
+        ISP_AF_REGISTER_S *pstRegister);
+HI_S32 HI_MPI_ISP_AeLibUnRegCallBack(ALG_LIB_S *pstAeLib);
+HI_S32 HI_MPI_ISP_AwbLibUnRegCallBack(ALG_LIB_S *pstAwbLib);
+HI_S32 HI_MPI_ISP_AfLibUnRegCallBack(ALG_LIB_S *pstAfLib);
+
+HI_S32 HI_MPI_ISP_SetInputTiming(const ISP_INPUT_TIMING_S *pstInputTiming);
+HI_S32 HI_MPI_ISP_GetInputTiming(ISP_INPUT_TIMING_S *pstInputTiming);
+
+HI_S32 HI_MPI_ISP_SetImageAttr(const ISP_IMAGE_ATTR_S *pstImageAttr);
+HI_S32 HI_MPI_ISP_GetImageAttr(ISP_IMAGE_ATTR_S *pstImageAttr);
+
+HI_S32 HI_MPI_ISP_SetWdrAttr(const ISP_WDR_ATTR_S *pstWdrAttr);
+HI_S32 HI_MPI_ISP_GetWdrAttr(ISP_WDR_ATTR_S *pstWdrAttr);
+
+HI_S32 HI_MPI_ISP_SetDebug(const ISP_DEBUG_INFO_S * pstIspDebug);
+HI_S32 HI_MPI_ISP_GetDebug(ISP_DEBUG_INFO_S * pstIspDebug);
 HI_S32 HI_MPI_ISP_FreezeFmw(HI_BOOL bFreeze);
 
 HI_S32 HI_MPI_ISP_SetModuleControl(HI_U32 u32ModFlag);
 HI_S32 HI_MPI_ISP_GetModuleControl(HI_U32 *pu32ModFlag);
 
-HI_S32 HI_MPI_ISP_GetExtRegAddr(HI_U32 *u32Addr);
-
-
-/* Exposure Settings */
-
-HI_S32 HI_MPI_ISP_SetExposureType(ISP_OP_TYPE_E enExpType);
-HI_S32 HI_MPI_ISP_GetExposureType(ISP_OP_TYPE_E *penExpType);
-
-HI_S32 HI_MPI_ISP_SetAEAttr(const ISP_AE_ATTR_S *pstAEAttr);
-HI_S32 HI_MPI_ISP_GetAEAttr(ISP_AE_ATTR_S *pstAEAttr);
-
-HI_S32 HI_MPI_ISP_SetAEAttrEx(const ISP_AE_ATTR_EX_S *pstAEAttrEx);
-HI_S32 HI_MPI_ISP_GetAEAttrEx(ISP_AE_ATTR_EX_S *pstAEAttrEx);
-
-HI_S32  HI_MPI_ISP_SetExpStaInfo(ISP_EXP_STA_INFO_S *pstExpStatistic);
-HI_S32  HI_MPI_ISP_GetExpStaInfo(ISP_EXP_STA_INFO_S *pstExpStatistic);
-
-HI_S32 HI_MPI_ISP_SetMEAttr(const ISP_ME_ATTR_S *pstMEAttr);
-HI_S32 HI_MPI_ISP_GetMEAttr(ISP_ME_ATTR_S *pstMEAttr);
-
-HI_S32 HI_MPI_ISP_SetMEAttrEx(const ISP_ME_ATTR_EX_S *pstMEAttrEx);
-HI_S32 HI_MPI_ISP_GetMEAttrEx(ISP_ME_ATTR_EX_S *pstMEAttrEx);
-
-HI_S32 HI_MPI_ISP_SetSlowFrameRate(HI_U8 u8Value);
-HI_S32 HI_MPI_ISP_GetSlowFrameRate(HI_U8 *pu8Value);
-
-/* White Balance Settings */
-
-HI_S32 HI_MPI_ISP_SetWBType(ISP_OP_TYPE_E enWBType);
-HI_S32 HI_MPI_ISP_GetWBType(ISP_OP_TYPE_E *penWBType);
-
-HI_S32 HI_MPI_ISP_SetAWBAttr(const ISP_AWB_ATTR_S *pstAWBAttr);
-HI_S32 HI_MPI_ISP_GetAWBAttr(ISP_AWB_ATTR_S *pstAWBAttr);
-
-HI_S32 HI_MPI_ISP_SetMWBAttr(const ISP_MWB_ATTR_S *pstMWBAttr);
-HI_S32 HI_MPI_ISP_GetMWBAttr(ISP_MWB_ATTR_S *pstMWBAttr);
-
-HI_S32 HI_MPI_ISP_SetColorTemp(const HI_U16 u16ColorTemp);     //not support yet
-HI_S32 HI_MPI_ISP_GetColorTemp(HI_U16 *pu16ColorTemp);
-
-HI_S32 HI_MPI_ISP_SetColorTone(ISP_COLORTONE_S *pstColorTone);
-HI_S32 HI_MPI_ISP_GetColorTone(ISP_COLORTONE_S *pstColorTone);
-HI_S32 HI_MPI_ISP_SetWBStaInfo(ISP_WB_STA_INFO_S *pstWBStatistic);
-HI_S32 HI_MPI_ISP_GetWBStaInfo(ISP_WB_STA_INFO_S *pstWBStatistic);
-
-HI_S32 HI_MPI_ISP_SetAWBAlgType(ISP_AWB_ALG_TYPE_E enALGType);
-HI_S32 HI_MPI_ISP_GetAWBAlgType(ISP_AWB_ALG_TYPE_E *penALGType);
-
-HI_S32 HI_MPI_ISP_SetAdvAWBAttr(ISP_ADV_AWB_ATTR_S *pstAdvAWBAttr);
-HI_S32 HI_MPI_ISP_GetAdvAWBAttr(ISP_ADV_AWB_ATTR_S *pstAdvAWBAttr);
-
-HI_S32 HI_MPI_ISP_SetLightSource(const ISP_AWB_ADD_LIGHTSOURCE_S *pstLightSource);
-HI_S32 HI_MPI_ISP_GetLightSource(ISP_AWB_ADD_LIGHTSOURCE_S *pstLightSource);
-
-/* Focus Settings */
-
-HI_S32 HI_MPI_ISP_SetFocusType(ISP_OP_TYPE_E enFocusType);    //not support yet
-HI_S32 HI_MPI_ISP_GetFocusType(ISP_OP_TYPE_E *penFocusType);  //not support yet
-
-HI_S32 HI_MPI_ISP_SetAFAttr(const ISP_AF_ATTR_S *pstAFAttr);  //not support yet
-HI_S32 HI_MPI_ISP_GetAFAttr(ISP_AF_ATTR_S *pstAFAttr);        //not support yet
-
-HI_S32 HI_MPI_ISP_SetMFAttr(const ISP_MF_ATTR_S *pstMFAttr);  //not support yet
-HI_S32 HI_MPI_ISP_GetMFAttr(ISP_MF_ATTR_S *pstMFAttr);        //not support yet
-
-HI_S32 HI_MPI_ISP_ManualFocusMove(HI_S32 s32MoveSteps);       //not support yet
-
-HI_S32 HI_MPI_ISP_SetFocusStaInfo(ISP_FOCUS_STA_INFO_S *pstFocusStatistic);
-HI_S32 HI_MPI_ISP_GetFocusStaInfo(ISP_FOCUS_STA_INFO_S *pstFocusStatistic);
-
-
-/* Iris Settings */
-
-HI_S32 HI_MPI_ISP_SetIrisType(ISP_OP_TYPE_E enIrisType);//not support yet
-HI_S32 HI_MPI_ISP_GetIrisType(ISP_OP_TYPE_E *penIrisType);    //not support yet
-
-HI_S32 HI_MPI_ISP_SetAIAttr(const ISP_AI_ATTR_S *pstAIAttr);
-HI_S32 HI_MPI_ISP_GetAIAttr(ISP_AI_ATTR_S *pstAIAttr);
-
-HI_S32 HI_MPI_ISP_SetMIAttr(const ISP_MI_ATTR_S *pstMIAttr);  //not support yet
-HI_S32 HI_MPI_ISP_GetMIAttr(ISP_MI_ATTR_S *pstMIAttr);        //not support yet
-
-
 /* General Function Settings */
-
 HI_S32 HI_MPI_ISP_SetDRCAttr(const ISP_DRC_ATTR_S *pstDRC);
 HI_S32 HI_MPI_ISP_GetDRCAttr(ISP_DRC_ATTR_S *pstDRC);
 
@@ -140,26 +87,14 @@ HI_S32 HI_MPI_ISP_GetDenoiseAttr(ISP_DENOISE_ATTR_S *pstDenoiseAttr);
 HI_S32 HI_MPI_ISP_SetGammaAttr(const ISP_GAMMA_ATTR_S* pstGammaAttr);
 HI_S32 HI_MPI_ISP_GetGammaAttr(ISP_GAMMA_ATTR_S* pstGammaAttr);
 
-HI_S32 HI_MPI_ISP_SetGammaTable(ISP_GAMMA_TABLE_S* pstGammaAttr);
+HI_S32 HI_MPI_ISP_SetGammaTable(const ISP_GAMMA_TABLE_S* pstGammaAttr);
 HI_S32 HI_MPI_ISP_GetGammaTable(ISP_GAMMA_TABLE_S* pstGammaAttr);
 
-HI_S32 HI_MPI_ISP_SetGammaFETable(ISP_GAMMA_TABLE_S* pstGammaAttr);
+HI_S32 HI_MPI_ISP_SetGammaFETable(const ISP_GAMMA_TABLE_S* pstGammaAttr);
 HI_S32 HI_MPI_ISP_GetGammaFETable(ISP_GAMMA_TABLE_S* pstGammaAttr);
 
 HI_S32 HI_MPI_ISP_SetSharpenAttr(const ISP_SHARPEN_ATTR_S *pstSharpenAttr);
 HI_S32 HI_MPI_ISP_GetSharpenAttr(ISP_SHARPEN_ATTR_S *pstSharpenAttr);
-
-HI_S32 HI_MPI_ISP_SetAntiFlickerAttr(const ISP_ANTIFLICKER_S *pstAntiflicker);
-HI_S32 HI_MPI_ISP_GetAntiFlickerAttr(ISP_ANTIFLICKER_S *pstAntiflicker);
-
-HI_S32 HI_MPI_ISP_SetCCM(const ISP_COLORMATRIX_S *pstColorMatrix);
-HI_S32 HI_MPI_ISP_GetCCM(ISP_COLORMATRIX_S *pstColorMatrix);
-
-HI_S32 HI_MPI_ISP_SetSaturationAttr(const ISP_SATURATION_ATTR_S *pstSatAttr);
-HI_S32 HI_MPI_ISP_GetSaturationAttr(ISP_SATURATION_ATTR_S *pstSatAttr);
-
-HI_S32 HI_MPI_ISP_SetSaturation(HI_U32 u32Value);
-HI_S32 HI_MPI_ISP_GetSaturation(HI_U32 *pu32Value);
 
 HI_S32 HI_MPI_ISP_SetCfg(HI_U32 u32Addr, HI_U32 u32Value);
 HI_S32 HI_MPI_ISP_GetCfg(HI_U32 u32Addr, HI_U32 *pu32Value);
@@ -169,6 +104,9 @@ HI_S32 HI_MPI_ISP_GetCrosstalkAttr(ISP_CR_ATTR_S *pstCRAttr);
 
 HI_S32 HI_MPI_ISP_SetNoiseProfileTable(ISP_NOISEPROFILE_TABLE_S *pstNoiseProfileTable);
 HI_S32 HI_MPI_ISP_GetNoiseProfileTable(ISP_NOISEPROFILE_TABLE_S *pstNoiseProfileTable);
+
+
+
 // TODO:
 HI_S32 HI_MPI_ISP_SetAntiFogAttr(const ISP_ANTIFOG_S *pstAntiFog);
 HI_S32 HI_MPI_ISP_GetAntiFogAttr(ISP_ANTIFOG_S *pstAntiFog);
@@ -181,39 +119,14 @@ HI_S32 HI_MPI_ISP_GetAntiFalseColorAttr(ISP_ANTI_FALSECOLOR_S *pstAntiFC);
 HI_S32 HI_MPI_ISP_SetDemosaicAttr(const ISP_DEMOSAIC_ATTR_S *pstDemosaicAttr);
 HI_S32 HI_MPI_ISP_GetDemosaicAttr(ISP_DEMOSAIC_ATTR_S *pstDemosaicAttr);
 
-HI_S32 HI_MPI_ISP_SetBlackLevelAttr(const ISP_BLACK_LEVEL_S *pstBlackLevel); 
-HI_S32 HI_MPI_ISP_GetBlackLevelAttr(ISP_BLACK_LEVEL_S *pstBlackLevel); 
+HI_S32 HI_MPI_ISP_SetBlackLevelAttr(const ISP_BLACK_LEVEL_S *pstBlackLevel);
+HI_S32 HI_MPI_ISP_GetBlackLevelAttr(ISP_BLACK_LEVEL_S *pstBlackLevel);
 
+HI_S32 HI_MPI_ISP_SnsRegsCfg(const ISP_SNS_REGS_INFO_S *pstSnsRegsInfo);
 
-/* Sensor Relative Operation */
+HI_S32 HI_MPI_ISP_GetVDTimeOut(ISP_VD_INFO_S *pstIspVdInfo, HI_U32 u32MilliSec);
 
-HI_S32 HI_MPI_ISP_SensorRegCallBack(SENSOR_EXP_FUNC_S *pstSensorExpFuncs);
-
-
-/* Firmware Main Operation */
-
-HI_S32 HI_MPI_ISP_SetInputTiming(const ISP_INPUT_TIMING_S *pstInputTiming);
-HI_S32 HI_MPI_ISP_GetInputTiming(ISP_INPUT_TIMING_S *pstInputTiming);
-
-HI_S32 HI_MPI_ISP_SetImageAttr(const ISP_IMAGE_ATTR_S *pstImageAttr);
-HI_S32 HI_MPI_ISP_GetImageAttr(ISP_IMAGE_ATTR_S *pstImageAttr);
-
-HI_S32 HI_MPI_ISP_Init(void);
-
-HI_S32 HI_MPI_ISP_Run(void);
-
-HI_S32 HI_MPI_ISP_Exit(void);
-
-HI_S32 HI_MPI_ISP_QueryInnerStateInfo(ISP_INNER_STATE_INFO_S *pstInnerStateInfo);
-HI_S32 HI_MPI_ISP_QueryInnerStateInfoEx(ISP_INNER_STATE_INFO_EX_S *pstInnerStateInfoEx);
-
-HI_S32 HI_MPI_ISP_SetDebug(const ISP_DEBUG_INFO_S *pstIspDebug);
-HI_S32 HI_MPI_ISP_GetDebug(ISP_DEBUG_INFO_S *pstIspDebug);
-
-HI_S32 HI_MPI_ISP_I2cWrite(ISP_I2C_DATA_S *pstI2cData);
-HI_S32 HI_MPI_ISP_SSPWrite(const ISP_SSP_DATA_S *pstSspData);
-
-HI_S32  HI_MPI_ISP_GetVDTimeOut(ISP_VD_INFO_S *pstIspVdInfo, HI_U32 u32MilliSec);
+HI_S32 HI_MPI_ISP_GetISPRegAttr(ISP_REG_ATTR_S * pstIspRegAttr);
 #ifdef __cplusplus
 #if __cplusplus
 }

--- a/libraries/sensor/hi3516cv100/aptina_9m034/m034_cmos.c
+++ b/libraries/sensor/hi3516cv100/aptina_9m034/m034_cmos.c
@@ -3,11 +3,13 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "m034_sensor_config.h"
 #include "hi_comm_sns.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "m034_sensor_config.h"
-#include "hi_isp_debug.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -15,173 +17,100 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
+#define M034_ID 9034
 
+/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker in antiflicker mode */
+/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance                       */
+/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                                         */
+#define CMOS_M034_ISP_WRITE_SENSOR_ENABLE (1)
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
 extern const unsigned int sensor_i2c_addr;
-extern const unsigned int sensor_addr_byte;
-extern const unsigned int sensor_data_byte;
+extern unsigned int sensor_addr_byte;
+extern unsigned int sensor_data_byte;
 
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
 HI_U8 gu8SensorMode = 0;
+static HI_U32 gu32FullLinesStd = 750;
 
-/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker */
-/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance   */
-/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                     */
-#define CMOS_9M034_ISP_WRITE_SENSOR_ENABLE (1)
+#if CMOS_M034_ISP_WRITE_SENSOR_ENABLE
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
+#endif
 
-static cmos_isp_default_t st_coms_isp_default_lin =
+static AWB_CCM_S g_stAwbCcm =
 {
-	// color correction matrix
+    5000,
     {
-        5000,
-        {
-            0x0227,0x80CE,0x8059,
-            0x8026,0x0151,0x802B,
-            0x001E,0x80C0,0x01A2
-        },
-
-        3200,
-        {
-            0x1da,0x809e,0x803c,
-            0x805f,0x175,0x8016,
-            0x802c,0x8124,0x250
-        },
-
-        2500,
-        {
-            0x02AD,0x814A,0x8063,
-            0x000C,0x00EB,0x0009,
-            0x0031,0x81BE,0x028D
-        }
+        0x0227,0x80CE,0x8059,
+        0x8026,0x0151,0x802B,
+        0x001E,0x80C0,0x01A2
     },
 
-	// black level for R, Gr, Gb, B channels
-	{0xA8,0xA8,0xA8,0xA8},
-
-	//calibration reference color temperature
-	5000,
-
-	//WB gain at Macbeth 5000K, must keep consistent with calibration color temperature
-    {0x018B,0x0100,0x0100,0x01A2},//for ref
-
-	// WB curve parameters, must keep consistent with reference color temperature.
-    {88,-17,-185,239197,128,-193985},  //for ref
-
-	// hist_thresh
-	{0xd,0x28,0x60,0x80},
-
-	0x00,	// iridix_balck
-	0x1,	// grbg
-
-	// gain
-	0x8,	0x8, // this is gain target, it will be constricted by sensor-gain.
-
-	//wdr_variance_space, wdr_variance_intensity, slope_max_write,  white_level_write
-	0x04,	0x01,	0x80, 	0x4FF,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x23, 	// sinter threshold
-
-	0x1,     //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
-	0x0,
-	546,
-
-    2
-};
-
-static cmos_isp_default_t st_coms_isp_default_wdr =
-{
-	// color correction matrix
+    3200,
     {
-        5000,
-        {
-            0x0227,0x80CE,0x8059,
-            0x8026,0x0151,0x802B,
-            0x001E,0x80C0,0x01A2
-        },
-
-        3200,
-        {
-            0x1da,0x809e,0x803c,
-            0x805f,0x175,0x8016,
-            0x802c,0x8124,0x250
-        },
-
-        2500,
-        {
-            0x02AD,0x814A,0x8063,
-            0x000C,0x00EB,0x0009,
-            0x0031,0x81BE,0x028D
-        }
+        0x1da,0x809e,0x803c,
+        0x805f,0x175,0x8016,
+        0x802c,0x8124,0x250
     },
 
-	// black level(wdr)
-	{0x00,0x00,0x00,0x00},
-
-	//calibration reference color temperature
-	5000,
-
-	//WB gain at Macbeth 5000K, must keep consistent with calibration color temperature
-    {0x018B,0x0100,0x0100,0x01A2},//for ref
-
-	// WB curve parameters, must keep consistent with reference color temperature.
-    {88,-17,-185,239197,128,-193985},  //for ref
-
-	// hist_thresh
-    {0x20,0x40,0x60,0x80},
-
-	0x00,	// iridix_balck
-	0x1,	// grbg
-
-	// gain
-	0x1,	0x8,
-
-	//wdr_variance_space, wdr_variance_intensity, slope_max_write,  white_level_write
-	0x04,	0x04,	0x3c, 	0xFFF,
-
-	0x0, 	// balance_fe
-	0x80,	// ae compensation
-	0x9, 	// sinter threshold
-
-	0x0,     //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
-	0x0,
-	0x0,
-     2
+    2500,
+    {
+        0x02AD,0x814A,0x8063,
+        0x000C,0x00EB,0x0009,
+        0x0031,0x81BE,0x028D
+    }
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTableLin =
 {
-    //sharpen_alt_d
-    {0x50,0x48,0x40,0x38,0x34,0x30,0x28,0x20},
-
-    //sharpen_alt_ud
-    {0x90,0x88,0x80,0x70,0x58,0x40,0x20,0x0a},
-
-    //snr_thresh
-    {0x23,0x2c,0x34,0x3E,0x46,0x4E,0x54,0x5A},
-    //{20,25,30,35,39,44,49,54},
-
-    //demosaic_lum_thresh
-    {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
-
-    //demosaic_np_offset
-    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x37},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
+    /* bvalid */
+    1,
 
     /* saturation */
     {0x80,0x80,0x6C,0x48,0x44,0x40,0x3C,0x38}
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table_wdr =
+static AWB_AGC_TABLE_S g_stAwbAgcTableWdr =
 {
-     /* sharpen_alt_d */
+    /* bvalid */
+    1,
+
+    /* saturation */
+    {0x80,0x80,0x80,0x80,0x70,0x60,0x50,0x40}
+};
+
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTableLin =
+{
+    /* bvalid */
+    1,
+
+    /* sharpen_alt_d */
+    {0x50,0x48,0x40,0x38,0x34,0x30,0x28,0x20},
+        
+    /* sharpen_alt_ud */
+    {0x90,0x88,0x80,0x70,0x58,0x40,0x20,0x0a},
+        
+    /* snr_thresh */
+    {0x23,0x2c,0x34,0x3E,0x46,0x4E,0x54,0x5A},
+        
+    /* demosaic_lum_thresh */
+    {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
+        
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x37},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
+};
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTableWdr =
+{
+    /* bvalid */
+    1,
+
+    /* sharpen_alt_d */
     {0x50,0x50,0x50,0x50,0x4a,0x45,0x40,0x3a},
         
     /* sharpen_alt_ud */
@@ -189,24 +118,25 @@ static cmos_isp_agc_table_t st_isp_agc_table_wdr =
         
     /* snr_thresh */
     {0x05,0x05,0x05,0x05,0x08,0x0c,0x10,0x18},
-
-    //demosaic_lum_thresh
+        
+    /* demosaic_lum_thresh */
     {0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80},
-
-    //demosaic_np_offset
+        
+    /* demosaic_np_offset */
     {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x37},
         
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
-
-    /* saturation */
-    {0x80,0x80,0x80,0x80,0x70,0x60,0x50,0x40}
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTableLin =
 {
-    /* nosie_profile_weight_lut */
-    {
+    /* bvalid */
+    1,
+    
+      /* nosie_profile_weight_lut */
+     {
        0,  0,  0,  0,  0,  2,  9, 14, 16, 19, 21, 23, 24, 25, 27, 28, 
       29, 30, 31, 31, 32, 33, 33, 34, 35, 35, 36, 36, 37, 37, 38, 38, 
       39, 39, 39, 40, 40, 40, 41, 41, 42, 42, 42, 42, 43, 43, 43, 44, 
@@ -215,9 +145,9 @@ static cmos_isp_noise_table_t st_isp_noise_table =
       50, 50, 50, 51, 51, 51, 51, 51, 51, 51, 51, 52, 52, 52, 52, 52, 
       52, 52, 53, 53, 53, 53, 53, 53, 53, 53, 53, 54, 54, 54, 54, 54, 
       54, 54, 54, 54, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 56, 56
-    },
-
-    /* demosaic_weight_lut */
+     }, 
+    
+     /* demosaic_weight_lut */
     {
       2,  9, 14, 16, 19, 21, 23, 24, 25, 27, 28, 29, 30, 31, 31, 32, 
      33, 33, 34, 35, 35, 36, 36, 37, 37, 38, 38, 39, 39, 39, 40, 40, 
@@ -228,23 +158,29 @@ static cmos_isp_noise_table_t st_isp_noise_table =
      53, 53, 53, 53, 53, 53, 54, 54, 54, 54, 54, 54, 54, 54, 54, 55, 
      55, 55, 55, 55, 55, 55, 55, 55, 55, 56, 56, 56, 56, 56, 56, 56
     }
-    };
+};
 
-static cmos_isp_noise_table_t st_isp_noise_table_wdr =
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTableWdr =
 {
-    /* nosie_profile_weight_lut WDR */
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {
         13,13,13,13,13,14,15,25,31,31,31,31,31,31,31,31,31,31,31,31,31,32,32,32,32,32,32,32,39,49,54,56,58,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60
     },
 
-    /* demosaic_weight_lut WDR */
+    /* demosaic_weight_lut */
     {
         13,13,13,13,13,14,15,25,31,31,31,31,31,31,31,31,31,31,31,31,31,32,32,32,32,32,32,32,39,49,54,56,58,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,59,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60,60
     }
 };
 
-static cmos_isp_demosaic_t st_isp_demosaic =
+
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaicLin =
 {
+	/* bvalid */
+	 1,
 	 
 	 /*vh_slope*/
 	 220,
@@ -284,661 +220,182 @@ static cmos_isp_demosaic_t st_isp_demosaic =
 
 };
 
-static cmos_isp_demosaic_t st_isp_demosaic_wdr =
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaicWdr =
 {
+    /* bvalid */
+    1,
+    
+    /*vh_slope*/
+    220,
 
-	 /*vh_slope*/
-	 220,
-	
-	 /*aa_slope*/
-	 200,
-	
-	 /*va_slope*/
-	 185,
-	
-	 /*uu_slope*/
-	 210,
-	
-	 /*sat_slope*/
-	 93,
-	
-	 /*ac_slope*/
-	 160,
-	
-	 /*vh_thresh*/
-	 0,
-	
-	 /*aa_thresh*/
-	 0,
-	
-	 /*va_thresh*/
-	 0,
-	
-	 /*uu_thresh*/
-	 8,
-	
-	 /*sat_thresh*/
-	 0,
-	
-	 /*ac_thresh*/
-	 0x1b3
+    /*aa_slope*/
+    200,
 
+    /*va_slope*/
+    185,
+
+    /*uu_slope*/
+    210,
+
+    /*sat_slope*/
+    93,
+
+    /*ac_slope*/
+    160,
+
+    /*vh_thresh*/
+    0,
+
+    /*aa_thresh*/
+    0,
+
+    /*va_thresh*/
+    0,
+
+    /*uu_thresh*/
+    8,
+
+    /*sat_thresh*/
+    0,
+
+    /*ac_thresh*/
+    0x1b3
 };
 
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static /*__inline*/ cmos_inttime_const_ptr_t cmos_inttime_initialize()
+
+static ISP_CMOS_GAMMAFE_S g_stGammafe = 
 {
-	cmos_inttime.full_lines_std = 750;
-	cmos_inttime.full_lines_std_30fps = 750;
-	cmos_inttime.full_lines = 750;
-	cmos_inttime.full_lines_del = 750; //TODO: remove
-	cmos_inttime.full_lines_limit = 65535;
-	cmos_inttime.max_lines = 748;
-	cmos_inttime.min_lines = 2;
-	cmos_inttime.vblanking_lines = 0;
+    /* bvalid */
+    1,
 
-	cmos_inttime.exposure_ashort = 0;
-	cmos_inttime.exposure_shift = 0;
-
-	cmos_inttime.lines_per_500ms = 750 * 30 / 2; // 500ms / 22.22us
-	cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-	cmos_inttime.max_lines_target = cmos_inttime.max_lines;
-	cmos_inttime.min_lines_target = cmos_inttime.min_lines;
-	//cmos_inttime.max_flicker_lines = cmos_inttime.max_lines_target;
-	//cmos_inttime.min_flicker_lines = cmos_inttime.min_lines_target;
-	//cmos_inttime.input_changed = 0;
-
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0: //linear mode
-            cmos_inttime.max_lines = 748;
-            cmos_inttime.min_lines = 2;
-            cmos_inttime.max_lines_target = 748;
-            cmos_inttime.min_lines_target = 2;
-        break;
-        case 1: //WDR mode for T1 exposure, Exposure ratio = 16X16X
-            cmos_inttime.max_lines = 675;
-            cmos_inttime.min_lines = 128;
-            cmos_inttime.max_lines_target = 675;
-            cmos_inttime.min_lines_target = 128;
-        break;
+    { 
+       0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  16,  23,  28,
+      32,  36,  39,  42,  45,  48,  51,  53,  55,  58,  60,  62,  64,  66,  68,  70,
+      72,  73,  75,  77,  78,  80,  82,  83,  85,  86,  88,  89,  90,  92,  93,  95,
+      96,  97,  99, 100, 101, 102, 104, 105, 106, 107, 108, 110, 111, 112, 113, 114,
+     115, 116, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
+     132, 133, 134, 135, 136, 137, 138, 139, 139, 140, 141, 142, 143, 144, 145, 146,
+     147, 147, 148, 149, 150, 151, 152, 153, 153, 154, 155, 156, 157, 158, 158, 159,
+     160, 161, 162, 162, 163, 164, 165, 165, 166, 167, 168, 169, 169, 170, 171, 172,
+     172, 215, 250, 281, 309, 334, 358, 380, 401, 421, 440, 458, 476, 493, 509, 525,
+     540, 555, 570, 584, 598, 611, 624, 637, 650, 663, 675, 687, 699, 710, 722, 733,
+     744, 755, 766, 776, 787, 797, 807, 818, 827, 837, 847, 857, 866, 876, 885, 894,
+     903, 912, 921, 930, 939, 947, 956, 965, 973, 981, 990, 998,1006,1014,1022,1143,
+    1253,1353,1447,1535,1618,1697,1772,1845,1914,1982,2047,2110,2171,2231,2289,2345,
+    2400,2454,2507,2559,2609,2659,2708,2756,2803,2849,2895,2940,2984,3028,3071,3113,
+    3155,3196,3237,3277,3317,3356,3395,3433,3471,3509,3546,3583,3619,3655,3691,3726,
+    3761,3796,3830,3864,3898,3931,3965,3997,4030,4063,4095,4095,4095,4095,4095,4095,4095
     }
+};
 
-	return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-#if CMOS_9M034_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x3012;
-    stI2cData.u32Data = p_inttime->exposure_ashort >> p_inttime->exposure_shift;
-    HI_MPI_ISP_I2cWrite(&stI2cData);        
-#else
-	HI_U16 _time = p_inttime->exposure_ashort >> p_inttime->exposure_shift;
-	sensor_write_register(0x3012, _time);
-#endif
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-     int  _fulllines= p_inttime->full_lines;
-
-       sensor_write_register(0x300A, _fulllines);
-
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-	p_inttime->exposure_along  = p_inttime->exposure_ashort;
-
-	if(p_inttime->exposure_along < p_inttime->full_lines_std - 2)
-	{
-		p_inttime->full_lines_del = p_inttime->full_lines_std;
-	}
-	if(p_inttime->exposure_along >= p_inttime->full_lines_std - 2)
-	{
-		p_inttime->full_lines_del = p_inttime->exposure_along + 2;
-	}
-#if defined(TRACE_ALL)
-	alt_printf("full_lines_del = %x\n", p_inttime->full_lines_del);
-#endif
-	p_inttime->vblanking_lines = p_inttime->full_lines_del - 720;
-#if defined(TRACE_ALL)
-	alt_printf("vblanking_lines = %x\n", p_inttime->vblanking_lines);
-#endif
-	return p_inttime->exposure_ashort;
-}
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-	switch(fps)
-	{
-		case 30:
-	
-			sensor_write_register(0x300C, 0xCE4);
-            p_inttime->lines_per_500ms = 750 * 30 / 2;
-            
-		break;
-
-		case 25:
-	
-			sensor_write_register(0x300C, 0xF78);
-            p_inttime->lines_per_500ms = 750 * 25 / 2;
-            
-		break;
-
-		default:
-		break;
-	}
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static /*__inline*/ cmos_gains_ptr_t cmos_gains_initialize()
-{
-	cmos_gains.max_again = 8;
-
-	cmos_gains.max_dgain = 255;
-	cmos_gains.max_again_target = cmos_gains.max_again;
-	cmos_gains.max_dgain_target = cmos_gains.max_dgain;
-
-	cmos_gains.again_shift = 0;
-	cmos_gains.dgain_shift = 5;
-	cmos_gains.dgain_fine_shift = 0;
-
-	cmos_gains.again = 1;
-	cmos_gains.dgain = 1;
-	cmos_gains.dgain_fine = 1;
-	cmos_gains.again_db = 0;
-	cmos_gains.dgain_db = 0;
-
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_FALSE;
-
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0: //linear mode
-            cmos_gains.max_again = 8 << cmos_gains.again_shift;
-            cmos_gains.max_dgain = 255;
-            cmos_gains.max_again_target = cmos_gains.max_again;
-            cmos_gains.max_dgain_target = cmos_gains.max_dgain;
-            cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-        break;
-        case 1: //WDR mode
-            cmos_gains.max_again = 8 << cmos_gains.again_shift;
-            cmos_gains.max_dgain = 255;
-            cmos_gains.max_again_target = cmos_gains.max_again;
-            cmos_gains.max_dgain_target = cmos_gains.max_dgain;
-            cmos_gains.max_isp_dgain_target = 32 << cmos_gains.isp_dgain_shift;
-        break;
-    }
-
-	return &cmos_gains;
-}
-
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{
-	int ag = p_gains->again;
-	int dg = p_gains->dgain;
-#if CMOS_9M034_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x30B0;
-    switch(ag)
-    {
-		case(0):
-            stI2cData.u32Data = 0x1300;
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-			break;
-		case(1):
-			stI2cData.u32Data = 0x1300;
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-			break;
-		case(2):
-            stI2cData.u32Data = 0x1310;
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-			break;
-		case(4):
-            stI2cData.u32Data = 0x1320;
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-			break;
-		case(8):
-            stI2cData.u32Data = 0x1330;
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-			break;
-	}  
-
-    stI2cData.u32RegAddr = 0x305E;
-    stI2cData.u32Data = dg;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-#else
-	switch(ag)
-	{
-		case(0):
-			sensor_write_register(0x30B0, 0x1300);
-			break;
-		case(1):
-			sensor_write_register(0x30B0, 0x1300);
-			break;
-		case(2):
-			sensor_write_register(0x30B0, 0x1310);
-			break;
-		case(4):
-			sensor_write_register(0x30B0, 0x1320);
-			break;
-		case(8):
-			sensor_write_register(0x30B0, 0x1330);
-			break;
-	}
-
-	sensor_write_register(0x305E, dg);
-#endif
-}
-
-/* Emulate digital fine gain */
-static __inline void em_dgain_fine_update(cmos_gains_ptr_t p_gains)
-{
-}
-
-static HI_U32 cmos_gains_lin_to_db_convert(HI_U32 data, HI_U32 shift_in)
-{
-    #define PRECISION 8
-	HI_U32 _res = 0;
-	if(0 == data)
-		return _res;
-
-    data = data << PRECISION; // to ensure precision.
-	for(;;)
-	{
-        /* Note to avoid endless loop here. */
-		data = (data * 913) >> 10;
-        // data = (data*913 + (1<<9)) >> 10; // endless loop when shift_in is 0. */
-		if(data <= ((1<<shift_in) << PRECISION))
-		{
-			break;
-		}
-		++_res;
-	}
-	return _res;
-}
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-	HI_U32 _again = 1<<p_gains->again_shift;
-	//HI_U32 _ares = 1<<p_gains->again_shift;
-	//HI_U32 _lres = 0;
-	int shft = 0;
-
-	while (exposure > (1<<20))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-
-	if(exposure > exposure_max)
-	{
-        //when setting manual exposure line, exposure_max>>shift should not be 0.
-        exposure_max = DIV_0_TO_1(exposure_max);
-		_again = (exposure  * _again)  / exposure_max;
-//		exposure = exposure_max;
-
-		if (_again >= 1<< 3) { _again = 1<<3; }
-		else if (_again >= 1<< 2) { _again = 1<<2; }
-		else if (_again >= 1<< 1) { _again = 1<<1; }
-		else if (_again >= 1)     { _again = 1;    }
-
-		_again = _again < (1<<p_gains->again_shift) ? (1<<p_gains->again_shift) : _again;
-		_again = _again > p_gains->max_again_target ? p_gains->max_again_target : _again;
-
-		exposure = (exposure / _again);
-	}
-	else
-	{
-		//_again = (_again * exposure) / (exposure / exposure_shift) / exposure_shift;
-	}
-
-	p_gains->again = _again;
-    p_gains->again_db = cmos_gains_lin_to_db_convert(p_gains->again, p_gains->again_shift);
-	return (exposure << shft);
-}
-
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
-
-    while (exposure > (1 << 22))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shift;
-}
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift
-		)
-{
-	HI_U32 _dgain = 1<<p_gains->dgain_shift;
-    HI_U32 exposure0;
-    int shft = 0;
-
-	while (exposure > (1<<20))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-
-    exposure0 = exposure;
-	if(exposure > exposure_max)
-	{
-        //when setting manual exposure line, exposure_max>>shift should not be 0.
-        exposure_max = DIV_0_TO_1(exposure_max);
-        _dgain = (exposure  * _dgain) / exposure_max;
-        exposure = exposure_max;
-	}
-	else
-	{
-        //TODO: after anti-flick, dgain may need to decrease.
-		//_dgain = (_dgain * exposure) / (exposure / exposure_shift) / exposure_shift;
-	}
-	_dgain = _dgain < (1<<p_gains->dgain_shift) ? (1<<p_gains->dgain_shift) : _dgain;
-	_dgain = (_dgain > p_gains->max_dgain_target) ? p_gains->max_dgain_target : _dgain;
-
-	p_gains->dgain = _dgain;
-    p_gains->dgain_db = cmos_gains_lin_to_db_convert(p_gains->dgain, p_gains->dgain_shift);
-
-	return exposure << shft;
-}
-
-static __inline void sensor_update(
-	cmos_gains_const_ptr_t p_gains,
-	cmos_inttime_ptr_t p_inttime,
-	HI_U8 frame
-    )
-{
-	if(frame == 0)
-	{
-		cmos_inttime_update(p_inttime);
-	}
-	if(frame == 1)
-	{
-		cmos_gains_update(p_gains);
-	}
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-	HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-	HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-
-	p_gains->iso =  ((_again * _dgain * 100) >> (p_gains->again_shift + p_gains->dgain_shift));
-    p_gains->iso = (p_gains->iso * p_gains->isp_dgain) >> p_gains->isp_dgain_shift;
-
-
-	return p_gains->iso;
-}
-
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    //return cmos_gains_lin_to_db_convert(p_gains->again, p_gains->again_shift);
-    return p_gains->again_db;
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-    //return cmos_gains_lin_to_db_convert(p_gains->dgain, p_gains->dgain_shift);
-    return p_gains->dgain_db;
-}
-
-#if 0
-static HI_U8 cmos_get_digital_fine_gain(cmos_gains_ptr_t p_gains)
-{
-    return cmos_gains_lin_to_db_convert(p_gains->dgain_fine, p_gains->dgain_shift);
-}
-#endif
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-    if (NULL == p_coms_isp_default)
+    if (HI_NULL == pstDef)
     {
         printf("null pointer when get isp default value!\n");
         return -1;
     }
 
-    switch(gu8SensorMode)
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
+    
+    switch (gu8SensorMode)
     {
         default:
         case 0:
-            memcpy(p_coms_isp_default, &st_coms_isp_default_lin, sizeof(cmos_isp_default_t));
+            pstDef->stComm.u8Rggb           = 0x1;      //1: grbg
+            pstDef->stComm.u8BalanceFe      = 0x1;
+
+            pstDef->stDenoise.u8SinterThresh= 0x23;
+            pstDef->stDenoise.u8NoiseProfile= 0x1;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+            pstDef->stDenoise.u16Nr0        = 0x0;
+            pstDef->stDenoise.u16Nr1        = 546;
+
+            pstDef->stDrc.u8DrcBlack        = 0x00;
+            pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+            pstDef->stDrc.u8DrcVi           = 0x01;     // variance intensity
+            pstDef->stDrc.u8DrcSm           = 0x80;     // slope max
+            pstDef->stDrc.u16DrcWl          = 0x4FF;    // white level
+
+            memcpy(&pstDef->stDemosaic, &g_stIspDemosaicLin, sizeof(ISP_CMOS_DEMOSAIC_S));
+            memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTableLin, sizeof(ISP_CMOS_NOISE_TABLE_S));
+            memcpy(&pstDef->stAgcTbl, &g_stIspAgcTableLin, sizeof(ISP_CMOS_AGC_TABLE_S));
         break;
         case 1:
-            memcpy(p_coms_isp_default, &st_coms_isp_default_wdr, sizeof(cmos_isp_default_t));
+            pstDef->stComm.u8Rggb           = 0x1;      //1: grbg 
+            pstDef->stComm.u8BalanceFe      = 0x0;
+
+            pstDef->stDenoise.u8SinterThresh= 0x9;
+            pstDef->stDenoise.u8NoiseProfile= 0x0;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+            pstDef->stDenoise.u16Nr0        = 0x0;
+            pstDef->stDenoise.u16Nr1        = 0x0;
+
+            pstDef->stDrc.u8DrcBlack        = 0x00;
+            pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+            pstDef->stDrc.u8DrcVi           = 0x04;     // variance intensity
+            pstDef->stDrc.u8DrcSm           = 0x3c;     // slope max
+            pstDef->stDrc.u16DrcWl          = 0xFFF;    // white level
+
+            memcpy(&pstDef->stDemosaic, &g_stIspDemosaicWdr, sizeof(ISP_CMOS_DEMOSAIC_S));
+            memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTableWdr, sizeof(ISP_CMOS_NOISE_TABLE_S));
+            memcpy(&pstDef->stGammafe, &g_stGammafe, sizeof(ISP_CMOS_GAMMAFE_S));
+            memcpy(&pstDef->stAgcTbl, &g_stIspAgcTableWdr, sizeof(ISP_CMOS_AGC_TABLE_S));
         break;
     }
-    return 0;
-}
-
-void setup_sensor(int isp_mode)
-{
-	if(0 == isp_mode) /* ISP 'normal' isp_mode */
-	{
-        sensor_write_register(0x300C, 0xCE4);	//30fps
-	}
-	else if(1 == isp_mode) /* ISP pixel calibration isp_mode */
-	{
-		sensor_write_register(0x300C, 0x4D58);	//5fps
-		sensor_write_register(0x3012, 0x118);	//max exposure lines
-		sensor_write_register(0x30B0, 0x1300);	//AG, Context A
-		sensor_write_register(0x305E, 0x0020);	//DG, Context A
-	}
-}
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0:
-            memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-        break;
-        case 1:
-            memcpy(p_cmos_isp_agc_table, &st_isp_agc_table_wdr, sizeof(cmos_isp_agc_table_t));
-        break;
-    }
-
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0:
-            memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-        break;
-        case 1:
-            memcpy(p_cmos_isp_noise_table, &st_isp_noise_table_wdr, sizeof(cmos_isp_noise_table_t));
-        break;
-    }
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
-{
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0:
-            memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-        break;
-        case 1:
-            memcpy(p_cmos_isp_demosaic, &st_isp_demosaic_wdr,sizeof(cmos_isp_demosaic_t));
-        break;
-    }
-
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-
-HI_U32 cmos_get_sensor_mode(void)
-{
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0:
-            return isp_special_alg_m034_lin;
-        break;
-        case 1:
-            return isp_special_alg_m034_wdr;
-        break;
-    }
-}
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1280;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 720;
 
     return 0;
 }
 
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-static SENSOR_EXP_FUNC_S stSensorExpFuncs =
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
+    HI_S32  i;
+    
+    if (HI_NULL == pstBlackLevel)
+    {
+        printf("null pointer when get isp black level value!\n");
+        return -1;
+    }
 
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
 
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
+    switch (gu8SensorMode)
+    {
+        default :
+        case 0 :
+            for (i=0; i<4; i++)
+            {
+                pstBlackLevel->au16BlackLevel[i] = 0xA8;
+            }
+            break;
+        case 1 :
+            for (i=0; i<4; i++)
+            {
+                pstBlackLevel->au16BlackLevel[i] = 0x0;
+            }
+            break;
+    }
 
-    .pfn_setup_sensor = setup_sensor,
-
-    .pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-    .pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-	.pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-    .pfn_cmos_get_isp_default = cmos_get_isp_default,
-    .pfn_cmos_get_isp_special_alg = cmos_get_sensor_mode,
-	.pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-	.pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-	.pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-	.pfn_cmos_get_isp_shading_table = NULL,
-	.pfn_cmos_get_isp_gamma_table = NULL,
-    .pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-    .pfn_cmos_set_sensor_image_mode = NULL,
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-	return 0;
+    return 0;    
 }
 
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
+{
+    if (bEnable) /* setup for ISP pixel calibration mode */
+    {
+        sensor_write_register(0x300C, 0x4D58);    //5fps
+        sensor_write_register(0x3012, 0x118);    //max exposure lines
+        sensor_write_register(0x30B0, 0x1300);    //AG, Context A
+        sensor_write_register(0x305E, 0x0020);    //DG, Context A
+    }
+    else /* setup for ISP 'normal mode' */
+    {
+        sensor_write_register(0x300C, 0xCE4);    //30fps
+    }
+
+    return;
+}
+
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
@@ -974,12 +431,401 @@ int sensor_mode_set(HI_U8 u8Mode)
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+    gu32FullLinesStd = 750;
+    
+    pstAeSnsDft->u32LinesPer500ms = 750*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_DB;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 6;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.03125;
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    switch(gu8SensorMode)
+    {
+        default:
+        case 0: //linear mode
+            pstAeSnsDft->au8HistThresh[0] = 0xd;
+            pstAeSnsDft->au8HistThresh[1] = 0x28;
+            pstAeSnsDft->au8HistThresh[2] = 0x60;
+            pstAeSnsDft->au8HistThresh[3] = 0x80;
+            
+            pstAeSnsDft->u8AeCompensation = 0x40;
+            
+            pstAeSnsDft->u32MaxIntTime = 748;
+            pstAeSnsDft->u32MinIntTime = 2;
+            pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+            pstAeSnsDft->u32MinIntTimeTarget = 2;
+            
+            pstAeSnsDft->u32MaxAgain = 3;  /* 18db / 6db = 3 */
+            pstAeSnsDft->u32MinAgain = 0;
+            pstAeSnsDft->u32MaxAgainTarget = 3;
+            pstAeSnsDft->u32MinAgainTarget = 0;
+            
+            pstAeSnsDft->u32MaxDgain = 255;  /* 8 / 0.03125 = 256 */
+            pstAeSnsDft->u32MinDgain = 32;
+            pstAeSnsDft->u32MaxDgainTarget = 256;
+            pstAeSnsDft->u32MinDgainTarget = 32;
+            
+            pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+        break;
+        case 1: //WDR mode
+            pstAeSnsDft->au8HistThresh[0] = 0x20;
+            pstAeSnsDft->au8HistThresh[1] = 0x40;
+            pstAeSnsDft->au8HistThresh[2] = 0x60;
+            pstAeSnsDft->au8HistThresh[3] = 0x80;
+            
+            pstAeSnsDft->u8AeCompensation = 0x40;
+
+            pstAeSnsDft->u32MaxIntTime = 675;
+            pstAeSnsDft->u32MinIntTime = 128;
+            pstAeSnsDft->u32MaxIntTimeTarget = 675;  /* for short exposure, Exposure ratio = 16X */
+            pstAeSnsDft->u32MinIntTimeTarget = 128;
+
+            pstAeSnsDft->u32MaxAgain = 3;  /* 18db / 6db = 3 */
+            pstAeSnsDft->u32MinAgain = 0;
+            pstAeSnsDft->u32MaxAgainTarget = 3;
+            pstAeSnsDft->u32MinAgainTarget = 0;
+            
+            pstAeSnsDft->u32MaxDgain = 255;  /* 8 / 0.03125 = 256 */
+            pstAeSnsDft->u32MinDgain = 32;
+            pstAeSnsDft->u32MaxDgainTarget = 256;
+            pstAeSnsDft->u32MinDgainTarget = 32;
+            
+            pstAeSnsDft->u32MaxISPDgainTarget = 32 << pstAeSnsDft->u32ISPDgainShift;
+        break;
+    }
+
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
     return 0;
 }
 
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    switch(u8Fps)
+    {
+        case 30:
+            gu32FullLinesStd = 750;
+            pstAeSnsDft->u32MaxIntTime = 748;
+            pstAeSnsDft->u32LinesPer500ms = 750 * 30 / 2;
+            sensor_write_register(0x300C, 0xCE4);
+        break;
+        case 25:
+            gu32FullLinesStd = 750;
+            pstAeSnsDft->u32MaxIntTime = 748;
+            pstAeSnsDft->u32LinesPer500ms = 750 * 25 / 2;
+            sensor_write_register(0x300C, 0xF78);
+        break;        
+        default:
+        break;
+    }
+
+    if(1 == gu8SensorMode)
+    {
+        pstAeSnsDft->u32MaxIntTime = 675;
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{ 
+    sensor_write_register(0x300A, u16FullLines);
+
+    pstAeSnsDft->u32MaxIntTime = u16FullLines - 2;
+
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_M034_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+    static HI_BOOL bInit = HI_FALSE;
+
+    if (HI_FALSE == bInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_I2C_TYPE;
+        g_stSnsRegsInfo.u32RegNum = 3;
+        for (i=0; i<3; i++)
+        {
+            g_stSnsRegsInfo.astI2cData[i].u8DevAddr = sensor_i2c_addr;
+            g_stSnsRegsInfo.astI2cData[i].u32AddrByteNum = sensor_addr_byte;
+            g_stSnsRegsInfo.astI2cData[i].u32DataByteNum = sensor_data_byte;
+        }
+        g_stSnsRegsInfo.astI2cData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[0].u32RegAddr = 0x3012;
+        g_stSnsRegsInfo.astI2cData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[1].u32RegAddr = 0x30B0;
+        g_stSnsRegsInfo.astI2cData[2].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[2].u32RegAddr = 0x305E;
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_FALSE;
+
+        bInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+#if CMOS_M034_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[0].u32Data = u32IntTime;
+#else
+    sensor_write_register(0x3012, u32IntTime);
+#endif
+    return;
+}
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+#if CMOS_M034_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+
+    switch(u32Again)
+    {
+        case 0:
+            g_stSnsRegsInfo.astI2cData[1].u32Data = 0x1300;
+            break;
+        case 1:
+            g_stSnsRegsInfo.astI2cData[1].u32Data = 0x1310;
+            break;
+        case 2:
+            g_stSnsRegsInfo.astI2cData[1].u32Data = 0x1320;
+            break;
+        case 3:
+            g_stSnsRegsInfo.astI2cData[1].u32Data = 0x1330;
+            break;
+    }
+
+    g_stSnsRegsInfo.astI2cData[2].u32Data = u32Dgain;
+    HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+#else
+    switch(u32Again)
+    {
+        case 0:
+            sensor_write_register(0x30B0, 0x1300);
+            break;
+        case 1:
+            sensor_write_register(0x30B0, 0x1310);
+            break;
+        case 2:
+            sensor_write_register(0x30B0, 0x1320);
+            break;
+        case 3:
+            sensor_write_register(0x30B0, 0x1330);
+            break;
+    }
+
+    sensor_write_register(0x305E, u32Dgain);
+#endif
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 5000;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x018B;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x01A2;
+
+    pstAwbSnsDft->as32WbPara[0] = 88;
+    pstAwbSnsDft->as32WbPara[1] = -17;
+    pstAwbSnsDft->as32WbPara[2] = -185;
+    pstAwbSnsDft->as32WbPara[3] = 239197;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -193985;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+
+    switch (gu8SensorMode)
+    {
+        default:
+        case 0:
+            memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTableLin, sizeof(AWB_AGC_TABLE_S));
+        break;
+        case 1:
+            memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTableWdr, sizeof(AWB_AGC_TABLE_S));
+        break;
+    }
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(M034_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, M034_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, M034_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(M034_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, M034_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, M034_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -987,4 +833,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-#endif // __M034_CMOS_H_
+#endif // __IMX104_CMOS_H_

--- a/libraries/sensor/hi3516cv100/aptina_9m034/m034_sensor_config.h
+++ b/libraries/sensor/hi3516cv100/aptina_9m034/m034_sensor_config.h
@@ -1,7 +1,7 @@
 
 //9m034 720P 30fps linear
 static int sensor_rom_30_lin[] = {
-        // [Apical Linear Mode 720p 30fps AE=on EMBEDDED=on]
+        // [Linear Mode 720p 30fps AE=on EMBEDDED=on]
 //[Demo Initialization]
 //Load = Reset
 //[Reset]
@@ -404,7 +404,7 @@ static int sensor_rom_30_lin[] = {
 
 //9m034 720P 30fps wdr
 static int sensor_rom_30_wdr[] = {
-        // [Apical Linear Mode 720p 30fps AE=on EMBEDDED=on]
+        // [Linear Mode 720p 30fps AE=on EMBEDDED=on]
 //[Demo Initialization]
 //Load = Reset
 //[Reset]

--- a/libraries/sensor/hi3516cv100/aptina_9m034/m034_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/aptina_9m034/m034_sensor_ctl.c
@@ -47,6 +47,7 @@ int sensor_write_register(int addr, int data)
     if (ret)
     {
         printf("GPIO-I2C write faild!\n");
+        close(fd);
         return -1;
     }
 
@@ -75,6 +76,7 @@ int sensor_write_register(int addr, int data)
     if (ret)
     {
         printf("hi_i2c write faild!\n");
+        close(fd);
         return -1;
     }
 

--- a/libraries/sensor/hi3516cv100/aptina_ar0130/ar0130_cmos.c
+++ b/libraries/sensor/hi3516cv100/aptina_ar0130/ar0130_cmos.c
@@ -3,10 +3,13 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 #include "hi_comm_sns.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_isp_debug.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -14,27 +17,30 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
+#define AR0130_ID 130
+
+/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker in antiflicker mode */
+/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance                       */
+/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                                         */
+#define CMOS_AR0130_ISP_WRITE_SENSOR_ENABLE (1)
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
 extern const unsigned int sensor_i2c_addr;
-extern const unsigned int sensor_addr_byte;
-extern const unsigned int sensor_data_byte;
+extern unsigned int sensor_addr_byte;
+extern unsigned int sensor_data_byte;
 
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
+HI_U32 gu32FullLinesStd = 750;
 HI_U8 gu8SensorMode = 0;
 
-/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker */
-/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance   */
-/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                     */
+#if CMOS_AR0130_ISP_WRITE_SENSOR_ENABLE
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
+#endif
 
-#define CMOS_AR0130_ISP_WRITE_SENSOR_ENABLE (1)
-
-static cmos_isp_default_t st_coms_isp_default =
+static AWB_CCM_S g_stAwbCcm =
 {
-    {
+ 
        5000,
        {
          0x01a2, 0x8080, 0x8022,
@@ -55,54 +61,23 @@ static cmos_isp_default_t st_coms_isp_default =
          0x8057, 0x015C, 0x8005,
          0x8020, 0x8290, 0x03b0
        }
-    },
-
-	// black level for R, Gr, Gb, B channels
-	{0xC8,0xC8,0xC8,0xC8},
-
-	//calibration reference color temperature
-	5000,
-
-	//WB gain at Macbeth 5000K, must keep consistent with calibration color temperature
-
-    // {0x181,0x100,0x100,0x1b3}, //for demo
-    //{0x0197,0x0100,0x0100,0x01C4},//for ref
-
-    {0x018b,0x0100,0x0100,0x01a7},//7.5
-
-	// WB curve parameters, must keep consistent with reference color temperature.
-
-    // {96,-23,-182,225343,128,-178914}, //for demo
-  //  {66,36,-153,213987,128,-166117},  //for ref
-     {86,-16,-182,243836,128,-195566},
-
-
-	// hist_thresh
-	{0xd,0x28,0x60,0x80},
-
-	0x00,	// iridix_balck
-	0x1,	// rggb
-
-	// gain
-	23,	0x8, // this is gain target, it will be constricted by sensor-gain.
-	//0x8,	0x4, /* The purpose of setting max dgain target to 4 is to reduce FPN */
-
-	//wdr_variance_space, wdr_variance_intensity, slope_max_write,  white_level_write
-	0x04,	0x01,	0x80, 	0x4FF,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x23, 	// sinter threshold
-
-	0x1,     //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
-	0x0,
-	546,
-
-    2
+ 
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
+    /* bvalid */
+    1,
+
+    /* saturation */    
+    {0x80,0x80,0x6C,0x48,0x44,0x40,0x3C,0x38}
+};
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
+{
+    /* bvalid */
+    1,
+
     /* sharpen_alt_d */
    {50,50,45,35,30,30,20,15}, 
     
@@ -112,22 +87,22 @@ static cmos_isp_agc_table_t st_isp_agc_table =
     //snr_thresh
     {8,12,18,26,36,46,56,66},
 
-    //demosaic_lum_thresh
+    /* demosaic_lum_thresh */
     {0x50,0x50,0x40,0x40,0x30,0x30,0x20,0x20},
-
-    //demosaic_np_offset
+        
+    /* demosaic_np_offset */
     {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x35},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
-
-    /* saturation */
-    {0x80,0x80,0x6C,0x48,0x44,0x40,0x3C,0x38}
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
 {
-    //nosie_profile_weight_lut
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {0,  0,  0,  0,  0,  0,  0, 12, 17, 21, 24, 26, 28, 30, 31, 32, 
     33, 34, 35, 36, 37, 38, 39, 39, 40, 41, 41, 42, 42, 43, 43, 44,
     44, 45, 45, 45, 46, 46, 46, 47, 47, 47, 48, 48, 48, 49, 49, 49,
@@ -137,7 +112,7 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     58, 58, 58, 59, 59, 59, 59, 59, 59, 59, 59, 60, 60, 60, 60, 60,
     60, 60, 60, 60, 61, 61, 61, 61, 61, 61, 61, 61, 61, 61, 62, 62},
 
-    //demosaic_weight_lut
+    /* demosaic_weight_lut */
     {0, 12, 17, 21, 24, 26, 28, 30, 31, 32, 33, 34, 35, 36, 37, 38, 
     39, 39, 40, 41, 41, 42, 42, 43, 43, 44, 44, 45, 45, 45, 46, 46, 
     46, 47, 47, 47, 48, 48, 48, 49, 49, 49, 50, 50, 50, 50, 51, 51, 
@@ -146,11 +121,13 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     57, 57, 57, 57, 57, 58, 58, 58, 58, 58, 58, 58, 58, 59, 59, 59, 
     59, 59, 59, 59, 59, 60, 60, 60, 60, 60, 60, 60, 60, 60, 61, 61, 
     61, 61, 61, 61, 61, 61, 61, 61, 62, 62, 62, 62, 62, 62, 62, 62}
-    
 };
 
-static cmos_isp_demosaic_t st_isp_demosaic =
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
+    /* bvalid */
+    1,
+    
     /*vh_slope*/
     220,
 
@@ -188,670 +165,123 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x1b3
 };
 
-static cmos_isp_gamma_table_t st_isp_gamma_table =
+static ISP_CMOS_GAMMA_S g_stIspGamma =
 {
-#if 1
-
-{0   ,120 ,220 ,310 ,390 ,470 ,540 ,610 ,670 ,730 ,786 ,842 ,894 ,944 ,994 ,1050,    
-1096,1138,1178,1218,1254,1280,1314,1346,1378,1408,1438,1467,1493,1519,1543,1568,    
-1592,1615,1638,1661,1683,1705,1726,1748,1769,1789,1810,1830,1849,1869,1888,1907,    
-1926,1945,1963,1981,1999,2017,2034,2052,2069,2086,2102,2119,2136,2152,2168,2184,    
-2200,2216,2231,2247,2262,2277,2292,2307,2322,2337,2351,2366,2380,2394,2408,2422,    
-2436,2450,2464,2477,2491,2504,2518,2531,2544,2557,2570,2583,2596,2609,2621,2634,    
-2646,2659,2671,2683,2696,2708,2720,2732,2744,2756,2767,2779,2791,2802,2814,2825,    
-2837,2848,2859,2871,2882,2893,2904,2915,2926,2937,2948,2959,2969,2980,2991,3001,    
-3012,3023,3033,3043,3054,3064,3074,3085,3095,3105,3115,3125,3135,3145,3155,3165,    
-3175,3185,3194,3204,3214,3224,3233,3243,3252,3262,3271,3281,3290,3300,3309,3318,    
-3327,3337,3346,3355,3364,3373,3382,3391,3400,3409,3418,3427,3436,3445,3454,3463,    
-3471,3480,3489,3498,3506,3515,3523,3532,3540,3549,3557,3566,3574,3583,3591,3600,    
-3608,3616,3624,3633,3641,3649,3657,3665,3674,3682,3690,3698,3706,3714,3722,3730,    
-3738,3746,3754,3762,3769,3777,3785,3793,3801,3808,3816,3824,3832,3839,3847,3855,    
-3862,3870,3877,3885,3892,3900,3907,3915,3922,3930,3937,3945,3952,3959,3967,3974,    
-3981,3989,3996,4003,4010,4018,4025,4032,4039,4046,4054,4061,4068,4075,4082,4089,4095}
-
-
+    /* bvalid */
+    1,
+    
+#if 1    
+    {0  ,120 ,220 ,310 ,390 ,470 ,540 ,610 ,670 ,730 ,786 ,842 ,894 ,944 ,994 ,1050,    
+    1096,1138,1178,1218,1254,1280,1314,1346,1378,1408,1438,1467,1493,1519,1543,1568,    
+    1592,1615,1638,1661,1683,1705,1726,1748,1769,1789,1810,1830,1849,1869,1888,1907,    
+    1926,1945,1963,1981,1999,2017,2034,2052,2069,2086,2102,2119,2136,2152,2168,2184,    
+    2200,2216,2231,2247,2262,2277,2292,2307,2322,2337,2351,2366,2380,2394,2408,2422,    
+    2436,2450,2464,2477,2491,2504,2518,2531,2544,2557,2570,2583,2596,2609,2621,2634,    
+    2646,2659,2671,2683,2696,2708,2720,2732,2744,2756,2767,2779,2791,2802,2814,2825,    
+    2837,2848,2859,2871,2882,2893,2904,2915,2926,2937,2948,2959,2969,2980,2991,3001,    
+    3012,3023,3033,3043,3054,3064,3074,3085,3095,3105,3115,3125,3135,3145,3155,3165,    
+    3175,3185,3194,3204,3214,3224,3233,3243,3252,3262,3271,3281,3290,3300,3309,3318,    
+    3327,3337,3346,3355,3364,3373,3382,3391,3400,3409,3418,3427,3436,3445,3454,3463,    
+    3471,3480,3489,3498,3506,3515,3523,3532,3540,3549,3557,3566,3574,3583,3591,3600,    
+    3608,3616,3624,3633,3641,3649,3657,3665,3674,3682,3690,3698,3706,3714,3722,3730,    
+    3738,3746,3754,3762,3769,3777,3785,3793,3801,3808,3816,3824,3832,3839,3847,3855,    
+    3862,3870,3877,3885,3892,3900,3907,3915,3922,3930,3937,3945,3952,3959,3967,3974,    
+    3981,3989,3996,4003,4010,4018,4025,4032,4039,4046,4054,4061,4068,4075,4082,4089,4095}
 #else  /*higher  contrast*/
-
- 0  ,  54 ,  106,  158,  209,  259,  308,  356,  403,  450,  495,  540,  584,  628,  670,  713, 
-754 , 795 ,  835,  874,  913,  951,  989, 1026, 1062, 1098, 1133, 1168, 1203, 1236, 1270, 1303, 
-1335, 1367, 1398, 1429, 1460, 1490, 1520, 1549, 1578, 1607, 1635, 1663, 1690, 1717, 1744, 1770,
-1796, 1822, 1848, 1873, 1897, 1922, 1946, 1970, 1993, 2017, 2040, 2062, 2085, 2107, 2129, 2150, 
-2172, 2193, 2214, 2235, 2255, 2275, 2295, 2315, 2335, 2354, 2373, 2392, 2411, 2429, 2447, 2465, 
-2483, 2501, 2519, 2536, 2553, 2570, 2587, 2603, 2620, 2636, 2652, 2668, 2684, 2700, 2715, 2731, 
-2746, 2761, 2776, 2790, 2805, 2819, 2834, 2848, 2862, 2876, 2890, 2903, 2917, 2930, 2944, 2957, 
-2970, 2983, 2996, 3008, 3021, 3033, 3046, 3058, 3070, 3082, 3094, 3106, 3118, 3129, 3141, 3152, 
-3164, 3175, 3186, 3197, 3208, 3219, 3230, 3240, 3251, 3262, 3272, 3282, 3293, 3303, 3313, 3323, 
-3333, 3343, 3352, 3362, 3372, 3381, 3391, 3400, 3410, 3419, 3428, 3437, 3446, 3455, 3464, 3473, 
-3482, 3490, 3499, 3508, 3516, 3525, 3533, 3541, 3550, 3558, 3566, 3574, 3582, 3590, 3598, 3606, 
-3614, 3621, 3629, 3637, 3644, 3652, 3660, 3667, 3674, 3682, 3689, 3696, 3703, 3711, 3718, 3725, 
-3732, 3739, 3746, 3752, 3759, 3766, 3773, 3779, 3786, 3793, 3799, 3806, 3812, 3819, 3825, 3831, 
-3838, 3844, 3850, 3856, 3863, 3869, 3875, 3881, 3887, 3893, 3899, 3905, 3910, 3916, 3922, 3928, 
-3933, 3939, 3945, 3950, 3956, 3962, 3967, 3973, 3978, 3983, 3989, 3994, 3999, 4005, 4010, 4015, 
-4020, 4026, 4031, 4036, 4041, 4046, 4051, 4056, 4061, 4066, 4071, 4076, 4081, 4085, 4090, 4095, 4095
-
-
+    {0  , 54 , 106, 158, 209, 259, 308, 356, 403, 450, 495, 540, 584, 628, 670, 713,
+    754 ,795 , 835, 874, 913, 951, 989,1026,1062,1098,1133,1168,1203,1236,1270,1303,
+    1335,1367,1398,1429,1460,1490,1520,1549,1578,1607,1635,1663,1690,1717,1744,1770,
+    1796,1822,1848,1873,1897,1922,1946,1970,1993,2017,2040,2062,2085,2107,2129,2150,
+    2172,2193,2214,2235,2255,2275,2295,2315,2335,2354,2373,2392,2411,2429,2447,2465,
+    2483,2501,2519,2536,2553,2570,2587,2603,2620,2636,2652,2668,2684,2700,2715,2731,
+    2746,2761,2776,2790,2805,2819,2834,2848,2862,2876,2890,2903,2917,2930,2944,2957,
+    2970,2983,2996,3008,3021,3033,3046,3058,3070,3082,3094,3106,3118,3129,3141,3152,
+    3164,3175,3186,3197,3208,3219,3230,3240,3251,3262,3272,3282,3293,3303,3313,3323,
+    3333,3343,3352,3362,3372,3381,3391,3400,3410,3419,3428,3437,3446,3455,3464,3473,
+    3482,3490,3499,3508,3516,3525,3533,3541,3550,3558,3566,3574,3582,3590,3598,3606,
+    3614,3621,3629,3637,3644,3652,3660,3667,3674,3682,3689,3696,3703,3711,3718,3725,
+    3732,3739,3746,3752,3759,3766,3773,3779,3786,3793,3799,3806,3812,3819,3825,3831,
+    3838,3844,3850,3856,3863,3869,3875,3881,3887,3893,3899,3905,3910,3916,3922,3928,
+    3933,3939,3945,3950,3956,3962,3967,3973,3978,3983,3989,3994,3999,4005,4010,4015,
+    4020,4026,4031,4036,4041,4046,4051,4056,4061,4066,4071,4076,4081,4085,4090,4095,4095}
 #endif
-
 };
 
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static /*__inline*/ cmos_inttime_const_ptr_t cmos_inttime_initialize()
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-    //TODO: min/max integration time control.
-   	//cmos_inttime.min_lines_std = 128;
-	cmos_inttime.full_lines_std = 750;
-	cmos_inttime.full_lines_std_30fps = 750;
-	cmos_inttime.full_lines = 750;
-	cmos_inttime.full_lines_del = 750; //TODO: remove
-	cmos_inttime.full_lines_limit = 65535;
-	cmos_inttime.max_lines = 748;
-	cmos_inttime.min_lines = 2;
-	cmos_inttime.vblanking_lines = 0;
-
-	cmos_inttime.exposure_ashort = 0;
-	cmos_inttime.exposure_shift = 0;
-
-	cmos_inttime.lines_per_500ms = 750*30/2; // 500ms / 22.22us
-	cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-	cmos_inttime.max_lines_target = cmos_inttime.max_lines;
-	cmos_inttime.min_lines_target = cmos_inttime.min_lines;
-	//cmos_inttime.max_flicker_lines = cmos_inttime.max_lines_target;
-	//cmos_inttime.min_flicker_lines = cmos_inttime.min_lines_target;
-	//cmos_inttime.input_changed = 0;
-	return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
-{
-#if CMOS_AR0130_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-
-
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x3012;
-    stI2cData.u32Data = p_inttime->exposure_ashort >> p_inttime->exposure_shift;
-    HI_MPI_ISP_I2cWrite(&stI2cData);        
-#else
-	HI_U16 _time = p_inttime->exposure_ashort >> p_inttime->exposure_shift;
-	sensor_write_register(0x3012, _time);
-#endif
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-     int  _fulllines= p_inttime->full_lines;
-
-       sensor_write_register(0x300A, _fulllines);
-
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-	p_inttime->exposure_along  = p_inttime->exposure_ashort;
-
-	if(p_inttime->exposure_along < p_inttime->full_lines_std - 2)
-	{
-		p_inttime->full_lines_del = p_inttime->full_lines_std;
-	}
-	if(p_inttime->exposure_along >= p_inttime->full_lines_std - 2)
-	{
-		p_inttime->full_lines_del = p_inttime->exposure_along + 2;
-	}
-
-    if(p_inttime->exposure_ashort > p_inttime->full_lines - 2)
+    if (HI_NULL == pstDef)
     {
-       p_inttime->exposure_ashort = p_inttime->full_lines - 2;
+        printf("null pointer when get isp default value!\n");
+        return -1;
     }
+
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
+
+    pstDef->stComm.u8Rggb           = 0x1;      //1: rggb 
+    pstDef->stComm.u8BalanceFe      = 0x1;
+
+    pstDef->stDenoise.u8SinterThresh= 0x23;
+    pstDef->stDenoise.u8NoiseProfile= 0x1;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 546;
+
+    pstDef->stDrc.u8DrcBlack        = 0x00;
+    pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x01;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0x80;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x4FF;    // white level
+
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+    memcpy(&pstDef->stGamma, &g_stIspGamma, sizeof(ISP_CMOS_GAMMA_S));
+
+    return 0;
+}
+
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
+{
+    HI_S32  i;
     
-    
-#if defined(TRACE_ALL)
-	alt_printf("full_lines_del = %x\n", p_inttime->full_lines_del);
-#endif
-	p_inttime->vblanking_lines = p_inttime->full_lines_del - 720;
-#if defined(TRACE_ALL)
-	alt_printf("vblanking_lines = %x\n", p_inttime->vblanking_lines);
-#endif
-	return p_inttime->exposure_ashort;
-}
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-	switch(fps)
-	{
-		case 30:
-            p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2;
-			sensor_write_register(0x300c, 0x8ba);
-		break;
-
-		case 25:
-            p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_30fps * 25 / 2;
-			sensor_write_register(0x300c, 0xa78);
-		break;
-
-		default:
-		break;
-	}
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static /*__inline*/ cmos_gains_ptr_t cmos_gains_initialize()
-{
-
-	cmos_gains.max_again = 360;
-	cmos_gains.max_dgain = 255;
-	cmos_gains.max_again_target = cmos_gains.max_again;
-	cmos_gains.max_dgain_target = cmos_gains.max_dgain;
-
-	cmos_gains.again_shift = 4;
-	cmos_gains.dgain_shift = 5;
-	cmos_gains.dgain_fine_shift = 0;
-
-	cmos_gains.again = 1;
-	cmos_gains.dgain = 1;
-	cmos_gains.dgain_fine = 1;
-	cmos_gains.again_db = 0;
-	cmos_gains.dgain_db = 0;
-
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_FALSE;
-
-//	cmos_gains.input_changed = 0;
-
-	return &cmos_gains;
-}
-
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{
-#if CMOS_AR0130_ISP_WRITE_SENSOR_ENABLE
-    int dg = p_gains->dgain;
-    ISP_I2C_DATA_S stI2cData;
-
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x3100;
-    if(p_gains->again_db & 1)
+    if (HI_NULL == pstBlackLevel)
     {
-        stI2cData.u32Data = 0x0004;
-        HI_MPI_ISP_I2cWrite(&stI2cData);
-    }
-    else
-    {
-        stI2cData.u32Data = 0x0000;
-        HI_MPI_ISP_I2cWrite(&stI2cData);
+        printf("null pointer when get isp black level value!\n");
+        return -1;
     }
 
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x30B0;
-    switch(p_gains->again_db >> 1)
-	{
-		case(0):
-            stI2cData.u32Data = 0x1300;
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-			break;
-		case(1):
-			stI2cData.u32Data = 0x1300;
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-			break;
-		case(2):
-            stI2cData.u32Data = 0x1310;
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-			break;
-		case(4):
-            stI2cData.u32Data = 0x1320;
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-			break;
-		case(8):
-            stI2cData.u32Data = 0x1330;
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-			break;
-	}
-
-    stI2cData.u32RegAddr = 0x305E;
-    stI2cData.u32Data = dg;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-#else
-    int ag = p_gains->again;
-    int dg = p_gains->dgain;
-	if(p_gains->again_db & 1)
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+            
+    for (i=0; i<4; i++)
     {
-        sensor_write_register(0x3100, 0x0004);
+        pstBlackLevel->au16BlackLevel[i] = 0xC8;
     }
-    else
+
+    return 0;    
+}
+
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
+{
+    if (bEnable) /* setup for ISP pixel calibration mode */
     {
+        sensor_write_register(0x300C, 0x4D58);	//5fps
+        sensor_write_register(0x3012, 0x05DA);	//max exposure lines
+        sensor_write_register(0x30B0, 0x1300);	//AG, Context A
+        sensor_write_register(0x305E, 0x0020);	//DG, Context A
         sensor_write_register(0x3100, 0x0000);
+	    sensor_write_register(0x3ee4, 0xd208);
     }
-    
-    switch(p_gains->again_db >> 1)
-	{
-		case(0):
-			sensor_write_register(0x30B0, 0x1300);
-			break;
-		case(1):
-			sensor_write_register(0x30B0, 0x1300);
-			break;
-		case(2):
-			sensor_write_register(0x30B0, 0x1310);
-			break;
-		case(4):
-			sensor_write_register(0x30B0, 0x1320);
-			break;
-		case(8):
-			sensor_write_register(0x30B0, 0x1330);
-			break;
-	}
-
-	sensor_write_register(0x305E, dg);
-#endif
-}
-
-/* Emulate digital fine gain */
-static __inline void em_dgain_fine_update(cmos_gains_ptr_t p_gains)
-{
-}
-
-static HI_U32 cmos_gains_lin_to_db_convert(HI_U32 data, HI_U32 shift_in)
-{
-    #define PRECISION 8
-	HI_U32 _res = 0;
-	if(0 == data)
-		return _res;
-
-    data = data << PRECISION; // to ensure precision.
-	for(;;)
-	{
-        /* Note to avoid endless loop here. */
-		data = (data * 913) >> 10;
-        // data = (data*913 + (1<<9)) >> 10; // endless loop when shift_in is 0. */
-		if(data <= ((1<<shift_in) << PRECISION))
-		{
-			break;
-		}
-		++_res;
-	}
-	return _res;
-}
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-	HI_U32 _again = 1 << p_gains->again_shift;
-    HI_U32 _again_tmp;
-	int shft = 0;
-    HI_U32 exposure0 = exposure;
-
-	while (exposure > (1 << 26))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-
-    exposure_max = DIV_0_TO_1(exposure_max);
-
-    if(exposure > exposure_max)
-	{
-		_again_tmp = (exposure << 4) / exposure_max;
-
-		if (_again_tmp >= 45)
-        {
-            p_gains->again_db = 1;
-            _again = 45;
-            exposure = (exposure << 4) / 45;
-        }
-        else
-        {
-            p_gains->again_db = 0;
-        }
-	}
-	else
-	{
-	}
-    
-	if(exposure > exposure_max)
-	{
-        //when setting manual exposure line, exposure_max>>shift should not be 0.
-		_again_tmp = exposure  / exposure_max;
-
-		if (_again_tmp >= 1<< 3) { _again_tmp = 1<<3; }
-		else if (_again_tmp >= 1<< 2) { _again_tmp = 1<<2; }
-		else if (_again_tmp >= 1<< 1) { _again_tmp = 1<<1; }
-		else if (_again_tmp >= 1)     { _again_tmp = 1;    }
-
-		_again = _again * _again_tmp;      
-        
-		_again = _again < (1<<p_gains->again_shift) ? (1<<p_gains->again_shift) : _again;
-		_again = _again > p_gains->max_again_target ? p_gains->max_again_target : _again;
-
-
-        if(_again >= 45)
-        {
-            if (_again >= 45<<3 ) { _again_tmp = 1<<3; }
-        	else if (_again >= 45<< 2) { _again_tmp = 1<<2; }
-        	else if (_again >= 45<< 1) { _again_tmp = 1<<1; }
-        	else if (_again >= 45)     { _again_tmp = 1;    }
-
-            p_gains->again_db |= _again_tmp << 1;
-        }
-        else
-        {
-            if (_again >= 16<< 3) { _again_tmp = 1<<3; }
-        	else if (_again >= 16<< 2) { _again_tmp = 1<<2; }
-        	else if (_again >= 16<< 1) { _again_tmp = 1<<1; }
-        	else if (_again >= 16)     { _again_tmp = 1;    } 
-
-            p_gains->again_db |= _again_tmp << 1;
-
-        }
-        
-		exposure = ((exposure0 << p_gains->again_shift) / _again);
-
-	}
-	else
-	{
-		//_again = (_again * exposure) / (exposure / exposure_shift) / exposure_shift;
-	} 
-    
-	p_gains->again = _again;
-	return (exposure << shft);
-}
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
-
-    while (exposure > (1 << 22))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shift;
-}
-
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift
-		)
-{
-	HI_U32 _dgain = 1<<p_gains->dgain_shift;
-    HI_U32 exposure0;
-    int shft = 0;
-
-	while (exposure > (1<<20))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-    
-    exposure0 = exposure;
-	if(exposure > exposure_max)
-	{
-	    //when setting manual exposure line, exposure_max>>shift should not be 0.
-            exposure_max = DIV_0_TO_1(exposure_max);
-            _dgain = (exposure  * _dgain) / exposure_max;
-            exposure = exposure_max;
-	}
-	else
-	{
-        //TODO: after anti-flick, dgain may need to decrease.
-		//_dgain = (_dgain * exposure) / (exposure / exposure_shift) / exposure_shift;
-	}
-	_dgain = _dgain < (1<<p_gains->dgain_shift) ? (1<<p_gains->dgain_shift) : _dgain;
-	_dgain = (_dgain > p_gains->max_dgain_target) ? p_gains->max_dgain_target : _dgain;
-
-	p_gains->dgain = _dgain;
-    p_gains->dgain_db = cmos_gains_lin_to_db_convert(p_gains->dgain, p_gains->dgain_shift);
-
-	return exposure << shft;
-}
-
-static __inline void sensor_update(
-	cmos_gains_const_ptr_t p_gains,
-	cmos_inttime_ptr_t p_inttime,
-	HI_U8 frame
-    )
-{
-	if(frame == 0)
-	{
-		cmos_inttime_update(p_inttime);
-	}
-	if(frame == 1)
-	{
-		cmos_gains_update(p_gains);
-	}
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-	HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-	HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _ispdgain = p_gains->isp_dgain == 0 ? 1 : p_gains->isp_dgain;
-
-	p_gains->iso =  ((_again * _dgain * _ispdgain * 100) 
-        >> (p_gains->again_shift + p_gains->dgain_shift 
-        + p_gains->isp_dgain_shift));
-
-	return p_gains->iso;
-}
-
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    //return cmos_gains_lin_to_db_convert(p_gains->again, p_gains->again_shift);
-    return p_gains->again_db;
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-    //return cmos_gains_lin_to_db_convert(p_gains->dgain, p_gains->dgain_shift);
-    return p_gains->dgain_db;
-}
-
-#if 0
-static HI_U8 cmos_get_digital_fine_gain(cmos_gains_ptr_t p_gains)
-{
-    return cmos_gains_lin_to_db_convert(p_gains->dgain_fine, p_gains->dgain_shift);
-}
-#endif
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-	if (NULL == p_coms_isp_default)
-	{
-	    printf("null pointer when get isp default value!\n");
-	    return -1;
-	}
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
-{
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-
-static HI_U32 cmos_get_isp_gamma_table(cmos_isp_gamma_table_ptr_t p_cmos_isp_gamma_table)
-{
-   if(NULL == p_cmos_isp_gamma_table)
-   {
-    printf("null pointer when get isp gamma table!\n");
-    return -1;
-   }
-   memcpy(p_cmos_isp_gamma_table,&st_isp_gamma_table, sizeof(cmos_isp_gamma_table_t));
-   return 0;
-   
-}
-
-
-void setup_sensor(int isp_mode)
-{
-    if(0 == isp_mode) /* ISP 'normal' isp_mode */
+    else /* setup for ISP 'normal mode' */
     {
         sensor_write_register(0x300C, 0xa78);	//25fps
         sensor_write_register(0x3ee4, 0xd308);
  	    sensor_write_register(0x3100, 0x0004);
     }
-    else if(1 == isp_mode) /* ISP pixel calibration isp_mode */
-    {
-        sensor_write_register(0x300C, 0x4D58);	//5fps
-        sensor_write_register(0x3012, 0x05DA);	//max exposure lines
-        sensor_write_register(0x30B0, 0x1300);	//AG, Context A	1
-        sensor_write_register(0x305E, 0x0020);	//DG, Context A      	1
-        sensor_write_register(0x3100, 0x0000);
-	    sensor_write_register(0x3ee4, 0xd208);
-    }
+
+    return;
 }
 
-
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1280;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 720;
-
-    return 0;
-}
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-static SENSOR_EXP_FUNC_S stSensorExpFuncs =
-{
-	.pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-	.pfn_cmos_inttime_update = cmos_inttime_update,
-
-	.pfn_cmos_gains_initialize = cmos_gains_initialize,
-	.pfn_cmos_gains_update = cmos_gains_update,
-	.pfn_cmos_gains_update2 = NULL,
-	.pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-	.pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-	.pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-
-	.pfn_cmos_fps_set = cmos_fps_set,
-	.pfn_vblanking_calculate = vblanking_calculate,
-	.pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-	.pfn_setup_sensor = setup_sensor,
-
-	.pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-	.pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-	.pfn_cmos_get_digital_fine_gain = NULL,
-	.pfn_cmos_get_iso = cmos_get_ISO,
-
-	.pfn_cmos_get_isp_default = cmos_get_isp_default,
-	.pfn_cmos_get_isp_special_alg = NULL,
-	.pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-	.pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-	.pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-	.pfn_cmos_get_isp_shading_table = NULL,
-	.pfn_cmos_get_isp_gamma_table = cmos_get_isp_gamma_table,
-    .pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-    .pfn_cmos_set_sensor_image_mode = NULL,
-
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-	return 0;
-}
-
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
@@ -868,12 +298,424 @@ int sensor_mode_set(HI_U8 u8Mode)
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_U32 analog_gain_table[6] =
+{
+     1024, 2048, 2886, 5772, 11544, 23088
+
+};
+
+
+static HI_VOID cmos_again_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
+{
+    int i;
+
+    if(HI_NULL == pstAeSnsGainInfo)
+    {
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
+    }
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+
+    if (u32InTimes >= analog_gain_table[5])
+    {
+         pstAeSnsGainInfo->u32SnsTimes = analog_gain_table[5];
+         pstAeSnsGainInfo->u32GainDb = 5;
+         return ;
+    }
+    
+    for(i = 1; i < 6; i++)
+    {
+        if(u32InTimes < analog_gain_table[i])
+        {
+
+            pstAeSnsGainInfo->u32SnsTimes = analog_gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
+
+    }
+
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 750;
+    
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32LinesPer500ms = 750*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 748;
+    pstAeSnsDft->u32MinIntTime = 2;    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 2;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 6;    
+    pstAeSnsDft->u32MaxAgain = 23088;  /* 9db + 18db(8) */
+    pstAeSnsDft->u32MinAgain = 1024;
+    pstAeSnsDft->u32MaxAgainTarget = 23088;
+    pstAeSnsDft->u32MinAgainTarget = 1024;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.03125;    
+    pstAeSnsDft->u32MaxDgain = 255;  /* (8 - 0.3125) / 0.03125 = 255 */
+    pstAeSnsDft->u32MinDgain = 32;
+    pstAeSnsDft->u32MaxDgainTarget = 255;
+    pstAeSnsDft->u32MinDgainTarget = 32;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
     return 0;
 }
 
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    switch(u8Fps)
+    {
+        case 30:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 750;
+            pstAeSnsDft->u32MaxIntTime = 748;
+            pstAeSnsDft->u32LinesPer500ms = 750 * 30 / 2;
+            sensor_write_register(0x300c, 0x8ba);
+        break;
+        
+        case 25:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 750;
+            pstAeSnsDft->u32MaxIntTime = 748;
+            pstAeSnsDft->u32LinesPer500ms = 750 * 25 / 2;
+            sensor_write_register(0x300c, 0xa78);
+        break;
+        
+        default:
+        break;
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    sensor_write_register(0x300A, u16FullLines);
+
+    pstAeSnsDft->u32MaxIntTime = u16FullLines - 2;
+    
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_AR0130_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+    static HI_BOOL bInit = HI_FALSE;
+
+    if (HI_FALSE == bInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_I2C_TYPE;
+        g_stSnsRegsInfo.u32RegNum = 4;
+        for (i=0; i<g_stSnsRegsInfo.u32RegNum; i++)
+        {
+            g_stSnsRegsInfo.astI2cData[i].u8DevAddr = sensor_i2c_addr;
+            g_stSnsRegsInfo.astI2cData[i].u32AddrByteNum = sensor_addr_byte;
+            g_stSnsRegsInfo.astI2cData[i].u32DataByteNum = sensor_data_byte;
+        }
+        g_stSnsRegsInfo.astI2cData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[0].u32RegAddr = 0x3012;
+        g_stSnsRegsInfo.astI2cData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[1].u32RegAddr = 0x30B0;
+        g_stSnsRegsInfo.astI2cData[2].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[2].u32RegAddr = 0x305E;
+        g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[3].u32RegAddr = 0x3100;
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_FALSE;
+
+        bInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+#if CMOS_AR0130_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[0].u32Data = u32IntTime;
+#else
+    sensor_write_register(0x3012, u32IntTime);
+#endif
+    return;
+}
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+#if CMOS_AR0130_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    
+        if(u32Again >= 2)
+        {
+            g_stSnsRegsInfo.astI2cData[3].u32Data = 0x0004;
+        }
+        else
+        {
+            g_stSnsRegsInfo.astI2cData[3].u32Data = 0x0000;
+        }
+        
+        switch(u32Again)
+        {
+            case 0:
+            case 2:
+                g_stSnsRegsInfo.astI2cData[1].u32Data = 0x1300;
+                break;
+            case 1:
+            case 3:
+                g_stSnsRegsInfo.astI2cData[1].u32Data = 0x1310;
+                break;
+            case 4:
+                g_stSnsRegsInfo.astI2cData[1].u32Data = 0x1320;
+                break;
+            case 5:
+                g_stSnsRegsInfo.astI2cData[1].u32Data = 0x1330;
+                break;
+        }
+        
+        g_stSnsRegsInfo.astI2cData[2].u32Data = u32Dgain;
+    
+        HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+#else
+        if(u32Again >= 2)
+        {
+            sensor_write_register(0x3100, 0x0004);
+        }
+        else
+        {
+            sensor_write_register(0x3100, 0x0000);
+        }
+        
+        switch(u32Again)
+        {
+            case 0:
+            case 2:
+                sensor_write_register(0x30B0, 0x1300);
+                break;
+            case 1:
+            case 3:
+                sensor_write_register(0x30B0, 0x1310);
+                break;
+            case 4:
+                sensor_write_register(0x30B0, 0x1320);
+                break;
+            case 5:
+                sensor_write_register(0x30B0, 0x1330);
+                break;
+        }
+    
+        sensor_write_register(0x305E, u32Dgain);
+    
+#endif
+        return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 5000;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x018b;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x01a7;
+
+    pstAwbSnsDft->as32WbPara[0] = 86;
+    pstAwbSnsDft->as32WbPara[1] = -16;
+    pstAwbSnsDft->as32WbPara[2] = -182;
+    pstAwbSnsDft->as32WbPara[3] = 243836;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -195566;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+    pstExpFuncs->pfn_cmos_again_calc_table  = cmos_again_calc_table;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(AR0130_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, AR0130_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, AR0130_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(AR0130_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, AR0130_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, AR0130_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -881,6 +723,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-
-
-#endif // __AR0130_CMOS_H_
+#endif // __IMX104_CMOS_H_

--- a/libraries/sensor/hi3516cv100/aptina_ar0130/ar0130_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/aptina_ar0130/ar0130_sensor_ctl.c
@@ -44,6 +44,7 @@ int sensor_write_register(int addr, int data)
     i2c_data.data_byte_num = sensor_data_byte;
 
     ret = ioctl(fd, GPIO_I2C_WRITE, &i2c_data);
+
     if (ret)
     {
         printf("GPIO-I2C write faild!\n");
@@ -71,6 +72,7 @@ int sensor_write_register(int addr, int data)
     i2c_data.data_byte_num = sensor_data_byte;
 
     ret = ioctl(fd, CMD_I2C_WRITE, &i2c_data);
+
     if (ret)
     {
         printf("hi_i2c write faild!\n");
@@ -99,7 +101,7 @@ void sensor_prog(int* rom)
         } else if (addr == 0xFFFF) {
             return;
         } else {
-			sensor_write_register(addr, data);
+            sensor_write_register(addr, data);
         }
     }
 }
@@ -108,296 +110,296 @@ void sensor_init()
 {
 //[720p30]
 #if 0	
-	sensor_write_register(0x301A, 0x0001); 	// RESET_REGISTER
-	sensor_write_register(0x301A, 0x10D8); 	// RESET_REGISTER
-	
-	delay_ms(200);	//DELAY= 200
-	
-	sensor_write_register(0x3088, 0x8000); 	// SEQ_CTRL_PORT
-	sensor_write_register(0x3086, 0x0225); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x5050); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2D26); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0828); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0D17); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0926); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0028); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0526); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0xA728); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0725); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x8080); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2917); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0525); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0040); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2702); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1616); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2706); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1736); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x26A6); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1703); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x26A4); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x171F); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2805); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2620); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2804); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2520); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2027); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0017); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1E25); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0020); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2117); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1028); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x051B); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1703); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2706); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1703); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1741); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2660); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x17AE); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2500); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x9027); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0026); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1828); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x002E); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2A28); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x081E); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0831); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1440); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x4014); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2020); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1410); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1034); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1400); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1014); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0020); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1400); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x4013); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1802); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1470); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x7004); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1470); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x7003); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1470); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x7017); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2002); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1400); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2002); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1400); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x5004); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1400); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2004); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x1400); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x5022); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0314); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0020); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0314); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x0050); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2C2C); 	// SEQ_DATA_PORT
-	sensor_write_register(0x3086, 0x2C2C); 	// SEQ_DATA_PORT
-	sensor_write_register(0x309E, 0x0000); 	// ERS_PROG_START_ADDR
-	
-	delay_ms(200);	//DELAY= 200
-	
-	sensor_write_register(0x30E4, 0x6372); 	// ADC_BITS_6_7
-	sensor_write_register(0x30E2, 0x7253); 	// ADC_BITS_4_5
-	sensor_write_register(0x30E0, 0x5470); 	// ADC_BITS_2_3
-	sensor_write_register(0x30E6, 0xC4CC); 	// ADC_CONFIG1
-	sensor_write_register(0x30E8, 0x8050); 	// ADC_CONFIG2
-	sensor_write_register(0x3082, 0x0029); 	// OPERATION_MODE_CTRL
-	sensor_write_register(0x30B0, 0x1300); 	// DIGITAL_TEST
-	sensor_write_register(0x30D4, 0xE007); 	// COLUMN_CORRECTION
-	sensor_write_register(0x301A, 0x10DC); 	// RESET_REGISTER
-	sensor_write_register(0x301A, 0x10D8); 	// RESET_REGISTER
-	sensor_write_register(0x3044, 0x0400); 	// DARK_CONTROL
-	sensor_write_register(0x3EDA, 0x0F03); 	// DAC_LD_14_15
-	sensor_write_register(0x3ED8, 0x01EF); 	// DAC_LD_12_13
-	sensor_write_register(0x3012, 0x02A0); 	// COARSE_INTEGRATION_TIME
-	sensor_write_register(0x3032, 0x0000); 	// DIGITAL_BINNING
-	sensor_write_register(0x3002, 0x003e); 	// Y_ADDR_START
-	sensor_write_register(0x3004, 0x0004); 	// X_ADDR_START
-	sensor_write_register(0x3006, 0x030d); 	// Y_ADDR_END
-	sensor_write_register(0x3008, 0x0503); 	// X_ADDR_END
-	sensor_write_register(0x300A, 0x02EE); 	// FRAME_LENGTH_LINES
-	sensor_write_register(0x300C, 0x0CE4); 	// LINE_LENGTH_PCK
-	sensor_write_register(0x301A, 0x10D8); 	// RESET_REGISTER
-	sensor_write_register(0x31D0, 0x0001); 	// HDR_COMP
+    sensor_write_register(0x301A, 0x0001);  // RESET_REGISTER
+    sensor_write_register(0x301A, 0x10D8);  // RESET_REGISTER
+    
+    delay_ms(200);  //DELAY= 200
+    
+    sensor_write_register(0x3088, 0x8000);  // SEQ_CTRL_PORT
+    sensor_write_register(0x3086, 0x0225);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x5050);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2D26);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0828);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0D17);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0926);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0028);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0526);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0xA728);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0725);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x8080);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2917);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0525);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0040);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2702);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1616);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2706);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1736);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x26A6);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1703);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x26A4);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x171F);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2805);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2620);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2804);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2520);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2027);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0017);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1E25);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0020);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2117);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1028);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x051B);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1703);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2706);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1703);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1741);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2660);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x17AE);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2500);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x9027);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0026);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1828);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x002E);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2A28);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x081E);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0831);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1440);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x4014);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2020);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1410);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1034);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1400);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1014);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0020);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1400);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x4013);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1802);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1470);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x7004);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1470);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x7003);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1470);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x7017);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2002);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1400);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2002);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1400);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x5004);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1400);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2004);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x1400);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x5022);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0314);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0020);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0314);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x0050);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2C2C);  // SEQ_DATA_PORT
+    sensor_write_register(0x3086, 0x2C2C);  // SEQ_DATA_PORT
+    sensor_write_register(0x309E, 0x0000);  // ERS_PROG_START_ADDR
+    
+    delay_ms(200);  //DELAY= 200
+    
+    sensor_write_register(0x30E4, 0x6372);  // ADC_BITS_6_7
+    sensor_write_register(0x30E2, 0x7253);  // ADC_BITS_4_5
+    sensor_write_register(0x30E0, 0x5470);  // ADC_BITS_2_3
+    sensor_write_register(0x30E6, 0xC4CC);  // ADC_CONFIG1
+    sensor_write_register(0x30E8, 0x8050);  // ADC_CONFIG2
+    sensor_write_register(0x3082, 0x0029);  // OPERATION_MODE_CTRL
+    sensor_write_register(0x30B0, 0x1300);  // DIGITAL_TEST
+    sensor_write_register(0x30D4, 0xE007);  // COLUMN_CORRECTION
+    sensor_write_register(0x301A, 0x10DC);  // RESET_REGISTER
+    sensor_write_register(0x301A, 0x10D8);  // RESET_REGISTER
+    sensor_write_register(0x3044, 0x0400);  // DARK_CONTROL
+    sensor_write_register(0x3EDA, 0x0F03);  // DAC_LD_14_15
+    sensor_write_register(0x3ED8, 0x01EF);  // DAC_LD_12_13
+    sensor_write_register(0x3012, 0x02A0);  // COARSE_INTEGRATION_TIME
+    sensor_write_register(0x3032, 0x0000);  // DIGITAL_BINNING
+    sensor_write_register(0x3002, 0x003e);  // Y_ADDR_START
+    sensor_write_register(0x3004, 0x0004);  // X_ADDR_START
+    sensor_write_register(0x3006, 0x030d);  // Y_ADDR_END
+    sensor_write_register(0x3008, 0x0503);  // X_ADDR_END
+    sensor_write_register(0x300A, 0x02EE);  // FRAME_LENGTH_LINES
+    sensor_write_register(0x300C, 0x0CE4);  // LINE_LENGTH_PCK
+    sensor_write_register(0x301A, 0x10D8);  // RESET_REGISTER
+    sensor_write_register(0x31D0, 0x0001);  // HDR_COMP
 
-	//Load = PLL Enabled 27Mhz to 74.25Mhz
-	sensor_write_register(0x302C, 0x0002); 	// VT_SYS_CLK_DIV
-	sensor_write_register(0x302A, 0x0004); 	// VT_PIX_CLK_DIV
-	sensor_write_register(0x302E, 0x0002); 	// PRE_PLL_CLK_DIV
-	sensor_write_register(0x3030, 0x002C); 	// PLL_MULTIPLIER
-	sensor_write_register(0x30B0, 0x0000); 	// DIGITAL_TEST	
-	delay_ms(100);	//DELAY= 100
+    //Load = PLL Enabled 27Mhz to 74.25Mhz
+    sensor_write_register(0x302C, 0x0002);  // VT_SYS_CLK_DIV
+    sensor_write_register(0x302A, 0x0004);  // VT_PIX_CLK_DIV
+    sensor_write_register(0x302E, 0x0002);  // PRE_PLL_CLK_DIV
+    sensor_write_register(0x3030, 0x002C);  // PLL_MULTIPLIER
+    sensor_write_register(0x30B0, 0x0000);  // DIGITAL_TEST 
+    delay_ms(100);  //DELAY= 100
 #endif
-	sensor_write_register( 0x301A, 0x0001 );	// RESET_REGISTER
-	delay_ms(200); //ms
-	sensor_write_register( 0x301A, 0x10D8 );	// RESET_REGISTER
-	delay_ms(200); //ms
-	//Linear Mode Setup
-	//AR0130 Rev1 Linear sequencer load  8-2-2011
-	sensor_write_register( 0x3088, 0x8000 );// SEQ_CTRL_PORT
-	sensor_write_register( 0x3086, 0x0225 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x5050 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2D26 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0828 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0D17 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0926 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0028 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0526 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0xA728 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0725 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x8080 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2917 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0525 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0040 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2702 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1616 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2706 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1736 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x26A6 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1703 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x26A4 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x171F );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2805 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2620 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2804 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2520 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2027 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0017 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1E25 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0020 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2117 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1028 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x051B );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1703 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2706 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1703 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1747 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2660 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x17AE );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2500 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x9027 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0026 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1828 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x002E );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2A28 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x081E );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0831 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1440 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x4014 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2020 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1410 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1034 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1014 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0020 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x4013 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1802 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1470 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x7004 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1470 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x7003 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1470 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x7017 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2002 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2002 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x5004 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2004 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x5022 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0314 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0020 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0314 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x0050 );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2C2C );// SEQ_DATA_PORT
-	sensor_write_register( 0x3086, 0x2C2C );// SEQ_DATA_PORT
-	sensor_write_register( 0x309E, 0x0000 );// DCDS_PROG_START_ADDR
-	sensor_write_register( 0x30E4, 0x6372 );// ADC_BITS_6_7
-	sensor_write_register( 0x30E2, 0x7253 );// ADC_BITS_4_5
-	sensor_write_register( 0x30E0, 0x5470 );// ADC_BITS_2_3
-	sensor_write_register( 0x30E6, 0xC4CC );// ADC_CONFIG1
-	sensor_write_register( 0x30E8, 0x8050 );// ADC_CONFIG2
-	delay_ms(200); //ms
-	sensor_write_register( 0x3082, 0x0029 );	// OPERATION_MODE_CTRL
-	//AR0130 Rev1 Optimized settings
-	sensor_write_register( 0x301E, 0x00C8); // DATA_PEDESTAL
-	sensor_write_register( 0x3EDA, 0x0F03); // DAC_LD_14_15
-	sensor_write_register( 0x3EDE, 0xC005); // DAC_LD_18_19
-	sensor_write_register( 0x3ED8, 0x09EF); // DAC_LD_12_13
-	sensor_write_register( 0x3EE2, 0xA46B); // DAC_LD_22_23
-	sensor_write_register( 0x3EE0, 0x047D); // DAC_LD_20_21
-	sensor_write_register( 0x3EDC, 0x0070); // DAC_LD_16_17
-	sensor_write_register( 0x3044, 0x0404); // DARK_CONTROL
-	sensor_write_register( 0x3EE6, 0x8303); // DAC_LD_26_27
-	sensor_write_register( 0x3EE4, 0xD208); // DAC_LD_24_25
-	sensor_write_register( 0x3ED6, 0x00BD); // DAC_LD_10_11
-	sensor_write_register( 0x30B0, 0x1300); // DIGITAL_TEST
-	sensor_write_register( 0x30D4, 0xE007); // COLUMN_CORRECTION
-	sensor_write_register( 0x301A, 0x10DC); // RESET_REGISTER
-	delay_ms(500 );//ms					
-	sensor_write_register( 0x301A, 0x10D8); // RESET_REGISTER
-	delay_ms(500); //ms					  
-	sensor_write_register( 0x3044, 0x0400); // DARK_CONTROL
-									
-	sensor_write_register( 0x3012, 0x02A0); // COARSE_INTEGRATION_TIME
+    sensor_write_register( 0x301A, 0x0001 );    // RESET_REGISTER
+    delay_ms(200); //ms
+    sensor_write_register( 0x301A, 0x10D8 );    // RESET_REGISTER
+    delay_ms(200); //ms
+    //Linear Mode Setup
+    //AR0130 Rev1 Linear sequencer load  8-2-2011
+    sensor_write_register( 0x3088, 0x8000 );// SEQ_CTRL_PORT
+    sensor_write_register( 0x3086, 0x0225 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x5050 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2D26 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0828 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0D17 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0926 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0028 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0526 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0xA728 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0725 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x8080 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2917 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0525 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0040 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2702 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1616 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2706 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1736 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x26A6 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1703 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x26A4 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x171F );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2805 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2620 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2804 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2520 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2027 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0017 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1E25 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0020 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2117 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1028 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x051B );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1703 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2706 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1703 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1747 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2660 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x17AE );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2500 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x9027 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0026 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1828 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x002E );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2A28 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x081E );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0831 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1440 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x4014 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2020 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1410 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1034 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1014 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0020 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x4013 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1802 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1470 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x7004 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1470 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x7003 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1470 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x7017 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2002 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2002 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x5004 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2004 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x1400 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x5022 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0314 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0020 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0314 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x0050 );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2C2C );// SEQ_DATA_PORT
+    sensor_write_register( 0x3086, 0x2C2C );// SEQ_DATA_PORT
+    sensor_write_register( 0x309E, 0x0000 );// DCDS_PROG_START_ADDR
+    sensor_write_register( 0x30E4, 0x6372 );// ADC_BITS_6_7
+    sensor_write_register( 0x30E2, 0x7253 );// ADC_BITS_4_5
+    sensor_write_register( 0x30E0, 0x5470 );// ADC_BITS_2_3
+    sensor_write_register( 0x30E6, 0xC4CC );// ADC_CONFIG1
+    sensor_write_register( 0x30E8, 0x8050 );// ADC_CONFIG2
+    delay_ms(200); //ms
+    sensor_write_register( 0x3082, 0x0029 );    // OPERATION_MODE_CTRL
+    //AR0130 Rev1 Optimized settings
+    sensor_write_register( 0x301E, 0x00C8); // DATA_PEDESTAL
+    sensor_write_register( 0x3EDA, 0x0F03); // DAC_LD_14_15
+    sensor_write_register( 0x3EDE, 0xC005); // DAC_LD_18_19
+    sensor_write_register( 0x3ED8, 0x09EF); // DAC_LD_12_13
+    sensor_write_register( 0x3EE2, 0xA46B); // DAC_LD_22_23
+    sensor_write_register( 0x3EE0, 0x047D); // DAC_LD_20_21
+    sensor_write_register( 0x3EDC, 0x0070); // DAC_LD_16_17
+    sensor_write_register( 0x3044, 0x0404); // DARK_CONTROL
+    sensor_write_register( 0x3EE6, 0x8303); // DAC_LD_26_27
+    sensor_write_register( 0x3EE4, 0xD208); // DAC_LD_24_25
+    sensor_write_register( 0x3ED6, 0x00BD); // DAC_LD_10_11
+    sensor_write_register( 0x30B0, 0x1300); // DIGITAL_TEST
+    sensor_write_register( 0x30D4, 0xE007); // COLUMN_CORRECTION
+    sensor_write_register( 0x301A, 0x10DC); // RESET_REGISTER
+    delay_ms(500 );//ms                 
+    sensor_write_register( 0x301A, 0x10D8); // RESET_REGISTER
+    delay_ms(500); //ms                   
+    sensor_write_register( 0x3044, 0x0400); // DARK_CONTROL
+                                    
+    sensor_write_register( 0x3012, 0x02A0); // COARSE_INTEGRATION_TIME
 
-	
-	//720p 30fps Setup					 
-	sensor_write_register( 0x3032, 0x0000); // DIGITAL_BINNING
-	sensor_write_register( 0x3002, 0x0002); // Y_ADDR_START
-	sensor_write_register( 0x3004, 0x0000); // X_ADDR_START
-	sensor_write_register( 0x3006, 0x02D1);//Row End (A) = 721
-	sensor_write_register( 0x3008, 0x04FF);//Column End (A) = 1279
-	sensor_write_register( 0x300A, 0x02EA);//Frame Lines (A) = 746
-	sensor_write_register( 0x300C, 0x08ba);
-	sensor_write_register( 0x3012, 0x0133);//Coarse_IT_Time (A) = 307
-	sensor_write_register( 0x306e, 0x9211);//Coarse_IT_Time (A) = 307
-
-
-	//Enable Parallel Mode
-	sensor_write_register( 0x301A, 0x10D8);	// RESET_REGISTER
-	sensor_write_register( 0x31D0, 0x0001);	// HDR_COMP
-	
-	//PLL Enabled 27Mhz to 50Mhz
-	sensor_write_register( 0x302A, 0x0009 );//VT_PIX_CLK_DIV = 9
-	sensor_write_register( 0x302C, 0x0001 );//VT_SYS_CLK_DIV = 1
-	sensor_write_register( 0x302E, 0x0003 );//PRE_PLL_CLK_DIV = 3
-	sensor_write_register( 0x3030, 0x0032 );//PLL_MULTIPLIER = 50
-	sensor_write_register( 0x30B0, 0x1300 ); 	// DIGITAL_TEST
-	delay_ms(100); //ms
-	sensor_write_register( 0x301A, 0x10DC );	// RESET_REGISTER
-	sensor_write_register( 0x301A, 0x10DC );	// RESET_REGISTER
-										  
-	//exposure							  
-	sensor_write_register( 0x3012, 0x0671 );	// COARSE_INTEGRATION_TIME
-	sensor_write_register( 0x30B0, 0x1330 );	// DIGITAL_TEST
-	sensor_write_register( 0x3056, 0x003B );	// GREEN1_GAIN
-	sensor_write_register( 0x305C, 0x003B );	// GREEN2_GAIN
-	sensor_write_register( 0x305A, 0x003B );	// RED_GAIN
-	sensor_write_register( 0x3058, 0x003B );	// BLUE_GAIN
-	//High Conversion gain				  
-	sensor_write_register( 0x3100, 0x0004 );	// AE_CTRL_REG
+    
+    //720p 30fps Setup                   
+    sensor_write_register( 0x3032, 0x0000); // DIGITAL_BINNING
+    sensor_write_register( 0x3002, 0x0002); // Y_ADDR_START
+    sensor_write_register( 0x3004, 0x0000); // X_ADDR_START
+    sensor_write_register( 0x3006, 0x02D1);//Row End (A) = 721
+    sensor_write_register( 0x3008, 0x04FF);//Column End (A) = 1279
+    sensor_write_register( 0x300A, 0x02EA);//Frame Lines (A) = 746
+    sensor_write_register( 0x300C, 0x08ba);
+    sensor_write_register( 0x3012, 0x0133);//Coarse_IT_Time (A) = 307
+    sensor_write_register( 0x306e, 0x9211);//Coarse_IT_Time (A) = 307
 
 
-	//LOAD= Disable Embedded Data and Stats
-	sensor_write_register(0x3064, 0x1802); 	// SMIA_TEST, EMBEDDED_STATS_EN, 0x0000
-	sensor_write_register(0x3064, 0x1802); 	// SMIA_TEST, EMBEDDED_DATA, 0x0000 
+    //Enable Parallel Mode
+    sensor_write_register( 0x301A, 0x10D8); // RESET_REGISTER
+    sensor_write_register( 0x31D0, 0x0001); // HDR_COMP
+    
+    //PLL Enabled 27Mhz to 50Mhz
+    sensor_write_register( 0x302A, 0x0009 );//VT_PIX_CLK_DIV = 9
+    sensor_write_register( 0x302C, 0x0001 );//VT_SYS_CLK_DIV = 1
+    sensor_write_register( 0x302E, 0x0003 );//PRE_PLL_CLK_DIV = 3
+    sensor_write_register( 0x3030, 0x0032 );//PLL_MULTIPLIER = 50
+    sensor_write_register( 0x30B0, 0x1300 );    // DIGITAL_TEST
+    delay_ms(100); //ms
+    sensor_write_register( 0x301A, 0x10DC );    // RESET_REGISTER
+    sensor_write_register( 0x301A, 0x10DC );    // RESET_REGISTER
+                                          
+    //exposure                            
+    sensor_write_register( 0x3012, 0x0671 );    // COARSE_INTEGRATION_TIME
+    sensor_write_register( 0x30B0, 0x1330 );    // DIGITAL_TEST
+    sensor_write_register( 0x3056, 0x003B );    // GREEN1_GAIN
+    sensor_write_register( 0x305C, 0x003B );    // GREEN2_GAIN
+    sensor_write_register( 0x305A, 0x003B );    // RED_GAIN
+    sensor_write_register( 0x3058, 0x003B );    // BLUE_GAIN
+    //High Conversion gain                
+    sensor_write_register( 0x3100, 0x0004 );    // AE_CTRL_REG
 
-	sensor_write_register(0x30BA, 0x0008);       //20120502
 
-	sensor_write_register(0x3EE4, 0xD308);  //the default value former is 0xd208
+    //LOAD= Disable Embedded Data and Stats
+    sensor_write_register(0x3064, 0x1802);  // SMIA_TEST, EMBEDDED_STATS_EN, 0x0000
+    sensor_write_register(0x3064, 0x1802);  // SMIA_TEST, EMBEDDED_DATA, 0x0000 
 
-	sensor_write_register(0x301A, 0x10DC); 	// RESET_REGISTER
+    sensor_write_register(0x30BA, 0x0008);       //20120502
 
-	delay_ms(200);	//DELAY= 200
+    sensor_write_register(0x3EE4, 0xD308);  //the default value former is 0xd208
+
+    sensor_write_register(0x301A, 0x10DC);  // RESET_REGISTER
+
+    delay_ms(200);  //DELAY= 200
 
 
-	printf("Aptina AR0130 sensor 720P30fps init success!\n");
-	
+    printf("Aptina AR0130 sensor 720P30fps init success!\n");
+    
 }
 
 

--- a/libraries/sensor/hi3516cv100/aptina_ar0330/ar0330_cmos.c
+++ b/libraries/sensor/hi3516cv100/aptina_ar0330/ar0330_cmos.c
@@ -3,10 +3,13 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 #include "hi_comm_sns.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_isp_debug.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -14,87 +17,68 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
+#define AR0330_ID 330
+
+/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker in antiflicker mode */
+/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance                       */
+/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                                         */
+#define CMOS_AR0330_ISP_WRITE_SENSOR_ENABLE (1)
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
 extern const unsigned int sensor_i2c_addr;
-extern const unsigned int sensor_addr_byte;
-extern const unsigned int sensor_data_byte;
+extern unsigned int sensor_addr_byte;
+extern unsigned int sensor_data_byte;
 
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
+HI_U32 gu32FullLinesStd = 1092;
 HI_U8 gu8SensorMode = 0;
 
-/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker */
-/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance   */
-/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                     */
-#define CMOS_AR0330_ISP_WRITE_SENSOR_ENABLE (1)
+#if CMOS_AR0330_ISP_WRITE_SENSOR_ENABLE
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
+#endif
 
-static cmos_isp_default_t st_coms_isp_default =
+static AWB_CCM_S g_stAwbCcm =
 {
+ 
+    4900,
     {
-        4900,
-        {
-            0x0206, 0x80a0, 0x8066,
-            0x8063, 0x0190, 0x802d,
-            0x800f, 0x80bd, 0x01cc
-        },
+        0x0206, 0x80a0, 0x8066,
+        0x8063, 0x0190, 0x802d,
+        0x800f, 0x80bd, 0x01cc
+    },
         
-        3100,
-        {
-            0x01e2, 0x8097, 0x804b,
-            0x806d, 0x0185, 0x8018,
-            0x8010, 0x80f3, 0x0203
-	  },
-
-        2470,
-        {
-            0x01a5, 0x8066, 0x803f,
-            0x805f, 0x0153, 0xb,
-            0x8061, 0x80e8, 0x249
-        }
+    3100,
+    {
+        0x01e2, 0x8097, 0x804b,
+        0x806d, 0x0185, 0x8018,
+        0x8010, 0x80f3, 0x0203
     },
 
-	// black level for R, Gr, Gb, B channels
-	{0xA8,0xA8,0xA8,0xA8},
-    	//{187,198,178,163},
-
-	//calibration reference color temperature
-	4900,
-
-	//WB gain at Macbeth 5000K, must keep consistent with calibration color temperature
-    	{0x198,0x100,0x100,0x1b2},
-	// WB curve parameters, must keep consistent with reference color temperature.
-    //{104,-38,-190,224624,128,-176434},
-        {55,24,-177,271396,128,-220863},
-	// hist_thresh
-	{0xd,0x28,0x60,0x80},
-
-	0x00,	// iridix_balck
-	0x1,	// rggb
-
-	// gain
-	0x8,	0x10, // this is gain target, it will be constricted by sensor-gain.
-	//0x8,	0x4, /* The purpose of setting max dgain target to 4 is to reduce FPN */
-
-	//wdr_variance_space, wdr_variance_intensity, slope_max_write,  white_level_write
-	0x04,	0x01,	0x30, 	0x4FF,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x23, 	// sinter threshold
-
-	0x1,     //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
-	0x0,
-	546,
-
-    2
+    2470,
+    {
+        0x01a5, 0x8066, 0x803f,
+        0x805f, 0x0153, 0xb,
+        0x8061, 0x80e8, 0x249
+    }
+ 
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
-    //sharpen_alt_d
+    /* bvalid */
+    1,
+
+    /* saturation */    
+    {0x80,0x80,0x6C,0x48,0x44,0x40,0x3C,0x38}
+};
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
+{
+    /* bvalid */
+    1,
+
+    /* sharpen_alt_d */
     {0x50,0x48,0x40,0x38,0x34,0x30,0x28,0x28},
 
     //sharpen_alt_ud
@@ -103,22 +87,22 @@ static cmos_isp_agc_table_t st_isp_agc_table =
     //snr_thresh
     {0x13,0x19,0x20,0x26,0x2c,0x32,0x38,0x38},
 
-    //demosaic_lum_thresh
+    /* demosaic_lum_thresh */
     {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
-
-    //demosaic_np_offset
+        
+    /* demosaic_np_offset */
     {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
-
-    /* saturation */
-    {0x80,0x80,0x6C,0x48,0x44,0x40,0x3C,0x38}
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
 {
-    //nosie_profile_weight_lut
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {0,  0,  0,  0,  0,  0,  11, 15, 17, 19, 20, 21, 22, 22, 23, 24,
     25, 25, 26, 26, 26, 27, 27, 27, 28, 28, 28, 29, 29, 29, 29, 29,
     30, 30, 30, 30, 30, 31, 31, 31, 31, 31, 32, 32, 32, 32, 32, 32,
@@ -127,20 +111,23 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 37, 37,
     37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 38, 38,
     38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38},
-
-    //demosaic_weight_lut
-    {0,11,15,17,19,20,21,22,23,23,24,25,25,26,26,26,
-    27,27,27,28,28,28,29,29,29,29,29,30,30,30,30,30,
-    31,31,31,31,31,32,32,32,32,32,32,32,33,33,33,33,
-    33,33,33,33,33,34,34,34,34,34,34,34,34,34,34,35,
-    35,35,35,35,35,35,35,35,35,35,35,36,36,36,36,36,
-    36,36,36,36,36,36,36,36,36,37,37,37,37,37,37,37,
-    37,37,37,37,37,37,37,37,37,38,38,38,38,38,38,38,
-    38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38}
+    
+    /* demosaic_weight_lut */
+    {0, 11, 15, 17, 19, 20, 21, 22, 23, 23, 24, 25, 25, 26, 26, 26,
+    27, 27, 27, 28, 28, 28, 29, 29, 29, 29, 29, 30, 30, 30, 30, 30,
+    31, 31, 31, 31, 31, 32, 32, 32, 32, 32, 32, 32, 33, 33, 33, 33,
+    33, 33, 33, 33, 33, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 35,
+    35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 36, 36, 36, 36, 36,
+    36, 36, 36, 36, 36, 36, 36, 36, 36, 37, 37, 37, 37, 37, 37, 37,
+    37, 37, 37, 37, 37, 37, 37, 37, 37, 38, 38, 38, 38, 38, 38, 38,
+    38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38}
 };
 
-static cmos_isp_demosaic_t st_isp_demosaic =
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
+    /* bvalid */
+    1,
+    
     /*vh_slope*/
     0xe9,
 
@@ -160,16 +147,16 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0xcf,
 
     /*vh_thresh*/
-    0xd8,
+    0,
 
     /*aa_thresh*/
-    0xd5,
+    0,
 
     /*va_thresh*/
-    0xb6,
+    0,
 
     /*uu_thresh*/
-    0xc4,
+    0,
 
     /*sat_thresh*/
     0x171,
@@ -178,481 +165,133 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x1b3
 };
 
-static HI_U32 analog_gain_table[29] =
+static ISP_CMOS_GAMMA_S g_stIspGamma =
+{
+    /* bvalid */
+    1,
+    
+#if 1    
+    {0  ,120 ,220 ,310 ,390 ,470 ,540 ,610 ,670 ,730 ,786 ,842 ,894 ,944 ,994 ,1050,    
+    1096,1138,1178,1218,1254,1280,1314,1346,1378,1408,1438,1467,1493,1519,1543,1568,    
+    1592,1615,1638,1661,1683,1705,1726,1748,1769,1789,1810,1830,1849,1869,1888,1907,    
+    1926,1945,1963,1981,1999,2017,2034,2052,2069,2086,2102,2119,2136,2152,2168,2184,    
+    2200,2216,2231,2247,2262,2277,2292,2307,2322,2337,2351,2366,2380,2394,2408,2422,    
+    2436,2450,2464,2477,2491,2504,2518,2531,2544,2557,2570,2583,2596,2609,2621,2634,    
+    2646,2659,2671,2683,2696,2708,2720,2732,2744,2756,2767,2779,2791,2802,2814,2825,    
+    2837,2848,2859,2871,2882,2893,2904,2915,2926,2937,2948,2959,2969,2980,2991,3001,    
+    3012,3023,3033,3043,3054,3064,3074,3085,3095,3105,3115,3125,3135,3145,3155,3165,    
+    3175,3185,3194,3204,3214,3224,3233,3243,3252,3262,3271,3281,3290,3300,3309,3318,    
+    3327,3337,3346,3355,3364,3373,3382,3391,3400,3409,3418,3427,3436,3445,3454,3463,    
+    3471,3480,3489,3498,3506,3515,3523,3532,3540,3549,3557,3566,3574,3583,3591,3600,    
+    3608,3616,3624,3633,3641,3649,3657,3665,3674,3682,3690,3698,3706,3714,3722,3730,    
+    3738,3746,3754,3762,3769,3777,3785,3793,3801,3808,3816,3824,3832,3839,3847,3855,    
+    3862,3870,3877,3885,3892,3900,3907,3915,3922,3930,3937,3945,3952,3959,3967,3974,    
+    3981,3989,3996,4003,4010,4018,4025,4032,4039,4046,4054,4061,4068,4075,4082,4089,4095}
+#else  /*higher  contrast*/
+    {0  , 54 , 106, 158, 209, 259, 308, 356, 403, 450, 495, 540, 584, 628, 670, 713,
+    754 ,795 , 835, 874, 913, 951, 989,1026,1062,1098,1133,1168,1203,1236,1270,1303,
+    1335,1367,1398,1429,1460,1490,1520,1549,1578,1607,1635,1663,1690,1717,1744,1770,
+    1796,1822,1848,1873,1897,1922,1946,1970,1993,2017,2040,2062,2085,2107,2129,2150,
+    2172,2193,2214,2235,2255,2275,2295,2315,2335,2354,2373,2392,2411,2429,2447,2465,
+    2483,2501,2519,2536,2553,2570,2587,2603,2620,2636,2652,2668,2684,2700,2715,2731,
+    2746,2761,2776,2790,2805,2819,2834,2848,2862,2876,2890,2903,2917,2930,2944,2957,
+    2970,2983,2996,3008,3021,3033,3046,3058,3070,3082,3094,3106,3118,3129,3141,3152,
+    3164,3175,3186,3197,3208,3219,3230,3240,3251,3262,3272,3282,3293,3303,3313,3323,
+    3333,3343,3352,3362,3372,3381,3391,3400,3410,3419,3428,3437,3446,3455,3464,3473,
+    3482,3490,3499,3508,3516,3525,3533,3541,3550,3558,3566,3574,3582,3590,3598,3606,
+    3614,3621,3629,3637,3644,3652,3660,3667,3674,3682,3689,3696,3703,3711,3718,3725,
+    3732,3739,3746,3752,3759,3766,3773,3779,3786,3793,3799,3806,3812,3819,3825,3831,
+    3838,3844,3850,3856,3863,3869,3875,3881,3887,3893,3899,3905,3910,3916,3922,3928,
+    3933,3939,3945,3950,3956,3962,3967,3973,3978,3983,3989,3994,3999,4005,4010,4015,
+    4020,4026,4031,4036,4041,4046,4051,4056,4061,4066,4071,4076,4081,4085,4090,4095,4095}
+#endif
+};
+
+static  HI_U32   analog_gain_table[29]={ 
+     128,131,136,140,145,152,157,163,170,177,
+     185,194,204,215,227,240,256,272,293,314,
+     341,372,409,455,512,584,682,819,1024
+};
+
+
+static  HI_U32   gain_table[29] = 
 { 
     1024,1054,1096,1126,1167,1218,1259,1311,1362,1423,1484,1556,1638,1720,1822,1925,
     2048,2181,2345,2519,2734,2979,3276,3645,4096,4679,5458,6553,8192
 };
 
-
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static /*__inline*/ cmos_inttime_const_ptr_t cmos_inttime_initialize()
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-    
-    cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-    cmos_inttime.exposure_shift = 0;
-    cmos_inttime.full_lines_std = 1092;
-
-    cmos_inttime.full_lines_std_30fps = 1092;
-    cmos_inttime.full_lines_std_25fps = 1310;
-
-    cmos_inttime.lines_per_500ms = cmos_inttime.full_lines_std_30fps*30/2;
-	
-    
-    return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
-{
-   static HI_U32 _last_exposure_time = 0xFFFFFFFF;
-
-   if(_last_exposure_time == (p_inttime->exposure_ashort>>p_inttime->exposure_shift))
-   {
-        return ;
-   }else
-   {
-        _last_exposure_time = (p_inttime->exposure_ashort>>p_inttime->exposure_shift);
-   }
-   
- #if CMOS_AR0330_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr= 0x3012;
-    stI2cData.u32Data = p_inttime->exposure_ashort>>p_inttime->exposure_shift;
-
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-#else
-    HI_U16 _time = p_inttime->exposure_ashort>>p_inttime->exposure_shift;
-    sensor_write_register(0x3012, _time);
-#endif
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-    int  _fulllines= p_inttime->full_lines;
-
-    static HI_U16 last_vblanking_lines = 0xFFFF;
-    
-    if(last_vblanking_lines != p_inttime->full_lines)
+    if (HI_NULL == pstDef)
     {
-         sensor_write_register(0x300A, _fulllines);
-         last_vblanking_lines = p_inttime->full_lines;
-    } 
-   
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-    if(p_inttime->exposure_ashort >= p_inttime->full_lines - 2)
-    {
-        p_inttime->exposure_ashort = p_inttime->full_lines - 2;
-    }
-    
-    return p_inttime->exposure_ashort;
-
-}
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-    switch(fps)
-    {
-        case 30:
-            p_inttime->full_lines_std= p_inttime->full_lines_std_30fps;
-            sensor_write_register(0x300A, 0x444);
-            break;
-        case 25:
-            p_inttime->full_lines_std= p_inttime->full_lines_std_25fps;
-            sensor_write_register(0x300A, 0x51E);
-            break;
-        default:
-            break;
-    }
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static /*__inline*/ cmos_gains_ptr_t cmos_gains_initialize()
-{
-    cmos_gains.max_again = 8192;
-    cmos_gains.max_dgain = 2047;
-
-    cmos_gains.max_again_target = cmos_gains.max_again;
-    cmos_gains.max_dgain_target = cmos_gains.max_dgain;
-        
-    cmos_gains.again_shift = 10;
-    cmos_gains.dgain_shift = 7;    //
-    cmos_gains.dgain_fine_shift = 0;
-
-    cmos_gains.again = (1<<cmos_gains.again_shift);
-    cmos_gains.dgain = (1<<cmos_gains.dgain_shift);
-
-    cmos_gains.isp_dgain_shift = 8;         // max shift supported:8,make it to be 4 currently
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;    // max isp_dgain supported:4
-    
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-
-    cmos_gains.isp_dgain_delay_cfg = HI_FALSE;
-    return &cmos_gains;
-}
-
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{
-    HI_U32 step = p_gains->again_db;
-    static HI_U32 last_again = 0xFFFFFFFF;
-    static HI_U32 last_dgain = 0xFFFFFFFF;
-    
-    if((last_again ==  p_gains->again) && (last_dgain == p_gains->dgain))
-    {
-        return ;
-    }
-    else
-    {
-        last_again = p_gains->again;
-        last_dgain = p_gains->dgain;
-    }
-    
-#if CMOS_AR0330_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x3060;
-    
-    if(step < 16)
-    {
-        stI2cData.u32Data = 0x00 + step;
-    }
-    else if(step < 24)
-    {
-        stI2cData.u32Data = 0x10 + (step - 16) * 2;
-    }
-    else if(step < 28)
-    {
-        stI2cData.u32Data = 0x20 + (step - 24) * 4;
-    }
-    else
-    {
-        stI2cData.u32Data = 0x30;
-    }
-
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    
-    stI2cData.u32RegAddr = 0x305E;
-    stI2cData.u32Data = p_gains->dgain;
-
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    
-    
-#else          
-    if(step < 16)
-    {
-        sensor_write_register(0x305E, step);
-    }
-    else if(step <24)
-    {
-        sensor_write_register(0x305E, 0x10 + (step - 16) * 2);
-    }
-    else if(step <28)
-    {
-        sensor_write_register(0x305E, 0x20 + (step - 24) * 4);
-    }
-    else
-    {
-        sensor_write_register(0x305E, 0x30);
-    }
-
-    sensor_write_register(0x305E, p_gains->dgain);
-#endif
-}
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 again = 1024;
-    HI_U32 step = 0;
-    HI_S32 shift = 0;
-    HI_S32 i = 0;
-
-    while (exposure > (1 << 20))
-    {
-        exposure     >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-    
-    if(exposure > exposure_max)
-    {
-        again = (exposure << 10) / exposure_max;
-        again = again < 1024? 1024: again;
-        again = again > p_gains->max_again_target? p_gains->max_again_target: again;
-    
-        if (again >= analog_gain_table[28])
-        {
-             again = analog_gain_table[28];
-             step = 28;
-        }
-        else
-        {
-            for(i = 1; i < 29; i++)
-            {
-                if(again < analog_gain_table[i])
-                {
-                    again = analog_gain_table[i - 1];
-                    step = i - 1;
-                    break;
-                }
-            }
-        }
-        
-        exposure = (exposure << 10) / again;
-    }
-
-    p_gains->again = again;
-    p_gains->again_db = step;
-    
-    return (exposure << shift);
-}
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
-
-    while (exposure > (1 << 22))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shift;
-}
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-    cmos_gains_ptr_t p_gains,
-    HI_U32 exposure,
-    HI_U32 exposure_max,
-    HI_U32 exposure_shift)
-{
-    HI_U32 _dgain = 1<<p_gains->dgain_shift;    
-
-    int shft = 0;
-
-    while (exposure > (1<<20))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shft;
-    }
-
-    if(exposure > exposure_max)
-    {
-        exposure_max = DIV_0_TO_1(exposure_max);
-        _dgain = (exposure  * _dgain) / exposure_max;
-    }
-    else
-    {
-
-    }
-    _dgain = _dgain < (1<<p_gains->dgain_shift) ? (1<<p_gains->dgain_shift) : _dgain;
-    _dgain = _dgain >  p_gains->max_dgain_target ? p_gains->max_dgain_target : _dgain;
-
-    p_gains->dgain = _dgain;
-    exposure = (exposure << p_gains->dgain_shift) / p_gains->dgain;
-    
-    return exposure << shft;
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-    HI_U32  _again = p_gains->again == 0 ? 1 : p_gains->again;
-    HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _isp_dgain = p_gains->isp_dgain = 0 ? 1 : p_gains->isp_dgain;
-
-    p_gains->iso =  (((HI_U64)_again * _dgain * _isp_dgain * 100) >> (p_gains->again_shift + p_gains->dgain_shift + p_gains->isp_dgain_shift));
-
-    return p_gains->iso;
-}
-
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    return p_gains->again_db;
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-    return p_gains->dgain_db;
-}
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-    if (NULL == p_coms_isp_default)
-        {
-            printf("null pointer when get isp default value!\n");
-            return -1;
-        }
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-    if (NULL == p_cmos_isp_agc_table)
-    {
-        printf("null pointer when get isp agc table value!\n");
+        printf("null pointer when get isp default value!\n");
         return -1;
     }
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
+
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
+
+    pstDef->stComm.u8Rggb = 0x1;      //1: rggb 
+    pstDef->stComm.u8BalanceFe = 0x1;
+
+    pstDef->stDenoise.u8SinterThresh = 0x23;
+    pstDef->stDenoise.u8NoiseProfile= 0x1;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0 = 0x0;
+    pstDef->stDenoise.u16Nr1 = 546;
+
+    pstDef->stDrc.u8DrcBlack = 0x00;
+    pstDef->stDrc.u8DrcVs = 0x04;     // variance space
+    pstDef->stDrc.u8DrcVi = 0x01;     // variance intensity
+    pstDef->stDrc.u8DrcSm = 0x30;     // slope max
+    pstDef->stDrc.u16DrcWl = 0x4FF;    // white level
+
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+    memcpy(&pstDef->stGamma, &g_stIspGamma, sizeof(ISP_CMOS_GAMMA_S));
+
     return 0;
 }
 
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-    if (NULL == p_cmos_isp_noise_table)
+    HI_S32  i;
+    
+    if (HI_NULL == pstBlackLevel)
     {
-        printf("null pointer when get isp noise table value!\n");
+        printf("null pointer when get isp black level value!\n");
         return -1;
     }
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
+
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+            
+    for (i=0; i<4; i++)
+    {
+        pstBlackLevel->au16BlackLevel[i] = 0xA8;
+    }
+
+    return 0;    
 }
 
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-    if (NULL == p_cmos_isp_demosaic)
-    {
-        printf("null pointer when get isp demosaic value!\n");
-        return -1;
-    }
-    memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-    return 0;
-}
-
-void setup_sensor(int isp_mode)
-{
-    if(0 == isp_mode) /* ISP 'normal' isp_mode */
-    {
-        sensor_write_register(0x300A, 0444);	//30fps
-    }
-    else if(1 == isp_mode) /* ISP pixel calibration isp_mode */
+    if (bEnable) /* setup for ISP pixel calibration mode */
     {
         sensor_write_register(0x300A, 0x1998);	//5fps
         sensor_write_register(0x3012, 0x1996);	//max exposure lines
         sensor_write_register(0x3060, 0x1300);	//AG, Context A
         sensor_write_register(0x305E, 0x0128);	//DG, Context A
     }
-}
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1920;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 1080;
-
-    return 0;
-}
-
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-static SENSOR_EXP_FUNC_S stSensorExpFuncs =
-{
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
-
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-
-    .pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-    .pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-    .pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-    .pfn_cmos_get_isp_default = cmos_get_isp_default,
-    .pfn_cmos_get_isp_special_alg = NULL,
-    .pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-    .pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-    .pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-    .pfn_cmos_get_isp_shading_table = NULL,
-	.pfn_cmos_get_isp_gamma_table = NULL,
-    .pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-    .pfn_cmos_set_sensor_image_mode = NULL,
-};
-
-int sensor_register_callback(void)
-{
-    int ret;
-    ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-    if (ret)
+    else /* setup for ISP 'normal mode' */
     {
-        printf(">>sensor register callback function failed!\n");
-        return ret;
+       sensor_write_register(0x300A, 0x444);	//30fps
     }
-    return 0;
+
+    return;
 }
 
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
-    
     switch(u8Mode)
     {
         //sensor mode 0
@@ -668,12 +307,406 @@ int sensor_mode_set(HI_U8 u8Mode)
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 1092;
+    
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32LinesPer500ms = 1092*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 1090;
+    pstAeSnsDft->u32MinIntTime = 2;    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 2;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 0.0078125;
+    pstAeSnsDft->u32MaxAgain = 8192;  /* 8/0.0078125= 1024 */
+    pstAeSnsDft->u32MinAgain = 1024;
+    pstAeSnsDft->u32MaxAgainTarget = 8192;
+    pstAeSnsDft->u32MinAgainTarget = 1024;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.0078125;    
+    pstAeSnsDft->u32MaxDgain = 2047;/* 16 / 0.0078125 = 2047;*/
+    pstAeSnsDft->u32MinDgain = 128;
+    pstAeSnsDft->u32MaxDgainTarget = 2047;
+    pstAeSnsDft->u32MinDgainTarget = 128;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
     return 0;
 }
 
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1920;
+    pstSensorMaxResolution->u32MaxHeight = 1080;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    switch(u8Fps)
+    {
+        case 30:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 1092;
+            pstAeSnsDft->u32MaxIntTime = 1090;
+            pstAeSnsDft->u32LinesPer500ms = 1092 * 30 / 2;
+             sensor_write_register(0x300A, 0x444);
+        break;
+        
+        case 25:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 1310;
+            pstAeSnsDft->u32MaxIntTime = 1308;
+            pstAeSnsDft->u32LinesPer500ms = 1310 * 25 / 2;
+           sensor_write_register(0x300A, 0x51E);
+        break;
+        
+        default:
+        break;
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+
+    sensor_write_register(0x300A, u16FullLines);
+
+    pstAeSnsDft->u32MaxIntTime = u16FullLines - 2;
+    
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+    
+#if CMOS_AR0330_ISP_WRITE_SENSOR_ENABLE
+
+    HI_S32 i;
+    static HI_BOOL bInit = HI_FALSE;
+
+    if (HI_FALSE == bInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_I2C_TYPE;
+        g_stSnsRegsInfo.u32RegNum = 3;
+        for (i=0; i<g_stSnsRegsInfo.u32RegNum; i++)
+        {
+            g_stSnsRegsInfo.astI2cData[i].u8DevAddr = sensor_i2c_addr;
+            g_stSnsRegsInfo.astI2cData[i].u32AddrByteNum = sensor_addr_byte;
+            g_stSnsRegsInfo.astI2cData[i].u32DataByteNum = sensor_data_byte;
+        }
+        g_stSnsRegsInfo.astI2cData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[0].u32RegAddr = 0x3012;
+        g_stSnsRegsInfo.astI2cData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[1].u32RegAddr = 0x3060;
+        g_stSnsRegsInfo.astI2cData[2].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[2].u32RegAddr = 0x305E;
+
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_FALSE;
+
+        bInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+    static HI_U32 _last_exposure_time = 0xFFFFFFFF;
+
+    if(_last_exposure_time == u32IntTime)
+    {
+        return ;
+    }else
+    {
+        _last_exposure_time = u32IntTime;
+    }
+    
+#if CMOS_AR0330_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[0].u32Data = u32IntTime;
+#else
+    sensor_write_register(0x3012, u32IntTime);
+#endif
+    return;
+}
+
+
+static HI_VOID cmos_again_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
+{
+    int i;
+
+    if(HI_NULL == pstAeSnsGainInfo)
+    {
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
+    }
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+   
+    if (u32InTimes >= gain_table[28])
+    {
+         pstAeSnsGainInfo->u32SnsTimes = gain_table[28];
+         pstAeSnsGainInfo->u32GainDb = 28;
+         return ;
+    }
+    
+    for(i = 1; i < 29; i++)
+    {
+        if(u32InTimes < gain_table[i])
+        {
+            pstAeSnsGainInfo->u32SnsTimes = gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
+
+    }
+          
+    return;
+
+}
+
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    static HI_U32 _last_again = 0xFFFFFFFF;
+    static HI_U32 _last_dgain = 0xFFFFFFFF;
+    static HI_U32 _last_exposure = 0xFFFFFFFF;
+ 
+    if((_last_again ==  u32Again ) && (_last_dgain == u32Dgain)&& g_stSnsRegsInfo.astI2cData[0].u32Data == _last_exposure)
+    {
+        return ;
+    }
+    else
+    {
+        _last_again = u32Again;
+        _last_dgain= u32Dgain;
+        _last_exposure = g_stSnsRegsInfo.astI2cData[0].u32Data;
+    }
+    
+#if CMOS_AR0330_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+       
+    if( u32Again < 16)
+    {
+        g_stSnsRegsInfo.astI2cData[1].u32Data = 0x00 + u32Again;
+    }else if( u32Again <24)
+    {
+        g_stSnsRegsInfo.astI2cData[1].u32Data = 0x10 + (u32Again - 16) * 2;
+    }else if( u32Again <28)
+    {
+        g_stSnsRegsInfo.astI2cData[1].u32Data = 0x20 + (u32Again - 24) * 4;
+    }else if( u32Again == 28)
+    {
+        g_stSnsRegsInfo.astI2cData[1].u32Data = 0x30;
+    }
+  
+    g_stSnsRegsInfo.astI2cData[2].u32Data = u32Dgain;
+
+
+    HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+#endif
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 4900;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x198;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x1b2;
+
+    pstAwbSnsDft->as32WbPara[0] = 55;
+    pstAwbSnsDft->as32WbPara[1] = 24;
+    pstAwbSnsDft->as32WbPara[2] = -177;
+    pstAwbSnsDft->as32WbPara[3] = 271396;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -220863;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update = cmos_gains_update;
+    pstExpFuncs->pfn_cmos_again_calc_table  = cmos_again_calc_table;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(AR0330_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, AR0330_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, AR0330_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(AR0330_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, AR0330_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, AR0330_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -681,5 +714,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-#endif // __AR0330_CMOS_H_
-
+#endif // __IMX104_CMOS_H_

--- a/libraries/sensor/hi3516cv100/aptina_mt9p006/mt9p006_cmos.c
+++ b/libraries/sensor/hi3516cv100/aptina_mt9p006/mt9p006_cmos.c
@@ -3,10 +3,13 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 #include "hi_comm_sns.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_isp_debug.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -14,87 +17,86 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
+#define MT9P006_ID 9006
+
+/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker */
+/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance   */
+/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                     */
+#define CMOS_MT9P006_ISP_WRITE_SENSOR_ENABLE (1)
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
 extern const unsigned int sensor_i2c_addr;
 extern const unsigned int sensor_addr_byte;
 extern const unsigned int sensor_data_byte;
 
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
-static HI_U8 gu8SensorMode = 0;
+HI_U32 gu32FullLinesStd = 1132;
+HI_U8 gu8SensorMode = 0;
+#if CMOS_MT9P006_ISP_WRITE_SENSOR_ENABLE
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
+static HI_BOOL gsbRegInit = HI_FALSE;
+#endif
 
-/****************************************************************************
- * MACRO DEFINITION                                                         *
- ****************************************************************************/
-
-/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker */
-/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance   */
-/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                     */
-#define CMOS_MT9P006_ISP_WRITE_SENSOR_ENABLE (1)
-
-static cmos_isp_default_t st_coms_isp_default = 
+static AWB_CCM_S g_stAwbCcm =
 {
-	// color matrix[9]
-    {
-        5000,
-        {   0x0236, 0x80fd, 0x8039,
-            0x804b, 0x018d, 0x8041,
-            0x8006, 0x80ca, 0x01d0
-        },
-        3200,
-        {   0x025a, 0x80e7, 0x8073,
-            0x8078, 0x01b5, 0x803d,
-            0x802b, 0x8119, 0x0244
-        },
-        2450,
-        {
-            0x0214, 0x8089, 0x808b,
-            0x809d, 0x01ce, 0x8031,
-            0x8068, 0x81e7, 0x034f
-        }
-    },
-
-
-	// black level
-	{0xAc,0xAc,0xAc,0xAc},
-
-    //calibration reference color temperature 
     5000,
-
-    //WB gain at 6500K, must keep consistent with calibration color temperature 
-	{0x158, 0x100, 0x100, 0x18f},
-
-    // WB curve parameters, must keep consistent with reference color temperature.
-	{89, 3, -164, 232133, 128, -183491},
-
-	// hist_thresh
-	{0xd,0x28,0x60,0x80},
-
-	0x0,	// iridix_balck
-	0x1,	// grbg
-
-	/* limit max gain for reducing noise,    */
-    /* when again equals its max value,there will be much noise */
-	0x8,	0x10,
-
-	// iridix
-	0x04,	0x08,	0xa0, 	0x4ff,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x15, 	// sinter threshold
-
-	0x0,  0,  0,  //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
-
-    2
+    {   0x0236, 0x80fd, 0x8039,
+        0x804b, 0x018d, 0x8041,
+        0x8006, 0x80ca, 0x01d0
+    },
+    3200,
+    {   0x025a, 0x80e7, 0x8073,
+        0x8078, 0x01b5, 0x803d,
+        0x802b, 0x8119, 0x0244
+    },
+    2450,
+    {
+        0x0214, 0x8089, 0x808b,
+        0x809d, 0x01ce, 0x8031,
+        0x8068, 0x81e7, 0x034f
+    }
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
-    //nosie_profile_weight_lut
+    /* bvalid */
+    1,
+
+    /* saturation */    
+    {0x80,0x80,0x80,0x80,0x68,0x48,0x35,0x30}
+};
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
+{
+    /* bvalid */
+    1,
+
+    /* sharpen_alt_d */
+    {0xeb,0xea,0xe9,0xe8,0xe7,0xe6,0xe5,0x89},
+        
+    /* sharpen_alt_ud */
+    {0xa2,0xa0,0x97,0x91,0x90,0x8e,0x3e,0x3c},
+        
+    /* snr_thresh */
+    {0x13,0x14,0x16,0x25,0x2a,0x2e,0x3a,0x44},
+        
+    /* demosaic_lum_thresh */
+    {0x40,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
+        
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55}
+};
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
+{
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {0x0,0x0,0x0,0x0,0x0,0x0,0x2a,0x2e,0x30,0x32,0x33,0x34,0x35,0x36,0x36,0x37,0x38,0x38,
 	0x38,0x39,0x39,0x3a,0x3a,0x3a,0x3b,0x3b,0x3b,0x3c,0x3c,0x3c,0x3c,0x3c,0x3d,0x3d,0x3d,
 	0x3d,0x3e,0x3e,0x3e,0x3e,0x3e,0x3e,0x3f,0x3f,0x3f,0x3f,0x3f,0x3f,0x3f,0x40,0x40,0x40,
@@ -104,7 +106,7 @@ static cmos_isp_noise_table_t st_isp_noise_table =
 	0x44,0x44,0x44,0x44,0x44,0x44,0x44,0x45,0x45,0x45,0x45,0x45,0x45,0x45,0x45,0x45,0x45,
 	0x45,0x45,0x45,0x45,0x45,0x45,0x45,0x45},
 
-    //demosaic_weight_lut
+    /* demosaic_weight_lut */
     {0x0,0x2a,0x2e,0x30,0x32,0x33,0x34,0x35,0x36,0x36,0x37,0x38,0x38,0x38,0x39,0x39,0x3a,
 	0x3a,0x3a,0x3b,0x3b,0x3b,0x3c,0x3c,0x3c,0x3c,0x3c,0x3d,0x3d,0x3d,0x3d,0x3e,0x3e,0x3e,
 	0x3e,0x3e,0x3e,0x3f,0x3f,0x3f,0x3f,0x3f,0x3f,0x3f,0x40,0x40,0x40,0x40,0x40,0x40,0x40,
@@ -115,34 +117,11 @@ static cmos_isp_noise_table_t st_isp_noise_table =
 	0x45,0x45,0x45,0x45,0x45,0x45,0x45,0x45,0x45}
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
-    //sharpen_alt_d
-    {0xeb,0xea,0xe9,0xe8,0xe7,0xe6,0xe5,0x89},
-
-    //sharpen_alt_ud
-    {0xa2,0xa0,0x97,0x91,0x90,0x8e,0x3e,0x3c},
-
-    //snr_thresh
-    {0x13,0x14,0x16,0x25,0x2a,0x2e,0x3a,0x44},
-
-    //demosaic_lum_thresh
-    {0x40,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
-
-    //demosaic_np_offset
-    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55},
-
-    /* saturation */
-    {0x80,0x80,0x80,0x80,0x68,0x48,0x35,0x30}
-
-};
-
-
-static cmos_isp_demosaic_t st_isp_demosaic =
-{
+    /* bvalid */
+    1,
+    
     /*vh_slope*/
     0xc2,
 
@@ -180,434 +159,78 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x1b3
 };
 
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-	cmos_inttime.full_lines_std = 1132;
-	cmos_inttime.full_lines_std_30fps = 1132;
-    cmos_inttime.full_lines_std_25fps = 1358;
-	cmos_inttime.vblanking_lines = 48;
+    if (HI_NULL == pstDef)
+    {
+        printf("null pointer when get isp default value!\n");
+        return -1;
+    }
 
-	cmos_inttime.exposure_ashort = 0;
-	cmos_inttime.exposure_shift = 0;
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
 
-	cmos_inttime.lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2;
-	cmos_inttime.flicker_freq = 0;//60*256;//50*256;
+    pstDef->stComm.u8Rggb           = 0x1;
+    pstDef->stComm.u8BalanceFe      = 0x1;
 
-	return &cmos_inttime;
+    pstDef->stDenoise.u8SinterThresh= 0x15;
+    pstDef->stDenoise.u8NoiseProfile= 0x0;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 0x0;
+
+    pstDef->stDrc.u8DrcBlack        = 0x00;
+    pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0xa0;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x4FF;    // white level
+
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+
+    return 0;
 }
 
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime) 
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-#if CMOS_MT9P006_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x09;
-    stI2cData.u32Data = p_inttime->exposure_ashort & 0xffff;
-    HI_MPI_ISP_I2cWrite(&stI2cData);        
-#else
-    //when set exposure time more than one frame, the sensor's fps will be decreased automatically
-    sensor_write_register(0x09, p_inttime->exposure_ashort & 0xffff);
-    //sensor_write_register(0x08, (p_inttime->exposure_ashort >> 16) & 0xffff);
-#endif
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-    HI_U16 _vblanking_lines = p_inttime->vblanking_lines;
-
-    _vblanking_lines = (_vblanking_lines > 2048)? 2048: _vblanking_lines;
-    sensor_write_register(0x06, _vblanking_lines - 1);
-
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-
-	if(p_inttime->exposure_ashort >= p_inttime->full_lines - 2)
-	{
-		p_inttime->exposure_ashort = p_inttime->full_lines - 2;
-	}
-
-	p_inttime->vblanking_lines = p_inttime->full_lines - 1084;
+    HI_S32  i;
     
-	return p_inttime->exposure_ashort;
-}
+    if (HI_NULL == pstBlackLevel)
+    {
+        printf("null pointer when get isp black level value!\n");
+        return -1;
+    }
 
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-	switch(fps)
-	{
-		case 30:
-			// Change the frame rate via changing the horizontal blanking
-			p_inttime->full_lines_std = cmos_inttime.full_lines_std_30fps;
-    		break;
-		case 25:
-			// Change the frame rate via changing both vertical and horizontal blanking
-			p_inttime->full_lines_std = cmos_inttime.full_lines_std_25fps;
-    		break;
-        default:
-            break;
-	}
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
     
+    for (i=0; i<4; i++)
+    {
+        pstBlackLevel->au16BlackLevel[i] = 0xAc;
+    }
+
+    return 0;    
 }
 
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-    cmos_gains.max_again = 126;
-	cmos_gains.max_dgain = 128;
-
-	cmos_gains.again_shift = 3;
-	cmos_gains.dgain_shift = 3;
-	cmos_gains.dgain_fine_shift = 0;
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;  
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_TRUE;
-	
-	return &cmos_gains;
-}
-
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{
-#if CMOS_MT9P006_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-
-    stI2cData.bDelayCfg = HI_TRUE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x35;
-    stI2cData.u32Data = (((p_gains->dgain - 8) << 8) 
-        + ((p_gains->again > 32) ? (0x40 + (p_gains->again >> 1)) : p_gains->again));
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-
-    stI2cData.u32RegAddr = 0x3e;
-    if(p_gains->again > 32)
+    if (bEnable) /* setup for ISP pixel calibration mode */
     {
-        stI2cData.u32Data = 0x0087;
-    }
-    else
-    {
-        stI2cData.u32Data = 0x0007;
-    }
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-#else
-    sensor_write_register(0x35, (((p_gains->dgain - 8) << 8) 
-        + ((p_gains->again > 32) ? (0x40 + (p_gains->again >> 1)) : p_gains->again)));
-
-    if(p_gains->again > 32)
-    {
-        sensor_write_register(0x3e, 0x0087);
-    }
-    else
-    {
-        sensor_write_register(0x3e, 0x0007);
-    }
-
-#endif
-}
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-	HI_U32 _again = 12;
-	int shft = 0;
-
-	while (exposure > (1 << 27))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-    exposure_max = DIV_0_TO_1(exposure_max);
-
-    if(exposure > exposure_max)
-    {
-    	_again = (exposure << p_gains->again_shift) / exposure_max;
-        
-        /*limit again to more than 1.5 times*/
-    	_again = _again < 12 ? 12 : _again;
-
-    	if(_again > 32) 
-    	{
-            _again &= ~(HI_U32)0x1;
-    	}
-
-    	_again = _again > p_gains->max_again_target ? p_gains->max_again_target : _again;
-    }
-    else
-    {
-    }
-    exposure = (exposure << p_gains->again_shift) / _again;
-
-	p_gains->again = _again;
-
-	return (exposure << shft);    
-}
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    int shft = 0;
-
-    while (exposure > (1 << 22))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-    exposure_max = DIV_0_TO_1(exposure_max);
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    else
-	{
-	}
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shft;
-}
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-
-	HI_U32 _dgain = 1 << p_gains->dgain_shift;
-	int shft = 0;
-
-	while (exposure > (1 << 27))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-    exposure_max = DIV_0_TO_1(exposure_max);
-
-	if(exposure > exposure_max)
-	{
-		_dgain = (exposure << p_gains->dgain_shift) / exposure_max;
-		_dgain = _dgain < 8 ? 8 : _dgain;
-		_dgain = _dgain > p_gains->max_dgain_target ? p_gains->max_dgain_target : _dgain; 
-
-		exposure = (exposure << p_gains->dgain_shift) / _dgain;
-	}
-	else
-	{
-	}
-    p_gains->dgain = _dgain;
-
-    return  exposure << shft;
-
-
-}
-
-static void setup_sensor(int isp_mode)
-{
-	if(0 == isp_mode) /* ISP 'normal' isp_mode */
-	{
-        sensor_write_register(0x09, 0x046a);
-	}
-	else if(1 == isp_mode) /* ISP pixel calibration isp_mode */
-	{
-        //no need to change vblanking_lines
-        //set exposure time to 200ms/5 fps
+        /* no need to change vblanking_lines */
+        /* set exposure time to 200ms/5 fps */
 		sensor_write_register(0x09, 0x1a86);
 
-        //min gain
+        /* min gain */
 		sensor_write_register(0x35, 0x12);
-	}
+    }
+    else /* setup for ISP 'normal mode' */
+    {
+        sensor_write_register(0x09, 0x046a);
+    }
+
+    return;
 }
 
-static HI_U32 cmos_gains_lin_to_db_convert(HI_U32 data, HI_U32 shift_in)
-{
-	HI_U32 _res = 0;
-	if(0 == data)
-		return _res;
-
-	for(;;)
-	{
-		data = (data*913 + (1<<9)) >> 10;
-		if(data < (1<<shift_in))
-			break;
-		++_res;
-	}
-	return _res;
-}
-
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
-{
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-	HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-	HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _isp_dgain = p_gains->isp_dgain == 0 ? 1 : p_gains->isp_dgain;
-
-	p_gains->iso =  ((_again * _dgain * _isp_dgain * 100) 
-                     >> (p_gains->again_shift + p_gains->dgain_shift + p_gains->isp_dgain_shift));
-
-	return p_gains->iso;
-}
-
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    return cmos_gains_lin_to_db_convert(p_gains->again, p_gains->again_shift);
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-    return cmos_gains_lin_to_db_convert(p_gains->dgain, p_gains->dgain_shift);
-}
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-	if (NULL == p_coms_isp_default)
-	{
-	    printf("null pointer when get isp default value!\n");
-	    return -1;
-	}
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
-    return 0;
-}
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1920;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 1080;
-
-    return 0;
-}
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-SENSOR_EXP_FUNC_S stSensorExpFuncs =
-{
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
-
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-    
-
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-
-	.pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-	.pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-	.pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-	.pfn_cmos_get_isp_default = cmos_get_isp_default,
-	.pfn_cmos_get_isp_special_alg = NULL,
-	.pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-	.pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-	.pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-	.pfn_cmos_get_isp_shading_table = NULL,
-	.pfn_cmos_get_isp_gamma_table = NULL,
-    .pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-    .pfn_cmos_set_sensor_image_mode = NULL,
-	
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-
-	return 0;
-}
-
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
@@ -624,12 +247,354 @@ int sensor_mode_set(HI_U8 u8Mode)
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 1132;
+
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32LinesPer500ms = 1132*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 1130;
+    pstAeSnsDft->u32MinIntTime = 2;    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 2;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 0.125;    
+    pstAeSnsDft->u32MaxAgain = 126;  /* 16 / 0.125 = 128 *//* register max */
+    pstAeSnsDft->u32MinAgain = 12;   /* sensor manufactuer suggerts the minimum again is 1.5 */
+    pstAeSnsDft->u32MaxAgainTarget = 126;
+    pstAeSnsDft->u32MinAgainTarget = 12;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.125;    
+    pstAeSnsDft->u32MaxDgain = 128;  /* 16 / 0.125 = 128 */
+    pstAeSnsDft->u32MinDgain = 8;
+    pstAeSnsDft->u32MaxDgainTarget = 128;
+    pstAeSnsDft->u32MinDgainTarget = 8;
+    
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
     return 0;
 }
 
+
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1920;
+    pstSensorMaxResolution->u32MaxHeight = 1080;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    HI_U16 u16Vblank;
+    switch(u8Fps)
+    {
+        case 30:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 1132;
+            pstAeSnsDft->u32MaxIntTime = 1130;
+            pstAeSnsDft->u32LinesPer500ms = 1132 * 30 / 2;
+        break;
+        
+        case 25:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 1358;
+            pstAeSnsDft->u32MaxIntTime = 1356;
+        break;
+        
+        default:
+        break;
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    
+    u16Vblank = gu32FullLinesStd - 1084 - 1;
+    sensor_write_register(0x06, u16Vblank);
+
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    HI_U16 u16FullLine = u16FullLines;
+
+    if (u16FullLine > (2048 + 1084))    /* max vblank lines is 2048 */
+    {
+        u16FullLine = (2048 + 1084);
+    }
+
+    pstAeSnsDft->u32MaxIntTime = u16FullLine - 2;
+
+    sensor_write_register(0x06, (u16FullLine - 1084 - 1));
+    
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_MT9P006_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+
+    if (HI_FALSE == gsbRegInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_I2C_TYPE;
+        g_stSnsRegsInfo.u32RegNum = 3;
+        for (i=0; i<3; i++)
+        {
+            
+            g_stSnsRegsInfo.astI2cData[i].u8DevAddr = sensor_i2c_addr;
+            g_stSnsRegsInfo.astI2cData[i].u32AddrByteNum = sensor_addr_byte;
+            g_stSnsRegsInfo.astI2cData[i].u32DataByteNum = sensor_data_byte;
+        }
+        g_stSnsRegsInfo.astI2cData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[0].u32RegAddr = 0x09;
+        g_stSnsRegsInfo.astI2cData[1].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[1].u32RegAddr = 0x35;
+        g_stSnsRegsInfo.astI2cData[2].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[2].u32RegAddr = 0x3e;
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_TRUE;
+        gsbRegInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+#if CMOS_MT9P006_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[0].u32Data = u32IntTime & 0xffff;
+#else
+
+    /* when set exposure time more than one frame, the sensor's fps will be decreased automatically */
+    sensor_write_register(0x09, u32IntTime & 0xffff);
+
+    /* Unlock sensor's regisers which were locked at the time of update gains. */
+    //sensor_write_register(0x07, 0x1f8e);
+#endif
+    return;
+}
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    HI_U32 u32AgainAdv, u32Tmp;    
+
+    if (u32Again > 32)
+    {
+        u32AgainAdv = 0x0087;
+        u32Tmp = (u32Again >> 1) + 0x40;
+    }
+    else
+    {
+        u32AgainAdv = 0x0007;
+        u32Tmp = u32Again;
+    }
+
+    u32Tmp += ((u32Dgain - 8) << 8);
+
+#if CMOS_MT9P006_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[1].u32Data = u32Tmp;
+    g_stSnsRegsInfo.astI2cData[2].u32Data = u32AgainAdv;
+    HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+#else
+    /* Lock sensor's regisers which were unlocked at the time of update inttime. */
+    //sensor_write_register(0x07, 0x1f8f);
+    sensor_write_register(0x35, u32Tmp);
+    sensor_write_register(0x3e, u32AgainAdv);
+#endif
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 5000;
+    
+    pstAwbSnsDft->au16GainOffset[0] = 0x158;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x18f;
+
+    pstAwbSnsDft->as32WbPara[0] = 89;
+    pstAwbSnsDft->as32WbPara[1] = 3;
+    pstAwbSnsDft->as32WbPara[2] = -164;
+    pstAwbSnsDft->as32WbPara[3] = 232133;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -183491;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(MT9P006_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, MT9P006_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, MT9P006_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(MT9P006_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, MT9P006_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, MT9P006_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -637,5 +602,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-
-#endif // __APTINA_MT9P006_CMOS_H_
+#endif // __IMX104_CMOS_H_

--- a/libraries/sensor/hi3516cv100/aptina_mt9p006/mt9p006_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/aptina_mt9p006/mt9p006_sensor_ctl.c
@@ -12,7 +12,7 @@
 #include "hi_i2c.h"
 #endif
 
-const unsigned int  sensor_i2c_addr  	=	0x90;		/* I2C Address of MT9P006 */
+const unsigned int  sensor_i2c_addr	=	0x90;		/* I2C Address of MT9P006 */
 const unsigned int  sensor_addr_byte	=	1;
 const unsigned int  sensor_data_byte	=	2;
 
@@ -305,4 +305,6 @@ void sensor_init()
  
     printf("Aptina MT9P006 sensor 1080P30fps init success!\n");
 }
+
+
 

--- a/libraries/sensor/hi3516cv100/himax_1375/himax1375_cmos.c
+++ b/libraries/sensor/hi3516cv100/himax_1375/himax1375_cmos.c
@@ -1,12 +1,14 @@
-#if !defined(__HIMAX_1375_CMOS_H_)
-#define __HIMAX_1375_CMOS_H_
+#if !defined(__HIMAX1375_CMOS_H_)
+#define __HIMAX1375_CMOS_H_
 
 #include <stdio.h>
 #include <string.h>
 #include "hi_comm_sns.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_isp_debug.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -14,108 +16,74 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-#define CMOS_HIMAX1375_ISP_WRITE_SENSOR_ENABLE (1)
+#define HIMAX1375_ID 1375
+
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
-extern const unsigned int sensor_i2c_addr;
-extern const unsigned int sensor_addr_byte;
-extern const unsigned int sensor_data_byte;
 
-
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
+HI_U32 gu32FullLinesStd = 832;
+HI_U32 gu32FullLines = 832;
 HI_U8 gu8SensorMode = 0;
 
-static cmos_isp_default_t st_coms_isp_default =
+static AWB_CCM_S g_stAwbCcm =
 {
-	// color matrix[9]
-    {
-        4950,
-        {   0x1bb, 0x8083, 0x8038,
-            0x803c, 0x01a1, 0x8065,
-            0x8002, 0x80f2, 0x01f4
-        },
-        3100,
-        {   0x016e, 0x8028, 0x8046,
-            0x8064, 0x01a0, 0x803c,
-            0x8035, 0x813b, 0x0270
-        },
-        2480,
-        {   0x01a8, 0x8008, 0x80a0,
-            0x805f, 0x01b0, 0x8051,
-            0x808e, 0x8204, 0x0392
-        }
-    },
-
-
-    // black level
-    {0,0,0,0},
-
-    //calibration reference color temperature
     4950,
-
-    //WB gain at 5000, must keep consistent with calibration color temperature
-    //{0x185, 0x100, 0x100, 0x17d},
-    {0x187, 0x100, 0x100, 0x179},
-    
-
-    // WB curve parameters, must keep consistent with reference color temperature.   
-    //{110,16,-127,138235,128,-87002},//newest
-    {123,-15,-144,136180,128,-85414},
-	// hist_thresh
-    {0xd,0x28,0x60,0x80},
-    //{0x10,0x40,0xc0,0xf0},
-
-    0x0,	// iridix_balck
-    0x3,	// bggr
-
-	/* limit max gain for reducing noise, the max dgain is 169, about 2.64 times*/
-    16,  3,
-
-	// iridix
-    0x04,	0x08,	0xa0, 	0x4ff,
-
-    0x1, 	// balance_fe
-    0x80,	// ae compensation
-    0x15, 	// sinter threshold
-
-    0x0,  0,  0,  //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
-#if CMOS_HIMAX1375_ISP_WRITE_SENSOR_ENABLE 
-    2
-#else
-    1
-#endif
+    {   0x1bb, 0x8083, 0x8038,
+        0x803c, 0x01a1, 0x8065,
+        0x8002, 0x80f2, 0x01f4
+    },
+    3100,
+    {   0x016e, 0x8028, 0x8046,
+        0x8064, 0x01a0, 0x803c,
+        0x8035, 0x813b, 0x0270
+    },
+    2480,
+    {   0x01a8, 0x8008, 0x80a0,
+        0x805f, 0x01b0, 0x8051,
+        0x808e, 0x8204, 0x0392
+    }
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
-    //sharpen_alt_d
-    {0x8e,0x8b,0x88,0x83,0x7d,0x76,0x76,0x76},
-
-    //sharpen_alt_ud
-    {0x8f,0x89,0x7e,0x78,0x6f,0x3c,0x3c,0x3c},
-
-    //snr_thresh
-    {0x19,0x1e,0x2d,0x32,0x39,0x3f,0x3f,0x3f},
-
-    //demosaic_lum_thresh
-    {0x40,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
-
-    //demosaic_np_offset
-    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55},
+    /* bvalid */
+    1,
 
     /* saturation */
     {0x80,0x80,0x80,0x80,0x68,0x48,0x35,0x30}
-
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
 {
-    //nosie_profile_weight_lut
+    /* bvalid */
+    1,
+
+    /* sharpen_alt_d */
+    {0x8e,0x8b,0x88,0x83,0x7d,0x76,0x76,0x76},
+        
+    /* sharpen_alt_ud */
+    {0x8f,0x89,0x7e,0x78,0x6f,0x3c,0x3c,0x3c},
+        
+    /* snr_thresh */
+    {0x19,0x1e,0x2d,0x32,0x39,0x3f,0x3f,0x3f},
+        
+    /* demosaic_lum_thresh */
+    {0x40,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
+        
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55}
+};
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
+{
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {0, 27, 31, 33, 35, 36, 37, 38, 39, 40, 40, 41, 41, 42, 42, 43,
     43, 43, 44, 44, 44, 45, 45, 45, 45, 46, 46, 46, 46, 46, 47, 47,
     47, 47, 47, 48, 48, 48, 48, 48, 48, 48, 49, 49, 49, 49, 49, 49,
@@ -125,7 +93,7 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     53, 53, 53, 53, 54, 54, 54, 54, 54, 54, 54, 54, 54, 54, 54, 54,
     54, 54, 54, 54, 54, 54, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55},
 
-    //demosaic_weight_lut
+    /* demosaic_weight_lut */
     {0, 27, 31, 33, 35, 36, 37, 38, 39, 40, 40, 41, 41, 42, 42, 43,
     43, 43, 44, 44, 44, 45, 45, 45, 45, 46, 46, 46, 46, 46, 47, 47,
     47, 47, 47, 48, 48, 48, 48, 48, 48, 48, 49, 49, 49, 49, 49, 49,
@@ -136,8 +104,11 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     54, 54, 54, 54, 54, 54, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55}
 };
 
-static cmos_isp_demosaic_t st_isp_demosaic =
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
+    /* bvalid */
+    1,
+    
     /*vh_slope*/
     0xda,
 
@@ -175,522 +146,72 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x1b3
 };
 
-
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-    cmos_inttime.full_lines_std = 832;
-    cmos_inttime.full_lines_std_30fps = 832;
-    cmos_inttime.full_lines_std_25fps = 998;
-    cmos_inttime.full_lines = 832;
-    cmos_inttime.full_lines_limit = 65535;
-    cmos_inttime.max_lines = 832;
-    cmos_inttime.min_lines = 2;
-    cmos_inttime.max_lines_target = cmos_inttime.max_lines;
-    cmos_inttime.min_lines_target = cmos_inttime.min_lines;
-
-    cmos_inttime.vblanking_lines = 0;
-
-    cmos_inttime.exposure_ashort = 0;
-    cmos_inttime.exposure_shift = 0;
-
-    cmos_inttime.lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2; 
-    cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-    return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
-{
-    static HI_U32 _last_exposure_time = 0xFFFFFFFF;
-
-    if(p_inttime->exposure_ashort != _last_exposure_time)
-    {
-        #if CMOS_HIMAX1375_ISP_WRITE_SENSOR_ENABLE
-        ISP_I2C_DATA_S stI2cData;
-    
-        stI2cData.bDelayCfg = HI_TRUE;
-        stI2cData.u8DevAddr = sensor_i2c_addr;
-        stI2cData.u32AddrByteNum = sensor_addr_byte;
-        stI2cData.u32DataByteNum = sensor_data_byte;
-
-        stI2cData.u32RegAddr = 0x0016;
-        stI2cData.u32Data = p_inttime->exposure_ashort&0xFF;
-        HI_MPI_ISP_I2cWrite(&stI2cData);
-
-        stI2cData.u32RegAddr = 0x0015;
-        stI2cData.u32Data = (p_inttime->exposure_ashort>>8)&0xFF;
-        HI_MPI_ISP_I2cWrite(&stI2cData);
-
-        stI2cData.u32RegAddr = 0x0100;
-        stI2cData.u32Data = 0x01;
-        HI_MPI_ISP_I2cWrite(&stI2cData);
-        
-        #else
-        sensor_write_register(0x0016, p_inttime->exposure_ashort&0xFF);
-        sensor_write_register(0x0015, (p_inttime->exposure_ashort>>8)&0xFF);
-        
-        //refresh  exposure register
-        sensor_write_register(0x0100,0x01);
-        #endif
-        _last_exposure_time = p_inttime->exposure_ashort;
-    }
-    
-
-    return;
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-    static HI_U16 last_vblanking_lines = 0xFFFF;
-    if(p_inttime->vblanking_lines != last_vblanking_lines)
-    {
-        sensor_write_register(0x0011, p_inttime->vblanking_lines & 0xff);
-        sensor_write_register(0x0010, (p_inttime->vblanking_lines & 0xff00) >> 8);
-        
-         //refresh   register
-        sensor_write_register(0x0100,0x01);
-        last_vblanking_lines = p_inttime->vblanking_lines;
-    }
-
-    return;
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-    if(p_inttime->exposure_ashort >= p_inttime->full_lines - 4)
-    {
-    	p_inttime->exposure_ashort = p_inttime->full_lines - 4;
-    }
-
-    p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std_30fps+2;
-
-    return p_inttime->exposure_ashort;
-}
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-	switch(fps)
-	{
-		case 30:
-            p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2; 
-            p_inttime->full_lines_std= p_inttime->full_lines_std_30fps;
-		break;
-
-		case 25:
-            /* do not change full_lines_std */
-            p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_25fps * 25 / 2;
-            p_inttime->full_lines_std= p_inttime->full_lines_std_25fps;
-            
-        break;
-
-		default:
-		break;
-	}
-    
-	return;
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
-{
-    cmos_gains.max_again = 16;
-    cmos_gains.max_dgain = 169;
-
-
-    cmos_gains.max_again_target = cmos_gains.max_again; 
-    cmos_gains.max_dgain_target = 169;//when the dgain > 169,the image quality is bad
-    cmos_gains.again_shift = 0;
-    cmos_gains.dgain_shift = 6;
-    cmos_gains.dgain_fine_shift = 0;
-
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1<< cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_TRUE;
-
-    return &cmos_gains;
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{ 
-    HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-    HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _isp_dgain = p_gains->isp_dgain== 0 ? 1 : p_gains->isp_dgain;
-
-    p_gains->iso =  (((HI_U64)_again * _dgain *_isp_dgain* 100) >>(p_gains->again_shift + p_gains->dgain_shift+p_gains->isp_dgain_shift)); 
-    
-    return p_gains->iso;
-}
-
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{
-    static HI_U32 _last_again = 0xFFFFFFFF;
-    static HI_U32 _last_dgain = 0xFFFFFFFF;
-    HI_BOOL _update = HI_FALSE;
-
-    #if CMOS_HIMAX1375_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-
-    stI2cData.bDelayCfg = HI_TRUE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-
-    if(p_gains->again!= _last_again)
-    { 
-        stI2cData.u32RegAddr = 0x0018;
-        switch(p_gains->again)
-        {
-            case (16):
-                stI2cData.u32Data = 0x4;
-            break;
-            case (8):
-                stI2cData.u32Data = 0x3;    
-            break;
-            case (4):
-                stI2cData.u32Data = 0x2;
-            break;
-            case (2):
-                stI2cData.u32Data = 0x1;
-            break;
-            default:
-                stI2cData.u32Data = 0x0;
-        }
-        HI_MPI_ISP_I2cWrite(&stI2cData);
-        _last_again = p_gains->again;
-        _update = HI_TRUE;
-    }
-    
-    if(p_gains->dgain!= _last_dgain)
-    { 
-        stI2cData.u32RegAddr = 0x001D;
-        stI2cData.u32Data = p_gains->dgain;
-        HI_MPI_ISP_I2cWrite(&stI2cData);
-        _last_dgain = p_gains->dgain;
-        _update = HI_TRUE;
-    }    
-   
-    //refresh   register
-    if(_update)
-    {
-        stI2cData.u32RegAddr = 0x0100;
-        stI2cData.u32Data = 0x01;
-        HI_MPI_ISP_I2cWrite(&stI2cData);
-    }
-    
-    #else
-    if(p_gains->again!= _last_again)
-    { 
-        switch(p_gains->again)
-        {
-            case (16):
-                sensor_write_register(0x0018, 0x4);
-            break;
-                 
-            case (8):
-                sensor_write_register(0x0018, 0x3);    
-            break;
-            
-            case (4):
-                sensor_write_register(0x0018, 0x2);
-            break;
-            
-            case (2):
-                sensor_write_register(0x0018, 0x1);
-            break;
-            default:
-                sensor_write_register(0x0018, 0x0);
-        }
-        _last_again = p_gains->again;
-        _update = HI_TRUE;
-    }
-    
-    if(p_gains->dgain!= _last_dgain)
-    { 
-        sensor_write_register(0x001D, p_gains->dgain);
-        _last_dgain = p_gains->dgain;
-        _update = HI_TRUE;
-    }    
-   
-    //refresh   register
-    if(_update)
-    {
-        sensor_write_register(0x0100,0x01);
-    }
-    #endif 
-    return;
-}
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-    HI_U32 _again = 1 << p_gains->again_shift;
-    int shift = 0;
-
-    //prevent overlow of exposure
-    while (exposure > (1<<22))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    
-    _again = (exposure<<p_gains->again_shift) /exposure_max;
-    _again = (_again < (1<<p_gains->again_shift)) ? (1<<p_gains->again_shift) : _again;        
-    _again = (_again > p_gains->max_again_target) ? p_gains->max_again_target : _again;
-    
-    if (_again >= 16) { _again = 16; }
-    else if (_again >= 8) { _again = 8; }
-    else if (_again >= 4) { _again = 4; }
-    else if (_again >= 2) { _again = 2; }
-    else{_again = 1;}
-    
-    p_gains->again = _again;
-    exposure = (exposure<<p_gains->again_shift) / p_gains->again;
-    
-    return exposure<<shift;
-    
-}
-
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
-
-    while (exposure > (1 << 22))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = DIV_0_TO_1(exposure_max);
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shift;
-}
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-    HI_U32 exposure0;
-    int shift = 0;	
-    HI_U32 _dgain=1<<p_gains->dgain_shift; 
-	//prevent overlow of exposure
-    while (exposure > (1<<22))
-    {
-    	exposure >>= 1;
-    	exposure_max >>= 1;
-    	++shift;
-    }
-    exposure_max = (0 == exposure_max)? 1: exposure_max;
-    exposure0=exposure;
-    
-    //calculate digital gain
-    if(exposure > exposure_max)
-    {
-       _dgain = (exposure << p_gains->dgain_shift)/exposure_max;
-    }
-    
-    _dgain = (_dgain>(p_gains->max_dgain_target))?(p_gains->max_dgain_target):_dgain;
-    _dgain = (_dgain < (1<<p_gains->dgain_shift)) ? (1<<p_gains->dgain_shift) : _dgain;
-    
-    p_gains->dgain= _dgain;
-    exposure=(exposure << p_gains->dgain_shift) / p_gains->dgain;
-    
-    return exposure<<shift;
-}
-
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-    if (NULL == p_cmos_isp_agc_table)
-    {
-        printf("null pointer when get isp agc table value!\n");
-        return -1;
-    }
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-    if (NULL == p_cmos_isp_noise_table)
-    {
-        printf("null pointer when get isp noise table value!\n");
-        return -1;
-    }
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
-{
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-static void setup_sensor(int isp_mode)
-{
-    //return;
-    if(0 == isp_mode) /* ISP 'normal' isp_mode */
-    {
-        sensor_write_register(0x0010, 0x0);
-        sensor_write_register(0x0011, 0x0);
-    }
-    else if(1 == isp_mode) /* ISP pixel calibration isp_mode */
-    {
-        /* 5 fps */
-        sensor_write_register(0x0010, 0x13); 
-        sensor_write_register(0x0011, 0x80); 
-        
-        /* min gain */
-        sensor_write_register(0x0018, 0x0);               
-        sensor_write_register(0x001d, 0x40); 
-        /* max exposure time*/
-        sensor_write_register(0x0016, 0x7e);
-        sensor_write_register(0x0015, 0x13);
-    }
-     //refresh  exposure register
-    sensor_write_register(0x0100,0x01);
-    sensor_write_register(0x0101,0x01);
-    sensor_write_register(0x0000,0x01);
-}
-
-
-
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    return 0;
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-    if (NULL == p_coms_isp_default)
+    if (HI_NULL == pstDef)
     {
         printf("null pointer when get isp default value!\n");
         return -1;
     }
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
+
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
+
+    pstDef->stComm.u8Rggb           = 0x3;      //1: rggb  
+    pstDef->stComm.u8BalanceFe      = 0x1;
+
+    pstDef->stDenoise.u8SinterThresh= 0x15;
+    pstDef->stDenoise.u8NoiseProfile= 0x0;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 0x0;
+
+    pstDef->stDrc.u8DrcBlack        = 0x0;
+    pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0xa0;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x4ff;    // white level
+
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+
     return 0;
 }
 
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
+    HI_S32  i;
+    
+    if (HI_NULL == pstBlackLevel)
+    {
+        printf("null pointer when get isp black level value!\n");
+        return -1;
+    }
 
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1280;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 720;
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+            
+    for (i=0; i<4; i++)
+    {
+        pstBlackLevel->au16BlackLevel[i] = 0x0;
+    }
 
-    return 0;
+    return 0;    
 }
 
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-SENSOR_EXP_FUNC_S stSensorExpFuncs =
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
+    if (bEnable) /* setup for ISP pixel calibration mode */
+    {
+        //TODO: finish this.
+    }
+    else /* setup for ISP 'normal mode' */
+    {
+    }
 
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-
-    .pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-    .pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-    .pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-    .pfn_cmos_get_isp_default = cmos_get_isp_default,
-    .pfn_cmos_get_isp_special_alg = NULL,
-    .pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-    .pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-    .pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-    .pfn_cmos_get_isp_shading_table = NULL,
-    .pfn_cmos_get_isp_gamma_table = NULL,    
-	.pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-	.pfn_cmos_set_sensor_image_mode = NULL,
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-
-	return 0;
+    return;
 }
 
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
@@ -707,12 +228,307 @@ int sensor_mode_set(HI_U8 u8Mode)
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 832;
+
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32LinesPer500ms = 832*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 832;
+    pstAeSnsDft->u32MinIntTime = 2;    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 2;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_DB;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 6;    
+    pstAeSnsDft->u32MaxAgain = 4;  /* 24db / 6db = 4 */
+    pstAeSnsDft->u32MinAgain = 0;
+    pstAeSnsDft->u32MaxAgainTarget = 7;
+    pstAeSnsDft->u32MinAgainTarget = 0;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.015625;
+    pstAeSnsDft->u32MaxDgain = 256;  /* 4 / 0.015625 = 256 */
+    pstAeSnsDft->u32MinDgain = 64;
+    pstAeSnsDft->u32MaxDgainTarget = 169;   /* 2.75 / 0.015625 = 176 */
+    pstAeSnsDft->u32MinDgainTarget = 64;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
     return 0;
 }
 
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    switch(u8Fps)
+    {
+        case 30:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 832;
+            pstAeSnsDft->u32MaxIntTime = 830;
+            pstAeSnsDft->u32LinesPer500ms = 832 * 30 / 2;
+        break;
+        
+        case 25:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 832;
+            pstAeSnsDft->u32MaxIntTime = 830;
+            pstAeSnsDft->u32LinesPer500ms = 832 * 25 / 2;
+        break;
+        
+        default:
+        break;
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    HI_U32 u32VblankLine;
+    
+    gu32FullLines = u16FullLines;
+    
+    u32VblankLine = gu32FullLines - gu32FullLinesStd + 2;
+
+    sensor_write_register(0x0011, u32VblankLine & 0xff);
+    sensor_write_register(0x0010, (u32VblankLine & 0xff00) >> 8);
+    
+    //refresh   register
+    sensor_write_register(0x0100,0x01);
+    sensor_write_register(0x0101,0x01);
+    sensor_write_register(0x0000,0x01);
+    
+    pstAeSnsDft->u32MaxIntTime = gu32FullLines - 4;
+    
+    return;
+}
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+    HI_U32 u32Value = u32IntTime;
+    
+    sensor_write_register(0x0016, u32Value & 0xFF);
+    sensor_write_register(0x0015, (u32Value >> 8) & 0xFF);
+
+    //refresh  exposure register
+    sensor_write_register(0x0100,0x01);
+    sensor_write_register(0x0101,0x01);
+    sensor_write_register(0x0000,0x01);
+    
+    return;
+}
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    sensor_write_register(0x0018, u32Again);
+    sensor_write_register(0x001D, u32Dgain);
+    
+    //refresh   register
+    sensor_write_register(0x0100,0x01);
+    sensor_write_register(0x0101,0x01);
+    sensor_write_register(0x0000,0x01);
+
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 4950;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x187;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x179;
+
+    pstAwbSnsDft->as32WbPara[0] = 123;
+    pstAwbSnsDft->as32WbPara[1] = -15;
+    pstAwbSnsDft->as32WbPara[2] = -144;
+    pstAwbSnsDft->as32WbPara[3] = 136180;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -85414;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(HIMAX1375_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, HIMAX1375_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, HIMAX1375_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(HIMAX1375_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, HIMAX1375_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, HIMAX1375_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -720,5 +536,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-
-#endif // __HIMAX1375_CMOS_H_
+#endif

--- a/libraries/sensor/hi3516cv100/himax_1375/himax1375_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/himax_1375/himax1375_sensor_ctl.c
@@ -1,3 +1,4 @@
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -12,10 +13,9 @@
 #include "hi_i2c.h"
 #endif
 
-const unsigned int sensor_i2c_addr	=	0x48;		/* I2C Address of himax1375 */
-const unsigned int sensor_addr_byte	=	2;
-const unsigned int sensor_data_byte	=	1;
-
+const unsigned int sensor_i2c_addr  = 0x48;        /* I2C Address of himax1375 */
+const unsigned int sensor_addr_byte = 2;
+const unsigned int sensor_data_byte = 1;
 
 int sensor_read_register(int addr)
 {
@@ -37,6 +37,7 @@ int sensor_read_register(int addr)
     if (ret)
     {
         printf("GPIO-I2C read faild!\n");
+        close(fd);
         return -1;
     }
 
@@ -66,13 +67,14 @@ int sensor_read_register(int addr)
     if (ret)
     {
         printf("hi_i2c read faild!\n");
+        close(fd);
         return -1;
     }
 
     close(fd);
 #endif
 
-	return i2c_data.data;
+    return i2c_data.data;
 }
 
 int sensor_write_register(int addr, int data)
@@ -96,6 +98,7 @@ int sensor_write_register(int addr, int data)
     if (ret)
     {
         printf("GPIO-I2C write faild!\n");
+        close(fd);
         return -1;
     }
 
@@ -123,12 +126,13 @@ int sensor_write_register(int addr, int data)
     if (ret)
     {
         printf("hi_i2c write faild!\n");
+        close(fd);
         return -1;
     }
 
     close(fd);
 #endif
-	return 0;
+    return 0;
 }
 
 int sensor_write_register_bit(int addr, int data, int mask)
@@ -151,6 +155,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
     if (ret)
     {
         printf("GPIO-I2C read faild!\n");
+        close(fd);
         return -1;
     }
 
@@ -164,6 +169,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
     if (ret)
     {
         printf("GPIO-I2C write faild!\n");
+        close(fd);
         return -1;
     }
 
@@ -190,6 +196,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
     if (ret)
     {
         printf("hi_i2c read faild!\n");
+        close(fd);
         return -1;
     }
 
@@ -203,12 +210,13 @@ int sensor_write_register_bit(int addr, int data, int mask)
     if (ret)
     {
         printf("hi_i2c write faild!\n");
+        close(fd);
         return -1;
     }
 
     close(fd);
 #endif
-	return 0;
+    return 0;
 }
 
 
@@ -235,13 +243,13 @@ void sensor_prog(int* rom)
         }
         else
         {
-			sensor_write_register(addr, data);
+            sensor_write_register(addr, data);
         }
     }
 }
 
 void sensor_init()
-{	
+{    
     //HM1375 Raw 1280x720
     sensor_write_register(0x0022,0x00); //Software reset 
     sensor_write_register(0x000C,0x04);  
@@ -779,7 +787,6 @@ void sensor_init()
     sensor_write_register(0x002C,0x00);
     sensor_write_register(0x0005,0x01);
     
-	return ;
+    return ;
 }
-
 

--- a/libraries/sensor/hi3516cv100/ov_9712+/ov9712_plus_cmos.c
+++ b/libraries/sensor/hi3516cv100/ov_9712+/ov9712_plus_cmos.c
@@ -1,12 +1,16 @@
-#if !defined(__OV9712_CMOS_H_)
-#define __OV9712_CMOS_H_
+#if !defined(__OV9715_CMOS_H_)
+#define __OV9715_CMOS_H_
 
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 #include "hi_comm_sns.h"
+#include "hi_comm_isp.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_comm_isp.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -14,23 +18,7 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-/****************************************************************************
- * local variables															*
- ****************************************************************************/
-
-extern const unsigned int sensor_i2c_addr;
-extern const unsigned int sensor_addr_byte;
-extern const unsigned int sensor_data_byte;
-
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
-static HI_U8 gu8SensorMode = 0;
-
-static HI_U8 gu8Fps = 30;
-
-/****************************************************************************
- * MACRO DEFINITION                                                         *
- ****************************************************************************/
+#define OV9712_ID 9712
 
 /*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker in antiflicker mode */
 /*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance                       */
@@ -44,15 +32,31 @@ static HI_U8 gu8Fps = 30;
  * When the value is 1, add the line length to slow framerate. */
 #define CMOS_OV9712_SLOW_FRAMERATE_MODE (0)
 
-static cmos_isp_default_t st_coms_isp_default =
+/****************************************************************************
+ * local variables                                                            *
+ ****************************************************************************/
+
+extern const unsigned int sensor_i2c_addr;
+extern unsigned int sensor_addr_byte;
+extern unsigned int sensor_data_byte;
+
+HI_U8 gu8SensorMode = 0;
+
+static HI_U32 gu8Fps = 30;
+static HI_U32 gu32FullLinesStd = 810;
+static HI_U32 gu32FullLines = 810;
+
+#if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
+#endif
+
+static AWB_CCM_S g_stAwbCcm =
 {
-	// color matrix[9]
-    {
      5000,
      {
-        0x0146, 0x8068, 0x0021,
-        0x800c, 0x00e9, 0x0022,
-        0x0010, 0x80bd, 0x01ac
+      0x0146, 0x8068, 0x0021,
+      0x800c, 0x00e9, 0x0022,
+      0x0010, 0x80bd, 0x01ac
      },
      3200,
      {
@@ -66,44 +70,23 @@ static cmos_isp_default_t st_coms_isp_default =
       0x801d, 0x00da, 0x0042,
       0x8017, 0x81d2, 0x02e9
      }
-    },
-
-
-    // black level
-    {68,64,68,68},
-
-    //calibration reference color temperature
-    5000,
-
-    //WB gain at 5000, must keep consistent with calibration color temperature
-      {0x1d4, 0x100, 0x100, 0x1cc},  //ov9712+
-
-    // WB curve parameters, must keep consistent with reference color temperature.
-    {-133,650,261,159186,128,-107849},
-
-	// hist_thresh
-    {0xd,0x28,0x60,0x80},
-
-	0x0,	// iridix_balck
-	0x3,	// bggr
-
-	/* limit max gain for reducing noise,    */
-	0x1f,	0x1,
-
-	// iridix
-	0x04,	0x08,	0xa0, 	0x4ff,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x15, 	// sinter threshold
-
-	0x0,  0,  0,  //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
-
-    2
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
+    /* bvalid */
+    1,
+
+    /* saturation */
+    {0x90,0x90,0x80,0x80,0x68,0x48,0x35,0x30}
+};
+
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
+{
+    /* bvalid */
+    1,
+    
 #if CMOS_OV9712_MORE_SHARPEN
     //sharpen_alt_d
     {80,75,70,65,55,45,35,20},
@@ -114,16 +97,16 @@ static cmos_isp_agc_table_t st_isp_agc_table =
     //snr_thresh
     {0x23,0x28,0x2b,0x35,0x3f,0x46,0x4b,0x4f},
 #else    
-    //sharpen_alt_d
+    /* sharpen_alt_d */
     {0x8e,0x8b,0x88,0x83,0x7d,0x76,0x75,0x74},
-
-    //sharpen_alt_ud
+        
+    /* sharpen_alt_ud */
     {0x8f,0x89,0x7e,0x78,0x6f,0x44,0x40,0x35},
-
-    //snr_thresh
+        
+    /* snr_thresh */
     {0x19,0x1e,0x2d,0x32,0x39,0x3f,0x48,0x4b},
-#endif
-
+#endif    
+        
     //demosaic_lum_thresh
     {80,64,64,48,48,32,32,16},
 
@@ -133,27 +116,26 @@ static cmos_isp_agc_table_t st_isp_agc_table =
     //ge_strength
     {0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55},
 
-    /* saturation */
-    {0x90,0x90,0x80,0x80,0x68,0x48,0x35,0x30}
-
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
 {
-    //nosie_profile_weight_lut
-    {
-        0x00,0x04,0x10,0x16,0x1a,0x1d,0x1f,0x21,0x23,0x24,0x26,0x27,0x28,0x29,0x2a,0x2a,0x2b,
-        0x2c,0x2d,0x2d,0x2e,0x2e,0x2f,0x2f,0x30,0x30,0x31,0x31,0x32,0x32,0x33,0x33,0x33,0x34,
-        0x34,0x34,0x35,0x35,0x35,0x36,0x36,0x36,0x37,0x37,0x37,0x37,0x38,0x38,0x38,0x38,0x39,
-        0x39,0x39,0x39,0x39,0x3a,0x3a,0x3a,0x3a,0x3b,0x3b,0x3b,0x3b,0x3b,0x3b,0x3c,0x3c,0x3c,
-        0x3c,0x3c,0x3c,0x3d,0x3d,0x3d,0x3d,0x3d,0x3d,0x3e,0x3e,0x3e,0x3e,0x3e,0x3e,0x3e,0x3f,
-        0x3f,0x3f,0x3f,0x3f,0x3f,0x3f,0x40,0x40,0x40,0x40,0x40,0x40,0x40,0x40,0x41,0x41,0x41,
-        0x41,0x41,0x41,0x41,0x41,0x41,0x42,0x42,0x42,0x42,0x42,0x42,0x42,0x42,0x42,0x42,0x43,
-        0x43,0x43,0x43,0x43,0x43,0x43,0x43,0x43,0x43
-
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
+    {   
+    0x00,0x04,0x10,0x16,0x1a,0x1d,0x1f,0x21,0x23,0x24,0x26,0x27,0x28,0x29,0x2a,0x2a,
+    0x2b,0x2c,0x2d,0x2d,0x2e,0x2e,0x2f,0x2f,0x30,0x30,0x31,0x31,0x32,0x32,0x33,0x33,
+    0x33,0x34,0x34,0x34,0x35,0x35,0x35,0x36,0x36,0x36,0x37,0x37,0x37,0x37,0x38,0x38,
+    0x38,0x38,0x39,0x39,0x39,0x39,0x39,0x3a,0x3a,0x3a,0x3a,0x3b,0x3b,0x3b,0x3b,0x3b,
+    0x3b,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c,0x3d,0x3d,0x3d,0x3d,0x3d,0x3d,0x3e,0x3e,0x3e,
+    0x3e,0x3e,0x3e,0x3e,0x3f,0x3f,0x3f,0x3f,0x3f,0x3f,0x3f,0x40,0x40,0x40,0x40,0x40,
+    0x40,0x40,0x40,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x42,0x42,0x42,0x42,
+    0x42,0x42,0x42,0x42,0x42,0x42,0x43,0x43,0x43,0x43,0x43,0x43,0x43,0x43,0x43,0x43
     },
 
-    //demosaic_weight_lut
+    /* demosaic_weight_lut */
     {0, 27, 31, 33, 35, 36, 37, 38, 39, 40, 40, 41, 41, 42, 42, 43,
     43, 43, 44, 44, 44, 45, 45, 45, 45, 46, 46, 46, 46, 46, 47, 47,
     47, 47, 47, 48, 48, 48, 48, 48, 48, 48, 49, 49, 49, 49, 49, 49,
@@ -164,8 +146,11 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     54, 54, 54, 54, 54, 54, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55}
 };
 
-static cmos_isp_demosaic_t st_isp_demosaic =
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
+    /* bvalid */
+    1,
+    
     /*vh_slope*/
     205,
 
@@ -210,8 +195,11 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x1b3
 };
 
-static cmos_isp_shading_table_t st_isp_shading_table =
+static ISP_CMOS_SHADING_S g_stIspShading =
 {
+    /* bvalid */
+    1,
+    
     /*shading_center_r*/
     0x28f, 0x16c,
 
@@ -221,48 +209,47 @@ static cmos_isp_shading_table_t st_isp_shading_table =
     /*shading_center_b*/
     0x293, 0x16c,
 
-    {
-            0x1000,0x100c,0x1035,0x1065,0x1099,0x10cd,0x1102,0x1137,0x116c,0x11a1,0x11d5,0x1209,
-            0x123d,0x126f,0x12a2,0x12d3,0x1303,0x1335,0x1365,0x1394,0x13c2,0x13f0,0x141c,0x1449,
-            0x1475,0x149f,0x14c9,0x14f3,0x151b,0x1543,0x156a,0x1590,0x15b5,0x15d9,0x15fd,0x1620,
-            0x1642,0x1663,0x1684,0x16a3,0x16c2,0x16e0,0x16fd,0x1719,0x1735,0x1750,0x176a,0x1783,
-            0x179b,0x17b3,0x17ca,0x17e0,0x17f5,0x180a,0x181e,0x1831,0x1843,0x1855,0x1866,0x1877,
-            0x1887,0x1896,0x18a4,0x18b2,0x18bf,0x18cb,0x18d7,0x18e3,0x18ef,0x18f8,0x1903,0x190d,
-            0x1916,0x191e,0x1926,0x192d,0x1935,0x193c,0x1942,0x1948,0x194d,0x1953,0x1958,0x195d,
-            0x1961,0x1964,0x1968,0x196c,0x196f,0x1972,0x1975,0x1977,0x1978,0x197b,0x197d,0x197e,
-            0x1981,0x1982,0x1983,0x1984,0x1986,0x1987,0x1988,0x1989,0x198a,0x198a,0x198a,0x198c,
-            0x198d,0x198e,0x198e,0x198f,0x1990,0x1991,0x1992,0x1993,0x1994,0x1996,0x1997,0x1999,
-            0x199a,0x199c,0x199d,0x199f,0x19a2,0x19a5,0x19a7,0x19aa,0x19ac
-    },
+    /*shading_table_r*/
+  {   
+    0x1000,0x100c,0x1035,0x1065,0x1099,0x10cd,0x1102,0x1137,0x116c,0x11a1,0x11d5,0x1209,
+    0x123d,0x126f,0x12a2,0x12d3,0x1303,0x1335,0x1365,0x1394,0x13c2,0x13f0,0x141c,0x1449,
+    0x1475,0x149f,0x14c9,0x14f3,0x151b,0x1543,0x156a,0x1590,0x15b5,0x15d9,0x15fd,0x1620,
+    0x1642,0x1663,0x1684,0x16a3,0x16c2,0x16e0,0x16fd,0x1719,0x1735,0x1750,0x176a,0x1783,
+    0x179b,0x17b3,0x17ca,0x17e0,0x17f5,0x180a,0x181e,0x1831,0x1843,0x1855,0x1866,0x1877,
+    0x1887,0x1896,0x18a4,0x18b2,0x18bf,0x18cb,0x18d7,0x18e3,0x18ef,0x18f8,0x1903,0x190d,
+    0x1916,0x191e,0x1926,0x192d,0x1935,0x193c,0x1942,0x1948,0x194d,0x1953,0x1958,0x195d,
+    0x1961,0x1964,0x1968,0x196c,0x196f,0x1972,0x1975,0x1977,0x1978,0x197b,0x197d,0x197e,
+    0x1981,0x1982,0x1983,0x1984,0x1986,0x1987,0x1988,0x1989,0x198a,0x198a,0x198a,0x198c,
+    0x198d,0x198e,0x198e,0x198f,0x1990,0x1991,0x1992,0x1993,0x1994,0x1996,0x1997,0x1999,
+    0x199a,0x199c,0x199d,0x199f,0x19a2,0x19a5,0x19a7,0x19aa,0x19ac},
 
+    /*shading_table_g*/
     {
-            0x1000,0x1005,0x1028,0x1055,0x1087,0x10bb,0x10f0,0x1125,0x115b,0x1190,0x11c5,0x11fa,
-            0x122f,0x1263,0x1296,0x12c9,0x12fc,0x132d,0x135e,0x138f,0x13be,0x13ed,0x141b,0x1449,
-            0x1475,0x14a1,0x14cc,0x14f6,0x1520,0x1548,0x1570,0x1597,0x15bd,0x15e2,0x1606,0x1629,
-            0x164b,0x166d,0x168e,0x16ad,0x16cc,0x16ea,0x1707,0x1724,0x173f,0x175a,0x1773,0x178c,
-            0x17a4,0x17bc,0x17d2,0x17e8,0x17fc,0x1810,0x1824,0x1836,0x1848,0x1859,0x1869,0x1879,
-            0x1888,0x1896,0x18a4,0x18b1,0x18bd,0x18c9,0x18d4,0x18df,0x18e9,0x18f2,0x18fb,0x1904,
-            0x190c,0x1914,0x191b,0x1921,0x1928,0x192d,0x1933,0x1938,0x193d,0x1941,0x1945,0x1949,
-            0x194d,0x1950,0x1953,0x1956,0x1959,0x195b,0x195d,0x195f,0x1961,0x1963,0x1965,0x1966,
-            0x1967,0x1969,0x196a,0x196b,0x196d,0x196e,0x196f,0x1970,0x1972,0x1973,0x1974,0x1975,
-            0x1977,0x1978,0x197a,0x197c,0x197e,0x1980,0x1982,0x1984,0x1987,0x1989,0x198c,0x198f,
-            0x1992,0x1996,0x199a,0x199e,0x19a2,0x19a6,0x19ab,0x19b0,0x19b4
-    },
+    0x1000,0x1005,0x1028,0x1055,0x1087,0x10bb,0x10f0,0x1125,0x115b,0x1190,0x11c5,0x11fa,
+    0x122f,0x1263,0x1296,0x12c9,0x12fc,0x132d,0x135e,0x138f,0x13be,0x13ed,0x141b,0x1449,
+    0x1475,0x14a1,0x14cc,0x14f6,0x1520,0x1548,0x1570,0x1597,0x15bd,0x15e2,0x1606,0x1629,
+    0x164b,0x166d,0x168e,0x16ad,0x16cc,0x16ea,0x1707,0x1724,0x173f,0x175a,0x1773,0x178c,
+    0x17a4,0x17bc,0x17d2,0x17e8,0x17fc,0x1810,0x1824,0x1836,0x1848,0x1859,0x1869,0x1879,
+    0x1888,0x1896,0x18a4,0x18b1,0x18bd,0x18c9,0x18d4,0x18df,0x18e9,0x18f2,0x18fb,0x1904,
+    0x190c,0x1914,0x191b,0x1921,0x1928,0x192d,0x1933,0x1938,0x193d,0x1941,0x1945,0x1949,
+    0x194d,0x1950,0x1953,0x1956,0x1959,0x195b,0x195d,0x195f,0x1961,0x1963,0x1965,0x1966,
+    0x1967,0x1969,0x196a,0x196b,0x196d,0x196e,0x196f,0x1970,0x1972,0x1973,0x1974,0x1975,
+    0x1977,0x1978,0x197a,0x197c,0x197e,0x1980,0x1982,0x1984,0x1987,0x1989,0x198c,0x198f,
+    0x1992,0x1996,0x199a,0x199e,0x19a2,0x19a6,0x19ab,0x19b0,0x19b4},
 
+    /*shading_table_b*/
     {
-           0x1000,0x1000,0x1011,0x102f,0x1054,0x107c,0x10a5,0x10cf,0x10fa,0x1125,0x1150,0x117c,
-           0x11a7,0x11d1,0x11fc,0x1226,0x1250,0x1279,0x12a2,0x12ca,0x12f2,0x131a,0x1340,0x1367,
-           0x138c,0x13b1,0x13d6,0x13fa,0x141d,0x143f,0x1461,0x1483,0x14a3,0x14c3,0x14e3,0x1502,
-           0x1520,0x153d,0x155a,0x1576,0x1591,0x15ac,0x15c6,0x15e0,0x15f8,0x1610,0x1628,0x163f,
-           0x1655,0x166b,0x1680,0x1694,0x16a8,0x16bb,0x16cd,0x16df,0x16f1,0x1701,0x1712,0x1721,
-           0x1730,0x173f,0x174d,0x175b,0x1768,0x1774,0x1780,0x178c,0x1797,0x17a2,0x17ac,0x17b6,
-           0x17bf,0x17c8,0x17d1,0x17d9,0x17e1,0x17e8,0x17ef,0x17f6,0x17fd,0x1803,0x1809,0x180f,
-           0x1814,0x1819,0x181e,0x1822,0x1827,0x182b,0x182f,0x1833,0x1836,0x183a,0x183d,0x1840,
-           0x1843,0x1846,0x1849,0x184b,0x184e,0x1850,0x1853,0x1855,0x1857,0x185a,0x185c,0x185e,
-           0x1860,0x1862,0x1864,0x1867,0x1869,0x186b,0x186d,0x1870,0x1872,0x1875,0x1877,0x187a,
-           0x187d,0x1880,0x1883,0x1886,0x1889,0x188c,0x1890,0x1894,0x1895
-
-    },
+    0x1000,0x1000,0x1011,0x102f,0x1054,0x107c,0x10a5,0x10cf,0x10fa,0x1125,0x1150,0x117c,
+    0x11a7,0x11d1,0x11fc,0x1226,0x1250,0x1279,0x12a2,0x12ca,0x12f2,0x131a,0x1340,0x1367,
+    0x138c,0x13b1,0x13d6,0x13fa,0x141d,0x143f,0x1461,0x1483,0x14a3,0x14c3,0x14e3,0x1502,
+    0x1520,0x153d,0x155a,0x1576,0x1591,0x15ac,0x15c6,0x15e0,0x15f8,0x1610,0x1628,0x163f,
+    0x1655,0x166b,0x1680,0x1694,0x16a8,0x16bb,0x16cd,0x16df,0x16f1,0x1701,0x1712,0x1721,
+    0x1730,0x173f,0x174d,0x175b,0x1768,0x1774,0x1780,0x178c,0x1797,0x17a2,0x17ac,0x17b6,
+    0x17bf,0x17c8,0x17d1,0x17d9,0x17e1,0x17e8,0x17ef,0x17f6,0x17fd,0x1803,0x1809,0x180f,
+    0x1814,0x1819,0x181e,0x1822,0x1827,0x182b,0x182f,0x1833,0x1836,0x183a,0x183d,0x1840,
+    0x1843,0x1846,0x1849,0x184b,0x184e,0x1850,0x1853,0x1855,0x1857,0x185a,0x185c,0x185e,
+    0x1860,0x1862,0x1864,0x1867,0x1869,0x186b,0x186d,0x1870,0x1872,0x1875,0x1877,0x187a,
+    0x187d,0x1880,0x1883,0x1886,0x1889,0x188c,0x1890,0x1894,0x1895},
 
     /*shading_off_center_r_g_b*/
     0xef0, 0xec3, 0xecd,
@@ -271,12 +258,12 @@ static cmos_isp_shading_table_t st_isp_shading_table =
     129
 };
 
-
-static cmos_isp_gamma_table_t st_isp_gamma_table =
+static ISP_CMOS_GAMMA_S g_stIspGamma =
 {
-
-   
-   { 0,  54, 106, 158, 209, 259, 308, 356, 403, 450, 495, 540, 584, 628, 670, 713, 
+    /* bvalid */
+    1,
+    
+    {0,  54, 106, 158, 209, 259, 308, 356, 403, 450, 495, 540, 584, 628, 670, 713, 
     754, 795, 835, 874, 913, 951, 989,1026,1062,1098,1133,1168,1203,1236,1270,1303, 
     1335,1367,1398,1429,1460,1490,1520,1549,1578,1607,1635,1663,1690,1717,1744,1770,
     1796,1822,1848,1873,1897,1922,1946,1970,1993,2017,2040,2062,2085,2107,2129,2150, 
@@ -292,526 +279,518 @@ static cmos_isp_gamma_table_t st_isp_gamma_table =
     3838,3844,3850,3856,3863,3869,3875,3881,3887,3893,3899,3905,3910,3916,3922,3928, 
     3933,3939,3945,3950,3956,3962,3967,3973,3978,3983,3989,3994,3999,4005,4010,4015, 
     4020,4026,4031,4036,4041,4046,4051,4056,4061,4066,4071,4076,4081,4085,4090,4095, 4095}
-
 };
 
-
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-    cmos_inttime.full_lines_std = 810;
-	cmos_inttime.full_lines_std_30fps = 810;
-	cmos_inttime.full_lines = 810;
-	cmos_inttime.full_lines_limit = 65535;
-    cmos_inttime.max_lines = 806;
-    cmos_inttime.min_lines = 2;
-	cmos_inttime.max_lines_target = cmos_inttime.max_lines;
-	cmos_inttime.min_lines_target = cmos_inttime.min_lines;
-
-	cmos_inttime.vblanking_lines = 0;
-
-	cmos_inttime.exposure_ashort = 0;
-	cmos_inttime.exposure_shift = 0;
-
-	cmos_inttime.lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2; 
-	cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-	return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
-{
-#if CMOS_OV9712_SLOW_FRAMERATE_MODE
-    p_inttime->exposure_ashort = (p_inttime->exposure_ashort << 4) / p_inttime->slow_framerate;
-    if(p_inttime->exposure_ashort >= p_inttime->full_lines_std - 4)
-	{
-		p_inttime->exposure_ashort = p_inttime->full_lines_std - 4;
-	}
-#endif
-#if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-    
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x10;
-    stI2cData.u32Data = p_inttime->exposure_ashort & 0xFF;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    
-    stI2cData.u32RegAddr = 0x16;
-    stI2cData.u32Data = (p_inttime->exposure_ashort >> 8) & 0xFF;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-#else
-	HI_U32 _curr = p_inttime->exposure_ashort;
-    
-    sensor_write_register(0x10, _curr & 0xFF);
-    sensor_write_register(0x16, (_curr >> 8) & 0xFF);    
-#endif
-
-    return;
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-#if CMOS_OV9712_SLOW_FRAMERATE_MODE
-    HI_U32 u32Tp = 50760;   /* (0x698 * 30) = 50640*/
-    u32Tp = (((u32Tp * p_inttime->slow_framerate) / gu8Fps) >> 4) + 3;
-    if (u32Tp > 0x2000)     /* the register 0x2a adn 0x2b's max value is 0x2000 */
+    if (HI_NULL == pstDef)
     {
-        u32Tp = 0x2000;
-        p_inttime->slow_framerate = ((gu8Fps * u32Tp) << 4) / 50760;
-        printf("Warning! The slow_framerate is out of ov9712's range!\n");
-    }
-    
-    #if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-    
-    stI2cData.bDelayCfg = HI_TRUE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x2a;
-    stI2cData.u32Data = u32Tp & 0xfc;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    
-    stI2cData.u32RegAddr = 0x2b;
-    stI2cData.u32Data = (u32Tp & 0xff00) >> 8;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    #else
-    sensor_write_register(0x2a, u32Tp & 0xfc);
-    sensor_write_register(0x2b, (u32Tp & 0xff00) >> 8);
-    #endif
-#else
-    static HI_U16 last_vblanking_lines = 65535;
-    if(p_inttime->vblanking_lines != last_vblanking_lines)
-    {
-        sensor_write_register(0x2d, p_inttime->vblanking_lines & 0xff);
-        sensor_write_register(0x2e, (p_inttime->vblanking_lines & 0xff00) >> 8);
-        last_vblanking_lines = p_inttime->vblanking_lines;
-    }
-#endif
-
-    return;
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-	if(p_inttime->exposure_ashort >= p_inttime->full_lines - 4)
-	{
-		p_inttime->exposure_ashort = p_inttime->full_lines - 4;
-	}
-
-	p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std_30fps;
-
-	return p_inttime->exposure_ashort;
-}
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-	switch(fps)
-	{
-		case 30:
-            p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2;
-            gu8Fps = 30;
-            sensor_write_register(0x2a, 0x9c);
-            sensor_write_register(0x2b, 0x6);
-		break;
-
-		case 25:
-            /* do not change full_lines_std */
-			p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_30fps * 25 / 2;
-            gu8Fps = 25;
-            sensor_write_register(0x2a, 0xf0);
-            sensor_write_register(0x2b, 0x7);
-        break;
-
-		default:
-		break;
-	}
-    
-	return;
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
-{
-    cmos_gains.max_again = 496;
-	cmos_gains.max_dgain = 1;
-
-	cmos_gains.again_shift = 4;
-	cmos_gains.dgain_shift = 0;
-	cmos_gains.dgain_fine_shift = 0;
-
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_TRUE;
-
-	return &cmos_gains;
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-	HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-	HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _isp_dgain = p_gains->isp_dgain == 0 ? 1 : p_gains->isp_dgain;
-
-	p_gains->iso =  ((_again * _dgain * _isp_dgain * 100) 
-                     >> (p_gains->again_shift + p_gains->dgain_shift 
-                         + p_gains->isp_dgain_shift));
-	return p_gains->iso;
-
-}
-
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{
-#if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-
-    stI2cData.bDelayCfg = HI_TRUE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x00;
-    stI2cData.u32Data = p_gains->again_db;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    
-#else
-    sensor_write_register(0x00, p_gains->again_db);
-#endif
-
-	return;
-}
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-    HI_U32 _again = 1 << p_gains->again_shift;
-    int shift = 0;
-    HI_U8 i = 0;
-
-    while (exposure > (1<<26))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
+        printf("null pointer when get isp default value!\n");
+        return -1;
     }
 
-    if(exposure > exposure_max)
-    {
-        _again = (exposure << p_gains->again_shift) / exposure_max;
-        _again = _again < 16? 16: _again;
-    	_again = _again > p_gains->max_again_target ? p_gains->max_again_target : _again;
-        
-        for(i = 0; i < 5; i++)
-        {
-            if(_again < 32)
-            {
-                break;
-            }
-            _again >>= 1;
-        }
-    }
-    else
-    {
-    }
-
-    p_gains->again_db = (1 << (i + 4)) + _again - 32;
-    p_gains->again = _again << i;
-
-    return (exposure << (shift + 4)) / p_gains->again;
-
-}
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    int shft = 0;
-
-    while (exposure > (1 << 22))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-    exposure_max = (0 == exposure_max)? 1: exposure_max;
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    else
-	{
-	}
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shft;
-}
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-    int shft = 0;
-    while (exposure > (1 << 22))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
     
-	p_gains->dgain = 1;
+    pstDef->stComm.u8Rggb           = 0x3;      //3: bggr  
+    pstDef->stComm.u8BalanceFe      = 0x1;
 
-	return exposure << shft;
-}
+    pstDef->stDenoise.u8SinterThresh= 0x15;
+    pstDef->stDenoise.u8NoiseProfile= 0x0;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 0x0;
 
+    pstDef->stDrc.u8DrcBlack        = 0x00;
+    pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0xa0;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x4ff;    // white level
 
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+    memcpy(&pstDef->stShading, &g_stIspShading, sizeof(ISP_CMOS_SHADING_S));
+    memcpy(&pstDef->stGamma, &g_stIspGamma, sizeof(ISP_CMOS_GAMMA_S));
+
     return 0;
 }
 
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
+    if (HI_NULL == pstBlackLevel)
+    {
+        printf("null pointer when get isp black level value!\n");
+        return -1;
+    }
+
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+
+    pstBlackLevel->au16BlackLevel[0] = 68;
+    pstBlackLevel->au16BlackLevel[1] = 64;
+    pstBlackLevel->au16BlackLevel[2] = 64;
+    pstBlackLevel->au16BlackLevel[3] = 68;
+
+    return 0;    
 }
 
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-static HI_U32 cmos_get_isp_shading_table(cmos_isp_shading_table_ptr_t p_cmos_isp_shading_table)
-{
-	if (NULL == p_cmos_isp_shading_table)
-	{
-	    printf("null pointer when get isp shading table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_shading_table, &st_isp_shading_table, sizeof(cmos_isp_shading_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_gamma_table(cmos_isp_gamma_table_ptr_t p_cmos_isp_gamma_table)
-{
-   if(NULL == p_cmos_isp_gamma_table)
-   {
-    printf("null pointer when get isp gamma table!\n");
-    return -1;
-   }
-   memcpy(p_cmos_isp_gamma_table,&st_isp_gamma_table, sizeof(cmos_isp_gamma_table_t));
-   return 0;
-   
-}
-
-
-
-static void setup_sensor(int isp_mode)
-{
-	if(0 == isp_mode) /* ISP 'normal' isp_mode */
-	{
-        sensor_write_register(0x2d, 0x0);
-        sensor_write_register(0x2e, 0x0);
-	}
-	else if(1 == isp_mode) /* ISP pixel calibration isp_mode */
-	{
+    if (bEnable) /* setup for ISP pixel calibration mode */
+    {
         /* 5 fps */
         sensor_write_register(0x2d, 0xd2); 
         sensor_write_register(0x2e, 0x0f); 
         
         /* min gain */
-        sensor_write_register(0x0, 0x00);               
+        sensor_write_register(0x0, 0x00);
 
         /* max exposure time*/
         sensor_write_register(0x10, 0xf8);
-    	sensor_write_register(0x16, 0x12);
-	}
-}
-
-static HI_U32 cmos_gains_lin_to_db_convert(HI_U32 data, HI_U32 shift_in)
-{
-    #define PRECISION 8
-    HI_U32 _res = 0;
-    if(0 == data)
-        return _res;
-
-    data = data << PRECISION; // to ensure precision.
-    for(;;)
-    {
-        /* Note to avoid endless loop here. */
-        data = (data * 913) >> 10;
-        // data = (data*913 + (1<<9)) >> 10; // endless loop when shift_in is 0. */
-        if(data <= ((1<<shift_in) << PRECISION))
-        {
-            break;
-        }
-        ++_res;
+        sensor_write_register(0x16, 0x12);
     }
-    return _res;
+    else /* setup for ISP 'normal mode' */
+    {
+        sensor_write_register(0x2d, 0x0);
+        sensor_write_register(0x2e, 0x0);
+    }
+
+    return;
 }
 
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    return cmos_gains_lin_to_db_convert(p_gains->again, p_gains->again_shift);
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-	if (NULL == p_coms_isp_default)
-	{
-	    printf("null pointer when get isp default value!\n");
-	    return -1;
-	}
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
-    return 0;
-}
-
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1280;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 720;
-
-    return 0;
-}
-
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-SENSOR_EXP_FUNC_S stSensorExpFuncs =
-{
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
-
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-
-	.pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-	.pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-	.pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-	.pfn_cmos_get_isp_default = cmos_get_isp_default,
-	.pfn_cmos_get_isp_special_alg = NULL,
-	.pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-	.pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-	.pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-	.pfn_cmos_get_isp_shading_table = cmos_get_isp_shading_table,
-	.pfn_cmos_get_isp_gamma_table = cmos_get_isp_gamma_table,
-	
-	.pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-	.pfn_cmos_set_sensor_image_mode = NULL,
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-
-	return 0;
-}
-
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
         //sensor mode 0
         case 0:
             gu8SensorMode = 0;
-            // TODO:
         break;
         //sensor mode 1
         case 1:
             gu8SensorMode = 1;
-             // TODO:
         break;
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 810;
+    
+    pstAeSnsDft->u32LinesPer500ms = 810*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+    
+    //gu8Fps = 30;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 806;
+    pstAeSnsDft->u32MinIntTime = 2;
+    
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 2;
+
+    /* 1(1+1/16), 1(1+2/16), ... , 2(1+1/16), ... , 16(1+15/16) */
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_DB;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 6;
+    pstAeSnsDft->u32MaxAgain = 4;  /* 1, 2, 4, ... 16 (0~24db, unit is 6db) */
+    pstAeSnsDft->u32MinAgain = 0;
+    pstAeSnsDft->u32MaxAgainTarget = 4;
+    pstAeSnsDft->u32MinAgainTarget = 0;
+    
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.0625;
+    pstAeSnsDft->u32MaxDgain = 31;  /* 1 ~ 31/16, unit is 1/16 */
+    pstAeSnsDft->u32MinDgain = 16;
+    pstAeSnsDft->u32MaxDgainTarget = 32;
+    pstAeSnsDft->u32MinDgainTarget = 16; 
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
     return 0;
 }
 
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    HI_U32 tp = 1692;
+#if 0
+    switch(fps)
+    {
+        case 30:
+            tp = 1688;
+            break;
+        case 25:
+            tp = 2028;
+            break;
+        default:
+            break;
+    }
+#endif
+    tp = 1692 * 30 / u8Fps + 3;
+    sensor_write_register(0x2a, tp & 0xfc);
+    sensor_write_register(0x2b, (tp & 0xff00) >> 8);
+
+    pstAeSnsDft->u32MaxIntTime = 806;
+    gu32FullLinesStd = 810;
+    gu8Fps = u8Fps;
+    pstAeSnsDft->u32LinesPer500ms = gu32FullLinesStd * u8Fps / 2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+/* Mode 1 : slow framerate by add the time of each line. */
+#if CMOS_OV9712_SLOW_FRAMERATE_MODE
+    HI_U32 u32Tp = 50760;   /* (0x69c * 30) = 50760*/
+    HI_U16 u16SlowFrameRate = (u16FullLines << 8) / gu32FullLinesStd;
+    u32Tp = (((u32Tp * u16SlowFrameRate) / gu8Fps) >> 8) + 3;
+    if (u32Tp > 0x2000)     /* the register 0x2a adn 0x2b's max value is 0x2000 */
+    {
+        u32Tp = 0x2000;
+        u16SlowFrameRate = ((gu8Fps * u32Tp) << 8) / 50760;
+        printf("Warning! The slow_framerate is out of ov9712's range!\n");
+    }
+
+    
+    pstAeSnsDft->u32LinesPer500ms = gu32FullLines * (gu8Fps << 8) / (2*u16SlowFrameRate);
+    pstAeSnsDft->u32MaxIntTime = ((gu32FullLines * u16SlowFrameRate) >> 8) - 4;
+    #if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
+    g_stSnsRegsInfo.u32RegNum = 5;
+    g_stSnsRegsInfo.astI2cData[3].u32Data = u32Tp & 0xfc;
+    g_stSnsRegsInfo.astI2cData[4].u32Data = (u32Tp & 0xff00) >> 8;
+    #else
+    sensor_write_register(0x2a, u32Tp & 0xfc);
+    sensor_write_register(0x2b, (u32Tp & 0xff00) >> 8);    
+    #endif
+#else
+/* Mode 2 : slow framerate by add the lines of each frame. */
+    #if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
+    HI_U32 u32VblankingLines;
+    static HI_U32 u32LastVblankingLines = 0;
+
+    gu32FullLines = u16FullLines;
+    u32VblankingLines = gu32FullLines - gu32FullLinesStd;
+
+    /*avoid flicker in slow frame rate*/
+    if(u32LastVblankingLines < u32VblankingLines)
+    {
+        g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[4].bDelayCfg = HI_FALSE;        
+    }
+    else
+    {
+        g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[4].bDelayCfg = HI_TRUE;
+    }
+    g_stSnsRegsInfo.u32RegNum = 5;
+    g_stSnsRegsInfo.astI2cData[3].u32Data = u32VblankingLines & 0xff;
+    g_stSnsRegsInfo.astI2cData[4].u32Data = (u32VblankingLines & 0xff00) >> 8;
+    u32LastVblankingLines = u32VblankingLines;
+    #else
+    HI_U32 u32VblankingLines;
+
+    gu32FullLines = u16FullLines;
+    u32VblankingLines = gu32FullLines - gu32FullLinesStd;
+    
+    sensor_write_register(0x2d, u32VblankingLines & 0xff);
+    sensor_write_register(0x2e, (u32VblankingLines & 0xff00) >> 8);
+    #endif
+    
+    pstAeSnsDft->u32MaxIntTime = gu32FullLines - 4;
+#endif
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+    static HI_BOOL bInit = HI_FALSE;
+
+    if (HI_FALSE == bInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_I2C_TYPE;
+        g_stSnsRegsInfo.u32RegNum = 3;
+        for (i=0; i<5; i++)
+        {
+            g_stSnsRegsInfo.astI2cData[i].u8DevAddr = sensor_i2c_addr;
+            g_stSnsRegsInfo.astI2cData[i].u32AddrByteNum = sensor_addr_byte;
+            g_stSnsRegsInfo.astI2cData[i].u32DataByteNum = sensor_data_byte;
+        }
+        g_stSnsRegsInfo.astI2cData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[0].u32RegAddr = 0x10;
+        g_stSnsRegsInfo.astI2cData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[1].u32RegAddr = 0x16;
+        g_stSnsRegsInfo.astI2cData[2].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[2].u32RegAddr = 0x00;
+    #if CMOS_OV9712_SLOW_FRAMERATE_MODE
+        g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[3].u32RegAddr = 0x2a;
+        g_stSnsRegsInfo.astI2cData[4].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[4].u32RegAddr = 0x2b;
+    #else
+        g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[3].u32RegAddr = 0x2d;
+        g_stSnsRegsInfo.astI2cData[4].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[4].u32RegAddr = 0x2e;
+    #endif
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_TRUE;
+
+        bInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+#if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[0].u32Data = u32IntTime & 0xFF;
+    g_stSnsRegsInfo.astI2cData[1].u32Data = (u32IntTime >> 8) & 0xFF;
+#else 
+    //refresh the sensor setting every frame to avoid defect pixel error
+    sensor_write_register(0x10, u32IntTime&0xFF);
+    sensor_write_register(0x16, (u32IntTime>>8)&0xFF);
+#endif
+    return;
+}
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    HI_U8 u8High, u8Low;
+    switch (u32Again)
+    {
+        case 0 :    /* 0db, 1 multiplies */
+            u8High = 0x00;
+            break;
+        case 1 :    /* 6db, 2 multiplies */
+            u8High = 0x10;
+            break;
+        case 2 :    /* 12db, 4 multiplies */
+            u8High = 0x30;
+            break;
+        case 3 :    /* 18db, 8 multiplies */
+            u8High = 0x70;
+            break;
+        case 4 :    /* 24db, 16 multiplies */
+            u8High = 0xf0;
+            break;
+        default:
+            u8High = 0x00;
+            break;
+    }
+
+    u8Low = (u32Dgain - 16) & 0xf;
+
+#if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[2].u32Data = (u8High | u8Low);
+    HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+    if (5 == g_stSnsRegsInfo.u32RegNum)
+    {
+        g_stSnsRegsInfo.u32RegNum = 3;
+    }
+#else
+    sensor_write_register(0x00, (u8High | u8Low));
+#endif
+
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+    
+    pstAwbSnsDft->u16WbRefTemp = 5000;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x015b;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x0199;
+
+    pstAwbSnsDft->as32WbPara[0] = 127;
+    pstAwbSnsDft->as32WbPara[1] = -23;
+    pstAwbSnsDft->as32WbPara[2] = -152;
+    pstAwbSnsDft->as32WbPara[3] = 154393;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -105036;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(OV9712_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, OV9712_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, OV9712_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(OV9712_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, OV9712_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, OV9712_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -820,4 +799,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif /* End of #ifdef __cplusplus */
 
 
-#endif // __OV9712_CMOS_H_
+#endif // __OV9715_CMOS_H_

--- a/libraries/sensor/hi3516cv100/ov_9712+/ov9712_plus_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/ov_9712+/ov9712_plus_sensor_ctl.c
@@ -12,7 +12,7 @@
 #include "hi_i2c.h"
 #endif
 
-const unsigned int sensor_i2c_addr	=	0x60;		/* I2C Address of OV9712 */
+const unsigned int sensor_i2c_addr	=	0x60;		/* I2C Address of OV9715 */
 const unsigned int sensor_addr_byte	=	1;
 const unsigned int sensor_data_byte	=	1;
 
@@ -23,7 +23,7 @@ int sensor_read_register(int addr)
     int fd = -1;
     int ret;
     int value;
-
+    
     fd = open("/dev/gpioi2c_ov", 0);
     if(fd<0)
     {
@@ -40,8 +40,8 @@ int sensor_read_register(int addr)
         close(fd);
         return -1;
     }
-
-    value &= 0xff;
+    
+    value &= 0xff;    
 
     close(fd);
     return value;
@@ -49,31 +49,31 @@ int sensor_read_register(int addr)
     int fd = -1;
     int ret;
     I2C_DATA_S i2c_data;
-
+	
     fd = open("/dev/hi_i2c", 0);
     if(fd<0)
     {
         printf("Open hi_i2c error!\n");
         return -1;
     }
-
+    
     i2c_data.dev_addr = sensor_i2c_addr;
     i2c_data.reg_addr = addr;
     i2c_data.addr_byte_num = sensor_addr_byte;
     i2c_data.data_byte_num = sensor_data_byte;
 
-    ret = ioctl(fd, CMD_I2C_READ, &i2c_data);
+    ret = ioctl(fd, CMD_I2C_WRITE, &i2c_data);
 
     if (ret)
     {
-        printf("hi_i2c read faild!\n");
+        printf("hi_i2c write faild!\n");
         close(fd);
         return -1;
     }
 
     close(fd);
 #endif
-
+	
 	return i2c_data.data;
 }
 
@@ -83,7 +83,7 @@ int sensor_write_register(int addr, int data)
     int fd = -1;
     int ret;
     int value;
-
+    
     fd = open("/dev/gpioi2c_ov", 0);
     if(fd<0)
     {
@@ -107,14 +107,14 @@ int sensor_write_register(int addr, int data)
     int fd = -1;
     int ret;
     I2C_DATA_S i2c_data;
-
+	
     fd = open("/dev/hi_i2c", 0);
     if(fd<0)
     {
         printf("Open hi_i2c error!\n");
         return -1;
     }
-
+    
     i2c_data.dev_addr = sensor_i2c_addr;
     i2c_data.reg_addr = addr;
     i2c_data.addr_byte_num = sensor_addr_byte;
@@ -141,7 +141,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
     int fd = -1;
     int ret;
     int value;
-
+    
     fd = open("/dev/gpioi2c_ov", 0);
     if(fd<0)
     {
@@ -161,7 +161,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
 
     value &= 0xff;
     value &= ~mask;
-    value |= data & mask;
+    value |= data & mask;    
 
     value = ((sensor_i2c_addr&0xff)<<24) | ((addr&0xff)<<16) | (value&0xff);
 
@@ -179,7 +179,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
     int ret;
     int value;
     I2C_DATA_S i2c_data;
-
+	
     fd = open("/dev/hi_i2c", 0);
     if(fd<0)
     {
@@ -202,10 +202,10 @@ int sensor_write_register_bit(int addr, int data, int mask)
 
     value = i2c_data.data;
     value &= ~mask;
-    value |= data & mask;
-
+    value |= data & mask; 
+    
     i2c_data.data = value;
-
+    
     ret = ioctl(fd, CMD_I2C_WRITE, &i2c_data);
     if (ret)
     {
@@ -221,11 +221,11 @@ int sensor_write_register_bit(int addr, int data, int mask)
 
 
 static void delay_ms(int ms)
-{
+{ 
     usleep(ms*1000);
 }
 
-void sensor_prog(int* rom)
+void sensor_prog(int* rom) 
 {
     int i = 0;
     while (1)
@@ -250,7 +250,7 @@ void sensor_prog(int* rom)
 
 void sensor_init()
 {
-	//Reset
+	//Reset 
 	sensor_write_register(0x12, 0x80);
 	sensor_write_register(0x09, 0x10);
 

--- a/libraries/sensor/hi3516cv100/ov_9712/ov9712_cmos.c
+++ b/libraries/sensor/hi3516cv100/ov_9712/ov9712_cmos.c
@@ -1,12 +1,16 @@
-#if !defined(__OV9712_CMOS_H_)
-#define __OV9712_CMOS_H_
+#if !defined(__OV9715_CMOS_H_)
+#define __OV9715_CMOS_H_
 
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 #include "hi_comm_sns.h"
+#include "hi_comm_isp.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_comm_isp.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -14,23 +18,7 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-/****************************************************************************
- * local variables															*
- ****************************************************************************/
-
-extern const unsigned int sensor_i2c_addr;
-extern const unsigned int sensor_addr_byte;
-extern const unsigned int sensor_data_byte;
-
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
-static HI_U8 gu8SensorMode = 0;
-
-static HI_U8 gu8Fps = 30;
-
-/****************************************************************************
- * MACRO DEFINITION                                                         *
- ****************************************************************************/
+#define OV9712_ID 9712
 
 /*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker in antiflicker mode */
 /*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance                       */
@@ -44,69 +32,58 @@ static HI_U8 gu8Fps = 30;
  * When the value is 1, add the line length to slow framerate. */
 #define CMOS_OV9712_SLOW_FRAMERATE_MODE (0)
 
-static cmos_isp_default_t st_coms_isp_default =
-{
-	// color matrix[9]
-    {
-        5300,
-        {   0x0254, 0x8102, 0x8052,
-            0x8041, 0x01d5, 0x8094,
-            0x8027, 0x8136, 0x025d
-        },
-        3558,
-        {   0x02a0, 0x8125, 0x807b,
-            0x8043, 0x0156, 0x8013,
-            0x802a, 0x8268, 0x0392
-        },
-        3084,
-        {   0x023a, 0x808d, 0x80ad,
-            0x8033, 0x01c0, 0x808d,
-            0x8071, 0x82af, 0x0420
-        }
-    },
+/****************************************************************************
+ * local variables                                                            *
+ ****************************************************************************/
 
+extern const unsigned int sensor_i2c_addr;
+extern unsigned int sensor_addr_byte;
+extern unsigned int sensor_data_byte;
 
-    // black level
-    {64,64,64,64},
+HI_U8 gu8SensorMode = 0;
 
-    //calibration reference color temperature
-    5000,
-
-    //WB gain at 5000, must keep consistent with calibration color temperature
-    {0x015b, 0x100, 0x100, 0x0199},
-
-    // WB curve parameters, must keep consistent with reference color temperature.
-    {127, -23, -152, 154393, 128, -105036},
-
-	// hist_thresh
-	{0xd,0x28,0x60,0x80},
-    //{0x10,0x40,0xc0,0xf0},
-
-	0x0,	// iridix_balck
-	0x3,	// bggr
-
-	/* limit max gain for reducing noise,    */
-	0x1f,	0x1,
-
-	// iridix
-	0x04,	0x08,	0xa0, 	0x4ff,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x15, 	// sinter threshold
-
-	0x0,  0,  0,  //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
+static HI_U32 gu8Fps = 30;
+static HI_U32 gu32FullLinesStd = 810;
+static HI_U32 gu32FullLines = 810;
 
 #if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
-    2
-#else
-    1
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
 #endif
 
+static AWB_CCM_S g_stAwbCcm =
+{
+    5300,
+    {   0x0254, 0x8102, 0x8052,
+        0x8041, 0x01d5, 0x8094,
+        0x8027, 0x8136, 0x025d
+    },
+    3558,
+    {   0x02a0, 0x8125, 0x807b,
+        0x8043, 0x0156, 0x8013,
+        0x802a, 0x8268, 0x0392
+    },
+    3084,
+    {   0x023a, 0x808d, 0x80ad,
+        0x8033, 0x01c0, 0x808d,
+        0x8071, 0x82af, 0x0420
+    }
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
+    /* bvalid */
+    1,
+
+    /* saturation */
+    {0x80,0x80,0x80,0x80,0x68,0x48,0x35,0x30}
+};
+
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
+{
+    /* bvalid */
+    1,
+    
 #if CMOS_OV9712_MORE_SHARPEN
     //sharpen_alt_d
     {0x50,0x4b,0x46,0x41,0x37,0x2c,0x1e,0xf},
@@ -117,33 +94,33 @@ static cmos_isp_agc_table_t st_isp_agc_table =
     //snr_thresh
     {0x10,0x14,0x1a,0x22,0x2a,0x37,0x46,0x50},
 #else    
-    //sharpen_alt_d
+    /* sharpen_alt_d */
     {0x8e,0x8b,0x88,0x83,0x7d,0x76,0x75,0x74},
-
-    //sharpen_alt_ud
+        
+    /* sharpen_alt_ud */
     {0x8f,0x89,0x7e,0x78,0x6f,0x44,0x40,0x35},
-
-    //snr_thresh
+        
+    /* snr_thresh */
     {0x19,0x1e,0x2d,0x32,0x39,0x3f,0x48,0x4b},
-#endif
-
-    //demosaic_lum_thresh
+#endif    
+        
+    /* demosaic_lum_thresh */
     {0x50,0x50,0x40,0x40,0x30,0x30,0x20,0x20},
-
-    //demosaic_np_offset
+        
+    /* demosaic_np_offset */
     {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55},
-
-    /* saturation */
-    {0x80,0x80,0x80,0x80,0x68,0x48,0x35,0x30}
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55}
 
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
 {
-    //nosie_profile_weight_lut
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {0, 27, 31, 33, 35, 36, 37, 38, 39, 40, 40, 41, 41, 42, 42, 43,
     43, 43, 44, 44, 44, 45, 45, 45, 45, 46, 46, 46, 46, 46, 47, 47,
     47, 47, 47, 48, 48, 48, 48, 48, 48, 48, 49, 49, 49, 49, 49, 49,
@@ -153,7 +130,7 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     53, 53, 53, 53, 54, 54, 54, 54, 54, 54, 54, 54, 54, 54, 54, 54,
     54, 54, 54, 54, 54, 54, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55},
 
-    //demosaic_weight_lut
+    /* demosaic_weight_lut */
     {0, 27, 31, 33, 35, 36, 37, 38, 39, 40, 40, 41, 41, 42, 42, 43,
     43, 43, 44, 44, 44, 45, 45, 45, 45, 46, 46, 46, 46, 46, 47, 47,
     47, 47, 47, 48, 48, 48, 48, 48, 48, 48, 49, 49, 49, 49, 49, 49,
@@ -164,8 +141,11 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     54, 54, 54, 54, 54, 54, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55}
 };
 
-static cmos_isp_demosaic_t st_isp_demosaic =
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
+    /* bvalid */
+    1,
+    
     /*vh_slope*/
     0xcd,
 
@@ -184,7 +164,6 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     /*uu_slope*/
     0xa0,
 #endif
-
     /*sat_slope*/
     0x5d,
 
@@ -210,8 +189,11 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x1b3
 };
 
-static cmos_isp_shading_table_t st_isp_shading_table =
+static ISP_CMOS_SHADING_S g_stIspShading =
 {
+    /* bvalid */
+    1,
+    
     /*shading_center_r*/
     0x27a, 0x168,
 
@@ -223,42 +205,42 @@ static cmos_isp_shading_table_t st_isp_shading_table =
 
     /*shading_table_r*/
     {0x1000,0x1018,0x1028,0x103a,0x104c,0x105c,0x1072,0x1089,0x109e,0x10ba,0x10d5,0x10ef,
-	0x110b,0x112b,0x114c,0x116d,0x118b,0x11ae,0x11d0,0x11f5,0x1218,0x123e,0x1260,0x1283,
-	0x12aa,0x12cf,0x12f7,0x131b,0x1341,0x1369,0x138f,0x13b5,0x13db,0x1401,0x1423,0x1446,
-	0x146d,0x148f,0x14b4,0x14d7,0x14fe,0x151e,0x153e,0x155a,0x1579,0x159a,0x15b7,0x15d3,
-	0x15f4,0x1612,0x162e,0x164d,0x1663,0x167f,0x169a,0x16b1,0x16cb,0x16e4,0x16fc,0x170f,
-	0x1727,0x173e,0x1753,0x176a,0x1783,0x1793,0x17a5,0x17b8,0x17c9,0x17da,0x17ec,0x17fe,
-	0x180d,0x181a,0x182a,0x183b,0x184c,0x185a,0x1865,0x1876,0x1883,0x1890,0x189f,0x18a9,
-	0x18b5,0x18c3,0x18cf,0x18d8,0x18e2,0x18e8,0x18ec,0x18f5,0x1901,0x190e,0x191f,0x1934,
-	0x1946,0x1955,0x1968,0x197e,0x1993,0x19a4,0x19b5,0x19cc,0x19e1,0x19f5,0x1a06,0x1a16,
-	0x1a2a,0x1a3d,0x1a4f,0x1a5d,0x1a6e,0x1a84,0x1a96,0x1aa7,0x1abb,0x1ad2,0x1ae5,0x1af9,
-	0x1b0e,0x1b27,0x1b40,0x1b59,0x1b68,0x1b72,0x1b91,0x1bbf,0x1bf6},
+    0x110b,0x112b,0x114c,0x116d,0x118b,0x11ae,0x11d0,0x11f5,0x1218,0x123e,0x1260,0x1283,
+    0x12aa,0x12cf,0x12f7,0x131b,0x1341,0x1369,0x138f,0x13b5,0x13db,0x1401,0x1423,0x1446,
+    0x146d,0x148f,0x14b4,0x14d7,0x14fe,0x151e,0x153e,0x155a,0x1579,0x159a,0x15b7,0x15d3,
+    0x15f4,0x1612,0x162e,0x164d,0x1663,0x167f,0x169a,0x16b1,0x16cb,0x16e4,0x16fc,0x170f,
+    0x1727,0x173e,0x1753,0x176a,0x1783,0x1793,0x17a5,0x17b8,0x17c9,0x17da,0x17ec,0x17fe,
+    0x180d,0x181a,0x182a,0x183b,0x184c,0x185a,0x1865,0x1876,0x1883,0x1890,0x189f,0x18a9,
+    0x18b5,0x18c3,0x18cf,0x18d8,0x18e2,0x18e8,0x18ec,0x18f5,0x1901,0x190e,0x191f,0x1934,
+    0x1946,0x1955,0x1968,0x197e,0x1993,0x19a4,0x19b5,0x19cc,0x19e1,0x19f5,0x1a06,0x1a16,
+    0x1a2a,0x1a3d,0x1a4f,0x1a5d,0x1a6e,0x1a84,0x1a96,0x1aa7,0x1abb,0x1ad2,0x1ae5,0x1af9,
+    0x1b0e,0x1b27,0x1b40,0x1b59,0x1b68,0x1b72,0x1b91,0x1bbf,0x1bf6},
 
     /*shading_table_g*/
     {0x1000,0x1013,0x1022,0x1033,0x1043,0x1054,0x1066,0x107b,0x108e,0x10a5,0x10bc,0x10d7,
-	0x10f1,0x110c,0x112a,0x114b,0x116b,0x118c,0x11ae,0x11d0,0x11f3,0x1216,0x1238,0x125c,
-	0x1282,0x12a9,0x12ce,0x12f3,0x131b,0x133f,0x1363,0x1386,0x13a9,0x13cc,0x13f0,0x1412,
-	0x1434,0x1457,0x1479,0x149c,0x14bc,0x14da,0x14fa,0x1519,0x1537,0x1557,0x1575,0x1590,
-	0x15ac,0x15c8,0x15e1,0x15fd,0x1617,0x162f,0x1648,0x165f,0x1673,0x168b,0x16a1,0x16b5,
-	0x16c9,0x16db,0x16ee,0x1702,0x1714,0x1726,0x1736,0x1744,0x1752,0x1760,0x176c,0x1778,
-	0x1785,0x1794,0x179e,0x17a8,0x17b5,0x17c1,0x17ca,0x17d5,0x17e1,0x17e9,0x17ef,0x17f3,
-	0x17f9,0x17ff,0x1800,0x1801,0x1803,0x1806,0x180d,0x181c,0x182f,0x183e,0x184a,0x1854,
-	0x185e,0x186a,0x1878,0x188b,0x189b,0x18a8,0x18b5,0x18c2,0x18d0,0x18e0,0x18ef,0x18fc,
-	0x1907,0x1910,0x191a,0x1927,0x1936,0x1941,0x194a,0x1958,0x1965,0x1971,0x197e,0x1989,
-	0x199c,0x19aa,0x19b7,0x19bd,0x19cc,0x19cc,0x19ce,0x19f6,0x1a0a},
+    0x10f1,0x110c,0x112a,0x114b,0x116b,0x118c,0x11ae,0x11d0,0x11f3,0x1216,0x1238,0x125c,
+    0x1282,0x12a9,0x12ce,0x12f3,0x131b,0x133f,0x1363,0x1386,0x13a9,0x13cc,0x13f0,0x1412,
+    0x1434,0x1457,0x1479,0x149c,0x14bc,0x14da,0x14fa,0x1519,0x1537,0x1557,0x1575,0x1590,
+    0x15ac,0x15c8,0x15e1,0x15fd,0x1617,0x162f,0x1648,0x165f,0x1673,0x168b,0x16a1,0x16b5,
+    0x16c9,0x16db,0x16ee,0x1702,0x1714,0x1726,0x1736,0x1744,0x1752,0x1760,0x176c,0x1778,
+    0x1785,0x1794,0x179e,0x17a8,0x17b5,0x17c1,0x17ca,0x17d5,0x17e1,0x17e9,0x17ef,0x17f3,
+    0x17f9,0x17ff,0x1800,0x1801,0x1803,0x1806,0x180d,0x181c,0x182f,0x183e,0x184a,0x1854,
+    0x185e,0x186a,0x1878,0x188b,0x189b,0x18a8,0x18b5,0x18c2,0x18d0,0x18e0,0x18ef,0x18fc,
+    0x1907,0x1910,0x191a,0x1927,0x1936,0x1941,0x194a,0x1958,0x1965,0x1971,0x197e,0x1989,
+    0x199c,0x19aa,0x19b7,0x19bd,0x19cc,0x19cc,0x19ce,0x19f6,0x1a0a},
 
     /*shading_table_b*/
     {0x1000,0x1012,0x101c,0x1025,0x102c,0x1031,0x103b,0x1045,0x104f,0x1059,0x1060,0x1072,
-	0x107f,0x108d,0x109f,0x10b5,0x10c9,0x10dc,0x10ee,0x1109,0x111c,0x1137,0x1150,0x1167,
-	0x1183,0x119e,0x11bb,0x11d5,0x11f4,0x120c,0x1228,0x1242,0x125a,0x1276,0x1292,0x12ac,
-	0x12c7,0x12e0,0x12f9,0x1313,0x132d,0x1346,0x135d,0x1372,0x138a,0x13a4,0x13bb,0x13cf,
-	0x13e5,0x13fb,0x1410,0x1427,0x143c,0x1450,0x1462,0x1475,0x1488,0x1496,0x14a5,0x14b7,
-	0x14ca,0x14d7,0x14e5,0x14f4,0x1503,0x1511,0x151d,0x1529,0x1532,0x153c,0x1548,0x1552,
-	0x155b,0x1566,0x156c,0x1573,0x157d,0x1587,0x158d,0x1593,0x159b,0x15a3,0x15a9,0x15ac,
-	0x15b1,0x15b4,0x15b5,0x15b5,0x15b6,0x15b5,0x15b5,0x15ba,0x15c4,0x15d3,0x15e2,0x15ef,
-	0x15f9,0x1604,0x1611,0x161e,0x1626,0x1632,0x1641,0x164c,0x165b,0x1667,0x1672,0x1679,
-	0x1681,0x168e,0x1699,0x16a0,0x16aa,0x16bc,0x16ce,0x16dc,0x16e9,0x16f1,0x16f9,0x170c,
-	0x1722,0x1735,0x173d,0x1739,0x1739,0x173c,0x173c,0x1731,0x1724},
+    0x107f,0x108d,0x109f,0x10b5,0x10c9,0x10dc,0x10ee,0x1109,0x111c,0x1137,0x1150,0x1167,
+    0x1183,0x119e,0x11bb,0x11d5,0x11f4,0x120c,0x1228,0x1242,0x125a,0x1276,0x1292,0x12ac,
+    0x12c7,0x12e0,0x12f9,0x1313,0x132d,0x1346,0x135d,0x1372,0x138a,0x13a4,0x13bb,0x13cf,
+    0x13e5,0x13fb,0x1410,0x1427,0x143c,0x1450,0x1462,0x1475,0x1488,0x1496,0x14a5,0x14b7,
+    0x14ca,0x14d7,0x14e5,0x14f4,0x1503,0x1511,0x151d,0x1529,0x1532,0x153c,0x1548,0x1552,
+    0x155b,0x1566,0x156c,0x1573,0x157d,0x1587,0x158d,0x1593,0x159b,0x15a3,0x15a9,0x15ac,
+    0x15b1,0x15b4,0x15b5,0x15b5,0x15b6,0x15b5,0x15b5,0x15ba,0x15c4,0x15d3,0x15e2,0x15ef,
+    0x15f9,0x1604,0x1611,0x161e,0x1626,0x1632,0x1641,0x164c,0x165b,0x1667,0x1672,0x1679,
+    0x1681,0x168e,0x1699,0x16a0,0x16aa,0x16bc,0x16ce,0x16dc,0x16e9,0x16f1,0x16f9,0x170c,
+    0x1722,0x1735,0x173d,0x1739,0x1739,0x173c,0x173c,0x1731,0x1724},
 
     /*shading_off_center_r_g_b*/
     0xf57, 0xf0e, 0xf42,
@@ -267,542 +249,538 @@ static cmos_isp_shading_table_t st_isp_shading_table =
     129
 };
 
-
-static cmos_isp_gamma_table_t st_isp_gamma_table =
+static ISP_CMOS_GAMMA_S g_stIspGamma =
 {
-    {0  , 27  , 60  , 100 , 140 , 178 , 216 , 242 , 276 , 312 , 346 , 380 , 412 , 444 , 476 , 508,
-    540 , 572 , 604 , 636 , 667 , 698 , 729 , 760 , 791 , 822 , 853 , 884 , 915 , 945 , 975 , 1005,
-    1035, 1065, 1095, 1125, 1155, 1185, 1215, 1245, 1275, 1305, 1335, 1365, 1395, 1425, 1455, 1485,
-    1515, 1544, 1573, 1602, 1631, 1660, 1689, 1718, 1746, 1774, 1802, 1830, 1858, 1886, 1914, 1942,
-    1970, 1998, 2026, 2054, 2082, 2110, 2136, 2162, 2186, 2220, 2244, 2268, 2292, 2316, 2340, 2362,
-    2384, 2406, 2428, 2448, 2468, 2488, 2508, 2528, 2548, 2568, 2588, 2608, 2628, 2648, 2668, 2688,
-    2708, 2728, 2748, 2768, 2788, 2808, 2828, 2846, 2862, 2876, 2890, 2903, 2917, 2930, 2944, 2957,
-    2970, 2983, 2996, 3008, 3021, 3033, 3046, 3058, 3070, 3082, 3094, 3106, 3118, 3129, 3141, 3152,
-    3164, 3175, 3186, 3197, 3208, 3219, 3230, 3240, 3251, 3262, 3272, 3282, 3293, 3303, 3313, 3323,
-    3333, 3343, 3352, 3362, 3372, 3381, 3391, 3400, 3410, 3419, 3428, 3437, 3446, 3455, 3464, 3473,
-    3482, 3490, 3499, 3508, 3516, 3525, 3533, 3541, 3550, 3558, 3566, 3574, 3582, 3590, 3598, 3606,
-    3614, 3621, 3629, 3637, 3644, 3652, 3660, 3667, 3674, 3682, 3689, 3696, 3703, 3711, 3718, 3725,
-    3732, 3739, 3746, 3752, 3759, 3766, 3773, 3779, 3786, 3793, 3799, 3806, 3812, 3819, 3825, 3831,
-    3838, 3844, 3850, 3856, 3863, 3869, 3875, 3881, 3887, 3893, 3899, 3905, 3910, 3916, 3922, 3928,
-    3933, 3939, 3945, 3950, 3956, 3962, 3967, 3973, 3978, 3983, 3989, 3994, 3999, 4005, 4010, 4015,
-    4020, 4026, 4031, 4036, 4041, 4046, 4051, 4056, 4061, 4066, 4071, 4076, 4081, 4085, 4090, 4095, 4095}
+    /* bvalid */
+    1,
+    
+    {0  ,27  ,60  ,100 ,140 ,178 ,216 ,242 ,276 ,312 ,346 ,380 ,412 ,444 ,476 ,508,
+    540 ,572 ,604 ,636 ,667 ,698 ,729 ,760 ,791 ,822 ,853 ,884 ,915 ,945 ,975 ,1005,
+    1035,1065,1095,1125,1155,1185,1215,1245,1275,1305,1335,1365,1395,1425,1455,1485,
+    1515,1544,1573,1602,1631,1660,1689,1718,1746,1774,1802,1830,1858,1886,1914,1942,
+    1970,1998,2026,2054,2082,2110,2136,2162,2186,2220,2244,2268,2292,2316,2340,2362,
+    2384,2406,2428,2448,2468,2488,2508,2528,2548,2568,2588,2608,2628,2648,2668,2688,
+    2708,2728,2748,2768,2788,2808,2828,2846,2862,2876,2890,2903,2917,2930,2944,2957,
+    2970,2983,2996,3008,3021,3033,3046,3058,3070,3082,3094,3106,3118,3129,3141,3152,
+    3164,3175,3186,3197,3208,3219,3230,3240,3251,3262,3272,3282,3293,3303,3313,3323,
+    3333,3343,3352,3362,3372,3381,3391,3400,3410,3419,3428,3437,3446,3455,3464,3473,
+    3482,3490,3499,3508,3516,3525,3533,3541,3550,3558,3566,3574,3582,3590,3598,3606,
+    3614,3621,3629,3637,3644,3652,3660,3667,3674,3682,3689,3696,3703,3711,3718,3725,
+    3732,3739,3746,3752,3759,3766,3773,3779,3786,3793,3799,3806,3812,3819,3825,3831,
+    3838,3844,3850,3856,3863,3869,3875,3881,3887,3893,3899,3905,3910,3916,3922,3928,
+    3933,3939,3945,3950,3956,3962,3967,3973,3978,3983,3989,3994,3999,4005,4010,4015,
+    4020,4026,4031,4036,4041,4046,4051,4056,4061,4066,4071,4076,4081,4085,4090,4095,4095}
 };
 
-
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-    cmos_inttime.full_lines_std = 810;
-	cmos_inttime.full_lines_std_30fps = 810;
-	cmos_inttime.full_lines = 810;
-	cmos_inttime.full_lines_limit = 65535;
-    cmos_inttime.max_lines = 806;
-    cmos_inttime.min_lines = 2;
-	cmos_inttime.max_lines_target = cmos_inttime.max_lines;
-	cmos_inttime.min_lines_target = cmos_inttime.min_lines;
-
-	cmos_inttime.vblanking_lines = 0;
-
-	cmos_inttime.exposure_ashort = 0;
-	cmos_inttime.exposure_shift = 0;
-
-	cmos_inttime.lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2; 
-	cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-	return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
-{
-#if CMOS_OV9712_SLOW_FRAMERATE_MODE
-    p_inttime->exposure_ashort = (p_inttime->exposure_ashort << 4) / p_inttime->slow_framerate;
-    if(p_inttime->exposure_ashort >= p_inttime->full_lines_std - 4)
-	{
-		p_inttime->exposure_ashort = p_inttime->full_lines_std - 4;
-	}
-#endif
-#if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-    
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x10;
-    stI2cData.u32Data = p_inttime->exposure_ashort & 0xFF;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    
-    stI2cData.u32RegAddr = 0x16;
-    stI2cData.u32Data = (p_inttime->exposure_ashort >> 8) & 0xFF;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-#else
-	HI_U32 _curr = p_inttime->exposure_ashort;
-    
-    sensor_write_register(0x10, _curr & 0xFF);
-    sensor_write_register(0x16, (_curr >> 8) & 0xFF);    
-#endif
-
-    return;
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-#if CMOS_OV9712_SLOW_FRAMERATE_MODE
-    HI_U32 u32Tp = 50760;   /* (0x698 * 30) = 50640*/
-    u32Tp = (((u32Tp * p_inttime->slow_framerate) / gu8Fps) >> 4) + 3;
-    if (u32Tp > 0x2000)     /* the register 0x2a adn 0x2b's max value is 0x2000 */
+    if (HI_NULL == pstDef)
     {
-        u32Tp = 0x2000;
-        p_inttime->slow_framerate = ((gu8Fps * u32Tp) << 4) / 50760;
-        printf("Warning! The slow_framerate is out of ov9712's range!\n");
-    }
-    
-    #if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-    
-    stI2cData.bDelayCfg = HI_TRUE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x2a;
-    stI2cData.u32Data = u32Tp & 0xfc;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    
-    stI2cData.u32RegAddr = 0x2b;
-    stI2cData.u32Data = (u32Tp & 0xff00) >> 8;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    #else
-    sensor_write_register(0x2a, u32Tp & 0xfc);
-    sensor_write_register(0x2b, (u32Tp & 0xff00) >> 8);
-    #endif
-#else
-    static HI_U16 last_vblanking_lines = 65535;
-    if(p_inttime->vblanking_lines != last_vblanking_lines)
-    {
-        sensor_write_register(0x2d, p_inttime->vblanking_lines & 0xff);
-        sensor_write_register(0x2e, (p_inttime->vblanking_lines & 0xff00) >> 8);
-        last_vblanking_lines = p_inttime->vblanking_lines;
-    }
-#endif
-
-    return;
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-	if(p_inttime->exposure_ashort >= p_inttime->full_lines - 4)
-	{
-		p_inttime->exposure_ashort = p_inttime->full_lines - 4;
-	}
-
-	p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std_30fps;
-
-	return p_inttime->exposure_ashort;
-}
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-	switch(fps)
-	{
-		case 30:
-            p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2;
-            gu8Fps = 30;
-            sensor_write_register(0x2a, 0x9c);
-            sensor_write_register(0x2b, 0x6);
-		break;
-
-		case 25:
-            /* do not change full_lines_std */
-			p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_30fps * 25 / 2;
-            gu8Fps = 25;
-            sensor_write_register(0x2a, 0xf0);
-            sensor_write_register(0x2b, 0x7);
-        break;
-
-		default:
-		break;
-	}
-    
-	return;
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
-{
-    cmos_gains.max_again = 496;
-	cmos_gains.max_dgain = 1;
-
-	cmos_gains.again_shift = 4;
-	cmos_gains.dgain_shift = 0;
-	cmos_gains.dgain_fine_shift = 0;
-
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_TRUE;
-
-	return &cmos_gains;
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-	HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-	HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _isp_dgain = p_gains->isp_dgain == 0 ? 1 : p_gains->isp_dgain;
-
-	p_gains->iso =  ((_again * _dgain * _isp_dgain * 100) 
-                     >> (p_gains->again_shift + p_gains->dgain_shift 
-                         + p_gains->isp_dgain_shift));
-	return p_gains->iso;
-
-}
-
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{
-#if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-
-    stI2cData.bDelayCfg = HI_TRUE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x00;
-    stI2cData.u32Data = p_gains->again_db;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    
-#else
-    sensor_write_register(0x00, p_gains->again_db);
-#endif
-
-	return;
-}
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-    HI_U32 _again = 1 << p_gains->again_shift;
-    int shift = 0;
-    HI_U8 i = 0;
-
-    while (exposure > (1<<26))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
+        printf("null pointer when get isp default value!\n");
+        return -1;
     }
 
-    if(exposure > exposure_max)
-    {
-        _again = (exposure << p_gains->again_shift) / exposure_max;
-        _again = _again < 16? 16: _again;
-    	_again = _again > p_gains->max_again_target ? p_gains->max_again_target : _again;
-        
-        for(i = 0; i < 5; i++)
-        {
-            if(_again < 32)
-            {
-                break;
-            }
-            _again >>= 1;
-        }
-    }
-    else
-    {
-    }
-
-    p_gains->again_db = (1 << (i + 4)) + _again - 32;
-    p_gains->again = _again << i;
-
-    return (exposure << (shift + 4)) / p_gains->again;
-
-}
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    int shft = 0;
-
-    while (exposure > (1 << 22))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-    exposure_max = (0 == exposure_max)? 1: exposure_max;
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    else
-	{
-	}
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shft;
-}
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-    int shft = 0;    
-    while (exposure > (1 << 22))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
     
-	p_gains->dgain = 1;
+    pstDef->stComm.u8Rggb           = 0x3;      //3: bggr  
+    pstDef->stComm.u8BalanceFe      = 0x1;
 
-	return exposure << shft;
-}
+    pstDef->stDenoise.u8SinterThresh= 0x15;
+    pstDef->stDenoise.u8NoiseProfile= 0x0;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 0x0;
 
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
+    pstDef->stDrc.u8DrcBlack        = 0x00;
+    pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0xa0;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x4ff;    // white level
+
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+    memcpy(&pstDef->stShading, &g_stIspShading, sizeof(ISP_CMOS_SHADING_S));
+    memcpy(&pstDef->stGamma, &g_stIspGamma, sizeof(ISP_CMOS_GAMMA_S));
+
     return 0;
 }
 
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
+    if (HI_NULL == pstBlackLevel)
+    {
+        printf("null pointer when get isp black level value!\n");
+        return -1;
+    }
+
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+
+    pstBlackLevel->au16BlackLevel[0] = 64;
+    pstBlackLevel->au16BlackLevel[1] = 64;
+    pstBlackLevel->au16BlackLevel[2] = 64;
+    pstBlackLevel->au16BlackLevel[3] = 64;
+
+    return 0;    
 }
 
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-static HI_U32 cmos_get_isp_shading_table(cmos_isp_shading_table_ptr_t p_cmos_isp_shading_table)
-{
-	if (NULL == p_cmos_isp_shading_table)
-	{
-	    printf("null pointer when get isp shading table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_shading_table, &st_isp_shading_table, sizeof(cmos_isp_shading_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_gamma_table(cmos_isp_gamma_table_ptr_t p_cmos_isp_gamma_table)
-{
-   if(NULL == p_cmos_isp_gamma_table)
-   {
-    printf("null pointer when get isp gamma table!\n");
-    return -1;
-   }
-   memcpy(p_cmos_isp_gamma_table,&st_isp_gamma_table, sizeof(cmos_isp_gamma_table_t));
-   return 0;
-   
-}
-
-
-
-static void setup_sensor(int isp_mode)
-{
-	if(0 == isp_mode) /* ISP 'normal' isp_mode */
-	{
-        sensor_write_register(0x2d, 0x0);
-        sensor_write_register(0x2e, 0x0);
-	}
-	else if(1 == isp_mode) /* ISP pixel calibration isp_mode */
-	{
+    if (bEnable) /* setup for ISP pixel calibration mode */
+    {
         /* 5 fps */
         sensor_write_register(0x2d, 0xd2); 
         sensor_write_register(0x2e, 0x0f); 
         
         /* min gain */
-        sensor_write_register(0x0, 0x00);               
+        sensor_write_register(0x0, 0x00);
 
         /* max exposure time*/
         sensor_write_register(0x10, 0xf8);
-    	sensor_write_register(0x16, 0x12);
-	}
-}
-
-static HI_U32 cmos_gains_lin_to_db_convert(HI_U32 data, HI_U32 shift_in)
-{
-    #define PRECISION 8
-    HI_U32 _res = 0;
-    if(0 == data)
-        return _res;
-
-    data = data << PRECISION; // to ensure precision.
-    for(;;)
-    {
-        /* Note to avoid endless loop here. */
-        data = (data * 913) >> 10;
-        // data = (data*913 + (1<<9)) >> 10; // endless loop when shift_in is 0. */
-        if(data <= ((1<<shift_in) << PRECISION))
-        {
-            break;
-        }
-        ++_res;
+        sensor_write_register(0x16, 0x12);
     }
-    return _res;
+    else /* setup for ISP 'normal mode' */
+    {
+        sensor_write_register(0x2d, 0x0);
+        sensor_write_register(0x2e, 0x0);
+    }
+
+    return;
 }
 
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    return cmos_gains_lin_to_db_convert(p_gains->again, p_gains->again_shift);
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-	if (NULL == p_coms_isp_default)
-	{
-	    printf("null pointer when get isp default value!\n");
-	    return -1;
-	}
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
-    return 0;
-}
-
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1280;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 720;
-
-    return 0;
-}
-
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-SENSOR_EXP_FUNC_S stSensorExpFuncs =
-{
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
-
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-
-	.pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-	.pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-	.pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-	.pfn_cmos_get_isp_default = cmos_get_isp_default,
-	.pfn_cmos_get_isp_special_alg = NULL,
-	.pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-	.pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-	.pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-	.pfn_cmos_get_isp_shading_table = cmos_get_isp_shading_table,
-	.pfn_cmos_get_isp_gamma_table = cmos_get_isp_gamma_table,
-    .pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-    .pfn_cmos_set_sensor_image_mode = NULL,
-
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-
-	return 0;
-}
-
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
         //sensor mode 0
         case 0:
             gu8SensorMode = 0;
-            // TODO:
         break;
         //sensor mode 1
         case 1:
             gu8SensorMode = 1;
-             // TODO:
         break;
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 810;
+    
+    pstAeSnsDft->u32LinesPer500ms = 810*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+   
+    //gu8Fps = 30;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 806;
+    pstAeSnsDft->u32MinIntTime = 2;
+    
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 2;
+
+    /* 1(1+1/16), 1(1+2/16), ... , 2(1+1/16), ... , 16(1+15/16) */
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_DB;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 6;
+    pstAeSnsDft->u32MaxAgain = 4;  /* 1, 2, 4, ... 16 (0~24db, unit is 6db) */
+    pstAeSnsDft->u32MinAgain = 0;
+    pstAeSnsDft->u32MaxAgainTarget = 4;
+    pstAeSnsDft->u32MinAgainTarget = 0;
+    
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.0625;
+    pstAeSnsDft->u32MaxDgain = 31;  /* 1 ~ 31/16, unit is 1/16 */
+    pstAeSnsDft->u32MinDgain = 16;
+    pstAeSnsDft->u32MaxDgainTarget = 32;
+    pstAeSnsDft->u32MinDgainTarget = 16; 
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
     return 0;
 }
 
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    HI_U32 tp = 1692;
+#if 0
+    switch(fps)
+    {
+        case 30:
+            tp = 1688;
+            break;
+        case 25:
+            tp = 2028;
+            break;
+        default:
+            break;
+    }
+#endif
+    tp = 1692 * 30 / u8Fps + 3;
+    sensor_write_register(0x2a, tp & 0xfc);
+    sensor_write_register(0x2b, (tp & 0xff00) >> 8);
+
+    pstAeSnsDft->u32MaxIntTime = 806;
+    gu32FullLinesStd = 810;
+    gu8Fps = u8Fps;
+    pstAeSnsDft->u32LinesPer500ms = gu32FullLinesStd * u8Fps / 2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+/* Mode 1 : slow framerate by add the time of each line. */
+#if CMOS_OV9712_SLOW_FRAMERATE_MODE
+    HI_U32 u32Tp = 50760;   /* (0x69c * 30) = 50760*/
+    HI_U16 u16SlowFrameRate = (u16FullLines << 8) / gu32FullLinesStd;
+    u32Tp = (((u32Tp * u16SlowFrameRate) / gu8Fps) >> 8) + 3;
+    if (u32Tp > 0x2000)     /* the register 0x2a adn 0x2b's max value is 0x2000 */
+    {
+        u32Tp = 0x2000;
+        u16SlowFrameRate = ((gu8Fps * u32Tp) << 8) / 50760;
+        printf("Warning! The slow_framerate is out of ov9712's range!\n");
+    }
+
+    pstAeSnsDft->u32LinesPer500ms = gu32FullLines * (gu8Fps << 8) / (2*u16SlowFrameRate);
+    pstAeSnsDft->u32MaxIntTime = ((gu32FullLines * u16SlowFrameRate) >> 8) - 4;
+    #if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
+    g_stSnsRegsInfo.u32RegNum = 5;
+    g_stSnsRegsInfo.astI2cData[3].u32Data = u32Tp & 0xfc;
+    g_stSnsRegsInfo.astI2cData[4].u32Data = (u32Tp & 0xff00) >> 8;
+    #else
+    sensor_write_register(0x2a, u32Tp & 0xfc);
+    sensor_write_register(0x2b, (u32Tp & 0xff00) >> 8);    
+    #endif
+#else
+/* Mode 2 : slow framerate by add the lines of each frame. */
+    #if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
+    HI_U32 u32VblankingLines;
+    static HI_U32 u32LastVblankingLines = 0;
+
+    gu32FullLines = u16FullLines;
+    u32VblankingLines = gu32FullLines - gu32FullLinesStd;
+
+    /*avoid flicker in slow frame rate*/
+    if(u32LastVblankingLines < u32VblankingLines)
+    {
+        g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[4].bDelayCfg = HI_FALSE;        
+    }
+    else
+    {
+        g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[4].bDelayCfg = HI_TRUE;
+    }
+    g_stSnsRegsInfo.u32RegNum = 5;
+    g_stSnsRegsInfo.astI2cData[3].u32Data = u32VblankingLines & 0xff;
+    g_stSnsRegsInfo.astI2cData[4].u32Data = (u32VblankingLines & 0xff00) >> 8;
+    u32LastVblankingLines = u32VblankingLines;
+    #else
+    HI_U32 u32VblankingLines;
+
+    gu32FullLines = u16FullLines;
+    u32VblankingLines = gu32FullLines - gu32FullLinesStd;
+    
+    sensor_write_register(0x2d, u32VblankingLines & 0xff);
+    sensor_write_register(0x2e, (u32VblankingLines & 0xff00) >> 8);
+    #endif
+    
+    pstAeSnsDft->u32MaxIntTime = gu32FullLines - 4;
+#endif
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+    static HI_BOOL bInit = HI_FALSE;
+
+    if (HI_FALSE == bInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_I2C_TYPE;
+        g_stSnsRegsInfo.u32RegNum = 3;
+        for (i=0; i<5; i++)
+        {
+            g_stSnsRegsInfo.astI2cData[i].u8DevAddr = sensor_i2c_addr;
+            g_stSnsRegsInfo.astI2cData[i].u32AddrByteNum = sensor_addr_byte;
+            g_stSnsRegsInfo.astI2cData[i].u32DataByteNum = sensor_data_byte;
+        }
+        g_stSnsRegsInfo.astI2cData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[0].u32RegAddr = 0x10;
+        g_stSnsRegsInfo.astI2cData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[1].u32RegAddr = 0x16;
+        g_stSnsRegsInfo.astI2cData[2].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[2].u32RegAddr = 0x00;
+    #if CMOS_OV9712_SLOW_FRAMERATE_MODE
+        g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[3].u32RegAddr = 0x2a;
+        g_stSnsRegsInfo.astI2cData[4].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[4].u32RegAddr = 0x2b;
+    #else
+        g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[3].u32RegAddr = 0x2d;
+        g_stSnsRegsInfo.astI2cData[4].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[4].u32RegAddr = 0x2e;
+    #endif
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_TRUE;
+
+        bInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+#if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[0].u32Data = u32IntTime & 0xFF;
+    g_stSnsRegsInfo.astI2cData[1].u32Data = (u32IntTime >> 8) & 0xFF;
+#else 
+    //refresh the sensor setting every frame to avoid defect pixel error
+    sensor_write_register(0x10, u32IntTime&0xFF);
+    sensor_write_register(0x16, (u32IntTime>>8)&0xFF);
+#endif
+    return;
+}
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    HI_U8 u8High, u8Low;
+    switch (u32Again)
+    {
+        case 0 :    /* 0db, 1 multiplies */
+            u8High = 0x00;
+            break;
+        case 1 :    /* 6db, 2 multiplies */
+            u8High = 0x10;
+            break;
+        case 2 :    /* 12db, 4 multiplies */
+            u8High = 0x30;
+            break;
+        case 3 :    /* 18db, 8 multiplies */
+            u8High = 0x70;
+            break;
+        case 4 :    /* 24db, 16 multiplies */
+            u8High = 0xf0;
+            break;
+        default:
+            u8High = 0x00;
+            break;
+    }
+
+    u8Low = (u32Dgain - 16) & 0xf;
+	
+#if CMOS_OV9712_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[2].u32Data = (u8High | u8Low);
+    HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+    if (5 == g_stSnsRegsInfo.u32RegNum)
+    {
+        g_stSnsRegsInfo.u32RegNum = 3;
+    }
+#else
+    sensor_write_register(0x00, (u8High | u8Low));
+#endif
+
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+    
+    pstAwbSnsDft->u16WbRefTemp = 5000;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x015b;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x0199;
+
+    pstAwbSnsDft->as32WbPara[0] = 127;
+    pstAwbSnsDft->as32WbPara[1] = -23;
+    pstAwbSnsDft->as32WbPara[2] = -152;
+    pstAwbSnsDft->as32WbPara[3] = 154393;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -105036;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(OV9712_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, OV9712_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, OV9712_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(OV9712_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, OV9712_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, OV9712_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -811,4 +789,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif /* End of #ifdef __cplusplus */
 
 
-#endif // __OV9712_CMOS_H_
+#endif // __OV9715_CMOS_H_

--- a/libraries/sensor/hi3516cv100/ov_9712/ov9712_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/ov_9712/ov9712_sensor_ctl.c
@@ -12,7 +12,7 @@
 #include "hi_i2c.h"
 #endif
 
-const unsigned int sensor_i2c_addr	=	0x60;		/* I2C Address of OV9712 */
+const unsigned int sensor_i2c_addr	=	0x60;		/* I2C Address of OV9715 */
 const unsigned int sensor_addr_byte	=	1;
 const unsigned int sensor_data_byte	=	1;
 
@@ -23,7 +23,7 @@ int sensor_read_register(int addr)
     int fd = -1;
     int ret;
     int value;
-
+    
     fd = open("/dev/gpioi2c_ov", 0);
     if(fd<0)
     {
@@ -40,8 +40,8 @@ int sensor_read_register(int addr)
         close(fd);
         return -1;
     }
-
-    value &= 0xff;
+    
+    value &= 0xff;    
 
     close(fd);
     return value;
@@ -49,31 +49,31 @@ int sensor_read_register(int addr)
     int fd = -1;
     int ret;
     I2C_DATA_S i2c_data;
-
+	
     fd = open("/dev/hi_i2c", 0);
     if(fd<0)
     {
         printf("Open hi_i2c error!\n");
         return -1;
     }
-
+    
     i2c_data.dev_addr = sensor_i2c_addr;
     i2c_data.reg_addr = addr;
     i2c_data.addr_byte_num = sensor_addr_byte;
     i2c_data.data_byte_num = sensor_data_byte;
 
-    ret = ioctl(fd, CMD_I2C_READ, &i2c_data);
+    ret = ioctl(fd, CMD_I2C_WRITE, &i2c_data);
 
     if (ret)
     {
-        printf("hi_i2c read faild!\n");
+        printf("hi_i2c write faild!\n");
         close(fd);
         return -1;
     }
 
     close(fd);
 #endif
-
+	
 	return i2c_data.data;
 }
 
@@ -83,7 +83,7 @@ int sensor_write_register(int addr, int data)
     int fd = -1;
     int ret;
     int value;
-
+    
     fd = open("/dev/gpioi2c_ov", 0);
     if(fd<0)
     {
@@ -107,14 +107,14 @@ int sensor_write_register(int addr, int data)
     int fd = -1;
     int ret;
     I2C_DATA_S i2c_data;
-
+	
     fd = open("/dev/hi_i2c", 0);
     if(fd<0)
     {
         printf("Open hi_i2c error!\n");
         return -1;
     }
-
+    
     i2c_data.dev_addr = sensor_i2c_addr;
     i2c_data.reg_addr = addr;
     i2c_data.addr_byte_num = sensor_addr_byte;
@@ -141,7 +141,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
     int fd = -1;
     int ret;
     int value;
-
+    
     fd = open("/dev/gpioi2c_ov", 0);
     if(fd<0)
     {
@@ -161,7 +161,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
 
     value &= 0xff;
     value &= ~mask;
-    value |= data & mask;
+    value |= data & mask;    
 
     value = ((sensor_i2c_addr&0xff)<<24) | ((addr&0xff)<<16) | (value&0xff);
 
@@ -179,7 +179,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
     int ret;
     int value;
     I2C_DATA_S i2c_data;
-
+	
     fd = open("/dev/hi_i2c", 0);
     if(fd<0)
     {
@@ -202,10 +202,10 @@ int sensor_write_register_bit(int addr, int data, int mask)
 
     value = i2c_data.data;
     value &= ~mask;
-    value |= data & mask;
-
+    value |= data & mask; 
+    
     i2c_data.data = value;
-
+    
     ret = ioctl(fd, CMD_I2C_WRITE, &i2c_data);
     if (ret)
     {
@@ -221,11 +221,11 @@ int sensor_write_register_bit(int addr, int data, int mask)
 
 
 static void delay_ms(int ms)
-{
+{ 
     usleep(ms*1000);
 }
 
-void sensor_prog(int* rom)
+void sensor_prog(int* rom) 
 {
     int i = 0;
     while (1)
@@ -250,7 +250,7 @@ void sensor_prog(int* rom)
 
 void sensor_init()
 {
-	//Reset
+	//Reset 
 	sensor_write_register(0x12, 0x80);
 	sensor_write_register(0x09, 0x10);
 

--- a/libraries/sensor/hi3516cv100/pana34031/pana34031_cmos.c
+++ b/libraries/sensor/hi3516cv100/pana34031/pana34031_cmos.c
@@ -1,19 +1,15 @@
-/******************************************************************************
-  A driver program of panasonic mn34031 on HI3518A 
- ******************************************************************************
-    Modification:  2013-04  Created
-******************************************************************************/
 #if !defined(__PANA_MN34031_H_)
 #define __PANA_MN34031_H_
 
 #include <stdio.h>
-#include <unistd.h>		
+#include <unistd.h>
 #include <string.h>
-
 #include "hi_comm_sns.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_isp_debug.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -21,97 +17,73 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
+#define PANA34031_ID 34031
 
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
+HI_U32 gu32FullLinesStd = 718;
 HI_U8 gu8SensorMode = 0;
 
-static cmos_isp_default_t st_coms_isp_default =
+static AWB_CCM_S g_stAwbCcm =
 {
-    // color correction matrix
-    {
-        5048,
-    	{	0x1f5, 0x80b1, 0x8044,
-    		0x803f, 0x1d2, 0x8094,
-    		0x1e, 0x80f8, 0x1db
-    	},
-        3200,
-    	{	0x01d5, 0x806d, 0x802e,
-    		0x8069, 0x1d2, 0x8069,
-    		0x25, 0x8115, 0x01ef
-    	},
-        2480,
-    	{	0x1f1, 0x80b8, 0x8039,
-    		0x8040, 0x1cf, 0x808f,
-    		0x1e, 0x80fc, 0x1dd
-    	}
-    },
-
-	// black level for R, Gr, Gb, B channels
-       {256,256,256,256},
-    // calibration reference color temperature
     5048,
-
-    //WB gain at 5000K, must keep consistent with calibration color temperature
-	{0x1cf, 0x100, 0x100, 0x1bd},
-
-    // WB curve parameters, must keep consistent with reference color temperature.
-	//{123, -8, -140, 22209, 128, -174188},
-    {67, 91, -98, 167236, 128, -119483},
-	// hist_thresh
-	{0x10,0x40,0xc0,0xf0},
-
-	0x00,	// iridix_balck
-	0x1,	// rggb
-
-	// gain
-	0x8,	0x10,
-
-	// iridix space, intensity, slope_max, white level
-	0x02,	0x08,	0x80, 	0x8ff,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x8, 	// sinter threshold
-
-	0x1,        //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
-	0,
-	1528,
-
-    1
+	{	0x1f5, 0x80b1, 0x8044,
+		0x803f, 0x1d2, 0x8094,
+		0x1e, 0x80f8, 0x1db
+	},
+    3200,
+	{	0x01d5, 0x806d, 0x802e,
+		0x8069, 0x1d2, 0x8069,
+		0x25, 0x8115, 0x01ef
+	},
+    2480,
+	{	0x1f1, 0x80b8, 0x8039,
+		0x8040, 0x1cf, 0x808f,
+		0x1e, 0x80fc, 0x1dd
+	}
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
-    //sharpen_alt_d
-    {0x50,0x45,0x40,0x38,0x34,0x40,0x30,0x5c},
-
-    //sharpen_alt_ud
-    {0x3b,0x38,0x34,0x30,0x2b,0x40,0x30,0x5f},
-
-    //snr_thresh
-    {0x23,0x2c,0x34,0x3e,0x46,0x60,0x70,0x8f},
-
-    //demosaic_lum_thresh
-    {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
-
-    //demosaic_np_offset
-    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
+    /* bvalid */
+    1,
 
     /* saturation */
     {0x80,0x80,0x80,0x80,0x68,0x48,0x35,0x30}
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
 {
-   //nosie_profile_weight_lut
+    /* bvalid */
+    1,
+
+    /* sharpen_alt_d */
+    {0x50,0x45,0x40,0x38,0x34,0x40,0x30,0x5c},
+        
+    /* sharpen_alt_ud */
+    {0x3b,0x38,0x34,0x30,0x2b,0x40,0x30,0x5f},
+        
+    /* snr_thresh */
+    {0x23,0x2c,0x34,0x3e,0x46,0x60,0x70,0x8f},
+        
+    /* demosaic_lum_thresh */
+    {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
+        
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
+};
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
+{
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3,0x9,0xd,0x10,0x12,0x14,0x16,0x17,0x18,0x1a,0x1b,
 	0x1c,0x1c,0x1d,0x1e,0x1f,0x1f,0x20,0x21,0x21,0x22,0x22,0x23,0x23,0x24,0x24,0x25,0x25,
 	0x25,0x26,0x26,0x27,0x27,0x27,0x28,0x28,0x28,0x29,0x29,0x29,0x29,0x2a,0x2a,0x2a,0x2a,
@@ -121,7 +93,7 @@ static cmos_isp_noise_table_t st_isp_noise_table =
 	0x33,0x33,0x34,0x34,0x34,0x34,0x34,0x34,0x34,0x34,0x34,0x35,0x35,0x35,0x35,0x35,0x35,
 	0x35,0x35,0x35,0x35,0x36,0x36,0x36},
 
-  //demosaic_weight_lut
+    /* demosaic_weight_lut */
     {0x0,0x3,0x9,0xd,0x10,0x12,0x14,0x16,0x17,0x18,0x1a,0x1b,
 	0x1c,0x1c,0x1d,0x1e,0x1f,0x1f,0x20,0x21,0x21,0x22,0x22,0x23,0x23,0x24,0x24,0x25,0x25,
 	0x25,0x26,0x26,0x27,0x27,0x27,0x28,0x28,0x28,0x29,0x29,0x29,0x29,0x2a,0x2a,0x2a,0x2a,
@@ -131,8 +103,12 @@ static cmos_isp_noise_table_t st_isp_noise_table =
 	0x33,0x33,0x34,0x34,0x34,0x34,0x34,0x34,0x34,0x34,0x34,0x35,0x35,0x35,0x35,0x35,0x35,
 	0x35,0x35,0x35,0x35,0x36,0x36,0x36,0x36,0x36,0x36,0x36,0x36,0x36,0x36}
 };
-static cmos_isp_demosaic_t st_isp_demosaic =
+
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
+    /* bvalid */
+    1,
+    
     /*vh_slope*/
     0xd6,
 
@@ -170,470 +146,78 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x1b3
 };
 
-static __inline HI_U16 digital_gain_lut_get_value(HI_U8 index)
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-    static HI_U16 gain_lut[] =
+    if (HI_NULL == pstDef)
     {
-        0x00,0x02,0x04,0x06,0x08,0x0a,0x0c,0x0e,
-        0x10,0x12,0x14,0x16,0x18,0x1a,0x1c,0x1e,
-        0x20,0x22,0x24,0x26,0x28,0x2a,0x2c,0x2e,
-        0x30,0x32,0x34,0x36,0x38,0x3a,0x3c,0x3e,
-        0x40,0x42,0x44,0x46,0x48,0x4a,0x4c,0x4e,
-        0x50,0x52,0x54,0x56,0x58,0x5a,0x5c,0x5e,
-        0x60,0x62,0x64,0x66,0x68,0x6a,0x6c,0x6e,
-        0x70,0x72,0x74,0x76,0x78,0x7a,0x7c,0x7e,
-        0x80,0x82,0x84,0x86,0x88,0x8a,0x8c,0x8e,
-        0x90,0x92,0x94,0x96,0x98,0x9a,0x9c,0x9e,
-        0xa0,0xa2,0xa4,0xa6,0xa8,0xaa,0xac,0xae,
-        0xb0,0xb2,0xb4,0xb6,0xb8,0xba,0xbc,0xbe,
-        0xc0,0xc2,0xc4,0xc6,0xc8,0xca,0xcc,0xce,
-        0xd0,0xd2,0xd4,0xd6,0xd8,0xda,0xdc,0xde,
-        0xe0,0xe2,0xe4,0xe6,0xe8,0xea,0xec,0xee,
-        0xf0,0xf2,0xf4,0xf6,0xf8,0xfa,0xfc,0xfe,0x100
-    };
-	return gain_lut[index];
+        printf("null pointer when get isp default value!\n");
+        return -1;
+    }
+
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
+
+    pstDef->stComm.u8Rggb           = 0x1;      //1: rggb
+    pstDef->stComm.u8BalanceFe      = 0x1;
+
+    pstDef->stDenoise.u8SinterThresh= 0x8;
+    pstDef->stDenoise.u8NoiseProfile= 0x1;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 1528;
+
+    pstDef->stDrc.u8DrcBlack        = 0x00;
+    pstDef->stDrc.u8DrcVs           = 0x02;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0x80;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x8ff;    // white level
+
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));            
+
+    return 0;
 }
 
-
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
+    HI_S32  i;
     
+    if (HI_NULL == pstBlackLevel)
+    {
+        printf("null pointer when get isp black level value!\n");
+        return -1;
+    }
+
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
     
-    cmos_inttime.full_lines_std = 1065;
-    cmos_inttime.full_lines_std_30fps = 1065;
-    cmos_inttime.full_lines_std_25fps=1278;
-	cmos_inttime.full_lines = 1065;
-    cmos_inttime.full_lines_del = 1065;
-    cmos_inttime.full_lines_limit = 65535;
-	cmos_inttime.max_lines_target = 1062;
-	cmos_inttime.min_lines_target = 2;
-	cmos_inttime.vblanking_lines = 1065;
-	
-	cmos_inttime.exposure_ashort = 0;
-	cmos_inttime.exposure_shift = 0;
-	cmos_inttime.lines_per_500ms = cmos_inttime.full_lines_std_30fps*30/2; // 500ms / 39.17us
-	cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-    
-	return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
-{
-
-	HI_U32 eshort = p_inttime->exposure_ashort;
-	HI_U32 exp_frames = eshort / p_inttime->full_lines_std;
-	
-	eshort = eshort - exp_frames * p_inttime->full_lines_std;
-	eshort = p_inttime->full_lines_std - eshort;
-	sensor_write_register(0x00A1, (eshort&0xffff));
-	sensor_write_register(0x00A3, exp_frames);
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-	int full_lines_lo16 = p_inttime->full_lines & 0xffff;
-	sensor_write_register(0x1A0, full_lines_lo16);
-	sensor_write_register(0x2A0, full_lines_lo16);
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-	if (p_inttime->exposure_ashort >= p_inttime->full_lines - 2)
-	{
-		p_inttime->exposure_ashort = p_inttime->full_lines - 2;
-	}
-
-	p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std;
-
-	return p_inttime->exposure_ashort;
-}
-
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-
-	usleep(40000);
-    int full_lines_lo16;
-	if (30 == fps)
-	{
-        
-		p_inttime->full_lines_std = 1065;
-		p_inttime->full_lines = 1065;
-		p_inttime->max_lines_target = 1062;
-		
-		full_lines_lo16 = p_inttime->full_lines & 0xffff;
-	    sensor_write_register(0x1A0, full_lines_lo16);
-	    sensor_write_register(0x2A0, full_lines_lo16);
-	    p_inttime->lines_per_500ms=p_inttime->full_lines*30/2;
-		
-	}
-	else if (25 == fps)
-	{
-	    
-		p_inttime->full_lines_std = 1278;
-		p_inttime->full_lines = 1278;
-		p_inttime->max_lines_target = 1275;
-		
-		full_lines_lo16 = p_inttime->full_lines & 0xffff;
-	    sensor_write_register(0x1A0, full_lines_lo16);
-	    sensor_write_register(0x2A0, full_lines_lo16);
-	    p_inttime->lines_per_500ms=p_inttime->full_lines*25/2;
-	}
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
-{
-	cmos_gains.max_again = 0x8;
-	cmos_gains.max_dgain = 0x800;
-	cmos_gains.again_shift = 0;
-	cmos_gains.dgain_shift = 6;
-	cmos_gains.dgain_fine = 0;
-
-    cmos_gains.isp_dgain_shift = 4;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 1 << cmos_gains.isp_dgain_shift;
-
-	return &cmos_gains;
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-	HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-	HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-
-	p_gains->iso =  ((_again * _dgain * 100) >> (p_gains->again_shift + p_gains->dgain_shift));
-
-	return p_gains->iso;
-}
-
-/*
- * This function applies the digital gain
- * input and output offset and correction
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{
-
-
-	switch (p_gains->again_db)
+    for (i=0; i<4; i++)
     {
-    case 0:
-
-        //r_colgsw = 0dB, r_a_gain = 0dB
-        sensor_write_register(0x20, 0x0080);
-        break;
-    case 6:
-
-        //r_colgsw = 6dB, r_a_gain = 0dB
-      sensor_write_register(0x20, 0x2080);
-        break;
-    case 12:
-
-        //r_colgsw = 12dB, r_a_gain = 0dB
-       sensor_write_register(0x20, 0x6080);
-        break;
-    case 18:
-
-        //r_colgsw = 12dB, r_a_gain = 6dB
-           sensor_write_register(0x20, 0xE080);
-
-        break;
-    default:
-        break;
+        pstBlackLevel->au16BlackLevel[i] = 256;
     }
 
-        HI_U32  lut_val;
-       lut_val = digital_gain_lut_get_value(p_gains->dgain_db);
-        sensor_write_register(0x21, lut_val);
-    
+    return 0;    
 }
 
-
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-	int _i;
-	HI_U32 _again = (1 << p_gains->again_shift);
-	HI_U32 _again_db = 0;
-	HI_U32 exposure1;
-	int shft = 0;
-
-	// normalizes
-	while (exposure > (1<<22))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-
-	for(_i = 0; _i <= 2; _i++)
-	{
-	      exposure1 = (exposure>>1);
-		if((exposure1 < exposure_max) || (_again >  p_gains->max_again_target))
-			break;
-
-		_again *= 2;
-		_again_db += 6;
-		exposure = exposure1;
-	}
-
-	p_gains->again = _again;
-	p_gains->again_db = _again_db;
-	return (exposure << shft);
-}
-
-
-//digital  step = 0.19db
-//是否需要加入四舍五入运算
-static HI_U32 mn34031_dgains_to_db_convert(HI_U32 data, HI_U32 shift_in)
-{
-
-	HI_U32 _res = 0;
-	if(0 == data)
-		return _res;
-
-	for(;;)
-	{
-		data = (data*1002 + (1<<9)) >> 10;
-		if(data < (1<<shift_in))
-			break;
-		++_res;
-	}
-	return _res;
-}
-
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    int shft = 0;
-
-    while (exposure > (1 << 22))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-    exposure_max = DIV_0_TO_1(exposure_max);
-
-    if(exposure > exposure_max)
+    if (bEnable) /* setup for ISP pixel calibration mode */
     {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    else
-	{
-	}
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shft;
-}
-
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-	HI_U32 _dgain = (1 << p_gains->dgain_shift);
-    int shft = 0;
-
-    while (exposure > (1 << 20))
-    {
-        exposure     >>= 1;
-        exposure_max >>= 1;
-        ++shft;
-    }
-
-    if (exposure > exposure_max)
-    {
-        //when setting manual exposure line, exposure_max>>shift should not be 0.
-        exposure_max = DIV_0_TO_1(exposure_max);
-        _dgain   = (exposure * _dgain) / exposure_max;
-        exposure = exposure_max;
-
-    }
-    if (_dgain >= p_gains->max_dgain_target)
-    {
-        _dgain = p_gains->max_dgain_target;
-    }
-    p_gains->dgain = _dgain;
-    p_gains->dgain_db = mn34031_dgains_to_db_convert(_dgain, p_gains->dgain_shift);
-    p_gains->dgain_fine = 0;
-    cmos_get_ISO(p_gains);
-
-    return exposure << shft;
-}
-
-static void setup_sensor(int isp_mode)
-{
-	if(0 == isp_mode) /* setup for ISP 'normal mode' */
-	{
-		sensor_write_register(0x00A3,0x0000);
-	}
-	else if(1 == isp_mode) /* setup for ISP pixel calibration mode */
-	{
         //set the gain to 0
 		sensor_write_register(0x0020,0x0080);
-		sensor_write_register(0x0021,0x0000);
-		//set exposure time
+		sensor_write_register(0x0021,0x0080);
 		sensor_write_register(0x00A1,0x0400);
-		sensor_write_register(0x00A3,0x0005);
-	}
+		sensor_write_register(0x00A2,0x0002);
+		sensor_write_register(0x00A5,0x0005);
+    }
+    else /* setup for ISP 'normal mode' */
+    {
+        sensor_write_register(0x00A5,0x0000);
+    }
+
+    return;
 }
 
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    return p_gains->again_db;
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-	return p_gains->dgain_db;
-}
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-	if (NULL == p_coms_isp_default)
-	{
-	    printf("null pointer when get isp default value!\n");
-	    return -1;
-	}
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
-    return 0;
-}
-
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
-{
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
-}
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1280;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 720;
-
-    return 0;
-}
-
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-SENSOR_EXP_FUNC_S stSensorExpFuncs =
-{
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
-
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-
-    .pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-    .pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-    .pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-    .pfn_cmos_get_isp_default = cmos_get_isp_default,
-    .pfn_cmos_get_isp_special_alg = NULL,
-    .pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-	.pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-	.pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-	.pfn_cmos_get_isp_shading_table = NULL,
-	.pfn_cmos_get_isp_gamma_table = NULL,
-    .pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-    .pfn_cmos_set_sensor_image_mode = NULL,
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-
-	return 0;
-}
-
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
@@ -650,12 +234,314 @@ int sensor_mode_set(HI_U8 u8Mode)
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 1065;
+    
+    pstAeSnsDft->au8HistThresh[0] = 0x10;
+    pstAeSnsDft->au8HistThresh[1] = 0x40;
+    pstAeSnsDft->au8HistThresh[2] = 0xc0;
+    pstAeSnsDft->au8HistThresh[3] = 0xf0;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32LinesPer500ms = 1065*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 718;
+    pstAeSnsDft->u32MinIntTime = 2;    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 2;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_DB;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 6;    
+    pstAeSnsDft->u32MaxAgain = 3;  /* 18db / 6db = 3 */
+    pstAeSnsDft->u32MinAgain = 0;
+    pstAeSnsDft->u32MaxAgainTarget = 3;
+    pstAeSnsDft->u32MinAgainTarget = 0;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_DB;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.19;    
+    pstAeSnsDft->u32MaxDgain = 128;
+    pstAeSnsDft->u32MinDgain = 0;
+    pstAeSnsDft->u32MaxDgainTarget = 128;
+    pstAeSnsDft->u32MinDgainTarget = 0;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
     return 0;
 }
 
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+	usleep(40000);
+    switch(u8Fps)
+    {
+        case 30:
+        pstAeSnsDft->u32MaxIntTime = 1062;
+        pstAeSnsDft->u32LinesPer500ms = 1062 * 30 / 2;
+        gu32FullLinesStd = 1065;
+	    sensor_write_register(0x1A0, gu32FullLinesStd & 0xffff);
+	    sensor_write_register(0x2A0, gu32FullLinesStd & 0xffff);
+        break;
+        
+        case 25:
+        pstAeSnsDft->u32MaxIntTime = 1275;
+        pstAeSnsDft->u32LinesPer500ms = 1278 * 25 / 2;
+        gu32FullLinesStd = 1278;
+	    sensor_write_register(0x1A0, gu32FullLinesStd & 0xffff);
+	    sensor_write_register(0x2A0, gu32FullLinesStd & 0xffff);
+        break;
+        
+        default:
+        break;
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    pstAeSnsDft->u32MaxIntTime = u16FullLines - 2;
+
+	sensor_write_register(0x1A0, u16FullLines & 0xffff);
+	sensor_write_register(0x2A0, u16FullLines & 0xffff);
+    
+    return;
+}
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+    HI_U32 u32Tmp = u32IntTime;
+	HI_U32 u32IntFrames = u32Tmp / gu32FullLinesStd;
+
+	u32Tmp = u32Tmp - u32IntFrames * gu32FullLinesStd;
+	u32Tmp = gu32FullLinesStd - u32Tmp;
+
+	sensor_write_register(0x00A1, (u32Tmp & 0xffff));
+	sensor_write_register(0x00A3, u32IntFrames);
+    
+    return;
+}
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    switch (u32Again)
+    {
+        case 0:
+            //r_colgsw = 0dB, r_a_gain = 0dB
+            sensor_write_register(0x20, 0x0080);
+            break;
+        case 1:
+            //r_colgsw = 6dB, r_a_gain = 0dB
+            sensor_write_register(0x20, 0x2080);
+            break;
+        case 2:
+            //r_colgsw = 12dB, r_a_gain = 0dB
+            sensor_write_register(0x20, 0x6080);
+            break;
+        case 3:
+            //r_colgsw = 12dB, r_a_gain = 6dB
+            sensor_write_register(0x20, 0xE080);
+            break;
+        default:
+            break;
+    }
+    
+    sensor_write_register(0x21, u32Dgain * 2);
+
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 5048;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x1CF;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x1BD;    
+
+    pstAwbSnsDft->as32WbPara[0] = 67;
+    pstAwbSnsDft->as32WbPara[1] = 91;
+    pstAwbSnsDft->as32WbPara[2] = -98;
+    pstAwbSnsDft->as32WbPara[3] = 167236;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -119483;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(PANA34031_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, PANA34031_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, PANA34031_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(PANA34031_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, PANA34031_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, PANA34031_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -663,5 +549,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-
-#endif // __PANA_MN34031_H_
+#endif // __IMX104_CMOS_H_

--- a/libraries/sensor/hi3516cv100/pana34031/pana34031_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/pana34031/pana34031_sensor_ctl.c
@@ -1,8 +1,3 @@
-/******************************************************************************
-  A driver program of panasonic mn34031 on HI3518A 
- ******************************************************************************
-    Modification:  2013-04  Created
-******************************************************************************/
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -491,6 +486,6 @@ void sensor_init()
      sensor_write_register(0x00D3,0x041B);
      sensor_write_register(0x0000,0x0113);
      sensor_write_register(0x0003,0x8260);
-	printf("-------sensor MN34031 initial ok!----\n");
+    printf("-------sensor MN34031 initial ok!----\n");
 }
 

--- a/libraries/sensor/hi3516cv100/pana34041/pana34041_cmos.c
+++ b/libraries/sensor/hi3516cv100/pana34041/pana34041_cmos.c
@@ -2,14 +2,14 @@
 #define __PANA_MN34041_H_
 
 #include <stdio.h>
-#include <unistd.h>		// usleep
 #include <string.h>
-
 #include "hi_comm_sns.h"
+#include "hi_comm_isp.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_isp_debug.h"
-#include "hi_comm_isp.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -17,102 +17,81 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
+#define PANA34041_ID 34041
 
+/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker */
+/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance   */
+/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                     */
+#define CMOS_PANA34041_ISP_WRITE_SENSOR_ENABLE (0)
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
-#define CMOS_PANA34041_ISP_WRITE_SENSOR_ENABLE (1)
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
+HI_U32 gu32FullLinesStd = 1125;
 HI_U8 gu8SensorMode = 0;
-
-static cmos_isp_default_t st_coms_isp_default =
-{
-    // color correction matrix
-    {
-        5000,
-    	{	0x022d, 0x8114, 0x8019,
-			0x8055, 0x01e4, 0x808f,
-			0x0016, 0x8178, 0x0262
-    	},
-        3200,
-    	{	0x020e, 0x80e7, 0x8027,
-			0x809a, 0x01fd, 0x8063,
-			0x002a, 0x81ee, 0x02c3
-    	},
-        2600,
-    	{	0x0207, 0x80d5, 0x8032,
-			0x8084, 0x01cb, 0x8047,
-			0x003f, 0x82c4, 0x0384
-    	}
-    },
-
-	// black level for R, Gr, Gb, B channels
-	{0x100,0x100,0x100,0x100},
-
-    // calibration reference color temperature
-    5000,
-
-    //WB gain at 5000K, must keep consistent with calibration color temperature
-	{0x1eb, 0x100, 0x100, 0x1c5},
-
-    // WB curve parameters, must keep consistent with reference color temperature.
-	{49, 121, -86, 185444, 0x80, -134952},
-
-	// hist_thresh
-	{0xd,0x28,0x60,0x80},
-
-	0x00,	// iridix_balck
-	0x1,	// rggb
-
-	// gain
-	0x8,	0x4,
-
-	// iridix space, intensity, slope_max, white level
-	0x02,	0x08,	0x80, 	0x8ff,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x8, 	// sinter threshold
-
-	0x1,        //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
-	0,
-	1528,
 #if CMOS_PANA34041_ISP_WRITE_SENSOR_ENABLE
-    2
-#else
-    1
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
+static HI_BOOL gsbRegInit = HI_FALSE;
 #endif
+
+static AWB_CCM_S g_stAwbCcm =
+{
+    5000,
+	{	0x022d, 0x8114, 0x8019,
+		0x8055, 0x01e4, 0x808f,
+		0x0016, 0x8178, 0x0262
+	},
+    3200,
+	{	0x020e, 0x80e7, 0x8027,
+		0x809a, 0x01fd, 0x8063,
+		0x002a, 0x81ee, 0x02c3
+	},
+    2600,
+	{	0x0207, 0x80d5, 0x8032,
+		0x8084, 0x01cb, 0x8047,
+		0x003f, 0x82c4, 0x0384
+	}
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
-    //sharpen_alt_d
-    {0x78,0x70,0x68,0x58,0x44,0x30,0x28,0x28},
-
-    //sharpen_alt_ud
-    {0x68,0x60,0x58,0x48,0x38,0x30,0x28,0x24},
-
-    //snr_thresh
-    {0x20,0x28,0x30,0x38,0x40,0x48,0x54,0x54},
-
-    //demosaic_lum_thresh
-    {0x60,0x60,0x40,0x40,0x40,0x30,0x30,0x30},
-
-    //demosaic_np_offset
-    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
+    /* bvalid */
+    1,
 
     /* saturation */
     {0x80,0x80,0x6C,0x48,0x44,0x40,0x3C,0x38}
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
 {
-  //nosie_profile_weight_lut
+    /* bvalid */
+    1,
+
+    /* sharpen_alt_d */
+    {0x78,0x70,0x68,0x58,0x44,0x30,0x28,0x28},
+        
+    /* sharpen_alt_ud */
+    {0x68,0x60,0x58,0x48,0x38,0x30,0x28,0x24},
+        
+    /* snr_thresh */
+    {0x20,0x28,0x30,0x38,0x40,0x48,0x54,0x54},
+        
+    /* demosaic_lum_thresh */
+    {0x60,0x60,0x40,0x40,0x40,0x30,0x30,0x30},
+        
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
+};
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
+{
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {0,  0,  0,  0,  0,  0,  11, 15, 17, 19, 20, 21, 22, 22, 23, 24,
     25, 25, 26, 26, 26, 27, 27, 27, 28, 28, 28, 29, 29, 29, 29, 29,
     30, 30, 30, 30, 30, 31, 31, 31, 31, 31, 32, 32, 32, 32, 32, 32,
@@ -122,7 +101,7 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 38, 38,
     38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38},
 
-  //demosaic_weight_lut
+    /* demosaic_weight_lut */
     {0,11,15,17,19,20,21,22,23,23,24,25,25,26,26,26,
     27,27,27,28,28,28,29,29,29,29,29,30,30,30,30,30,
     31,31,31,31,31,32,32,32,32,32,32,32,33,33,33,33,
@@ -133,23 +112,11 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38}
 };
 
-static HI_U32  digital_gain_table[129]=
-{ 
- 1024,  1035,  1046,  1058,  1069,  1081,  1093,  1104,  1116,  1129,  1141,  1153,  1166,  1178,  1191,  1204, 
- 1217,  1230,  1244,  1257,  1271,  1285,  1299,  1313,  1327,  1341,  1356,  1371,  1386,  1401,  1416,  1431, 
- 1447,  1462,  1478,  1494,  1511,  1527,  1544,  1560,  1577,  1594,  1612,  1629,  1647,  1665,  1683,  1701, 
- 1720,  1738,  1757,  1776,  1795,  1815,  1835,  1855,  1875,  1895,  1916,  1936,  1957,  1979,  2000,  2022, 
- 2044,  2066,  2089,  2111,  2134,  2157,  2181,  2204,  2228,  2253,  2277,  2302,  2327,  2352,  2377,  2403, 
- 2429,  2456,  2482,  2509,  2537,  2564,  2592,  2620,  2649,  2677,  2706,  2736,  2766,  2796,  2826,  2857, 
- 2888,  2919,  2951,  2983,  3015,  3048,  3081,  3114,  3148,  3182,  3217,  3252,  3287,  3323,  3359,  3395, 
- 3432,  3470,  3507,  3545,  3584,  3623,  3662,  3702,  3742,  3783,  3824,  3865,  3907,  3950,  3992,  4036, 
- 4080
-};
-
-
-
-static cmos_isp_demosaic_t st_isp_demosaic =
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
+    /* bvalid */
+    1,
+    
     /*vh_slope*/
     200,
 
@@ -187,518 +154,78 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x1b3
 };
 
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-	cmos_inttime.full_lines_std_30fps = 1125;
-	cmos_inttime.full_lines_std_25fps = 1350;
-	cmos_inttime.full_lines_std = 1125;
-	cmos_inttime.full_lines = 1125;
-	cmos_inttime.max_lines_target = 1122;
-
-	cmos_inttime.full_lines_limit = 65535;
-	cmos_inttime.min_lines_target = 1;
-	cmos_inttime.vblanking_lines = 1125;
-
-	cmos_inttime.exposure_ashort = 0;
-
-	cmos_inttime.lines_per_500ms = cmos_inttime.full_lines_std_30fps*30/2;
-	cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-	return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
-{
-
-	HI_U32 eshort = p_inttime->exposure_ashort;
-	HI_U32 exp_frames = eshort / p_inttime->full_lines_std;
-
-	eshort = eshort - exp_frames * p_inttime->full_lines_std;
-	eshort = p_inttime->full_lines_std - eshort;
-
-
-#if CMOS_PANA34041_ISP_WRITE_SENSOR_ENABLE 
-
-    ISP_SSP_DATA_S   stSspData;
-    stSspData.bDelayCfg = HI_FALSE;
-    stSspData.u32DevAddr = 0x00A1;    
-    stSspData.u32DevAddrByteNum = 2;
-    stSspData.u32RegAddr = 0;
-    stSspData.u32RegAddrByteNum = 0;
-    stSspData.u32Data = (eshort&0xffff);
-    stSspData.u32DataByteNum = 2;
-    HI_MPI_ISP_SSPWrite(&stSspData);
-
-    stSspData.u32DevAddr = 0x00A2;    
-    stSspData.u32DevAddrByteNum = 2;
-    stSspData.u32RegAddr = 0;
-    stSspData.u32RegAddrByteNum = 0;
-    stSspData.u32Data = 0x2 + ((eshort&0x10000) >> 16);
-    stSspData.u32DataByteNum = 2; 
-    HI_MPI_ISP_SSPWrite(&stSspData);
-
-
-    stSspData.u32DevAddr = 0x00A5;    
-    stSspData.u32DevAddrByteNum = 2;
-    stSspData.u32RegAddr = 0;
-    stSspData.u32RegAddrByteNum = 0;
-    stSspData.u32Data = exp_frames;
-    stSspData.u32DataByteNum = 2;   
-    HI_MPI_ISP_SSPWrite(&stSspData);
-
-    
-#else
-
-	sensor_write_register(0x00A1, (eshort&0xffff));
-	sensor_write_register(0x00A2, (0x2 + ((eshort&0x10000) >> 16) ));  //0x2 is the reserved bits value
-	sensor_write_register(0x00A5, exp_frames);
-    
-#endif
-
-
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-	return;
-	int full_lines_lo16 = p_inttime->full_lines & 0xffff;
-	int full_lines_hi16= (p_inttime->full_lines >> 16) & 0x1;
-
-	sensor_write_register(0x1A0, full_lines_lo16);
-	sensor_write_register(0x1A1, full_lines_hi16);
-	sensor_write_register(0x1A3, full_lines_lo16);
-	sensor_write_register(0x1A4, full_lines_hi16);
-	sensor_write_register(0x1A7, full_lines_lo16);
-	sensor_write_register(0x1A8, full_lines_hi16);
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-	if (p_inttime->exposure_ashort >= p_inttime->full_lines - 3)
-	{
-		p_inttime->exposure_ashort = p_inttime->full_lines - 3;
-	}
-
-	p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std;
-
-	return p_inttime->exposure_ashort;
-}
-
-extern void sensor_init_exit(int fps);
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-	usleep(40000);
-
-	if (30 == fps)
-	{
-
-//		sensor_init_exit(30);
-		p_inttime->full_lines_std = 1125;
-		p_inttime->full_lines = 1125;
-		p_inttime->max_lines_target = 1122;
-	}
-	else if (25 == fps)
-	{
-//		sensor_init_exit(25);
-		p_inttime->full_lines_std = 1350;
-		p_inttime->full_lines = 1350;
-		p_inttime->max_lines_target = 1347;
-	}
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
-{
-	cmos_gains.max_again = 0x8;
-	cmos_gains.max_dgain = 0xff0;
-
-	cmos_gains.again_shift = 0;
-	cmos_gains.dgain_shift = 10;
-	cmos_gains.dgain_fine = 0;
-
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_TRUE;
-
-	return &cmos_gains;
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-    HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-    HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _isp_dgain = p_gains->isp_dgain== 0 ? 1 : p_gains->isp_dgain;
-
-    p_gains->iso =  (((HI_U64)_again * _dgain *_isp_dgain* 100) 
-        >> (p_gains->again_shift + p_gains->dgain_shift+p_gains->isp_dgain_shift)); 
-    
-    return p_gains->iso;
-}
-
-/*
- * This function applies the digital gain
- * input and output offset and correction
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{ 
-#if CMOS_PANA34041_ISP_WRITE_SENSOR_ENABLE 
-    ISP_SSP_DATA_S stSspData;
-
-    stSspData.bDelayCfg = HI_TRUE;
-    stSspData.u32DevAddr = 0x0020;    
-    stSspData.u32DevAddrByteNum = 2;
-    stSspData.u32RegAddr = 0;
-    stSspData.u32RegAddrByteNum = 0;
-
-    switch (p_gains->again_db)  
+    if (HI_NULL == pstDef)
     {
-    case 0:
-        //r_colgsw = 0dB, r_a_gain = 0dB
-        stSspData.u32Data = 0x0080;
-        stSspData.u32DataByteNum = 2;
-        HI_MPI_ISP_SSPWrite(&stSspData);
-        break;
-    case 6:
-        //r_colgsw = 6dB, r_a_gain = 0dB
-        stSspData.u32Data = 0x8080;
-        stSspData.u32DataByteNum = 2;
-        HI_MPI_ISP_SSPWrite(&stSspData);
-        break;
-    case 12:
-        //r_colgsw = 12dB, r_a_gain = 0dB
-        stSspData.u32Data = 0xC080;
-        stSspData.u32DataByteNum = 2;
-        HI_MPI_ISP_SSPWrite(&stSspData);
-        break;
-    case 18:
-        //r_colgsw = 12dB, r_a_gain = 6dB
-        stSspData.u32Data = 0xC0C0;
-        stSspData.u32DataByteNum = 2;
-        HI_MPI_ISP_SSPWrite(&stSspData);
-        break;
-    default:
-        break;
+        printf("null pointer when get isp default value!\n");
+        return -1;
     }
 
-    stSspData.u32DevAddr = 0x0021;    
-    stSspData.u32DevAddrByteNum = 2;
-    stSspData.u32Data = 0x80 + p_gains->dgain_db;
-    stSspData.u32DataByteNum = 2;
-    HI_MPI_ISP_SSPWrite(&stSspData);
-    
-#else
-    switch (p_gains->again_db)
-    {
-    case 0:
-        //r_colgsw = 0dB, r_a_gain = 0dB
-        sensor_write_register(0x20, 0x0080);
-        break;
-    case 6:
-        //r_colgsw = 6dB, r_a_gain = 0dB
-        sensor_write_register(0x20, 0x8080);
-        break;
-    case 12:
-        //r_colgsw = 12dB, r_a_gain = 0dB
-        sensor_write_register(0x20, 0xC080);
-        break;
-    case 18:
-        //r_colgsw = 12dB, r_a_gain = 6dB
-        sensor_write_register(0x20, 0xC0C0);
-        break;
-    default:
-        break;
-    }
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
 
-    sensor_write_register(0x21, 0x80 + p_gains->dgain_db);
-#endif
-}
- 
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-	int _i;
-	HI_U32 _again = (1 << p_gains->again_shift);
-	HI_U32 _again_db = 0;
-	HI_U32 exposure1;
-	int shft = 0;
+    pstDef->stComm.u8Rggb           = 0x1;      //1: rggb  
+    pstDef->stComm.u8BalanceFe      = 0x1;
 
-	// normalize
-	while (exposure > (1<<22))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
+    pstDef->stDenoise.u8SinterThresh= 0x8;
+    pstDef->stDenoise.u8NoiseProfile= 0x1;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 1528;
 
-	for(_i = 0; _i <= 2; _i++)
-	{               
-		exposure1 = (exposure>>1);
-		if((exposure1 < exposure_max) || (_again >  p_gains->max_again_target))
-			break;
+    pstDef->stDrc.u8DrcBlack        = 0x00;
+    pstDef->stDrc.u8DrcVs           = 0x02;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0x80;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x8ff;    // white level
 
-		_again *= 2;
-		_again_db += 6;
-		exposure = exposure1;
-	}
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
 
-	p_gains->again = _again;
-	p_gains->again_db = _again_db;
-
-	return (exposure << shft);
+    return 0;
 }
 
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
-
-    while (exposure > (1 << 22))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = DIV_0_TO_1(exposure_max);
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
+    HI_S32  i;
     
-    p_gains->isp_dgain = isp_dgain;
+    if (HI_NULL == pstBlackLevel)
+    {
+        printf("null pointer when get isp black level value!\n");
+        return -1;
+    }
 
-    return exposure << shift;
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+            
+    for (i=0; i<4; i++)
+    {
+        pstBlackLevel->au16BlackLevel[i] = 0x100;
+    }
+
+    return 0;    
 }
 
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-    HI_U32 dgain = 1024;
-    HI_U32 step = 0;
-    HI_S32 shift = 0;
-    HI_S32 i = 0;
-    
-
-    while (exposure > (1 << 20))
+    if (bEnable) /* setup for ISP pixel calibration mode */
     {
-        exposure     >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    
-    if(exposure > exposure_max)
-    {
-        dgain = (exposure << 10) / exposure_max;
-        dgain = dgain < 1024? 1024: dgain;
-        dgain = dgain > p_gains->max_dgain_target? p_gains->max_dgain_target: dgain;
-    
-        if (dgain >= digital_gain_table[128])
-        {
-             dgain = digital_gain_table[128];
-             step = 128;
-        }
-        else
-        {
-            for(i = 1; i < 129; i++)
-            {
-                if(dgain < digital_gain_table[i])
-                {
-                    dgain = digital_gain_table[i-1];
-                    step = i-1 ;
-                    break;
-                }
-            }
-        }
-        
-        exposure = (exposure << 10) / dgain;
-    }
-    
-    
-    p_gains->dgain = dgain;
-    p_gains->dgain_db = step;
-    
-    return exposure << shift;
-}
-
-static void setup_sensor(int isp_mode)
-{
-	if(0 == isp_mode) /* setup for ISP 'normal mode' */
-	{
-		sensor_write_register(0x00A5,0x0000);
-	}
-	else if(1 == isp_mode) /* setup for ISP pixel calibration mode */
-	{
         //set the gain to 0
 		sensor_write_register(0x0020,0x0080);
 		sensor_write_register(0x0021,0x0080);
 		sensor_write_register(0x00A1,0x0400);
 		sensor_write_register(0x00A2,0x0002);
 		sensor_write_register(0x00A5,0x0005);
-	}
+    }
+    else /* setup for ISP 'normal mode' */
+    {
+        sensor_write_register(0x00A5,0x0000);
+    }
+
+    return;
 }
 
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    return p_gains->again_db;
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-	return p_gains->dgain_db;
-}
-/*
-static HI_U8 cmos_get_digital_fine_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return cmos_gains->dgain_fine;
-}
-*/
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-	if (NULL == p_coms_isp_default)
-	{
-	    printf("null pointer when get isp default value!\n");
-	    return -1;
-	}
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
-    return 0;
-}
-
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
-{
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1920;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 1080;
-
-    return 0;
-}
-
-
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-SENSOR_EXP_FUNC_S stSensorExpFuncs =
-{
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
-
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-
-    .pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-    .pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-    .pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-    .pfn_cmos_get_isp_default = cmos_get_isp_default,
-    .pfn_cmos_get_isp_special_alg = NULL,
-    .pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-	.pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-	.pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-	.pfn_cmos_get_isp_shading_table = NULL,
-	.pfn_cmos_get_isp_gamma_table = NULL,
-    .pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-    .pfn_cmos_set_sensor_image_mode = NULL,
-
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-
-	return 0;
-}
-
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
@@ -715,12 +242,438 @@ int sensor_mode_set(HI_U8 u8Mode)
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 1125;
+    
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32LinesPer500ms = 1125*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 1122;
+    pstAeSnsDft->u32MinIntTime = 1;    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 1;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_DB;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 6;    
+    pstAeSnsDft->u32MaxAgain = 3;  /* 18db / 6db = 3 */
+    pstAeSnsDft->u32MinAgain = 0;
+    pstAeSnsDft->u32MaxAgainTarget = 3;
+    pstAeSnsDft->u32MinAgainTarget = 0;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.1;    
+    pstAeSnsDft->u32MaxDgain = 4080;  /* 12db / 0.1 = 120 */
+    pstAeSnsDft->u32MinDgain = 1024;
+    pstAeSnsDft->u32MaxDgainTarget = 4080;
+    pstAeSnsDft->u32MinDgainTarget = 1024;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
     return 0;
 }
 
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1920;
+    pstSensorMaxResolution->u32MaxHeight = 1080;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    switch(u8Fps)
+    {
+        case 30:
+            //sensor_init_exit(30);
+            gu32FullLinesStd = 1125;
+            pstAeSnsDft->u32MaxIntTime = 1122;
+            pstAeSnsDft->u32LinesPer500ms = 1125 * 30 / 2;
+        break;
+        
+        case 25:
+            //sensor_init_exit(25);
+            gu32FullLinesStd = 1350;
+            pstAeSnsDft->u32MaxIntTime = 1347;
+            pstAeSnsDft->u32LinesPer500ms = 1350 * 25 / 2;
+        break;
+        
+        default:
+        break;
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    pstAeSnsDft->u32MaxIntTime = u16FullLines - 3;
+    
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_PANA34041_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+
+    if (HI_FALSE == gsbRegInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_SSP_TYPE;
+        g_stSnsRegsInfo.u32RegNum = 5;
+        for (i=0; i<5; i++)
+        {
+            g_stSnsRegsInfo.astSspData[i].u32RegAddr = 0x00;
+            g_stSnsRegsInfo.astSspData[i].u32DevAddrByteNum = 2;
+            g_stSnsRegsInfo.astSspData[i].u32RegAddrByteNum = 0;
+            g_stSnsRegsInfo.astSspData[i].u32DataByteNum = 2;
+        }
+        g_stSnsRegsInfo.astSspData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[0].u32DevAddr = 0x00A1;
+        g_stSnsRegsInfo.astSspData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[1].u32DevAddr = 0x00A2;
+        g_stSnsRegsInfo.astSspData[2].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[2].u32DevAddr = 0x00A5;
+        g_stSnsRegsInfo.astSspData[3].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astSspData[3].u32DevAddr = 0x0020;
+        g_stSnsRegsInfo.astSspData[4].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astSspData[4].u32DevAddr = 0x0021;
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_TRUE;
+
+        gsbRegInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+    HI_U32 u32Tmp = u32IntTime;
+	HI_U32 u32IntFrames = u32Tmp / gu32FullLinesStd;
+
+	u32Tmp = u32Tmp - u32IntFrames * gu32FullLinesStd;
+	u32Tmp = gu32FullLinesStd - u32Tmp;
+#if CMOS_PANA34041_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astSspData[0].u32Data = (u32Tmp & 0xffff);
+    g_stSnsRegsInfo.astSspData[1].u32Data = (0x2 + ((u32Tmp&0x10000) >> 16) );
+    g_stSnsRegsInfo.astSspData[2].u32Data = u32IntFrames;
+#else
+	sensor_write_register(0x00A1, (u32Tmp & 0xffff));
+	sensor_write_register(0x00A2, (0x2 + ((u32Tmp&0x10000) >> 16) ));  //0x2 is the reserved bits value
+	sensor_write_register(0x00A5, u32IntFrames);
+#endif
+    return;
+}
+
+static HI_U32  digital_gain_table[129]=
+{ 
+ 1024,  1035,  1046,  1058,  1069,  1081,  1093,  1104,  1116,  1129,  1141,  1153,  1166,  1178,  1191,  1204, 
+ 1217,  1230,  1244,  1257,  1271,  1285,  1299,  1313,  1327,  1341,  1356,  1371,  1386,  1401,  1416,  1431, 
+ 1447,  1462,  1478,  1494,  1511,  1527,  1544,  1560,  1577,  1594,  1612,  1629,  1647,  1665,  1683,  1701, 
+ 1720,  1738,  1757,  1776,  1795,  1815,  1835,  1855,  1875,  1895,  1916,  1936,  1957,  1979,  2000,  2022, 
+ 2044,  2066,  2089,  2111,  2134,  2157,  2181,  2204,  2228,  2253,  2277,  2302,  2327,  2352,  2377,  2403, 
+ 2429,  2456,  2482,  2509,  2537,  2564,  2592,  2620,  2649,  2677,  2706,  2736,  2766,  2796,  2826,  2857, 
+ 2888,  2919,  2951,  2983,  3015,  3048,  3081,  3114,  3148,  3182,  3217,  3252,  3287,  3323,  3359,  3395, 
+ 3432,  3470,  3507,  3545,  3584,  3623,  3662,  3702,  3742,  3783,  3824,  3865,  3907,  3950,  3992,  4036, 
+ 4080
+};
+
+static HI_VOID cmos_dgain_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
+{
+    int i;
+
+    if(HI_NULL == pstAeSnsGainInfo)
+    {
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
+    }
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+    if (u32InTimes >= digital_gain_table[128])
+    {
+         pstAeSnsGainInfo->u32SnsTimes = digital_gain_table[128];
+         pstAeSnsGainInfo->u32GainDb = 128;
+         return;
+    }
+    
+    for(i = 1; i < 129; i++)
+    {
+        if(u32InTimes < digital_gain_table[i])
+        {
+            pstAeSnsGainInfo->u32SnsTimes = digital_gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
+    }
+
+    return;
+
+}
+
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+#if CMOS_PANA34041_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    switch (u32Again)
+    {
+        case 0:
+            //r_colgsw = 0dB, r_a_gain = 0dB
+            g_stSnsRegsInfo.astSspData[3].u32Data = 0x0080;
+            break;
+        case 1:
+            //r_colgsw = 6dB, r_a_gain = 0dB
+            g_stSnsRegsInfo.astSspData[3].u32Data = 0x8080;
+            break;
+        case 2:
+            //r_colgsw = 12dB, r_a_gain = 0dB
+            g_stSnsRegsInfo.astSspData[3].u32Data = 0xC080;
+            break;
+        case 3:
+            //r_colgsw = 12dB, r_a_gain = 6dB
+            g_stSnsRegsInfo.astSspData[3].u32Data = 0xC0C0;
+            break;
+        default:
+            break;
+    }    
+
+    #if 0
+    for (i = 0; i < 0x80; i++)
+    {
+        if (u32Dgain >= gau8DgainFine[i] && u32Dgain <= gau8DgainFine[i+1])
+        {
+            break;
+        }
+    }
+    u32Dgain = 0x80 + i;
+    #endif
+    u32Dgain = 0x80 + u32Dgain;
+
+    g_stSnsRegsInfo.astSspData[4].u32Data = u32Dgain;
+    HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+#else
+    switch (u32Again)
+    {
+        case 0:
+            //r_colgsw = 0dB, r_a_gain = 0dB
+            sensor_write_register(0x20, 0x0080);
+            break;
+        case 1:
+            //r_colgsw = 6dB, r_a_gain = 0dB
+            sensor_write_register(0x20, 0x8080);
+            break;
+        case 2:
+            //r_colgsw = 12dB, r_a_gain = 0dB
+            sensor_write_register(0x20, 0xC080);
+            break;
+        case 3:
+            //r_colgsw = 12dB, r_a_gain = 6dB
+            sensor_write_register(0x20, 0xC0C0);
+            break;
+        default:
+            break;
+    }    
+
+    u32Dgain = 0x80 + u32Dgain;
+
+    sensor_write_register(0x21, u32Dgain);
+#endif
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 5000;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x1eb;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x1c5;
+
+    pstAwbSnsDft->as32WbPara[0] = 49;
+    pstAwbSnsDft->as32WbPara[1] = 121;
+    pstAwbSnsDft->as32WbPara[2] = -86;
+    pstAwbSnsDft->as32WbPara[3] = 185444;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -134952;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+    pstExpFuncs->pfn_cmos_dgain_calc_table  = cmos_dgain_calc_table;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(PANA34041_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, PANA34041_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, PANA34041_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(PANA34041_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, PANA34041_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, PANA34041_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -728,5 +681,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-
-#endif // __PANA_MN34041_H_
+#endif // __IMX104_CMOS_H_

--- a/libraries/sensor/hi3516cv100/pixelplus_3100k/po3100k_cmos.c
+++ b/libraries/sensor/hi3516cv100/pixelplus_3100k/po3100k_cmos.c
@@ -3,10 +3,13 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 #include "hi_comm_sns.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_isp_debug.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -14,114 +17,88 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
+#define PO3100K_ID 3100
+
+/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker in antiflicker mode */
+/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance                       */
+/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                                         */
+#define CMOS_PO3100K_ISP_WRITE_SENSOR_ENABLE (1)
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
 extern const unsigned int sensor_i2c_addr;
-extern const unsigned int sensor_addr_byte;
-extern const unsigned int sensor_data_byte;
+extern unsigned int sensor_addr_byte;
+extern unsigned int sensor_data_byte;
 
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
+HI_U32 gu32FullLinesStd = 750;
 HI_U8 gu8SensorMode = 0;
 
-/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker */
-/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance   */
-/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                     */
-#define CMOS_PO3100K_ISP_WRITE_SENSOR_ENABLE (1)
-
-static cmos_isp_default_t st_coms_isp_default =
-{
-    {
-        4850,
-        {
-           0x01ee, 0x80a3, 0x804b,
-           0x8040, 0x0195, 0x8055,
-           0x0006, 0x80f0, 0x01e9
-        },
-        
-        3100,
-        {
-           0x01f4, 0x804f, 0x80a5,
-           0x805b, 0x01bf, 0x8064,
-           0x8014, 0x8147, 0x025b
-        },
-        
-        2470,
-        {
-           0x0201, 0x80ca, 0x8037,
-           0x806d, 0x017a, 0x800d,
-           0x803c, 0x8285, 0x03c1
-        }
-    },
-
-	// black level for R, Gr, Gb, B channels
-    {4,4,4,4},
-
-	//calibration reference color temperature
-    4850,
-
-	//WB gain at Macbeth 5000K, must keep consistent with calibration color temperature
-    {0x177,0x0100,0x0100,0x0197},
-
-	// WB curve parameters, must keep consistent with reference color temperature.
-    {123,-28,-161,192773,128,-142978},
-
-	// hist_thresh
-    {0xd,0x28,0x60,0x80},
-
-    0x00,	// iridix_balck
-    0x0,	// rggb
-
-    // gain
-    64,	4, // this is gain target, it will be constricted by sensor-gain.
-	//0x8,	0x4, /* The purpose of setting max dgain target to 4 is to reduce FPN */
-
-	//wdr_variance_space, wdr_variance_intensity, slope_max_write,  white_level_write
-    0x04,	0x01,	0x30, 	0x4FF,
-
-    0x1, 	// balance_fe
-    0x80,	// ae compensation
-    0x23, 	// sinter threshold
-
-    0x1,     //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
-    0x0,
-    546,
 #if CMOS_PO3100K_ISP_WRITE_SENSOR_ENABLE
-    2
-#else
-    1
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
 #endif
+
+static AWB_CCM_S g_stAwbCcm =
+{
+    4850,
+    {
+        0x01ee, 0x80a3, 0x804b,
+        0x8040, 0x0195, 0x8055,
+        0x0006, 0x80f0, 0x01e9
+    },
+    3100,
+    {
+        0x01f4, 0x804f, 0x80a5,
+        0x805b, 0x01bf, 0x8064,
+        0x8014, 0x8147, 0x025b
+    },
+    2470,
+    {
+        0x0201, 0x80ca, 0x8037,
+        0x806d, 0x017a, 0x800d,
+        0x803c, 0x8285, 0x03c1
+    }
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
-    //sharpen_alt_d
-    {0x50,0x48,0x40,0x38,0x34,0x30,0x28,0x28},
+    /* bvalid */
+    1,
 
-    //sharpen_alt_ud
-    {0xb0,0xa0,0xa0,0x90,0x80,0x70,0x60,0x50},
-
-    //snr_thresh
-    {0x13,0x19,0x20,0x26,0x2c,0x32,0x38,0x38},
-
-    //demosaic_lum_thresh
-    {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
-
-    //demosaic_np_offset
-    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
-
-    /* saturation */
+    /* saturation */    
     {0x80,0x80,0x80,0x48,0x44,0x40,0x3C,0x38}
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
 {
-    //nosie_profile_weight_lut
+    /* bvalid */
+    1,
+
+    /* sharpen_alt_d */
+    {0x50,0x48,0x40,0x38,0x34,0x30,0x28,0x28},
+        
+    /* sharpen_alt_ud */
+    {0xb0,0xa0,0xa0,0x90,0x80,0x70,0x60,0x50},
+        
+    /* snr_thresh */
+    {0x13,0x19,0x20,0x26,0x2c,0x32,0x38,0x38},
+        
+    /* demosaic_lum_thresh */
+    {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
+        
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
+};
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
+{
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {0x11,0x17,0x1b,0x1e,0x20,0x22,0x24,0x26,0x27,0x28,0x29,0x2a,0x2b,0x2c,0x2d,0x2d,0x2e,
 	0x2f,0x2f,0x30,0x30,0x31,0x31,0x32,0x32,0x33,0x33,0x34,0x34,0x34,0x35,0x35,0x36,0x36,
 	0x36,0x37,0x37,0x37,0x37,0x38,0x38,0x38,0x39,0x39,0x39,0x39,0x3a,0x3a,0x3a,0x3a,0x3b,
@@ -131,7 +108,7 @@ static cmos_isp_noise_table_t st_isp_noise_table =
 	0x43,0x43,0x43,0x43,0x43,0x43,0x43,0x43,0x43,0x44,0x44,0x44,0x44,0x44,0x44,0x44,0x44,
 	0x44,0x44,0x45,0x45,0x45,0x45,0x45,0x45,0x45},
 
-    //demosaic_weight_lut
+    /* demosaic_weight_lut */
     {0x11,0x17,0x1b,0x1e,0x20,0x22,0x24,0x26,0x27,0x28,0x29,0x2a,0x2b,0x2c,0x2d,0x2d,0x2e,
 	0x2f,0x2f,0x30,0x30,0x31,0x31,0x32,0x32,0x33,0x33,0x34,0x34,0x34,0x35,0x35,0x36,0x36,
 	0x36,0x37,0x37,0x37,0x37,0x38,0x38,0x38,0x39,0x39,0x39,0x39,0x3a,0x3a,0x3a,0x3a,0x3b,
@@ -142,8 +119,11 @@ static cmos_isp_noise_table_t st_isp_noise_table =
 	0x44,0x44,0x45,0x45,0x45,0x45,0x45,0x45,0x45}
 };
 
-static cmos_isp_demosaic_t st_isp_demosaic =
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
+    /* bvalid */
+    1,
+    
     /*vh_slope*/
     0xf0,
 
@@ -181,439 +161,132 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x1b3
 };
 
-
-
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static /*__inline*/ cmos_inttime_const_ptr_t cmos_inttime_initialize()
+static HI_U32 gain_table[96]=
 {
-    //TODO: min/max integration time control.
-    //cmos_inttime.min_lines_std = 128;
-    cmos_inttime.full_lines_std = 750;
-    cmos_inttime.full_lines_std_30fps = 750;
-    cmos_inttime.full_lines_std_25fps = 900;
-    //cmos_inttime.full_lines = 750;
-    //cmos_inttime.full_lines_del = 750; //TODO: remove
-   // cmos_inttime.full_lines_limit = 65535;
-    //cmos_inttime.max_lines = 748;
-    cmos_inttime.min_lines = 2;
-    //cmos_inttime.vblanking_lines = 0;
+    1024,   1088,   1152,   1216,   1280,   1344,   1408,   1472,   1536,   1600,   1664,   1728,  1792,   1856, 
+    1920,   1984,   2048,   2176,   2304,   2432,   2560,   2688,   2816,   2944,   3072,   3200,  3328,   3456, 
+    3584,   3712,   3840,   3968,   4096,   4352,   4608,   4864,   5120,   5376,   5632,   5888,  6144,   6400,
+    6656,   6912,   7168,   7424,   7680,   7936,   8192,   8704,   9216,   9728,   10240, 10752, 11264, 11776,
+    12288, 12800, 13312, 13824, 14336, 14848, 15360, 15872, 16384, 17408, 18432, 19456, 
+    20480, 21504, 22528, 23552, 24576, 25600, 26624, 27648, 28672, 29696, 30720, 31744, 
+    32768, 34816, 36864, 38912, 40960, 43008, 45056, 47104, 49152, 51200, 53248, 55296, 
+    57344, 59392, 61440, 63488  
+};
 
-    //cmos_inttime.exposure_ashort = 0;
-    cmos_inttime.exposure_shift = 0;
-
-    cmos_inttime.lines_per_500ms = cmos_inttime.full_lines_std_30fps*30/2; // 500ms / 22.22us
-    cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-   // cmos_inttime.max_lines_target = cmos_inttime.max_lines;
-   // cmos_inttime.min_lines_target = cmos_inttime.min_lines;
-    //cmos_inttime.max_flicker_lines = cmos_inttime.max_lines_target;
-    //cmos_inttime.min_flicker_lines = cmos_inttime.min_lines_target;
-    //cmos_inttime.input_changed = 0;
-    return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
+static ISP_CMOS_GAMMA_S g_stIspGamma =
 {
-    static HI_U32 _last_exposure_time = 0xFFFFFFFF;
-    if(_last_exposure_time == p_inttime->exposure_ashort)
-    {
-        return;
-    }else
-    {
-        _last_exposure_time = p_inttime->exposure_ashort;
-    }
-
-    ISP_I2C_DATA_S stI2cData;
-
+    /* bvalid */
+    1,
     
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-
-    stI2cData.u32RegAddr = 0xc0;
-    stI2cData.u32Data = p_inttime->exposure_ashort >> (p_inttime->exposure_shift + 8);
-    HI_MPI_ISP_I2cWrite(&stI2cData); 
-
-    stI2cData.u32RegAddr = 0xc1;
-    stI2cData.u32Data = (p_inttime->exposure_ashort >> p_inttime->exposure_shift) & 0xff;
-    HI_MPI_ISP_I2cWrite(&stI2cData); 
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-    HI_U16  _fulllines = p_inttime->full_lines;
-    static HI_U16 last_vblanking_lines = 65535;
-    if(p_inttime->vblanking_lines != last_vblanking_lines)
-    {
-        sensor_write_register(0x03, 0x0);
-        sensor_write_register(0x08, _fulllines>>8);
-        sensor_write_register(0x09, _fulllines&0xFF);
-        sensor_write_register(0x0A, _fulllines>>8);
-        sensor_write_register(0x0B, _fulllines&0xFF);
-        sensor_write_register(0x03, 0x1);
-        last_vblanking_lines = p_inttime->vblanking_lines;
-    }
-    return;
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-    if(p_inttime->exposure_ashort >= p_inttime->full_lines - 2)
-    {
-        p_inttime->exposure_ashort = p_inttime->full_lines - 2;
-    }
-
-    p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std;
-
-    return p_inttime->exposure_ashort;
-}
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-
-    switch(fps)
-    {
-        case 30:
-            p_inttime->full_lines_std = cmos_inttime.full_lines_std_30fps;
-            p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2;
-            sensor_write_register(0x03, 0x00);
-            sensor_write_register(0x08, 0x02);
-            sensor_write_register(0x09, 0xED);
-            sensor_write_register(0x0A, 0x02);
-            sensor_write_register(0x0B, 0xED);
-            sensor_write_register(0x03, 0x01);
-        break;
-
-        case 25:
-            p_inttime->full_lines_std = cmos_inttime.full_lines_std_25fps;
-            p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_25fps * 25 / 2;
-            sensor_write_register(0x03, 0x00);
-            sensor_write_register(0x08, 0x03);
-            sensor_write_register(0x09, 0x83);
-            sensor_write_register(0x0A, 0x03);
-            sensor_write_register(0x0B, 0x83);
-            sensor_write_register(0x03, 0x01);
-        break;
-
-	default:
-	break;
-	}
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static /*__inline*/ cmos_gains_ptr_t cmos_gains_initialize()
-{
-
-    cmos_gains.max_again = 1024;
-    cmos_gains.max_dgain = 255;
-    cmos_gains.max_again_target = cmos_gains.max_again;
-    cmos_gains.max_dgain_target = cmos_gains.max_dgain;
-
-    cmos_gains.again_shift = 4;
-    cmos_gains.dgain_shift = 6;
-    cmos_gains.dgain_fine_shift = 0;
-
-    cmos_gains.again = 1;
-    cmos_gains.dgain = 1;
-    cmos_gains.dgain_fine = 1;
-    cmos_gains.again_db = 0;
-    cmos_gains.dgain_db = 0;
-
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_FALSE;
-
-//	cmos_gains.input_changed = 0;
-
-    return &cmos_gains;
-}
-
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{
-    static HI_U32 _last_again = 0xFFFFFFFF;
-    static HI_U32 _last_dgain = 0xFFFFFFFF;
-    if((_last_again == p_gains->again_db) && (_last_dgain == p_gains->dgain))
-    {
-        return;
-    }else
-    {
-        _last_again = p_gains->again_db;
-        _last_dgain = p_gains->dgain;
-    }
-    
-    
-    ISP_I2C_DATA_S stI2cData;
-
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    
-    stI2cData.u32RegAddr = 0xc3;
-    stI2cData.u32Data = p_gains->again_db;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-
-    stI2cData.u32RegAddr = 0xc4;
-    stI2cData.u32Data = p_gains->dgain;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-
-    return;
-}
-
-
-static HI_U32 cmos_gains_lin_to_db_convert(HI_U32 data, HI_U32 shift_in)
-{
-#define PRECISION 8
-    HI_U32 _res = 0;
-    if(0 == data)
-    return _res;
-
-    data = data << PRECISION; // to ensure precision.
-    for(;;)
-    {
-        /* Note to avoid endless loop here. */
-        data = (data * 913) >> 10;
-        // data = (data*913 + (1<<9)) >> 10; // endless loop when shift_in is 0. */
-        if(data <= ((1<<shift_in) << PRECISION))
-        {
-        	break;
-        }
-        ++_res;
-    }
-    return _res;
-}
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-
-    HI_U32 _again = 1 << p_gains->again_shift;
-    int shift = 0;
-    HI_U8 i = 0;
-
-    while (exposure > (1<<26))
-    {
-         exposure >>= 1;
-         exposure_max >>= 1;
-         ++shift;
-    }
-
-    if(exposure > exposure_max)
-    {
-        _again = (exposure << p_gains->again_shift) / exposure_max;
-        _again = _again < 16? 16: _again;
-        _again = _again > p_gains->max_again_target ? p_gains->max_again_target : _again;
-
-        for(i = 0; i < 6; i++)
-        {
-            if(_again < 32)
-            {
-                break;
-            }
-            _again >>= 1;
-        }
-    }
-    else
-    {
-    }
-
-    p_gains->again_db = (i << 4) + _again - 16;
-    p_gains->again = _again << i;
-
-    return (exposure << (shift + 4)) / p_gains->again;
-
-}
-
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
-
-    while (exposure > (1 << 22))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = DIV_0_TO_1(exposure_max);
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shift;
-}
-
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift
-		)
-{
-    HI_U32 _dgain = 1<<p_gains->dgain_shift;
-    HI_U32 exposure0;
-    int shft = 0;
-
-    while (exposure > (1<<20))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shft;
-    }
-
-    exposure0 = exposure;
-    if(exposure > exposure_max)
-    {
-        //when setting manual exposure line, exposure_max>>shift should not be 0.
-        exposure_max = DIV_0_TO_1(exposure_max);
-        _dgain = (exposure  * _dgain) / exposure_max;
-        exposure = exposure_max;
-    }
-    else
-    {
-    //TODO: after anti-flick, dgain may need to decrease.
-    //_dgain = (_dgain * exposure) / (exposure / exposure_shift) / exposure_shift;
-    }
-    _dgain = _dgain < (1<<p_gains->dgain_shift) ? (1<<p_gains->dgain_shift) : _dgain;
-    _dgain = (_dgain > p_gains->max_dgain_target) ? p_gains->max_dgain_target : _dgain;
-
-    p_gains->dgain = _dgain;
-    p_gains->dgain_db = cmos_gains_lin_to_db_convert(p_gains->dgain, p_gains->dgain_shift);
-    
-    return exposure << shft;
-}
-
-static __inline void sensor_update(
-	cmos_gains_const_ptr_t p_gains,
-	cmos_inttime_ptr_t p_inttime,
-	HI_U8 frame
-    )
-{
-    if(frame == 0)
-    {
-    	cmos_inttime_update(p_inttime);
-    }
-    if(frame == 1)
-    {
-    	cmos_gains_update(p_gains);
-    }
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-    HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-    HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _ispdgain = p_gains->isp_dgain == 0 ? 1 : p_gains->isp_dgain;
-
-    p_gains->iso =  (((HI_U64)_again * _dgain * _ispdgain * 100) 
-        >> (p_gains->again_shift + p_gains->dgain_shift 
-        + p_gains->isp_dgain_shift));
-
-    return p_gains->iso;
-}
-
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    //return cmos_gains_lin_to_db_convert(p_gains->again, p_gains->again_shift);
-    return p_gains->again_db;
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-    //return cmos_gains_lin_to_db_convert(p_gains->dgain, p_gains->dgain_shift);
-    return p_gains->dgain_db;
-}
-
-#if 0
-static HI_U8 cmos_get_digital_fine_gain(cmos_gains_ptr_t p_gains)
-{
-    return cmos_gains_lin_to_db_convert(p_gains->dgain_fine, p_gains->dgain_shift);
-}
+#if 1    
+    {0  ,120 ,220 ,310 ,390 ,470 ,540 ,610 ,670 ,730 ,786 ,842 ,894 ,944 ,994 ,1050,    
+    1096,1138,1178,1218,1254,1280,1314,1346,1378,1408,1438,1467,1493,1519,1543,1568,    
+    1592,1615,1638,1661,1683,1705,1726,1748,1769,1789,1810,1830,1849,1869,1888,1907,    
+    1926,1945,1963,1981,1999,2017,2034,2052,2069,2086,2102,2119,2136,2152,2168,2184,    
+    2200,2216,2231,2247,2262,2277,2292,2307,2322,2337,2351,2366,2380,2394,2408,2422,    
+    2436,2450,2464,2477,2491,2504,2518,2531,2544,2557,2570,2583,2596,2609,2621,2634,    
+    2646,2659,2671,2683,2696,2708,2720,2732,2744,2756,2767,2779,2791,2802,2814,2825,    
+    2837,2848,2859,2871,2882,2893,2904,2915,2926,2937,2948,2959,2969,2980,2991,3001,    
+    3012,3023,3033,3043,3054,3064,3074,3085,3095,3105,3115,3125,3135,3145,3155,3165,    
+    3175,3185,3194,3204,3214,3224,3233,3243,3252,3262,3271,3281,3290,3300,3309,3318,    
+    3327,3337,3346,3355,3364,3373,3382,3391,3400,3409,3418,3427,3436,3445,3454,3463,    
+    3471,3480,3489,3498,3506,3515,3523,3532,3540,3549,3557,3566,3574,3583,3591,3600,    
+    3608,3616,3624,3633,3641,3649,3657,3665,3674,3682,3690,3698,3706,3714,3722,3730,    
+    3738,3746,3754,3762,3769,3777,3785,3793,3801,3808,3816,3824,3832,3839,3847,3855,    
+    3862,3870,3877,3885,3892,3900,3907,3915,3922,3930,3937,3945,3952,3959,3967,3974,    
+    3981,3989,3996,4003,4010,4018,4025,4032,4039,4046,4054,4061,4068,4075,4082,4089,4095}
+#else  /*higher  contrast*/
+    {0  , 54 , 106, 158, 209, 259, 308, 356, 403, 450, 495, 540, 584, 628, 670, 713,
+    754 ,795 , 835, 874, 913, 951, 989,1026,1062,1098,1133,1168,1203,1236,1270,1303,
+    1335,1367,1398,1429,1460,1490,1520,1549,1578,1607,1635,1663,1690,1717,1744,1770,
+    1796,1822,1848,1873,1897,1922,1946,1970,1993,2017,2040,2062,2085,2107,2129,2150,
+    2172,2193,2214,2235,2255,2275,2295,2315,2335,2354,2373,2392,2411,2429,2447,2465,
+    2483,2501,2519,2536,2553,2570,2587,2603,2620,2636,2652,2668,2684,2700,2715,2731,
+    2746,2761,2776,2790,2805,2819,2834,2848,2862,2876,2890,2903,2917,2930,2944,2957,
+    2970,2983,2996,3008,3021,3033,3046,3058,3070,3082,3094,3106,3118,3129,3141,3152,
+    3164,3175,3186,3197,3208,3219,3230,3240,3251,3262,3272,3282,3293,3303,3313,3323,
+    3333,3343,3352,3362,3372,3381,3391,3400,3410,3419,3428,3437,3446,3455,3464,3473,
+    3482,3490,3499,3508,3516,3525,3533,3541,3550,3558,3566,3574,3582,3590,3598,3606,
+    3614,3621,3629,3637,3644,3652,3660,3667,3674,3682,3689,3696,3703,3711,3718,3725,
+    3732,3739,3746,3752,3759,3766,3773,3779,3786,3793,3799,3806,3812,3819,3825,3831,
+    3838,3844,3850,3856,3863,3869,3875,3881,3887,3893,3899,3905,3910,3916,3922,3928,
+    3933,3939,3945,3950,3956,3962,3967,3973,3978,3983,3989,3994,3999,4005,4010,4015,
+    4020,4026,4031,4036,4041,4046,4051,4056,4061,4066,4071,4076,4081,4085,4090,4095,4095}
 #endif
+};
 
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-    if (NULL == p_coms_isp_default)
+    if (HI_NULL == pstDef)
     {
         printf("null pointer when get isp default value!\n");
         return -1;
     }
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
+
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
+
+    pstDef->stComm.u8Rggb           = 0x1;      //1: rggb 
+    pstDef->stComm.u8BalanceFe      = 0x1;
+
+    pstDef->stDenoise.u8SinterThresh= 0x23;
+    pstDef->stDenoise.u8NoiseProfile= 0x1;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 546;
+
+    pstDef->stDrc.u8DrcBlack        = 0x00;
+    pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x01;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0x30;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x4FF;    // white level
+
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+    memcpy(&pstDef->stGamma, &g_stIspGamma, sizeof(ISP_CMOS_GAMMA_S));
+
     return 0;
 }
 
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-    if (NULL == p_cmos_isp_agc_table)
+    HI_S32  i;
+    
+    if (HI_NULL == pstBlackLevel)
     {
-        printf("null pointer when get isp agc table value!\n");
+        printf("null pointer when get isp black level value!\n");
         return -1;
     }
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
-}
 
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-    if (NULL == p_cmos_isp_noise_table)
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+            
+    for (i=0; i<4; i++)
     {
-        printf("null pointer when get isp noise table value!\n");
-        return -1;
+        pstBlackLevel->au16BlackLevel[i] = 0x4;
     }
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
+
+    return 0;    
 }
 
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-    if (NULL == p_cmos_isp_demosaic)
+    if (bEnable) /* setup for ISP pixel calibration mode */
     {
-        printf("null pointer when get isp demosaic value!\n");
-        return -1;
+        sensor_write_register(0x03, 0x00);//5fps
+        sensor_write_register(0x08, 0x11);
+        sensor_write_register(0x09, 0x94);
+        sensor_write_register(0x0A, 0x11);
+        sensor_write_register(0x0B, 0x94);
+
+        sensor_write_register(0x03, 0x01);
+
+        sensor_write_register(0xC0, 0x11);
+        sensor_write_register(0xC1, 0x92);
+
+        sensor_write_register(0xC3, 0x0);
+        sensor_write_register(0xC4, 0x40);
     }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-void setup_sensor(int isp_mode)
-{
-    if(0 == isp_mode) /* ISP 'normal' isp_mode */
+    else /* setup for ISP 'normal mode' */
     {
         sensor_write_register(0x03, 0x00);//30fps
         sensor_write_register(0x08, 0x02);
@@ -622,94 +295,11 @@ void setup_sensor(int isp_mode)
         sensor_write_register(0x0B, 0xED);
         sensor_write_register(0x03, 0x01);
     }
-    else if(1 == isp_mode) /* ISP pixel calibration isp_mode */
-    {
-        sensor_write_register(0x03, 0x00);//5fps
-        sensor_write_register(0x08, 0x11);
-        sensor_write_register(0x09, 0x94);
-        sensor_write_register(0x0A, 0x11);
-        sensor_write_register(0x0B, 0x94);
-        
-        sensor_write_register(0x03, 0x01);
 
-        sensor_write_register(0xC0, 0x11);
-        sensor_write_register(0xC1, 0x92);
-        
-        sensor_write_register(0xC3, 0x0);
-        sensor_write_register(0xC4, 0x40);
-        
-    }
+    return;
 }
 
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1280;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 720;
-
-    return 0;
-}
-
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-static SENSOR_EXP_FUNC_S stSensorExpFuncs =
-{
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
-
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-
-    .pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-    .pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-    .pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-    .pfn_cmos_get_isp_default = cmos_get_isp_default,
-    .pfn_cmos_get_isp_special_alg = NULL,
-    .pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-    .pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-    .pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-    .pfn_cmos_get_isp_shading_table = NULL,
-    .pfn_cmos_get_isp_gamma_table = NULL,
-    .pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-    .pfn_cmos_set_sensor_image_mode = NULL,
-
-};
-
-int sensor_register_callback(void)
-{
-    int ret;
-    ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-    if (ret)
-    {
-        printf("sensor register callback function failed!\n");
-        return ret;
-    }
-    return 0;
-}
-
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
@@ -726,19 +316,380 @@ int sensor_mode_set(HI_U8 u8Mode)
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 750;
+    
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32LinesPer500ms = 750*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 748;
+    pstAeSnsDft->u32MinIntTime = 2;    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 2;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 0.0009765625;    
+    pstAeSnsDft->u32MaxAgain = 63488;  /* 62 / 0.0009765625= 63488 */
+    pstAeSnsDft->u32MinAgain = 1024;
+    pstAeSnsDft->u32MaxAgainTarget = 63488;
+    pstAeSnsDft->u32MinAgainTarget = 1024;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.015625;    
+    pstAeSnsDft->u32MaxDgain = 255;  /* 4 / 0.015625 = 256;*/
+    pstAeSnsDft->u32MinDgain = 64;
+    pstAeSnsDft->u32MaxDgainTarget = 255;
+    pstAeSnsDft->u32MinDgainTarget = 64;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
     return 0;
 }
 
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    switch(u8Fps)
+    {
+        case 30:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 750;
+            pstAeSnsDft->u32MaxIntTime = 748;
+            pstAeSnsDft->u32LinesPer500ms = 750 * 30 / 2;
+            sensor_write_register(0x03, 0x00);
+            sensor_write_register(0x08, 0x02);
+            sensor_write_register(0x09, 0xED);
+            sensor_write_register(0x0A, 0x02);
+            sensor_write_register(0x0B, 0xED);
+            sensor_write_register(0x03, 0x01);
+        break;
+        
+        case 25:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 900;
+            pstAeSnsDft->u32MaxIntTime = 898;
+            pstAeSnsDft->u32LinesPer500ms = 900 * 25 / 2;
+            sensor_write_register(0x03, 0x00);
+            sensor_write_register(0x08, 0x03);
+            sensor_write_register(0x09, 0x83);
+            sensor_write_register(0x0A, 0x03);
+            sensor_write_register(0x0B, 0x83);
+            sensor_write_register(0x03, 0x01);
+        break;
+        
+        default:
+        break;
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    static HI_U16 last_vblanking_lines = 65535;
+    if(u16FullLines != last_vblanking_lines)
+    {
+        sensor_write_register(0x03, 0x0);
+        sensor_write_register(0x08, u16FullLines>>8);
+        sensor_write_register(0x09, u16FullLines&0xFF);
+        sensor_write_register(0x0A, u16FullLines>>8);
+        sensor_write_register(0x0B, u16FullLines&0xFF);
+        sensor_write_register(0x03, 0x1);
+        last_vblanking_lines = u16FullLines;
+    }  
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_PO3100K_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+    static HI_BOOL bInit = HI_FALSE;
+
+    if (HI_FALSE == bInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_I2C_TYPE;
+        g_stSnsRegsInfo.u32RegNum = 4;
+        for (i=0; i<g_stSnsRegsInfo.u32RegNum; i++)
+        {
+            g_stSnsRegsInfo.astI2cData[i].u8DevAddr = sensor_i2c_addr;
+            g_stSnsRegsInfo.astI2cData[i].u32AddrByteNum = sensor_addr_byte;
+            g_stSnsRegsInfo.astI2cData[i].u32DataByteNum = sensor_data_byte;
+        }
+        g_stSnsRegsInfo.astI2cData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[0].u32RegAddr = 0xc0;
+        g_stSnsRegsInfo.astI2cData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[1].u32RegAddr = 0xc1;
+        g_stSnsRegsInfo.astI2cData[2].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[2].u32RegAddr = 0xc3;
+        g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[3].u32RegAddr = 0xc4;
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_FALSE;
+
+        bInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+#if CMOS_PO3100K_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[0].u32Data = (u32IntTime>>8);
+    g_stSnsRegsInfo.astI2cData[1].u32Data = (u32IntTime & 0xff);
+#endif
+    return;
+}
+
+static HI_VOID cmos_again_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
+{
+    int i;
+
+    if(HI_NULL == pstAeSnsGainInfo)
+    {
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
+    }
+
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+
+    if (u32InTimes >= gain_table[95])
+    {
+        pstAeSnsGainInfo->u32SnsTimes = gain_table[95];
+        pstAeSnsGainInfo->u32GainDb = 95;
+        return ;
+    }
+
+    for(i = 1; i < 96; i++)
+    {
+        if(u32InTimes < gain_table[i])
+        {
+            pstAeSnsGainInfo->u32SnsTimes = gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
+    }
+
+    return;
+}
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+#if CMOS_PO3100K_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    
+    g_stSnsRegsInfo.astI2cData[2].u32Data = u32Again;                
+    g_stSnsRegsInfo.astI2cData[3].u32Data = u32Dgain;
+    
+    HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);    
+#endif
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 4850;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x177;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x0197;
+
+    pstAwbSnsDft->as32WbPara[0] = 123;
+    pstAwbSnsDft->as32WbPara[1] = -28;
+    pstAwbSnsDft->as32WbPara[2] = -161;
+    pstAwbSnsDft->as32WbPara[3] = 192773;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -142978;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+    pstExpFuncs->pfn_cmos_again_calc_table  = cmos_again_calc_table;
+    
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(PO3100K_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, PO3100K_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, PO3100K_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(PO3100K_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, PO3100K_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, PO3100K_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
 }
 #endif
 #endif /* End of #ifdef __cplusplus */
-
-
 
 #endif // __PO3100K_CMOS_H_

--- a/libraries/sensor/hi3516cv100/pixelplus_3100k/po3100k_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/pixelplus_3100k/po3100k_sensor_ctl.c
@@ -160,7 +160,7 @@ void sensor_prog(int* rom)
 
 void sensor_init()
 {
-    printf("-----------start init pixel plus 3100K------------\n");
+    printf("-----------start init pixel plus 3100K------------");
     sensor_write_register(0x03,0x00);   // --------  A
     sensor_write_register(0x2D,0x01);
     sensor_write_register(0x29,0x9D);

--- a/libraries/sensor/hi3516cv100/soi_h22/soih22_cmos.c
+++ b/libraries/sensor/hi3516cv100/soi_h22/soih22_cmos.c
@@ -1,16 +1,16 @@
-/******************************************************************************
-  A driver program of soi h22 on HI3518A 
- ******************************************************************************
-    Modification:  2013-03  Created
-******************************************************************************/
-
 #if !defined(__SOIH22_CMOS_H_)
 #define __SOIH22_CMOS_H_
+
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 #include "hi_comm_sns.h"
+#include "hi_comm_isp.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -18,106 +18,115 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-extern const unsigned int sensor_i2c_addr;
-extern const unsigned int sensor_addr_byte;
-extern const unsigned int sensor_data_byte;
+#define SOIH22_ID 22
 
 #define CMOS_SOIH22_ISP_WRITE_SENSOR_ENABLE (1)
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
+extern const unsigned int sensor_i2c_addr;
+extern unsigned int sensor_addr_byte;
+extern unsigned int sensor_data_byte;
+
 HI_U8 gu8SensorMode = 0;
 
-static cmos_isp_default_t st_coms_isp_default =
-{
-    {// color matrix[9] ccm     modified by daniel
-        5048,
-        {   0x1f5, 0x80be, 0x8037,
-            0x8045, 0x195, 0x8050,
-            0x800e, 0x8146, 0x255
-        },
-        3193,
-        {   0x1ee, 0x8017, 0x80d6,
-            0x8053, 0x1d2, 0x807e,
-            0x8023, 0x8176, 0x29a
-        },
-        2480,
-        {   0x21d, 0x8091, 0x808c,
-            0x8072, 0x19d, 0x802b,
-            0x80b3, 0x8366, 0x519
-        }
-    }
-    ,
+static HI_U32 gu32FullLinesStd = 767;
+static HI_U32 gu32FullLines = 767;
 
-	// black level
-    {1,1,1,1},  //calibration by tools added by wenyu
-
-    //calibration reference color temperature modified by daniel
-    5048,
-
-    //WB gain at 5000, must keep consistent with calibration color temperature
-    {0x152, 0x100, 0x100, 0X1ab},
-
-    // WB curve parameters, must keep consistent with reference color temperature.
-    {139, -51, -167, 184226, 128, -136368},
-
-    // hist_thresh
-    {0xd,0x28,0x60,0x80},
-    //{0x10,0x40,0xc0,0xf0},
-
-    0x0,	// iridix_balck
-    0x3,	// bggr
-
-    // gain
-    0X1f,	0x1,
-
-    // iridix
-    0x04,	0x08,	0xa0, 	0x4ff,
-
-    0x1, 	// balance_fe
-    0x80,	// ae compensation
-    0x15, 	// sinter threshold
-
-    0x0,  0,  0,  //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
-#if CMOS_SOIH22_ISP_WRITE_SENSOR_ENABLE 
-    2
-#else
-    1
+#if CMOS_SOIH22_ISP_WRITE_SENSOR_ENABLE
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
 #endif
+
+static AWB_CCM_S g_stAwbCcm =
+{
+    5048,
+    {   0x1f5, 0x80be, 0x8037,
+        0x8045, 0x195, 0x8050,
+        0x800e, 0x8146, 0x255
+    },
+    3193,
+    {   0x1ee, 0x8017, 0x80d6,
+        0x8053, 0x1d2, 0x807e,
+        0x8023, 0x8176, 0x29a
+    },
+    2480,
+    {   0x21d, 0x8091, 0x808c,
+        0x8072, 0x19d, 0x802b,
+        0x80b3, 0x8366, 0x519
+    }
 };
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
-    //100,200 ,400 ,800 ,1600,3200 ,6400
-    //sharpen_alt_d
-    {0xbc,0x6d,0x55,0x60,0x16,0x8e,0xd8,0x01},
-
-    //sharpen_alt_ud
-    {0x8e,0x46,0x3e,0x40,0x2f,0x3d,0x1e,0x20},
-
-    //snr_thresh modified by daniel
-    //{0x1d,0x1e,0x1f,0x4e,0x5a,0x59,0x64,0x59},
-    {0x1d,0x1e,0x1f,0x30,0x30,0x30,0x30,0x30},
-
-    //demosaic_lum_thresh
-    {0x40,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
-
-    //demosaic_np_offset
-    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
+    /* bvalid */
+    1,
 
     /* saturation */
     {0x80,0x80,0x80,0x80,0x68,0x48,0x35,0x30}
+};
+
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
+{
+    /* bvalid */
+    1,
+    
+    /* sharpen_alt_d */
+    {0xbc,0x6d,0x55,0x60,0x16,0x8e,0xd8,0x01},
+        
+    /* sharpen_alt_ud */
+    {0x8e,0x46,0x3e,0x40,0x2f,0x3d,0x1e,0x20},
+        
+    /* snr_thresh */
+    {0x1d,0x1e,0x1f,0x30,0x30,0x30,0x30,0x30},
+        
+    /* demosaic_lum_thresh */
+    {0x40,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
+        
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
 
 };
 
-static cmos_isp_demosaic_t st_isp_demosaic =
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
 {
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
+    {
+     0x19,0x20,0x24,0x27,0x29,0x2b,0x2d,0x2e,0x2f,0x31,0x32,0x33,0x34,0x34,0x35,0x36,0x37,\
+    0x37,0x38,0x38,0x39,0x3a,0x3a,0x3b,0x3b,0x3b,0x3c,0x3c,0x3d,0x3d,0x3d,0x3e,0x3e,0x3e,\
+    0x3f,0x3f,0x3f,0x40,0x40,0x40,0x41,0x41,0x41,0x41,0x42,0x42,0x42,0x42,0x43,0x43,0x43,\
+    0x43,0x44,0x44,0x44,0x44,0x44,0x45,0x45,0x45,0x45,0x45,0x46,0x46,0x46,0x46,0x46,0x46,\
+    0x47,0x47,0x47,0x47,0x47,0x47,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x49,0x49,0x49,0x49,\
+    0x49,0x49,0x49,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4b,0x4b,0x4b,0x4b,0x4b,\
+    0x4b,0x4b,0x4b,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4d,0x4d,0x4d,0x4d,\
+    0x4d,0x4d,0x4d,0x4d,0x4d,0x4d,0x4e,0x4e,0x4e
+    },
+
+    /* demosaic_weight_lut */
+    {
+        0x19,0x20,0x24,0x27,0x29,0x2b,0x2d,0x2e,0x2f,0x31,0x32,0x33,0x34,0x34,0x35,0x36,0x37,\
+    0x37,0x38,0x38,0x39,0x3a,0x3a,0x3b,0x3b,0x3b,0x3c,0x3c,0x3d,0x3d,0x3d,0x3e,0x3e,0x3e,\
+    0x3f,0x3f,0x3f,0x40,0x40,0x40,0x41,0x41,0x41,0x41,0x42,0x42,0x42,0x42,0x43,0x43,0x43,\
+    0x43,0x44,0x44,0x44,0x44,0x44,0x45,0x45,0x45,0x45,0x45,0x46,0x46,0x46,0x46,0x46,0x46,\
+    0x47,0x47,0x47,0x47,0x47,0x47,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x49,0x49,0x49,0x49,\
+    0x49,0x49,0x49,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4b,0x4b,0x4b,0x4b,0x4b,\
+    0x4b,0x4b,0x4b,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4d,0x4d,0x4d,0x4d,\
+    0x4d,0x4d,0x4d,0x4d,0x4d,0x4d,0x4e,0x4e,0x4e
+    }
+};
+
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
+{
+    /* bvalid */
+    1,
+    
     /*vh_slope*/
     0xff,
 
@@ -155,546 +164,467 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x1b3
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-//nosie_profile_weight_lut
-    {
-     0x19,0x20,0x24,0x27,0x29,0x2b,0x2d,0x2e,0x2f,0x31,0x32,0x33,0x34,0x34,0x35,0x36,0x37,\
-	0x37,0x38,0x38,0x39,0x3a,0x3a,0x3b,0x3b,0x3b,0x3c,0x3c,0x3d,0x3d,0x3d,0x3e,0x3e,0x3e,\
-	0x3f,0x3f,0x3f,0x40,0x40,0x40,0x41,0x41,0x41,0x41,0x42,0x42,0x42,0x42,0x43,0x43,0x43,\
-	0x43,0x44,0x44,0x44,0x44,0x44,0x45,0x45,0x45,0x45,0x45,0x46,0x46,0x46,0x46,0x46,0x46,\
-	0x47,0x47,0x47,0x47,0x47,0x47,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x49,0x49,0x49,0x49,\
-	0x49,0x49,0x49,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4b,0x4b,0x4b,0x4b,0x4b,\
-	0x4b,0x4b,0x4b,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4d,0x4d,0x4d,0x4d,\
-	0x4d,0x4d,0x4d,0x4d,0x4d,0x4d,0x4e,0x4e,0x4e
-    },
-    
-//demosaic_weight_lut
-    {
-        0x19,0x20,0x24,0x27,0x29,0x2b,0x2d,0x2e,0x2f,0x31,0x32,0x33,0x34,0x34,0x35,0x36,0x37,\
-	0x37,0x38,0x38,0x39,0x3a,0x3a,0x3b,0x3b,0x3b,0x3c,0x3c,0x3d,0x3d,0x3d,0x3e,0x3e,0x3e,\
-	0x3f,0x3f,0x3f,0x40,0x40,0x40,0x41,0x41,0x41,0x41,0x42,0x42,0x42,0x42,0x43,0x43,0x43,\
-	0x43,0x44,0x44,0x44,0x44,0x44,0x45,0x45,0x45,0x45,0x45,0x46,0x46,0x46,0x46,0x46,0x46,\
-	0x47,0x47,0x47,0x47,0x47,0x47,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x49,0x49,0x49,0x49,\
-	0x49,0x49,0x49,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4a,0x4b,0x4b,0x4b,0x4b,0x4b,\
-	0x4b,0x4b,0x4b,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4c,0x4d,0x4d,0x4d,0x4d,\
-	0x4d,0x4d,0x4d,0x4d,0x4d,0x4d,0x4e,0x4e,0x4e
-    }
-    
-};
-
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
-{
-/* 1280 * 736 */
-/* 1296 * 816 */ /* reg: 0x22/23/24/25 */
-#define STD_LINES 767
-    cmos_inttime.full_lines_std = STD_LINES;
-    cmos_inttime.full_lines_std_30fps = STD_LINES;
-    cmos_inttime.full_lines = STD_LINES;
-    cmos_inttime.full_lines_limit = 65535;
-    cmos_inttime.max_lines_target = STD_LINES;
-    cmos_inttime.min_lines_target = 8;
-    cmos_inttime.max_lines = STD_LINES;
-    cmos_inttime.vblanking_lines = 0;
-    cmos_inttime.exposure_ashort = 0;
-    cmos_inttime.exposure_shift = 0;
-    cmos_inttime.lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2; // 500ms / 39.17us
-    cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-    return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
-{
-
-    static HI_U32 _last_exposure_time = 0xFFFFFFFF;
-    if(p_inttime->exposure_ashort != _last_exposure_time)
-    {
-#if CMOS_SOIH22_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-
-    HI_U32 _curr = p_inttime->exposure_ashort ;
-    stI2cData.u32RegAddr = 0x01;
-    stI2cData.u32Data =  _curr&0xFF;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-
-    stI2cData.u32RegAddr = 0x02;
-    stI2cData.u32Data = (_curr>>8)&0xFF;
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    
-#else
-
-    HI_U32 _curr = p_inttime->exposure_ashort ;
-    //refresh the sensor setting every frame to avoid defect pixel error
-    sensor_write_register(0x01, _curr&0xFF);
-    sensor_write_register(0x02, (_curr>>8)&0xFF);    
-#endif	
-        _last_exposure_time = p_inttime->exposure_ashort ;
-    }
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-
-    static HI_U16 last_full_lines = 0xFFFF;
-     if(p_inttime->full_lines != last_full_lines)
-     {
-        sensor_write_register(0x22, (p_inttime->full_lines)&0xff);
-        sensor_write_register(0x23, (p_inttime->full_lines>>8));
-        last_full_lines = p_inttime->full_lines;
-     }
-    return;
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-    if(p_inttime->exposure_ashort >= p_inttime->full_lines -2)
-    {
-    	p_inttime->exposure_ashort = p_inttime->full_lines -2;
-    }
-                                 //expecting picture height      valid height of expecting picture  
-    p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std;
-    return p_inttime->exposure_ashort;
-}
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-    switch(fps)
-    {
-    	default://default30fps
-    	case 30:
-    	    p_inttime->full_lines=p_inttime->full_lines_std_30fps;
-    		p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2;
-            sensor_write_register(0x22, (p_inttime->full_lines)&0xff);
-            sensor_write_register(0x23, (p_inttime->full_lines>>8));
-            p_inttime->full_lines_std= p_inttime->full_lines;
-    	    p_inttime->lines_per_500ms=p_inttime->full_lines*30/2;//refresh the deflicker parameter
-            break;
-    	case 25:
-            p_inttime->full_lines=(30*p_inttime->full_lines_std_30fps)/25;
-    		p_inttime->lines_per_500ms = cmos_inttime.full_lines_std_30fps * 30 / 2;
-            sensor_write_register(0x22, (p_inttime->full_lines)&0xff);
-            sensor_write_register(0x23, (p_inttime->full_lines>>8));
-            p_inttime->full_lines_std= p_inttime->full_lines;
-    	    p_inttime->lines_per_500ms=p_inttime->full_lines*25/2;//refresh the deflicker parameter
-    	    break;
-    }
-
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
-{
-    cmos_gains.max_again = 496;//31<<4
-    cmos_gains.max_dgain = 4;
-    cmos_gains.isp_dgain_delay_cfg = HI_TRUE;
-    
-    cmos_gains.again_shift = 4;
-    cmos_gains.dgain_shift = 0;
-    cmos_gains.dgain_fine_shift = 0;
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-
-    return &cmos_gains;
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-    HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-    HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _isp_gain=p_gains->isp_dgain== 0 ? 1 : p_gains->isp_dgain;
-    p_gains->iso =  (((HI_U64)_again * _dgain *_isp_gain * 100) >> (p_gains->again_shift + p_gains->dgain_shift
-        + p_gains->isp_dgain_shift));
-    return p_gains->iso;
-}
-
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{  
-    static HI_U32 _last_again = 0xFFFFFFFF;
-    static HI_U32 _last_dgain = 0xFFFFFFFF;
-    //HI_BOOL _update = HI_FALSE;
-    if((_last_again != p_gains->again_db) ||( _last_dgain != p_gains->dgain))
-    {
-#if CMOS_SOIH22_ISP_WRITE_SENSOR_ENABLE
-    ISP_I2C_DATA_S stI2cData;
-    stI2cData.bDelayCfg = HI_TRUE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-    stI2cData.u32RegAddr = 0x00;
-    stI2cData.u32Data = p_gains->again_db;
-    
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-    //set dgain
-    stI2cData.u32RegAddr = 0x0d;
-    switch(p_gains->dgain)
-    {
-        case (4):
-            stI2cData.u32Data = 0x03;
-        break;
-        case (2):
-            stI2cData.u32Data = 0x01;
-        break;
-        default:
-            stI2cData.u32Data = 0x0;
-    }
-    HI_MPI_ISP_I2cWrite(&stI2cData);
-#else
-	//set again
-    sensor_write_register(0x00, p_gains->again_db);//again_db is again_string
-	//set dgain
-    switch(p_gains->dgain)
-    {
-        case (4):
-            sensor_write_register(0x0d, 0x03);
-        break;
-        case (2):
-            sensor_write_register(0x0d, 0x01);
-        break;
-        default:
-            sensor_write_register(0x0d, 0x00);
-    }
-#endif
-    _last_again = p_gains->again_db;
-    _last_dgain = p_gains->dgain;
-}
-    return;
-}
-
-static HI_U32 cmos_gains_lin_to_db_convert(HI_U32 data, HI_U32 shift_in)
-{
-    #define PRECISION 8
-    HI_U32 _res = 0;
-    if(0 == data)
-        return _res;
-
-    data = data << PRECISION; // to ensure precision.
-    for(;;)
-    {
-        /* Note to avoid endless loop here. */
-        data = (data * 913) >> 10;
-        // data = (data*913 + (1<<9)) >> 10; // endless loop when shift_in is 0. */
-        if(data <= ((1<<shift_in) << PRECISION))
-        {
-            break;
-        }
-        ++_res;
-    }
-    return _res;
-}
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-    //printf("exposure/max:%d\n",exposure/exposure_max);
-    int shift = 0;
-    HI_U8 i = 0;
-    HI_U32 _again = 1 << p_gains->again_shift;
-    //prevent overlow of exposure
-    while (exposure > (1<<20))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    if(exposure > exposure_max)
-    {
-        _again = (exposure << p_gains->again_shift) / exposure_max;
-        _again = _again < 16? 16: _again;
-        _again = _again > p_gains->max_again_target ? p_gains->max_again_target : _again;
-
-        for(i = 0; i < 5; i++)
-        {
-            if(_again < 32)
-            {
-                break;
-            }
-            _again >>= 1;
-        }
-    }
-    else
-    {
-    }
-
-    p_gains->again_db = (1 << (i + 4)) + _again - 32;
-    p_gains->again = _again << i;
-
-    return (exposure << (shift + 4)) / p_gains->again;
-
-}
-
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
-
-    while (exposure > (1 << 22))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = DIV_0_TO_1(exposure_max);
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shift;
-}
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
-{
-
-    HI_U32 _dgain = (1<<p_gains->dgain_shift);
-    int shift = 0;
-    int exposure0;
-    exposure0=exposure;
-    
-    HI_U32 isp_dgain=(1<< p_gains->isp_dgain_shift);
-    //prevent overlow of exposure
-    while (exposure > (1<<20))
-    {
-    	exposure >>= 1;
-    	exposure_max >>= 1;
-    	++shift;
-    }
-    if(exposure > exposure_max)
-    {
-        _dgain = (exposure<<p_gains->dgain_shift) / exposure_max;
-    }   
-    _dgain = (_dgain > p_gains->max_dgain_target) ? p_gains->max_dgain_target:_dgain;
-
-    if(_dgain >= 4)
-    {
-        _dgain = 4;
-    }
-    else if(_dgain >= 2)
-    {
-        _dgain = 2;
-    }
-    else
-    {
-        _dgain = 1;
-    }
-    
-    p_gains->dgain=_dgain;
-    p_gains->dgain_db = cmos_gains_lin_to_db_convert(p_gains->dgain,p_gains->dgain_shift);
-    exposure0 = (exposure<<p_gains->dgain_shift) /p_gains->dgain;
-
-    return exposure0<<shift;
-}
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
-{
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-static void setup_sensor(int isp_mode)
-{
-    if(0 == isp_mode) /* ISP 'normal' isp_mode */
-    {
-        int lines0=(767);//normal full lines is 767 lines ,30 fps
-        sensor_write_register(0x22, (lines0)&0xff);
-        sensor_write_register(0x23, (lines0>>8));
-    }
-    else if(1 == isp_mode) /* ISP pixel calibration isp_mode */
-    {
-        sensor_write_register(0x00, 0x00);//again=1;
-        sensor_write_register(0x0d,0x01);//dgain=1;
-        
-        int lines1=((30*767)/5);
-        sensor_write_register(0x22, (lines1)&0xff);
-        sensor_write_register(0x23, (lines1>>8));
-    }
-}
-
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    return cmos_gains_lin_to_db_convert(p_gains->again-(1<<p_gains->again_shift), p_gains->again_shift); //??
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-    return p_gains->dgain;
-}
-
-static HI_U8 cmos_get_digital_fine_gain(cmos_gains_ptr_t p_gains)
-{
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-    if (NULL == p_coms_isp_default)
+    if (HI_NULL == pstDef)
     {
         printf("null pointer when get isp default value!\n");
         return -1;
     }
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
+
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
+    
+    pstDef->stComm.u8Rggb           = 0x3;      //3: bggr  
+    pstDef->stComm.u8BalanceFe      = 0x1;
+
+    pstDef->stDenoise.u8SinterThresh= 0x15;
+    pstDef->stDenoise.u8NoiseProfile= 0x0;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 0x0;
+
+    pstDef->stDrc.u8DrcBlack        = 0x0;
+    pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0xa0;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x4ff;    // white level
+
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+
     return 0;
 }
 
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1280;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 720;
-
-    return 0;
-}
-
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-SENSOR_EXP_FUNC_S stSensorExpFuncs =
-{
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-
-    .pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-    .pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-    .pfn_cmos_get_digital_fine_gain = cmos_get_digital_fine_gain,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-    .pfn_cmos_get_isp_default = cmos_get_isp_default,
-    .pfn_cmos_get_isp_special_alg = NULL,
-    .pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-    .pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-    .pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-    .pfn_cmos_get_isp_shading_table = NULL,
-    .pfn_cmos_get_isp_gamma_table = NULL,
-    .pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-    .pfn_cmos_set_sensor_image_mode = NULL,
-};
-
-int sensor_register_callback(void)
-{
-    int ret;
-    ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-    if (ret)
+    if (HI_NULL == pstBlackLevel)
     {
-        printf("sensor register callback function failed!\n");
-        return ret;
+        printf("null pointer when get isp black level value!\n");
+        return -1;
     }
 
-    return 0;
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+
+    pstBlackLevel->au16BlackLevel[0] = 1;
+    pstBlackLevel->au16BlackLevel[1] = 1;
+    pstBlackLevel->au16BlackLevel[2] = 1;
+    pstBlackLevel->au16BlackLevel[3] = 1;
+
+    return 0;    
 }
 
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
+{
+    HI_S32 s32FullLines;
+    
+    if (bEnable) /* setup for ISP pixel calibration mode */
+    {
+        sensor_write_register(0x00, 0x00);//again=1;
+        sensor_write_register(0x0d,0x01);//dgain=1;
+        
+        s32FullLines =((30*767)/5);
+        sensor_write_register(0x22, (s32FullLines & 0xff));
+        sensor_write_register(0x23, (s32FullLines >> 8));
+    }
+    else /* setup for ISP 'normal mode' */
+    {
+        s32FullLines = 767;//normal full lines is 767 lines ,30 fps
+        sensor_write_register(0x22, (s32FullLines & 0xff));
+        sensor_write_register(0x23, (s32FullLines >> 8));
+    }
+
+    return;
+}
+
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
         //sensor mode 0
         case 0:
             gu8SensorMode = 0;
-            // TODO:
         break;
         //sensor mode 1
         case 1:
             gu8SensorMode = 1;
-             // TODO:
         break;
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 767;
+    
+    pstAeSnsDft->u32LinesPer500ms = 767*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+    /* 1280 * 736 */
+    /* 1296 * 816 */ /* reg: 0x22/23/24/25 */    
+    //gu8Fps = 30;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 767;
+    pstAeSnsDft->u32MinIntTime = 8;
+    
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 2;
+
+    /* 1(1+1/16), 1(1+2/16), ... , 2(1+1/16), ... , 16(1+15/16) */
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_DB;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 6;
+    pstAeSnsDft->u32MaxAgain = 6;  /* 1, 2, 4, 8, 16, 32, 64 (0~24db, unit is 6db) */
+    pstAeSnsDft->u32MinAgain = 0;
+    pstAeSnsDft->u32MaxAgainTarget = 4;
+    pstAeSnsDft->u32MinAgainTarget = 0;
+    
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.0625;
+    pstAeSnsDft->u32MaxDgain = 31;  /* 1 ~ 31/16, unit is 1/16 */
+    pstAeSnsDft->u32MinDgain = 16;
+    pstAeSnsDft->u32MaxDgainTarget = 31;
+    pstAeSnsDft->u32MinDgainTarget = 16; 
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
     return 0;
 }
 
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    switch(u8Fps)
+    {
+        case 30:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 767;
+            pstAeSnsDft->u32MaxIntTime = gu32FullLinesStd;
+            pstAeSnsDft->u32LinesPer500ms = gu32FullLinesStd * 30 / 2;
+            sensor_write_register(0x22, gu32FullLinesStd & 0xff);
+            sensor_write_register(0x23, (gu32FullLinesStd >> 8));
+        break;
+        
+        case 25:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = (30 * 767) / 25;
+            pstAeSnsDft->u32MaxIntTime = gu32FullLinesStd;
+            pstAeSnsDft->u32LinesPer500ms = gu32FullLinesStd * 25 / 2;
+            sensor_write_register(0x22, gu32FullLinesStd & 0xff);
+            sensor_write_register(0x23, (gu32FullLinesStd >> 8));
+        break;
+        
+        default:
+        break;
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    sensor_write_register(0x22, u16FullLines&0xff);
+    sensor_write_register(0x23, (u16FullLines >> 8));
+
+    pstAeSnsDft->u32MaxIntTime = u16FullLines - 2;
+    gu32FullLines = u16FullLines;
+
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_SOIH22_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+    static HI_BOOL bInit = HI_FALSE;
+
+    if (HI_FALSE == bInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_I2C_TYPE;
+        g_stSnsRegsInfo.u32RegNum = 4;
+        for (i=0; i<4; i++)
+        {
+            g_stSnsRegsInfo.astI2cData[i].u8DevAddr = sensor_i2c_addr;
+            g_stSnsRegsInfo.astI2cData[i].u32AddrByteNum = sensor_addr_byte;
+            g_stSnsRegsInfo.astI2cData[i].u32DataByteNum = sensor_data_byte;
+        }
+        g_stSnsRegsInfo.astI2cData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[0].u32RegAddr = 0x01;
+        g_stSnsRegsInfo.astI2cData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[1].u32RegAddr = 0x02;
+        g_stSnsRegsInfo.astI2cData[2].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[2].u32RegAddr = 0x00;
+        g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astI2cData[3].u32RegAddr = 0x0d;
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_TRUE;
+
+        bInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+#if CMOS_SOIH22_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[0].u32Data = u32IntTime & 0xFF;
+    g_stSnsRegsInfo.astI2cData[1].u32Data = (u32IntTime >> 8) & 0xFF;
+#else 
+    //refresh the sensor setting every frame to avoid defect pixel error
+    sensor_write_register(0x01, u32IntTime&0xFF);
+    sensor_write_register(0x02, (u32IntTime>>8)&0xFF);  
+#endif
+    return;
+}
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    HI_U8 u8High, u8Low, u8Dg;
+    switch (u32Again)
+    {
+        case 0 :    /* 0db, 1 multiplies */
+            u8High = 0x00;
+            u8Dg   = 0x00;
+            break;
+        case 1 :    /* 6db, 2 multiplies */
+            u8High = 0x10;
+            u8Dg   = 0x00;
+            break;
+        case 2 :    /* 12db, 4 multiplies */
+            u8High = 0x30;
+            u8Dg   = 0x00;
+            break;
+        case 3 :    /* 18db, 8 multiplies */
+            u8High = 0x70;
+            u8Dg   = 0x00;
+            break;
+        case 4 :    /* 24db, 16 multiplies */
+            u8High = 0xf0;
+            u8Dg   = 0x00;
+            break;
+        case 5 :    /* 30db, 32 multiplies */
+            u8High = 0xf0;
+            u8Dg   = 0x01;
+            break;
+        case 6 :    /* 36db, 64 multiplies */
+            u8High = 0xf0;
+            u8Dg   = 0x03;
+            break;
+        default:
+            u8High = 0x00;
+            u8Dg   = 0x00;
+            break;
+    }
+
+    u8Low = (u32Dgain - 16) & 0xf;
+
+#if CMOS_SOIH22_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astI2cData[2].u32Data = (u8High | u8Low);
+    g_stSnsRegsInfo.astI2cData[3].u32Data = u8Dg;
+    HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+#else
+    sensor_write_register(0x00, (u8High | u8Low));
+    sensor_write_register(0x0d, u8Dg);
+#endif
+
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+    
+    pstAwbSnsDft->u16WbRefTemp = 5048;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x152;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0X1ab;
+
+    pstAwbSnsDft->as32WbPara[0] = 139;
+    pstAwbSnsDft->as32WbPara[1] = -51;
+    pstAwbSnsDft->as32WbPara[2] = -167;
+    pstAwbSnsDft->as32WbPara[3] = 184226;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -136368;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(SOIH22_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, SOIH22_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, SOIH22_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(SOIH22_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, SOIH22_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, SOIH22_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -703,4 +633,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif /* End of #ifdef __cplusplus */
 
 
-#endif // __SOIH22_CMOS_H_
+#endif 

--- a/libraries/sensor/hi3516cv100/soi_h22/soih22_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/soi_h22/soih22_sensor_ctl.c
@@ -18,10 +18,10 @@
 #include "hi_i2c.h"
 #endif
 
-const unsigned int sensor_i2c_addr	=	0x60;		/* I2C Address of SOI H22 */
-//const unsigned int sensor_i2c_addr	=	0x6C;		/* I2C Address of SOI H22 */
-const unsigned int sensor_addr_byte	=	1;
-const unsigned int sensor_data_byte	=	1;
+const unsigned int sensor_i2c_addr    =    0x60;        /* I2C Address of SOI H22 */
+//const unsigned int sensor_i2c_addr    =    0x6C;        /* I2C Address of SOI H22 */
+const unsigned int sensor_addr_byte    =    1;
+const unsigned int sensor_data_byte    =    1;
 
 
 int sensor_read_register(int addr)
@@ -44,6 +44,7 @@ int sensor_read_register(int addr)
     if (ret)
     {
         printf("GPIO-I2C read faild!\n");
+        close(fd);
         return -1;
     }
     
@@ -55,7 +56,7 @@ int sensor_read_register(int addr)
     int fd = -1;
     int ret;
     I2C_DATA_S i2c_data;
-	
+    
     fd = open("/dev/hi_i2c", 0);
     if(fd<0)
     {
@@ -73,13 +74,14 @@ int sensor_read_register(int addr)
     if (ret)
     {
         printf("hi_i2c write faild!\n");
+        close(fd);
         return -1;
     }
 
     close(fd);
 #endif
-	
-	return i2c_data.data;
+    
+    return i2c_data.data;
 }
 
 int sensor_write_register(int addr, int data)
@@ -103,6 +105,7 @@ int sensor_write_register(int addr, int data)
     if (ret)
     {
         printf("GPIO-I2C write faild!\n");
+        close(fd);
         return -1;
     }
 
@@ -111,7 +114,7 @@ int sensor_write_register(int addr, int data)
     int fd = -1;
     int ret;
     I2C_DATA_S i2c_data;
-	
+    
     fd = open("/dev/hi_i2c", 0);
     if(fd<0)
     {
@@ -130,12 +133,13 @@ int sensor_write_register(int addr, int data)
     if (ret)
     {
         printf("hi_i2c write faild!\n");
+        close(fd);
         return -1;
     }
 
     close(fd);
 #endif
-	return 0;
+    return 0;
 }
 
 int sensor_write_register_bit(int addr, int data, int mask)
@@ -158,6 +162,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
     if (ret)
     {
         printf("GPIO-I2C read faild!\n");
+        close(fd);
         return -1;
     }
 
@@ -171,6 +176,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
     if (ret)
     {
         printf("GPIO-I2C write faild!\n");
+        close(fd);
         return -1;
     }
 
@@ -180,7 +186,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
     int ret;
     int value;
     I2C_DATA_S i2c_data;
-	
+    
     fd = open("/dev/hi_i2c", 0);
     if(fd<0)
     {
@@ -197,6 +203,7 @@ int sensor_write_register_bit(int addr, int data, int mask)
     if (ret)
     {
         printf("hi_i2c read faild!\n");
+        close(fd);
         return -1;
     }
 
@@ -210,12 +217,13 @@ int sensor_write_register_bit(int addr, int data, int mask)
     if (ret)
     {
         printf("hi_i2c write faild!\n");
+        close(fd);
         return -1;
     }
 
     close(fd);
 #endif
-	return 0;
+    return 0;
 }
 
 
@@ -242,57 +250,55 @@ void sensor_prog(int* rom)
         }
         else
         {
-			sensor_write_register(addr, data);
+            sensor_write_register(addr, data);
         }
     }
 }
 
 void sensor_init()
 {
+    sensor_write_register(0x0e, 0x1D);
+    sensor_write_register(0x0f, 0x0B);
+    sensor_write_register(0x10, 0x26);
+    sensor_write_register(0x11, 0x80);
+    sensor_write_register(0x1B, 0x4F);
+    sensor_write_register(0x1D, 0xFF);
 
-sensor_write_register(0x0e, 0x1D);
-sensor_write_register(0x0f, 0x0B);
-sensor_write_register(0x10, 0x26);
-sensor_write_register(0x11, 0x80);
-sensor_write_register(0x1B, 0x4F);
-sensor_write_register(0x1D, 0xFF);
+    sensor_write_register(0x1E, 0x9F);
+    sensor_write_register(0x20, 0x72);
+    sensor_write_register(0x21, 0x06);
+    sensor_write_register(0x22, 0xFF);
+    sensor_write_register(0x23, 0x02);
+    sensor_write_register(0x24, 0x00);
+    sensor_write_register(0x25, 0xE0);
+    sensor_write_register(0x26, 0x25);
+    sensor_write_register(0x27, 0xE9);
+    sensor_write_register(0x28, 0x0D);
+    sensor_write_register(0x29, 0x00);
+    sensor_write_register(0x2C, 0x00);
+    sensor_write_register(0x2D, 0x08);
+    sensor_write_register(0x2E, 0xC4);
+    sensor_write_register(0x2F, 0x20);
+    sensor_write_register(0x6C, 0x90);
+    sensor_write_register(0x2A, 0xD4);
+    sensor_write_register(0x30, 0x90);
+    sensor_write_register(0x31, 0x10);
+    sensor_write_register(0x32, 0x10);
+    sensor_write_register(0x33, 0x10);
+    sensor_write_register(0x34, 0x32);
+    sensor_write_register(0x14, 0x80);
+    sensor_write_register(0x18, 0xD5);
+    sensor_write_register(0x19, 0x10);
 
-sensor_write_register(0x1E, 0x9F);
-sensor_write_register(0x20, 0x72);
-sensor_write_register(0x21, 0x06);
-sensor_write_register(0x22, 0xFF);
-sensor_write_register(0x23, 0x02);
-sensor_write_register(0x24, 0x00);
-sensor_write_register(0x25, 0xE0);
-sensor_write_register(0x26, 0x25);
-sensor_write_register(0x27, 0xE9);
-sensor_write_register(0x28, 0x0D);
-sensor_write_register(0x29, 0x00);
-sensor_write_register(0x2C, 0x00);
-sensor_write_register(0x2D, 0x08);
-sensor_write_register(0x2E, 0xC4);
-sensor_write_register(0x2F, 0x20);
-sensor_write_register(0x6C, 0x90);
-sensor_write_register(0x2A, 0xD4);
-sensor_write_register(0x30, 0x90);
-sensor_write_register(0x31, 0x10);
-sensor_write_register(0x32, 0x10);
-sensor_write_register(0x33, 0x10);
-sensor_write_register(0x34, 0x32);
-sensor_write_register(0x14, 0x80);
-sensor_write_register(0x18, 0xD5);
-sensor_write_register(0x19, 0x10);
+    sensor_write_register(0x0d, 0x00);
+    sensor_write_register(0x1f, 0x00);
 
-sensor_write_register(0x0d, 0x00);
-sensor_write_register(0x1f, 0x00);
-
-sensor_write_register(0x13, 0x87);
-sensor_write_register(0x4A, 0x03);
-sensor_write_register(0x49, 0x06); 
-
-
-
-	return ;
+    sensor_write_register(0x13, 0x87);
+    sensor_write_register(0x4A, 0x03);
+    sensor_write_register(0x49, 0x06); 
+    
+    return ;
 }
+
 
 

--- a/libraries/sensor/hi3516cv100/soi_jxh42/Makefile
+++ b/libraries/sensor/hi3516cv100/soi_jxh42/Makefile
@@ -1,0 +1,18 @@
+LIB_NAME := libsns_jxh42
+
+override CFLAGS += -fPIC \
+	-I$(CURDIR)/../../../../kernel/include/hi3516cv100
+
+SRCS := $(wildcard *.c)
+OBJS := $(SRCS:%.c=%.o)
+
+all: $(LIB_NAME).so $(LIB_NAME).a
+
+$(LIB_NAME).so: $(OBJS)
+	$(CC) -shared -o $@ $(OBJS)
+
+$(LIB_NAME).a: $(OBJS)
+	$(AR) -rcs $(LIB_NAME).a $(OBJS)
+
+clean:
+	-rm -f $(OBJS) $(LIB_NAME).so $(LIB_NAME).a

--- a/libraries/sensor/hi3516cv100/soi_jxh42/jxh42_cmos.c
+++ b/libraries/sensor/hi3516cv100/soi_jxh42/jxh42_cmos.c
@@ -1,0 +1,589 @@
+#if !defined(__JXH42_CMOS_H_)
+#define __JXH42_CMOS_H_
+
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#include "hi_comm_sns.h"
+#include "hi_sns_ctrl.h"
+#include "mpi_isp.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
+#include "mpi_vpss.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#define FULL_LINES_DEFAULT 750
+
+#define JXH42_ID 42
+
+#define HIGH_8BITS(x) ((x & 0xff00) >> 8)
+#define LOW_8BITS(x) (x & 0x00ff)
+
+
+HI_U32 gu32FullLinesStd = FULL_LINES_DEFAULT;
+HI_U32 gu32FullLines = FULL_LINES_DEFAULT;
+
+HI_U8 gu8SensorMode = 0; // which WDR mode default?
+
+
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
+{
+    //fprintf(stderr, "DBG: cmos_set_wdr_mode(%d)\n", u8Mode);
+    if (u8Mode >= 2)
+    {
+        fprintf(stderr, "NO support for this mode!");
+    }
+    else
+    {
+        gu8SensorMode = u8Mode;
+    }
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    //fprintf(stderr, "DBG: cmos_get_ae_default(*)\n");
+    if (HI_NULL == pstAeSnsDft)
+    {
+        fprintf(stderr, "null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = FULL_LINES_DEFAULT;
+
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+
+    pstAeSnsDft->u8AeCompensation = 0x40;
+
+    pstAeSnsDft->u32LinesPer500ms = 11265; // FULL_LINES_DEFAULT * FPS30 / 2
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 747; // ??? FULL_LINES_DEFAULT - 1;
+    pstAeSnsDft->u32MinIntTime = 8;
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 2;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_DB;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 6.0;
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.0625;
+
+    pstAeSnsDft->u32MaxAgain = 3;
+    pstAeSnsDft->u32MinAgain = 0;
+    pstAeSnsDft->u32MaxDgain = 31;
+    pstAeSnsDft->u32MinDgain = 16;
+
+    pstAeSnsDft->u32MaxDgainTarget = 31;
+    pstAeSnsDft->u32MinDgainTarget = 16;
+    pstAeSnsDft->u32MaxAgainTarget = 3;
+    pstAeSnsDft->u32MinAgainTarget = 0;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 2 << pstAeSnsDft->u32ISPDgainShift; // 512
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift; // 256
+
+    return 0;
+}
+
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
+{
+    HI_S32  i;
+
+    if (HI_NULL == pstBlackLevel)
+    {
+        fprintf(stderr, "null pointer when get isp black level value!\n");
+        return -1;
+    }
+
+    //fprintf(stderr, "DBG: cmos_get_isp_black_level(*)\n");
+
+    pstBlackLevel->bUpdate = HI_FALSE;
+    pstBlackLevel->au16BlackLevel[0] = 0x14;
+    pstBlackLevel->au16BlackLevel[1] = 0x14;
+    pstBlackLevel->au16BlackLevel[2] = 0x14;
+    pstBlackLevel->au16BlackLevel[3] = 0x14;
+ 
+    return 0;
+}
+
+static unsigned old_gain_val = 0;
+
+unsigned int cmos_get_gaininfo()
+{
+    ISP_INNER_STATE_INFO_EX_S inf;
+    HI_MPI_ISP_QueryInnerStateInfoEx(&inf);
+//    fprintf(stderr, "\tu32AnalogGain, u32ISPDigitalGain = %u, %u\n", inf.u32AnalogGain, inf.u32ISPDigitalGain);
+    unsigned gain_val = (inf.u32AnalogGain * inf.u32ISPDigitalGain) >> 20;
+
+    if (old_gain_val == gain_val) return 0;
+
+    old_gain_val = gain_val;
+
+    return gain_val;
+}
+
+void cmos_Set_DPC(HI_U16 pxThresh, HI_U16 pxSlope)
+{
+    ISP_DP_ATTR_S dp;
+
+    HI_MPI_ISP_GetDefectPixelAttr(&dp);
+    dp.bEnableDynamic = HI_TRUE;
+    dp.u16DynamicBadPixelThresh = pxThresh;
+    dp.u16DynamicBadPixelSlope = pxSlope;
+    HI_MPI_ISP_SetDefectPixelAttr(&dp);
+}
+
+void cmos_Set_DRC(HI_BOOL en, HI_BOOL manual, HI_U32 strength_target)
+{
+    ISP_DRC_ATTR_S drc;
+
+    HI_MPI_ISP_GetDRCAttr(&drc);
+    drc.bDRCEnable = en;
+    drc.bDRCManualEnable = manual;
+    drc.u32StrengthTarget = strength_target;
+    HI_MPI_ISP_SetDRCAttr(&drc);
+}
+
+void cmos_set_3Ddenoise(HI_U32 sf, HI_U32 tf, HI_U32 chroma)
+{
+    VPSS_GRP_PARAM_S grp_param;
+
+    HI_MPI_VPSS_GetGrpParam(0, &grp_param);
+    grp_param.u32SfStrength = sf;
+    grp_param.u32TfStrength = tf;
+    grp_param.u32ChromaRange = chroma;
+    HI_MPI_VPSS_SetGrpParam(0, &grp_param);
+}
+
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+    unsigned gaininfo = cmos_get_gaininfo();
+    if (gaininfo)
+    {
+        //fprintf(stderr, "\tgaininfo = %u\n", gaininfo);
+        cmos_Set_DPC(40 - gaininfo, 38 * gaininfo + 1111);
+
+        if (gaininfo <= 2)
+        {
+            cmos_Set_DRC(HI_TRUE, HI_TRUE, 64);
+            cmos_set_3Ddenoise(28, 7, 60);
+        }
+        else if (gaininfo <= 4)
+        {
+            cmos_Set_DRC(HI_TRUE, HI_TRUE, 48);
+            cmos_set_3Ddenoise(32, 8, 80);
+        }
+        else if (gaininfo <= 6)
+        {
+            cmos_Set_DRC(HI_TRUE, HI_TRUE, 32);
+            cmos_set_3Ddenoise(36, 9, 100);
+        }
+        else if (gaininfo <= 8)
+        {
+            cmos_Set_DRC(HI_TRUE, HI_TRUE, 16);
+            cmos_set_3Ddenoise(40, 10, 120);
+        }
+        else if (gaininfo > 12)
+        {
+            cmos_Set_DRC(HI_FALSE, HI_FALSE, 0);
+            cmos_set_3Ddenoise(60, 12, 160);
+        }
+        else // 9...11
+        {
+            cmos_Set_DRC(HI_TRUE, HI_TRUE, 8);
+            cmos_set_3Ddenoise(50, 11, 140);
+        }
+    }
+
+    //fprintf(stderr, "DBG: set explosure to %u\n", u32IntTime);
+    unsigned explosure = u32IntTime;
+    sensor_write_register(0x1, explosure & 0xFF);
+    sensor_write_register(0x2, (explosure >> 8) & 0xFF);
+}
+
+static unsigned char additional_gain_vals[4] = { 0, 0x10, 0x20, 0x30 };
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    //fprintf(stderr, "DBG: cmos_gains_update(%u, %u)\n", u32Again, u32Dgain);
+    // TODO large work
+    unsigned char new_gain_value = u32Dgain & 0xF;
+    if (u32Again <= 3)
+    {
+        new_gain_value |= additional_gain_vals[u32Again];
+    }
+    //fprintf(stderr, "DBG: podsovyvaem 0x%u gain\n", new_gain_value);
+    sensor_write_register(0x0, new_gain_value);
+}
+
+void sensor_global_init()
+{
+    gu8SensorMode = 0;
+}
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
+{
+    /* bvalid */
+    1,
+
+    //nosie_profile_weight_lut
+   {
+        0x19, 0x20, 0x24, 0x27, 0x29, 0x2B, 0x2D, 0x2E, 0x2F, 0x31, 0x32, 0x33, 0x34, 0x34, 0x35, 0x36,
+        0x37, 0x37, 0x38, 0x38, 0x39, 0x3A, 0x3A, 0x3B, 0x3B, 0x3B, 0x3C, 0x3C, 0x3D, 0x3D, 0x3D, 0x3E,
+        0x3E, 0x3E, 0x3F, 0x3F, 0x3F, 0x40, 0x40, 0x40, 0x41, 0x41, 0x41, 0x41, 0x42, 0x42, 0x42, 0x42,
+        0x43, 0x43, 0x43, 0x43, 0x44, 0x44, 0x44, 0x44, 0x44, 0x45, 0x45, 0x45, 0x45, 0x45, 0x46, 0x46,
+        0x46, 0x46, 0x46, 0x46, 0x47, 0x47, 0x47, 0x47, 0x47, 0x47, 0x48, 0x48, 0x48, 0x48, 0x48, 0x48,
+        0x48, 0x49, 0x49, 0x49, 0x49, 0x49, 0x49, 0x49, 0x4A, 0x4A, 0x4A, 0x4A, 0x4A, 0x4A, 0x4A, 0x4A,
+        0x4A, 0x4B, 0x4B, 0x4B, 0x4B, 0x4B, 0x4B, 0x4B, 0x4B, 0x4C, 0x4C, 0x4C, 0x4C, 0x4C, 0x4C, 0x4C,
+        0x4C, 0x4C, 0x4C, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4E, 0x4E, 0x4E
+   },
+
+    //demosaic_weight_lut
+   {
+        0x19, 0x20, 0x24, 0x27, 0x29, 0x2B, 0x2D, 0x2E, 0x2F, 0x31, 0x32, 0x33, 0x34, 0x34, 0x35, 0x36,
+        0x37, 0x37, 0x38, 0x38, 0x39, 0x3A, 0x3A, 0x3B, 0x3B, 0x3B, 0x3C, 0x3C, 0x3D, 0x3D, 0x3D, 0x3E,
+        0x3E, 0x3E, 0x3F, 0x3F, 0x3F, 0x40, 0x40, 0x40, 0x41, 0x41, 0x41, 0x41, 0x42, 0x42, 0x42, 0x42,
+        0x43, 0x43, 0x43, 0x43, 0x44, 0x44, 0x44, 0x44, 0x44, 0x45, 0x45, 0x45, 0x45, 0x45, 0x46, 0x46,
+        0x46, 0x46, 0x46, 0x46, 0x47, 0x47, 0x47, 0x47, 0x47, 0x47, 0x48, 0x48, 0x48, 0x48, 0x48, 0x48,
+        0x48, 0x49, 0x49, 0x49, 0x49, 0x49, 0x49, 0x49, 0x4A, 0x4A, 0x4A, 0x4A, 0x4A, 0x4A, 0x4A, 0x4A,
+        0x4A, 0x4B, 0x4B, 0x4B, 0x4B, 0x4B, 0x4B, 0x4B, 0x4B, 0x4C, 0x4C, 0x4C, 0x4C, 0x4C, 0x4C, 0x4C,
+        0x4C, 0x4C, 0x4C, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4D, 0x4E, 0x4E, 0x4E
+   }
+
+};
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
+{
+    /* bvalid */
+    1,
+
+    /* sharpen_alt_d */
+   {0x48, 0x40, 0x38, 0x30, 0x28, 0x20, 0x18, 0x10},
+
+    /* sharpen_alt_ud */
+   {0xb0, 0xa0, 0x90, 0x80, 0x70, 0x60, 0x50, 0x40},
+
+    /* snr_thresh    */
+   {0x01, 0x09, 0x13, 0x1e, 0x28, 0x32, 0x3c, 0x46},
+
+    /*  demosaic_lum_thresh   */
+   {0x40,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
+
+    /* demosaic_np_offset   */
+   {0x02, 0x08, 0x12, 0x1a, 0x20, 0x28, 0x30, 0x30},
+
+    /* ge_strength    */
+   {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
+};
+
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
+{
+    /* bvalid */
+    1,
+
+    /*vh_slope*/
+    0xFF,
+
+    /*aa_slope*/
+    0xE4,
+
+    /*va_slope*/
+    0xEC,
+
+    /*uu_slope*/
+    0x9F,
+
+    /*sat_slope*/
+    0x5D,
+
+    /*ac_slope*/
+    0xCF,
+
+    /*vh_thresh*/
+    0x138,
+
+    /*aa_thresh*/
+    0xBA,
+
+    /*va_thresh*/
+    0xDA,
+
+    /*uu_thresh*/
+    0x148,
+
+    /*sat_thresh*/
+    0x171,
+
+    /*ac_thresh*/
+    0x1b3,
+};
+
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
+{
+    fprintf(stderr, "DNG: cmos_set_pixel_detect(%s)\n", bEnable ? "TRUE" : "FALSE");
+}
+
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        fprintf(stderr, "null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
+    return 0;
+}
+
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
+{   
+    if (HI_NULL == pstDef)
+    {
+        fprintf(stderr, "null pointer when get isp default value!\n");
+        return -1;
+    }
+
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
+
+    pstDef->stComm.u8Rggb = 3;
+    pstDef->stComm.u8BalanceFe = 1;
+
+    pstDef->stDenoise.u8SinterThresh = 21;
+    pstDef->stDenoise.u8NoiseProfile = 0;
+    pstDef->stDenoise.u16Nr0 = 0;
+    pstDef->stDenoise.u16Nr1 = 0;
+
+    pstDef->stDrc.u8DrcBlack = 0;
+    pstDef->stDrc.u8DrcVs = 4;
+    pstDef->stDrc.u8DrcVi = 8;
+    pstDef->stDrc.u8DrcSm = -96;
+    pstDef->stDrc.u16DrcWl = 1279;
+
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+}
+
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+void cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    //fprintf(stderr, "DBG: cmos_fps_set(u8Fps = %u)\n", u8Fps);
+    int full_lines; // r0
+
+    full_lines = 22530 / u8Fps;
+    gu32FullLinesStd = full_lines;
+    pstAeSnsDft->u32FullLinesStd = full_lines;
+    pstAeSnsDft->u32MaxIntTime = full_lines - 2;
+    pstAeSnsDft->u32LinesPer500ms = (unsigned int)(full_lines * u8Fps) >> 1;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    //fprintf(stderr, "DBG: cmos_slow_framerate_set(u16FullLines = %u)\n", u16FullLines);
+    HI_U16 full_lines = u16FullLines;
+    if (full_lines > 2253) full_lines = 2253;
+
+    gu32FullLines = full_lines;
+    sensor_write_register(0x22, LOW_8BITS(gu32FullLines));
+    sensor_write_register(0x23, HIGH_8BITS(gu32FullLines));
+
+    pstAeSnsDft->u32MaxIntTime = gu32FullLines - 2;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+
+    return 0;
+}
+
+static AWB_CCM_S g_stAwbCcm =
+{
+    4930,
+    {
+        0x1A3, 0x8073, 0x8030,
+        0x8042, 0x1C5, 0x8083, 
+        0x8007, 0x80A6, 0x1AD,
+    },
+    3885,
+    {
+        0x1FB, 0x80D4, 0x8027,
+        0x8058, 0x1B4, 0x805C, 
+        0x8005, 0x80C0, 0x1C5, 
+    },
+    2790,
+    {
+        0x1A8, 0x805B, 0x804D,
+        0x8072, 0x19D, 0x802B,
+        0x80B3, 0x8366, 0x519,
+    }
+
+};
+
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
+{
+    /* bvalid */
+    1,
+
+    /* saturation */
+    {0x80,0x78,0x70,0x68,0x60,0x58,0x50,0x48}
+};
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    //fprintf(stderr, "DBG: cmos_get_awb_default(*)\n");
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        fprintf(stderr, "null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 4930;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x1d2;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x199;
+
+    pstAwbSnsDft->as32WbPara[0] = 99;
+    pstAwbSnsDft->as32WbPara[1] = 47;
+    pstAwbSnsDft->as32WbPara[2] = -110;
+    pstAwbSnsDft->as32WbPara[3] = 152677;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -104036;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(JXH42_ID, &stIspRegister);
+    if (s32Ret)
+    {   
+        fprintf(stderr, "sensor register callback function failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, JXH42_ID, &stAeRegister);
+    if (s32Ret)
+    {   
+        fprintf(stderr, "sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, JXH42_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        fprintf(stderr, "sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    return 0;
+}
+    
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(JXH42_ID);
+    if (s32Ret)
+    {
+        fprintf(stderr, "sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, JXH42_ID);
+    if (s32Ret)
+    {
+        fprintf(stderr, "sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, JXH42_ID);
+    if (s32Ret)
+    {
+        fprintf(stderr, "sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    return 0;
+}
+
+
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#endif
+
+

--- a/libraries/sensor/hi3516cv100/soi_jxh42/jxh42_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/soi_jxh42/jxh42_sensor_ctl.c
@@ -1,0 +1,104 @@
+#include <stdio.h>
+// #include <sys/types.h>
+// #include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "hi_i2c.h"
+
+int sensor_write_register(int addr, int data)
+{
+    int fd = open("/dev/hi_i2c", 0);
+    if (fd < 0)
+    {
+        fprintf(stderr, "Open /dev/hi_i2c error!");
+        return -1;
+    }
+
+    I2C_DATA_S i2c_data;    
+    i2c_data.data = data;
+    i2c_data.dev_addr = 0x60;
+    i2c_data.reg_addr = addr;
+    i2c_data.addr_byte_num = 1;
+    i2c_data.data_byte_num = 1;
+
+    //fprintf(stderr, "DBG: sensor_write_register(0x%x, 0x%x)\n", i2c_data.reg_addr, i2c_data.data);
+
+    int ret = ioctl(fd, CMD_I2C_WRITE, &i2c_data);    
+    if (ret)
+    {
+        fprintf(stderr, "\tERROR write!\n");
+    }
+
+    close(fd);
+
+    return ret;
+}
+
+void sensor_init()
+{
+    sensor_write_register(0x12, 0x40);
+    sensor_write_register(0xD, 0x40);
+    sensor_write_register(0x1F, 4);
+    sensor_write_register(0xE, 0x1D);
+    sensor_write_register(0xF, 9);
+    sensor_write_register(0x10, 0x1E);
+    sensor_write_register(0x11, 0x80);
+    sensor_write_register(0x20, 0x40);
+    sensor_write_register(0x21, 6);
+    sensor_write_register(0x22, 0xF0);
+    sensor_write_register(0x23, 2);
+    sensor_write_register(0x24, 0);
+    sensor_write_register(0x25, 0xDC);
+    sensor_write_register(0x26, 0x25);
+    sensor_write_register(0x27, 0x3B);
+    sensor_write_register(0x28, 9);
+    sensor_write_register(0x29, 1);
+    sensor_write_register(0x2A, 0x24);
+    sensor_write_register(0x2B, 0x29);
+    sensor_write_register(0x2C, 4);
+    sensor_write_register(0x2D, 0);
+    sensor_write_register(0x2E, 0xBB);
+    sensor_write_register(0x2F, 0);
+    sensor_write_register(0x30, 0x92);
+    sensor_write_register(0x31, 0xA);
+    sensor_write_register(0x32, 0xAA);
+    sensor_write_register(0x33, 0x14);
+    sensor_write_register(0x34, 0x38);
+    sensor_write_register(0x35, 0x54);
+    sensor_write_register(0x42, 0x41);
+    sensor_write_register(0x43, 0x50);
+    sensor_write_register(0x1D, 0xFF);
+    sensor_write_register(0x1E, 0x9F);
+    sensor_write_register(0x6C, 0x90);
+    sensor_write_register(0x73, 0xB3);
+    sensor_write_register(0x70, 0x68);
+    sensor_write_register(0x76, 0x40);
+    sensor_write_register(0x77, 6);
+    sensor_write_register(0x60, 0xA4);
+    sensor_write_register(0x61, 0xFF);
+    sensor_write_register(0x62, 0x40);
+    sensor_write_register(0x63, 0x51);
+    sensor_write_register(0x65, 0);
+    sensor_write_register(0x66, 0x20);
+    sensor_write_register(0x67, 0x30);
+    sensor_write_register(0x68, 4);
+    sensor_write_register(0x69, 0x74);
+    sensor_write_register(0x6A, 9);
+    sensor_write_register(0x6F, 4);
+    sensor_write_register(0x13, 0x87);
+    sensor_write_register(0x14, 0x80);
+    sensor_write_register(0x16, 0xC0);
+    sensor_write_register(0x17, 0x40);
+    sensor_write_register(0x18, 0xE1);
+    sensor_write_register(0x38, 0x38);
+    sensor_write_register(0x39, 0x92);
+    sensor_write_register(0x4A, 3);
+    sensor_write_register(0x48, 0x40);
+    sensor_write_register(0x49, 4);
+    sensor_write_register(0xD, 0x40);
+    sensor_write_register(0x12, 0);
+    puts("soih42 sensor 720p init success!");
+}
+

--- a/libraries/sensor/hi3516cv100/sony_icx692/icx692_cmos.c
+++ b/libraries/sensor/hi3516cv100/sony_icx692/icx692_cmos.c
@@ -2,14 +2,14 @@
 #define __SONY_ICX692_H_
 
 #include <stdio.h>
-#include <unistd.h>		// usleep
 #include <string.h>
-
 #include "hi_comm_sns.h"
+#include "hi_comm_isp.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_comm_isp.h"
-
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -17,102 +17,84 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
+#define ICX692_ID 692
 
+/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker */
+/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance   */
+/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                     */
+#define CMOS_ICX692_ISP_WRITE_SENSOR_ENABLE (0)
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
-#define CMOS_ICX692_ISP_WRITE_SENSOR_ENABLE (0)
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
+HI_U32 gu32FullLinesStd = 748;
 HI_U8 gu8SensorMode = 0;
 
-static cmos_isp_default_t st_coms_isp_default =
+#if CMOS_ICX692_ISP_WRITE_SENSOR_ENABLE
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
+static HI_BOOL gsbRegInit = HI_FALSE;
+#endif
+
+static AWB_CCM_S g_stAwbCcm =
 {
-    // color correction matrix
-    {
-        5000,
-    	{	0x1e5,  0x80ba, 0x802b,
-    		0x8024, 0x0183, 0x805e,
-    		0x0021, 0x80ac, 0x018a
-    	},
-    	3200,
-        {
-            0x0241, 0x80c5, 0x807c,
-            0x802c, 0x016f, 0x8043,
-            0x003d, 0x80ee, 0x01b0
-        },
-        2600,
-        {
-            0x0245, 0x80ce, 0x8077,
-            0x802c, 0x0150, 0x8024,
-            0x54  , 0x820a, 0x02b6
-        }
-    },
-
-	// black level for R, Gr, Gb, B channels
-	{0xf,0xf,0xf,0xf},
-
-    // calibration reference color temperature
     5000,
-
-    //WB gain at 5000K, must keep consistent with calibration color temperature
-	{0x176, 0x100, 0x100, 0x1f1},
-
-    // WB curve parameters, must keep consistent with reference color temperature.
-	{33, 113, -110, 186795, 0x80, -138463},
-
-	// hist_thresh
-	{0xd,0x28,0x60,0x80},
-
-	0x00,	// iridix_balck
-	0x1,	// rggb
-
-	// gain
-	0x8,	0x40,
-
-	// iridix space, intensity, slope_max, white level
-	0x02,	0x08,	0x80, 	0x8ff,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x20, 	// sinter threshold
-
-	0x1,        //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
-	0,
-	1528,
-
-    1
+	{	0x1e5,  0x80ba, 0x802b,
+		0x8024, 0x0183, 0x805e,
+		0x0021, 0x80ac, 0x018a
+	},
+	3200,
+    {
+        0x0241, 0x80c5, 0x807c,
+        0x802c, 0x016f, 0x8043,
+        0x003d, 0x80ee, 0x01b0
+    },
+    2600,
+    {
+        0x0245, 0x80ce, 0x8077,
+        0x802c, 0x0150, 0x8024,
+        0x54  , 0x820a, 0x02b6
+    }
 };
 
-
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
-    //sharpen_alt_d
-    {0x50,0x45,0x40,0x38,0x34,0x30,0x28,0x28},
-
-    //sharpen_alt_ud
-    {0x3b,0x38,0x34,0x30,0x2b,0x28,0x24,0x20},
-
-    //snr_thresh
-    {0x23,0x2c,0x34,0x3e,0x46,0x4e,0x54,0x54},
-
-    //demosaic_lum_thresh
-    {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
-
-    //demosaic_np_offset
-    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
+    /* bvalid */
+    1,
 
     /* saturation */
     {0x80,0x80,0x6C,0x48,0x44,0x40,0x3C,0x38}
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
 {
-  //nosie_profile_weight_lut
+    /* bvalid */
+    1,
+
+    /* sharpen_alt_d */
+    {0x50,0x45,0x40,0x38,0x34,0x30,0x28,0x28},
+        
+    /* sharpen_alt_ud */
+    {0x3b,0x38,0x34,0x30,0x2b,0x28,0x24,0x20},
+        
+    /* snr_thresh */
+    {0x23,0x2c,0x34,0x3e,0x46,0x4e,0x54,0x54},
+        
+    /* demosaic_lum_thresh */
+    {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
+        
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
+};
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
+{
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {0,  0,  0,  0,  0,  0,  11, 15, 17, 19, 20, 21, 22, 22, 23, 24,
     25, 25, 26, 26, 26, 27, 27, 27, 28, 28, 28, 29, 29, 29, 29, 29,
     30, 30, 30, 30, 30, 31, 31, 31, 31, 31, 32, 32, 32, 32, 32, 32,
@@ -122,7 +104,7 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 38, 38,
     38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38, 38},
 
-  //demosaic_weight_lut
+    /* demosaic_weight_lut */
     {0,11,15,17,19,20,21,22,23,23,24,25,25,26,26,26,
     27,27,27,28,28,28,29,29,29,29,29,30,30,30,30,30,
     31,31,31,31,31,32,32,32,32,32,32,32,33,33,33,33,
@@ -133,295 +115,252 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38}
 };
 
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-	cmos_inttime.full_lines_std_30fps = 748;
-	cmos_inttime.full_lines_std_25fps = 748;
-	cmos_inttime.full_lines_std = 748;
-	cmos_inttime.full_lines = 748;
-	cmos_inttime.max_lines_target = 746;
+    if (HI_NULL == pstDef)
+    {
+        printf("null pointer when get isp default value!\n");
+        return -1;
+    }
 
-	cmos_inttime.full_lines_limit = 65535;
-	cmos_inttime.min_lines_target = 1;
-	cmos_inttime.vblanking_lines = 748;
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
 
-	cmos_inttime.exposure_ashort = 0;
+    pstDef->stComm.u8Rggb           = 0x1;      //1: rggb  
+    pstDef->stComm.u8BalanceFe      = 0x1;
 
-	cmos_inttime.lines_per_500ms = cmos_inttime.full_lines_std_30fps*30/2;
-	cmos_inttime.flicker_freq = 0;//60*256;//50*256;
+    pstDef->stDenoise.u8SinterThresh= 0x20;
+    pstDef->stDenoise.u8NoiseProfile= 0x1;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 1528;
 
-	return &cmos_inttime;
+    pstDef->stDrc.u8DrcBlack        = 0x00;
+    pstDef->stDrc.u8DrcVs           = 0x02;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0x80;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x8ff;    // white level
+
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+
+    return 0;
 }
 
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-
-    HI_U32 eshort = p_inttime->exposure_ashort;
-
-    HI_U32 exp_frames;
-   
-	exp_frames = eshort / p_inttime->full_lines_std;
-
-	eshort = eshort - exp_frames * p_inttime->full_lines_std;
-	eshort = p_inttime->full_lines_std - eshort;
-
-     
-#if CMOS_ICX692_ISP_WRITE_SENSOR_ENABLE
+    HI_S32  i;
     
-            ISP_SSP_DATA_S stSspData;
-    
-            stSspData.bDelayCfg = HI_FALSE;
-            stSspData.u32DevAddr = 0;
-            stSspData.u32DevAddrByteNum = 0;
-            stSspData.u32RegAddr = 0x7c14;
-            stSspData.u32RegAddrByteNum= 2;
-            stSspData.u32Data = (eshort&0xffff);
-            stSspData.u32DataByteNum = 2;
+    if (HI_NULL == pstBlackLevel)
+    {
+        printf("null pointer when get isp black level value!\n");
+        return -1;
+    }
+
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
             
-            HI_MPI_ISP_SSPWrite(&stSspData);
-           
-#else
+    for (i=0; i<4; i++)
+    {
+        pstBlackLevel->au16BlackLevel[i] = 0xf;
+    }
 
-
-
-   
-
-//	sensor_write_register(0x7c13, (eshort&0xffff));  //SUB Start lines
-	sensor_write_register(0x7c14, (eshort&0xffff));  //SUB End lines,only one sub pulse .
-	/*
-	sensor_write_register(0x7D03, 0x4);  			//Primary field counter enable,bit[2]
-	sensor_write_register(0x7C7C, ((exp_frames+1)&0x1fff));  //SGMASK_NUM,bit[12~0]
-	sensor_write_register(0x7C7D, ((exp_frames+1)&0x1fff));  //SUBCKMASK_NUM,bit[12~0]
-	sensor_write_register(0x7C7B, 0xA);  			//SUBCK_MASK_SKIP1,bit[1]
-	*/
-	
-#endif
-
+    return 0;    
 }
 
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
+    if (bEnable) /* setup for ISP pixel calibration mode */
+    {
+        sensor_write_register(0xC001, 0x4);
+        sensor_write_register(0xC002, 0x0);
+        sensor_write_register(0x407e, 0x1194);
+    }
+    else /* setup for ISP 'normal mode' */
+    {
+        sensor_write_register(0x407e,0x2EA);
+    }
+
+    return;
+}
+
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
+{
+    switch(u8Mode)
+    {
+        //sensor mode 0
+        case 0:
+            gu8SensorMode = 0;
+            // TODO:
+        break;
+        //sensor mode 1
+        case 1:
+            gu8SensorMode = 1;
+             // TODO:
+        break;
+
+        default:
+            printf("NOT support this mode!\n");
+            return;
+        break;
+    }
     
-    int    _fulllines = p_inttime->full_lines;
-
-    _fulllines = _fulllines - 4;
-        
-    sensor_write_register(0x407e, _fulllines);
-
-	return;
-
+    return;
 }
 
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
 {
-	if (p_inttime->exposure_ashort >= p_inttime->full_lines - 3)
-	{
-		p_inttime->exposure_ashort = p_inttime->full_lines - 3;
-	}
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
 
-	p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std;
+    gu32FullLinesStd = 748;
+    
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32LinesPer500ms = 748*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
 
-	return p_inttime->exposure_ashort;
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 746;
+    pstAeSnsDft->u32MinIntTime = 1;    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 1;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_DB;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 3;    
+    pstAeSnsDft->u32MaxAgain = 6;  /* 18db / 3db = 6 */
+    pstAeSnsDft->u32MinAgain = 4;
+    pstAeSnsDft->u32MaxAgainTarget = 6;
+    pstAeSnsDft->u32MinAgainTarget = 4;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.035;    
+    pstAeSnsDft->u32MaxDgain = 62921;  /* 36db / 0.035db = 1028 */
+    pstAeSnsDft->u32MinDgain = 1024;
+    pstAeSnsDft->u32MaxDgainTarget = 62921;
+    pstAeSnsDft->u32MinDgainTarget = 1024;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
+    return 0;
 }
 
-extern void sensor_init_exit(int fps);
 
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
 {
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
 
-   switch(fps)
-	{
-		case 30:
-			p_inttime->full_lines_std = 750;
-			p_inttime->lines_per_500ms = 750 * 30 / 2;
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    switch(u8Fps)
+    {
+        case 30:
+            gu32FullLinesStd = 750;
+            pstAeSnsDft->u32MaxIntTime = 748;
+            pstAeSnsDft->u32LinesPer500ms = 750 * 30 / 2;
 		   sensor_write_register(0x407e, 746);
-		break;
-
-		case 25:
-			p_inttime->full_lines_std = 900;
-			p_inttime->lines_per_500ms = 900 * 25 / 2;
+        break;        
+        case 25:
+            gu32FullLinesStd = 900;
+            pstAeSnsDft->u32MaxIntTime = 898;
+            pstAeSnsDft->u32LinesPer500ms = 900 * 25 / 2;
 			sensor_write_register(0x407e, 896);
-		break;
+        break;        
+        default:
+        break;
+    }
 
-		default:
-		break;
-	}
-   
-   return;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+
+    return;
 }
 
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
 {
-	cmos_gains.max_again = 0x8;
-	cmos_gains.max_dgain = 62921;
-    cmos_gains.min_again_target = 0x2;
-
-	cmos_gains.again_shift = 0;
-	cmos_gains.dgain_shift = 10;
-	cmos_gains.dgain_fine = 0;
-
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_TRUE;
-
-	return &cmos_gains;
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-    HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-    HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _isp_dgain = p_gains->isp_dgain== 0 ? 1 : p_gains->isp_dgain;
-
-    p_gains->iso =  ((HI_U64)_again * _dgain *_isp_dgain * 100)
-        >> (p_gains->again_shift + p_gains->dgain_shift + p_gains->isp_dgain_shift); 
     
-    return p_gains->iso;
+    pstAeSnsDft->u32MaxIntTime = u16FullLines - 3;
+
+    sensor_write_register(0x407e, u16FullLines - 4);
+    
+    return;
 }
 
-
-/*
- * This function applies the digital gain
- * input and output offset and correction
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
+static HI_VOID cmos_init_regs_info(HI_VOID)
 {
 #if CMOS_ICX692_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
 
-    ISP_SSP_DATA_S stSspData;
-
-    stSspData.bDelayCfg = HI_TRUE;
-    stSspData.u32DevAddr = 0;
-    stSspData.u32DevAddrByteNum = 0;
-    stSspData.u32RegAddr = 0xC001;
-    stSspData.u32RegAddrByteNum= 2;
-    stSspData.u32Data = (p_gains->again_db/3);
-    stSspData.u32DataByteNum = 2;
-
-    HI_MPI_ISP_SSPWrite(&stSspData);
-
-    stSspData.u32RegAddr = 0xC002;
-    stSspData.u32Data = (p_gains->dgain_db & 0x3ff);
-
-    stSspData.u32DataByteNum = 2;
-    HI_MPI_ISP_SSPWrite(&stSspData);
-        
-#else
-
-    switch (p_gains->again_db)
+    if (HI_FALSE == gsbRegInit)
     {
-    case 0:
-        sensor_write_register(0xC001, 0x0);
-    break;
-
-    case 3:
-        sensor_write_register(0xC001, 0x1);
-        break;
-
-    case 6:
-        sensor_write_register(0xC001, 0x2);
-        break;
-
-    case 9:
-        sensor_write_register(0xC001, 0x3);
-        break;
-
-    case 12:
-        sensor_write_register(0xC001, 0x4);
-        break;
-
-    case 15:
-        sensor_write_register(0xC001, 0x5);
-        break;
-
-    case 18:
-        sensor_write_register(0xC001, 0x6);
-        break;
-
-    default:
-        break;
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_SSP_TYPE;
+        g_stSnsRegsInfo.u32RegNum = 3;
+        for (i=0; i<3; i++)
+        {
+            g_stSnsRegsInfo.astSspData[i].u32DevAddr = 0x00;
+            g_stSnsRegsInfo.astSspData[i].u32DevAddrByteNum = 0;
+            g_stSnsRegsInfo.astSspData[i].u32RegAddrByteNum = 2;
+            g_stSnsRegsInfo.astSspData[i].u32DataByteNum = 2;
+        }
+        g_stSnsRegsInfo.astSspData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[0].u32RegAddr = 0x7c14;
+        g_stSnsRegsInfo.astSspData[1].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astSspData[1].u32RegAddr = 0xC001;
+        g_stSnsRegsInfo.astSspData[2].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astSspData[2].u32RegAddr = 0xC002;
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_TRUE;
+        gsbRegInit = HI_TRUE;
     }
-
-    //set the dgain
-    sensor_write_register(0xC002, (p_gains->dgain_db & 0x3ff));
-
-    //printf("again = %d,dgain = %d\n",p_gains->again_db,p_gains->dgain_db);
 #endif
-
+    return;
 }
 
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline HI_U16 cmos_gains_update2(cmos_gains_const_ptr_t p_gains)
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
 {
-	return 0;
+    HI_U32 u32Tmp = u32IntTime;
+	HI_U32 u32IntFrames = u32Tmp / gu32FullLinesStd;
+
+	u32Tmp = u32Tmp - u32IntFrames * gu32FullLinesStd;
+	u32Tmp = gu32FullLinesStd - u32Tmp;
+
+#if CMOS_ICX692_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astSspData[0].u32Data = (u32Tmp & 0xffff);
+#else
+	//sensor_write_register(0x7c13, (u32Tmp & 0xffff));  //SUB Start lines
+	sensor_write_register(0x7c14, (u32Tmp & 0xffff));  //SUB End lines,only one sub pulse .
+#endif
+    return;
 }
 
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-		cmos_gains_ptr_t p_gains,
-		HI_U32 exposure,
-		HI_U32 exposure_max,
-		HI_U32 exposure_shift)
+static HI_U32 digital_gain_table[1023]=
 {
-	int _i;
-	HI_U32 _again_db = 12;
-	HI_U32 exposure1,exposure0;
-	int shft = 0;
-
-	// normalize
-	while (exposure > (1<<22))
-	{
-		exposure >>= 1;
-		exposure_max >>= 1;
-		++shft;
-	}
-    
-	exposure0 = exposure>>2;
-        
-
-	   /* again unit: 3db */
-
-	for(_i = 4; _i <6 ; _i++)
-	{
-		exposure1 = (exposure0*725) >> 10;
-		if((exposure1 <= 2*exposure_max)|| exposure_max == 0 )
-			break;
-       
-		_again_db = _again_db +3;
-		exposure0 = exposure1;
-
-	}
-    if(exposure0 <=64)
-    {
-     exposure0 = 64;
-    }
-    
-	p_gains->again = (exposure << p_gains->again_shift) / exposure0;
-	p_gains->again_db = _again_db;
-
-	return (exposure0 << shft);
-}
-
-static HI_U32 digital_gain_table[1023] = {
  1024,   1028,   1032,   1036,   1040,   1044,   1049,   1053,   1057,   1061,   1066,   1070,   1074,   1079,  1083,   1087, 
  1092,   1096,   1101,   1105,   1109,   1114,   1118,   1123,   1127,   1132,   1137,   1141,   1146,   1150,  1155,   1160, 
  1164,   1169,   1174,   1179,   1183,   1188,   1193,   1198,   1203,   1207,   1212,   1217,   1222,   1227,  1232,   1237, 
@@ -489,252 +428,210 @@ static HI_U32 digital_gain_table[1023] = {
 
 };
 
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-                   cmos_gains_ptr_t p_gains,
-                   HI_U32 exposure,
-                   HI_U32 exposure_max,
-                   HI_U32 exposure_shift)
+
+static HI_VOID cmos_dgain_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
 {
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
+    int i;
 
-    while (exposure > (1 << 22))
+    if(HI_NULL == pstAeSnsGainInfo)
     {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
     }
-
-    if(exposure > exposure_max)
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+    
+    if (u32InTimes >= digital_gain_table[1022])
     {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shift;
-}
-
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-                   cmos_gains_ptr_t p_gains,
-                   HI_U32 exposure,
-                   HI_U32 exposure_max,
-                   HI_U32 exposure_shift)
-{
-    HI_U32 dgain = 1024;
-    HI_U32 step = 0;
-    HI_S32 shift = 0;
-    HI_S32 i = 0;
-    
-
-    while (exposure > (1 << 20))
-    {
-        exposure     >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    
-    if(exposure > exposure_max)
-    {
-        dgain = (exposure << 10) / exposure_max;
-        dgain = dgain < 1024? 1024: dgain;
-        dgain = dgain > p_gains->max_dgain_target? p_gains->max_dgain_target: dgain;
-    
-        if (dgain >= digital_gain_table[1022])
-        {
-             dgain = digital_gain_table[1022];
-             step = 1022;
-        }
-        else
-        {
-            for(i = 1; i < 1023; i++)
-            {
-                if(dgain < digital_gain_table[i])
-                {
-                    dgain = digital_gain_table[i-1];
-                    step = i-1 ;
-                    break;
-                }
-            }
-        }
+        pstAeSnsGainInfo->u32SnsTimes = digital_gain_table[1022];
+        pstAeSnsGainInfo->u32GainDb = 1022;
         
-        exposure = (exposure << 10) / dgain;
+        return;
     }
     
-    
-    p_gains->dgain = dgain;
-    p_gains->dgain_db = step;
-
-    return exposure << shift;
-    
-   // return isp_digital_gain_from_exposure_calculate(p_gains, (exposure << shift)
-     //                                               , (exposure_max << shift), exposure_shift);
-}
-
-static void setup_sensor(int isp_mode)
-{
-	
-	if(0 == isp_mode) /* setup for ISP 'normal mode' */
-	{
-		sensor_write_register(0x407e,0x2EA);
-	}
-    
-	else if(1 == isp_mode) /* setup for ISP pixel calibration mode */
-	{
-        //set the gain to 0
-        sensor_write_register(0xC001, 0x4);
-        sensor_write_register(0xC002, 0x0);
-        sensor_write_register(0x407e, 0x1194);
-	}
-    else
+    for(i = 1; i < 1023; i++)
     {
-
+        if(u32InTimes < digital_gain_table[i - 1])
+        {            
+            pstAeSnsGainInfo->u32SnsTimes = digital_gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
     }
+        
+    return;
+
+}
+
+
+
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+#if CMOS_ICX692_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();    
+    g_stSnsRegsInfo.astSspData[1].u32Data = u32Again;
+    g_stSnsRegsInfo.astSspData[2].u32Data = (u32Dgain & 0x3ff);
+    HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+#else
+    sensor_write_register(0xC001, u32Again);
+    sensor_write_register(0xC002, (u32Dgain & 0x3ff));
+#endif
+
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 5000;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x176;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x1f1;
     
-    return ;
-}
+    pstAwbSnsDft->as32WbPara[0] = 33;
+    pstAwbSnsDft->as32WbPara[1] = 113;
+    pstAwbSnsDft->as32WbPara[2] = -110;
+    pstAwbSnsDft->as32WbPara[3] = 186795;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -138463;
 
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t p_gains)
-{
-    return p_gains->again_db;
-}
-
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t p_gains)
-{
-	return p_gains->dgain_db;
-}
-/*
-static HI_U8 cmos_get_digital_fine_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return cmos_gains->dgain_fine;
-}
-*/
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-	if (NULL == p_coms_isp_default)
-	{
-	    printf("null pointer when get isp default value!\n");
-	    return -1;
-	}
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
     return 0;
 }
 
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
+HI_VOID sensor_global_init()
 {
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
+
+   gu8SensorMode = 0;
+   
 }
 
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
-}
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1280;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 720;
-
-    return 0;
-}
 
 /****************************************************************************
  * callback structure                                                       *
  ****************************************************************************/
-
-static SENSOR_EXP_FUNC_S stSensorExpFuncs =
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
 {
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
 
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
 
-    .pfn_setup_sensor = setup_sensor,
-
-    .pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-    .pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-    .pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-    .pfn_cmos_get_isp_default = cmos_get_isp_default,
-    .pfn_cmos_get_isp_special_alg = NULL,
-    .pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-	.pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-	.pfn_cmos_get_isp_demosaic = NULL,
-	.pfn_cmos_get_isp_shading_table = NULL,
-	.pfn_cmos_get_isp_gamma_table = NULL,
-    .pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-    .pfn_cmos_set_sensor_image_mode = NULL,
-
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-
-	return 0;
-}
-
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
-{
-    switch(u8Mode)
-    {
-        //sensor mode 0
-        case 0:
-            gu8SensorMode = 0;
-            // TODO:
-        break;
-        //sensor mode 1
-        case 1:
-            gu8SensorMode = 1;
-             // TODO:
-        break;
-
-        default:
-            printf("NOT support this mode!\n");
-            return -1;
-        break;
-    }
     return 0;
 }
 
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+    pstExpFuncs->pfn_cmos_dgain_calc_table  = cmos_dgain_calc_table;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(ICX692_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, ICX692_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, ICX692_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(ICX692_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, ICX692_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, ICX692_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -742,5 +639,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-
-#endif // __SONY_ICX692_H_
+#endif // __IMX104_CMOS_H_

--- a/libraries/sensor/hi3516cv100/sony_icx692/icx692_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/sony_icx692/icx692_sensor_ctl.c
@@ -58,392 +58,388 @@ void sensor_prog(int* rom)
 
 void sensor_init()
 {
-  printf("-------sensor ICX692 sensor_init!----\n");	
-  
-  sensor_write_register(0xc022	,0x0001);// a. software reset                                                                                  
-  sensor_write_register(0xc031	,0x0001);// b. sck select                                                                                      
-  sensor_write_register(0xc0ab  ,0x1100);   //[8] = Enable Oscillator Bias Current                                                             
-  sensor_write_register(0xc020	,0x028B);// c. ENABLE AFE, Buffer,reference                                                                    
-  sensor_write_register(0xc021	,0x0000);// d. Write to CLIDIVIDE as 1xclock                                                                   
-  sensor_write_register(0xc009  ,0x3207);   // e. Disable PLL                                                                                  
-  sensor_write_register(0xc020	,0x028f);// f. ENABLE TG core                                                                                  
-  sensor_write_register(0xc02f	,0x024c); //0x020c                                                                                                     
-  sensor_write_register(0xc030	,0x0001);// g. CLI SELECT  
-  //sensor_write_register(0xc028	,0x00f0);// g. CLI SELECT
-  sensor_write_register(0xc000	,0x0003);   // h.AFE operation OPRMODE                                                                         
-  sensor_write_register(0xc001  ,0x0003);   // cds gain                                                                                        
-  sensor_write_register(0xc002  ,0x0015);   // vga gain                                                                                        
-  sensor_write_register(0xc003  ,0x003c);   // black level     0x3d                                                                                
-  sensor_write_register(0xc060  ,0x0006);// enable 0xC001,0xC002 update in VD rising edge 
-  sensor_write_register(0xc020  ,0x02FF);   // Enable DCLK, DOUT, Hdrv OUT                                                                     
-  sensor_write_register(0xc0c0  ,0x0001);   // startup1                                                                                        
-  sensor_write_register(0xc0c1  ,0x0040);   // startup2                                                                                        
-  sensor_write_register(0xc023	,0x0000);// i.VD/HD INPUT ENABLE Master mode:00; Slave mode: 03                                                
-  sensor_write_register(0xc024	,0x01F6);	//  Master mode: 1f6 Enable VD/HD GPO1~5 as output; Slave mode:1f4 disabel VD/HD as output           
-  sensor_write_register(0xc025	,0x0001);// Disabling RESET on sync pin and enable Sync pin as input                                           
-  sensor_write_register(0xc026	,0x0001);	// Master mode:1;Slave Mode:0                                                                        
-  sensor_write_register(0xc027	,0x0007);	// configure Sync as a rising edge trigger and VD/HD active polarity                                 
-  sensor_write_register(0x7c0b	,0x00FF);// Master mode: 0xff ENABLE All TG Channels; slave mode 0xfB disable TG VD/HD channel                 
-  sensor_write_register(0xc029	,0x0021);// bit0:XV1 SELECT for XV16 to XV26; bit5: GUI XSG16 mappping                                         
-  sensor_write_register(0xc040	,0x0003);// j. HCLKMODE: 0x0, Mode 0i //*****!!!!!6/30 changing HCLKMODE=3                                     
-  sensor_write_register(0xc041	,0x2000);   // H1 Phase                                                                                        
-  sensor_write_register(0xc042	,0x4120);   // H2 Phase  //***** delay H2 rising and falling edge        0x0122                                      
-  sensor_write_register(0xc045	,0x2000);   //0x2505                                                                                                   
-  sensor_write_register(0xc046	,0x4a3d);   //0x1404                                                                                                   
-  sensor_write_register(0xc047	,0x1323);   // SHP Phase *1620 0x1019                                                                                
-  sensor_write_register(0xc048	,0x0003);   // SHD Phase      0x0000                                                                                 
-  sensor_write_register(0xC04a  ,0x2000);   // Dout phase Phase                                                                                
-  sensor_write_register(0xC04c  ,0x0e0f);   // enable H4 retime                                                                                
-  sensor_write_register(0xC04d  ,0x0040);   // Add one to H2/3/4                                                                               
-  sensor_write_register(0xc052	,0x0002);// select HPAT, generated from TG                                                                     
-  sensor_write_register(0xc053	,0x7777);// H1-clock drive strength    0x3323                                                                        
-  sensor_write_register(0xc054	,0x5555);   // H2-clock drive strength    0x2323                                                                     
-  sensor_write_register(0xc055	,0x5656);// H3-clock drive strength                                                                            
-  sensor_write_register(0xc056	,0x5656);   // H4-clock drive strength                                                                         
-  sensor_write_register(0xc057  ,0x0043);  // RG driver strength  // ***** reduce RGDRV from 6 to 2 to remove the oblique line noise    0x0042       
-  sensor_write_register(0x7c7b  ,0x0008);   // set XSUBCK to high                                                                              
-  sensor_write_register(0x4000  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4001  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4002  ,0x000b);		                                                                                                   
-  sensor_write_register(0x4003  ,0x0116);		                                                                                                   
-  sensor_write_register(0x4004  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4005  ,0x012c);		                                                                                                   
-  sensor_write_register(0x4006  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4007  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4008  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4009  ,0x0000);		                                                                                                   
-  sensor_write_register(0x400a  ,0x0000);		                                                                                                   
-  sensor_write_register(0x400b  ,0x0000);		                                                                                                   
-  sensor_write_register(0x400c  ,0x0000);		                                                                                                   
-  sensor_write_register(0x403e  ,0x0108);		                                                                                                   
-  sensor_write_register(0x4040  ,0x0002);		                                                                                                   
-  sensor_write_register(0x4041  ,0x0050);		                                                                                                   
-  sensor_write_register(0x4042  ,0x0051);		                                                                                                   
-  sensor_write_register(0x4043  ,0x0202);		                                                                                                   
-  sensor_write_register(0x4044  ,0x1202);		                                                                                                   
-  sensor_write_register(0x4045  ,0x0072);		                                                                                                   
-  sensor_write_register(0x4046  ,0x0051);		                                                                                                   
-  sensor_write_register(0x4047  ,0x0202);		                                                                                                   
-  sensor_write_register(0x4048  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4049  ,0x00c2);		                                                                                                   
-  sensor_write_register(0x404a  ,0x0648);		                                                                                                   
-  sensor_write_register(0x404b  ,0x005a);		                                                                                                   
-  sensor_write_register(0x404c 	,0x0051);		                                                                                                   
-  sensor_write_register(0x404d  ,0x0202);		                                                                                                   
-  sensor_write_register(0x404e  ,0x02eb);		                                                                                                   
-  sensor_write_register(0x404f  ,0x0026);		                                                                                                   
-  sensor_write_register(0x4050  ,0xff08);		                                                                                                   
-  sensor_write_register(0x4051  ,0xffff);		                                                                                                   
-  sensor_write_register(0x4052  ,0x0407);		                                                                                                   
-  sensor_write_register(0x4053  ,0xffff);		                                                                                                   
-  sensor_write_register(0x4054  ,0x1202);		                                                                                                   
-  sensor_write_register(0x4055  ,0x0073);		                                                                                                   
-  sensor_write_register(0x4056  ,0x0078);		                                                                                                   
-  sensor_write_register(0x4057  ,0x0909);		                                                                                                   
-  sensor_write_register(0x4058  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4059  ,0x00f6);		                                                                                                   
-  sensor_write_register(0x405a  ,0x0648);		                                                                                                   
-  sensor_write_register(0x405b  ,0x007d);		                                                                                                   
-  sensor_write_register(0x405c  ,0x007f);		                                                                                                   
-  sensor_write_register(0x405d  ,0x0404);		                                                                                                   
-  sensor_write_register(0x405e  ,0x02eb);		                                                                                                   
-  sensor_write_register(0x405f  ,0x0008);		                                                                                                   
-  sensor_write_register(0x4060  ,0x0306);		                                                                                                   
-  sensor_write_register(0x4061  ,0xffff);		                                                                                                   
-  sensor_write_register(0x4062  ,0x1202);		                                                                                                   
-  sensor_write_register(0x4063  ,0x005b);		                                                                                                   
-  sensor_write_register(0x4064  ,0x0066);		                                                                                                   
-  sensor_write_register(0x4065  ,0x1716);		                                                                                                   
-  sensor_write_register(0x4066  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4067  ,0x00c2);		                                                                                                   
-  sensor_write_register(0x4068  ,0x0648);		                                                                                                   
-  sensor_write_register(0x4069  ,0x0052);		                                                                                                   
-  sensor_write_register(0x406a  ,0x0056);		                                                                                                   
-  sensor_write_register(0x406b  ,0x0807);		                                                                                                   
-  sensor_write_register(0x406c  ,0x02eb);		                                                                                                   
-  sensor_write_register(0x406d  ,0x0026);		                                                                                                   
-  sensor_write_register(0x406e  ,0x0306);		                                                                                                   
-  sensor_write_register(0x406f  ,0xffff);		                                                                                                   
-  sensor_write_register(0x4070  ,0x0207);		                                                                                                   
-  sensor_write_register(0x4071  ,0x2081);		                                                                                                   
-  sensor_write_register(0x4072  ,0x0640);		                                                                                                   
-  sensor_write_register(0x4073  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4074  ,0x0807);		                                                                                                   
-  sensor_write_register(0x4075  ,0x2082);		                                                                                                   
-  sensor_write_register(0x4076  ,0x0001);		                                                                                                   
-  sensor_write_register(0x4077  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4078  ,0x0207);		                                                                                                   
-  sensor_write_register(0x4079  ,0x2083);		                                                                                                   
-  sensor_write_register(0x407a  ,0x0640);		                                                                                                   
-  sensor_write_register(0x407b  ,0x0000);		                                                                                                   
-  sensor_write_register(0x407c  ,0x8807);		                                                                                                   
-  sensor_write_register(0x407d  ,0x2082);		                                                                                                   
-  sensor_write_register(0x407e  ,0x02ea);		                                                                                                   
-  sensor_write_register(0x407f  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4080  ,0x4207);		                                                                                                   
-  sensor_write_register(0x4081  ,0x2082);		                                                                                                   
-  sensor_write_register(0x4082  ,0x0640);		                                                                                                   
-  sensor_write_register(0x4083  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4084  ,0x080a);		                                                                                                   
-  sensor_write_register(0x4085  ,0x0406);		                                                                                                   
-  sensor_write_register(0x4086  ,0xff02);		                                                                                                   
-  sensor_write_register(0x4087  ,0xffff);		                                                                                                   
-  sensor_write_register(0x40a0  ,0x000a);		                                                                                                   
-  sensor_write_register(0x40a1  ,0x0028);		                                                                                                   
-  sensor_write_register(0x40a2  ,0x0000);		                                                                                                   
-  sensor_write_register(0x40a3  ,0x0000);		                                                                                                   
-  sensor_write_register(0x40a4  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40a5  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40a6  ,0x0022);		                                                                                                   
-  sensor_write_register(0x40a7  ,0x0022);		                                                                                                   
-  sensor_write_register(0x40a8  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40a9  ,0x0022);		                                                                                                   
-  sensor_write_register(0x40aa  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40ab  ,0x0000);		                                                                                                   
-  sensor_write_register(0x40ac  ,0x0001);		                                                                                                   
-  sensor_write_register(0x40ad  ,0x0004);		                                                                                                   
-  sensor_write_register(0x40ae  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40af  ,0x0008);		                                                                                                   
-  sensor_write_register(0x40b0  ,0x0004);		                                                                                                   
-  sensor_write_register(0x40b1  ,0x0001);		                                                                                                   
-  sensor_write_register(0x40b2  ,0x0008);		                                                                                                   
-  sensor_write_register(0x40b3  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40b4  ,0x000a);		                                                                                                   
-  sensor_write_register(0x40b5  ,0x00b6);		                                                                                                   
-  sensor_write_register(0x40b6  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40b7  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40b8  ,0x0044);		                                                                                                   
-  sensor_write_register(0x40b9  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40ba  ,0x04ae);		                                                                                                   
-  sensor_write_register(0x40bb  ,0x00cc);		                                                                                                   
-  sensor_write_register(0x40bc  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40bd  ,0x0022);		                                                                                                   
-  sensor_write_register(0x40be  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40bf  ,0x0022);		                                                                                                   
-  sensor_write_register(0x40c0  ,0x0022);		                                                                                                   
-  sensor_write_register(0x40c1  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40c2  ,0x0022);		                                                                                                   
-  sensor_write_register(0x40c3  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40c4  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40c5  ,0x0022);		                                                                                                   
-  sensor_write_register(0x40c6  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40c7  ,0x0022);		                                                                                                   
-  sensor_write_register(0x40c8  ,0x0022);		                                                                                                   
-  sensor_write_register(0x40c9  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40ca  ,0x0022);		                                                                                                   
-  sensor_write_register(0x40cb  ,0x0016);		                                                                                                   
-  sensor_write_register(0x40cc  ,0x0001);		                                                                                                   
-  sensor_write_register(0x40cd  ,0x0004);		                                                                                                   
-  sensor_write_register(0x40ce  ,0x000a);		                                                                                                   
-  sensor_write_register(0x40cf  ,0x0004);		                                                                                                   
-  sensor_write_register(0x40d0  ,0x0001);		                                                                                                   
-  sensor_write_register(0x40d1  ,0x0008);		                                                                                                   
-  sensor_write_register(0x40d2  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40d3  ,0x0001);		                                                                                                   
-  sensor_write_register(0x40d4  ,0x0004);		                                                                                                   
-  sensor_write_register(0x40d5  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40d6  ,0x0008);		                                                                                                   
-  sensor_write_register(0x40d7  ,0x0004);		                                                                                                   
-  sensor_write_register(0x40d8  ,0x0001);		                                                                                                   
-  sensor_write_register(0x40d9  ,0x0008);		                                                                                                   
-  sensor_write_register(0x40da  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40db  ,0x0001);		                                                                                                   
-  sensor_write_register(0x40dc  ,0x0004);		                                                                                                   
-  sensor_write_register(0x40dd  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40de  ,0x0008);		                                                                                                   
-  sensor_write_register(0x40df  ,0x0004);		                                                                                                   
-  sensor_write_register(0x40e0  ,0x0001);		                                                                                                   
-  sensor_write_register(0x40e1  ,0x0008);		                                                                                                   
-  sensor_write_register(0x40e2  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40e3  ,0x0000);		                                                                                                   
-  sensor_write_register(0x40e4  ,0x000a);		                                                                                                   
-  sensor_write_register(0x40e5  ,0x07b8);		                                                                                                   
-  sensor_write_register(0x40e6  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40e7  ,0x04b5);		                                                                                                   
-  sensor_write_register(0x40e8  ,0x0010);		                                                                                                   
-  sensor_write_register(0x40e9  ,0x004c);		                                                                                                   
-  sensor_write_register(0x40ea  ,0x0010);		                                                                                                   
-  sensor_write_register(0x40eb  ,0x0027);		                                                                                                   
-  sensor_write_register(0x40ec  ,0x00f8);		                                                                                                   
-  sensor_write_register(0x40ed  ,0x0548);		                                                                                                   
-  sensor_write_register(0x40ee  ,0x00f8);		                                                                                                   
-  sensor_write_register(0x40ef  ,0x0000);		                                                                                                   
-  sensor_write_register(0x40f0  ,0x800c);		                                                                                                   
-  sensor_write_register(0x40f1  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40f2  ,0x0004);		                                                                                                   
-  sensor_write_register(0x40f3  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40f4  ,0x0004);		                                                                                                   
-  sensor_write_register(0x40f5  ,0x800c);		                                                                                                   
-  sensor_write_register(0x40f6  ,0x800c);		                                                                                                   
-  sensor_write_register(0x40f7  ,0x800c);		                                                                                                   
-  sensor_write_register(0x40f8  ,0x800c);		                                                                                                   
-  sensor_write_register(0x40f9  ,0x0000);		                                                                                                   
-  sensor_write_register(0x40fa  ,0x0002);		                                                                                                   
-  sensor_write_register(0x40fb  ,0x0014);		                                                                                                   
-  sensor_write_register(0x40fc  ,0x000a);		                                                                                                   
-  sensor_write_register(0x40fd  ,0x00f0);		                                                                                                   
-  sensor_write_register(0x40fe  ,0x8001);		                                                                                                   
-  sensor_write_register(0x40ff  ,0x8001);		                                                                                                   
-  sensor_write_register(0x4100  ,0x800c);		                                                                                                   
-  sensor_write_register(0x4101  ,0x800c);		                                                                                                   
-  sensor_write_register(0x4102  ,0xc000);		                                                                                                   
-  sensor_write_register(0x4103  ,0x8064);		                                                                                                   
-  sensor_write_register(0x4104  ,0x8000);		                                                                                                   
-  sensor_write_register(0x4105  ,0x8064);		                                                                                                   
-  sensor_write_register(0x4106  ,0xc000);		                                                                                                   
-  sensor_write_register(0x4107  ,0x8064);		                                                                                                   
-  sensor_write_register(0x4108  ,0x0000);		                                                                                                   
-  sensor_write_register(0x4109  ,0x0003);		                                                                                                   
-  sensor_write_register(0x410a  ,0x0000);		                                                                                                   
-  sensor_write_register(0x410b  ,0x2030);		                                                                                                   
-  sensor_write_register(0x410c  ,0x010d);		                                                                                                   
-  sensor_write_register(0x410d  ,0x0109);		                                                                                                   
-  sensor_write_register(0x410e  ,0x0042);		                                                                                                   
-  sensor_write_register(0x410f  ,0x0037);		                                                                                                   
-  sensor_write_register(0x4110  ,0x0029);		                                                                                                   
-  sensor_write_register(0x4111  ,0x0030);		                                                                                                   
-  sensor_write_register(0x4112  ,0xffff);		                                                                                                   
-  sensor_write_register(0x4113  ,0xffff);		                                                                                                   
-  sensor_write_register(0x4114  ,0xffff);		                                                                                                   
-  sensor_write_register(0x4115  ,0xff6f);	                                                                                                     
-  sensor_write_register(0x4116  ,0x1a06);	                                                                                                     
-  sensor_write_register(0x4117  ,0x0126);	                                                                                                     
-  sensor_write_register(0x4118  ,0x1b86);	                                                                                                     
-  sensor_write_register(0x4119  ,0x0122);	                                                                                                     
-  sensor_write_register(0x411a  ,0x001b);	                                                                                                     
-  sensor_write_register(0x411b  ,0x0132);	                                                                                                     
-  sensor_write_register(0x411c  ,0x0586);	                                                                                                     
-  sensor_write_register(0x411d  ,0x00ff);	                                                                                                     
-  sensor_write_register(0x411e  ,0x8086);	                                                                                                     
-  sensor_write_register(0x411f  ,0x0001);	                                                                                                     
-  sensor_write_register(0x4120  ,0x0015);	                                                                                                     
-  sensor_write_register(0x4121  ,0x0025);	                                                                                                     
-  sensor_write_register(0x4122  ,0x8186);	                                                                                                     
-  sensor_write_register(0x4123  ,0x008f);	                                                                                                     
-  sensor_write_register(0x4124  ,0x0035);	                                                                                                     
-  sensor_write_register(0x4125  ,0x000d);		                                                                                                   
-  sensor_write_register(0x4126  ,0x039c);	                                                                                                     
-  sensor_write_register(0x4127  ,0x0001);	                                                                                                     
-  sensor_write_register(0x4128  ,0x001c);	                                                                                                     
-  sensor_write_register(0x4129  ,0x0000);	                                                                                                     
-  sensor_write_register(0x412a  ,0x0003);	                                                                                                     
-  sensor_write_register(0x412b  ,0x000d);		                                                                                                   
-  sensor_write_register(0x412c  ,0x001b);	                                                                                                     
-  sensor_write_register(0x412d  ,0x0132);	                                                                                                     
-  sensor_write_register(0x412e  ,0x8086);	                                                                                                     
-  sensor_write_register(0x412f  ,0x0002);	                                                                                                     
-  sensor_write_register(0x4130  ,0x0035);	                                                                                                     
-  sensor_write_register(0x4131  ,0x000d);		                                                                                                   
-  sensor_write_register(0x4132  ,0x039c);	                                                                                                     
-  sensor_write_register(0x4133  ,0x0000);	                                                                                                     
-  sensor_write_register(0x4134  ,0x0086);	                                                                                                     
-  sensor_write_register(0x4135  ,0x010c);	                                                                                                     
-  sensor_write_register(0x4136  ,0x4400);	                                                                                                     
-  sensor_write_register(0x4137  ,0x000d);		                                                                                                   
-  sensor_write_register(0x4138  ,0x411c);	                                                                                                     
-  sensor_write_register(0x4139  ,0x0000);	                                                                                                     
-  sensor_write_register(0x413a  ,0x611c);	                                                                                                     
-  sensor_write_register(0x413b  ,0x0001);	                                                                                                     
-  sensor_write_register(0x413c  ,0x638c);	                                                                                                     
-  sensor_write_register(0x413d  ,0x3d25);	                                                                                                     
-  sensor_write_register(0x413e  ,0x611c);	                                                                                                     
-  sensor_write_register(0x413f  ,0x0002);	                                                                                                     
-  sensor_write_register(0x4140  ,0x638c);	                                                                                                     
-  sensor_write_register(0x4141  ,0x3d40);	                                                                                                     
-  sensor_write_register(0x4142  ,0x611c);	                                                                                                     
-  sensor_write_register(0x4143  ,0x0003);	                                                                                                     
-  sensor_write_register(0x4144  ,0x638c);	                                                                                                     
-  sensor_write_register(0x4145  ,0x3d60);	                                                                                                     
-  sensor_write_register(0x4146  ,0x611c);	                                                                                                     
-  sensor_write_register(0x4147  ,0x0004);	                                                                                                     
-  sensor_write_register(0x4148  ,0x638c);	                                                                                                     
-  sensor_write_register(0x4149  ,0x3d80);	                                                                                                     
-  sensor_write_register(0x414a  ,0x611c);	                                                                                                     
-  sensor_write_register(0x414b  ,0x0005);	                                                                                                     
-  sensor_write_register(0x414c  ,0x638c);	                                                                                                     
-  sensor_write_register(0x414d  ,0x3c35);	                                                                                                     
-  sensor_write_register(0x414e  ,0x611c);	                                                                                                     
-  sensor_write_register(0x414f  ,0x0006);	                                                                                                     
-  sensor_write_register(0x4150  ,0x638c);	                                                                                                     
-  sensor_write_register(0x4151  ,0x3c36);	                                                                                                     
-  sensor_write_register(0x4152  ,0x611c);	                                                                                                     
-  sensor_write_register(0x4153  ,0x0008);	                                                                                                     
-  sensor_write_register(0x4154  ,0x638c);	                                                                                                     
-  sensor_write_register(0x4155  ,0x3c20);	                                                                                                     
-  sensor_write_register(0x4156  ,0x611c);	                                                                                                     
-  sensor_write_register(0x4157  ,0x0000);	                                                                                                     
-  sensor_write_register(0x4158  ,0xa19c);	                                                                                                     
-  sensor_write_register(0x4159  ,0x0000);	                                                                                                     
-  sensor_write_register(0x415a  ,0xa38c);	                                                                                                     
-  sensor_write_register(0x415b  ,0x3d42);	                                                                                                     
-  sensor_write_register(0x415c  ,0xa19c);	                                                                                                     
-  sensor_write_register(0x415d  ,0x0001);	                                                                                                     
-  sensor_write_register(0x415e  ,0xa38c);	                                                                                                     
-  sensor_write_register(0x415f  ,0x3d62);	                                                                                                     
-  sensor_write_register(0x4160  ,0xa19c);	                                                                                                     
-  sensor_write_register(0x4161  ,0x0002);	                                                                                                     
-  sensor_write_register(0x4162  ,0xa38c);	                                                                                                     
-  sensor_write_register(0x4163  ,0x3d83);	                                                                                                     
-  sensor_write_register(0x4164  ,0x611c);	                                                                                                     
-  sensor_write_register(0x4165  ,0x0007);	                                                                                                     
-  sensor_write_register(0x4166  ,0xa19c);	                                                                                                     
-  sensor_write_register(0x4167  ,0x0000);	                                                                                                     
-  sensor_write_register(0x4168  ,0xa38c);	                                                                                                     
-  sensor_write_register(0x4169  ,0x3c33);	                                                                                                     
-  sensor_write_register(0x416a  ,0x0055);	                                                                                                     
-  sensor_write_register(0x7DA0	,0x0009);	                                                                                                     
-  sensor_write_register(0x7D41	,0x0044);	                                                                                                     
-  sensor_write_register(0x7D05	,0x0001);		//slave:0; master:1                                                                                
-  sensor_write_register(0x7D02	,0x00FF);	                                                                                                     
-  sensor_write_register(0x7C06	,0x0001);	                                                                                                     
-  sensor_write_register(0x7C07	,0x0000);	                                                                                                     
-  sensor_write_register(0x7D43	,0x2000);	                                                                                                     
-  sensor_write_register(0x7D63	,0x0005);	                                                                                                     
-  sensor_write_register(0x7D82	,0x7FFF);	                                                                                                     
-  sensor_write_register(0x7D83	,0x203C);	                                                                                                     
-  sensor_write_register(0x7d01	,0x0004);		 //Force initial value updated                                                                     
-  sensor_write_register(0xc028	,0x00f1);		//VDR ENABLE                                                                                       
-  sensor_write_register(0xc020  ,0x02FF);   // Enable DCLK, DOUT, Hdrv                                                                         
-  sensor_write_register(0x7c25	,0x7FFF);//                                                                                                    
-  sensor_write_register(0xc052  ,0x0000);                                                                                                      
-  sensor_write_register(0xc04c  ,0x1111);                                                                                                      
-  sensor_write_register(0xC080	,0xFFFF);// Set outen_reg0 register to enabled.                                                                
-  sensor_write_register(0xC081	,0xFFFF);// Set outen_reg1 register to enabled.                                                                
-  sensor_write_register(0xC082	,0xFFFF);// Set outen_reg2 register to enabled.                                                                
-  sensor_write_register(0xC083	,0xFFFF);// Set outen_reg3 register to enabled.                                                                
-  sensor_write_register(0xC084	,0x1C03);// Set outstandby_reg0 register to polarities of TG outputs(XVSG1-XVSG3, VD, HD to 1, others to 0)    
-  sensor_write_register(0xC085	,0x1FFF);// Set outstandby_reg1 register to polarities of TG outputs(XVSG4-XVSG16 to 1, others to 0)           
-  sensor_write_register(0xC086	,0x0000);// Set outstandby_reg2 register to polarities of TG outputs(XV1-XV16:  all to 0)                      
-  sensor_write_register(0xC087	,0x0000);// Set outstandby_reg3 register to polarities of TG outputs(XV1-XV16, RGBLK, SUBCK: all to 0)         
-  sensor_write_register(0x7c0f	,0x0011);// enable memory compression mode                                                                     
-  sensor_write_register(0x7c34	,0x0002);// b.Fixed start address at 0x4002 (SPI)                                                              
-  sensor_write_register(0x7c20	,0xFFFF);// IMASK, disalbe all interrupt                                                                       
-  sensor_write_register(0x7d00	,0x0002);//  c.TG running mode enable                                                                          
-  sensor_write_register(0x4000	,0x0000);// mode Id:0                                                                                          
-  sensor_write_register(0x7c22	,0x0000);// d.ILAT (CLEAR INTERRUPTS)                                                                          
-  sensor_write_register(0x7c21	,0x0000);// clear the PMASK                                                                                    
-  sensor_write_register(0x7c20	,0xffef);// e.IMASK to allow SYNC Interrupt                                                                    
-  sensor_write_register(0x7c22	,0x0010);// f. ILAT to trigger SYNC ISR                                                                        
-  sensor_write_register(0x7C73	,0x0001); 	//SUBCK_AUTO                                                                                       
-  sensor_write_register(0x7C7B	,0x0008); 	//SUBCK_CTRL                                                                                       
-  sensor_write_register(0x7C90	,0x00bd);//TOG1, 25                                                                                            
-  sensor_write_register(0x7C92	,0x00ea);//TOG2, 52                                                                                            
-  sensor_write_register(0x7C94	,0xffff);//HP_TOG1, disable                                                                                    
-  sensor_write_register(0x7C96	,0xffff);//HP_TOG2, disable                                                                                    
-  sensor_write_register(0x7C72	,0x0001);//SGLINE                                                                                              
-  sensor_write_register(0x7C13	,0x0008);//subck startline from SGLINE                                                                         
-  sensor_write_register(0x7C14	,0x0020);//subck endline from SGLINE                                                                           
-  sensor_write_register(0xc074 	,0x1110);// 9020 vdriver mux                                                                                   
-  sensor_write_register(0xc075 	,0x1312);                                                                                                      
-  sensor_write_register(0xc078 	,0x0908);                                                                                                      
-  sensor_write_register(0xc079 	,0x0b0a);    
+    printf("-------sensor ICX692 sensor_init!----\n");    
 
-  sensor_write_register(0xc0ae 	,0x8088); 
+    sensor_write_register(0xc022  ,0x0001);// a. software reset                                                                                  
+    sensor_write_register(0xc031  ,0x0001);// b. sck select                                                                                      
+    sensor_write_register(0xc0ab  ,0x1100);   //[8] = Enable Oscillator Bias Current                                                             
+    sensor_write_register(0xc020  ,0x028B);// c. ENABLE AFE, Buffer,reference                                                                    
+    sensor_write_register(0xc021  ,0x0000);// d. Write to CLIDIVIDE as 1xclock                                                                   
+    sensor_write_register(0xc009  ,0x3207);   // e. Disable PLL                                                                                  
+    sensor_write_register(0xc020  ,0x028f);// f. ENABLE TG core                                                                                  
+    sensor_write_register(0xc02f  ,0x024c); //0x020c                                                                                                     
+    sensor_write_register(0xc030  ,0x0001);// g. CLI SELECT  
+    //sensor_write_register(0xc028    ,0x00f0);// g. CLI SELECT
+    sensor_write_register(0xc000  ,0x0003);   // h.AFE operation OPRMODE                                                                         
+    sensor_write_register(0xc001  ,0x0003);   // cds gain                                                                                        
+    sensor_write_register(0xc002  ,0x0015);   // vga gain                                                                                        
+    sensor_write_register(0xc003  ,0x003c);   // black level     0x3d                                                                                
+    sensor_write_register(0xc060  ,0x0006);// enable 0xC001,0xC002 update in VD rising edge 
+    sensor_write_register(0xc020  ,0x02FF);   // Enable DCLK, DOUT, Hdrv OUT                                                                     
+    sensor_write_register(0xc0c0  ,0x0001);   // startup1                                                                                        
+    sensor_write_register(0xc0c1  ,0x0040);   // startup2                                                                                        
+    sensor_write_register(0xc023  ,0x0000);// i.VD/HD INPUT ENABLE Master mode:00; Slave mode: 03                                                
+    sensor_write_register(0xc024  ,0x01F6);   //  Master mode: 1f6 Enable VD/HD GPO1~5 as output; Slave mode:1f4 disabel VD/HD as output           
+    sensor_write_register(0xc025  ,0x0001);// Disabling RESET on sync pin and enable Sync pin as input                                           
+    sensor_write_register(0xc026  ,0x0001);   // Master mode:1;Slave Mode:0                                                                        
+    sensor_write_register(0xc027  ,0x0007);   // configure Sync as a rising edge trigger and VD/HD active polarity                                 
+    sensor_write_register(0x7c0b  ,0x00FF);// Master mode: 0xff ENABLE All TG Channels; slave mode 0xfB disable TG VD/HD channel                 
+    sensor_write_register(0xc029  ,0x0021);// bit0:XV1 SELECT for XV16 to XV26; bit5: GUI XSG16 mappping                                         
+    sensor_write_register(0xc040  ,0x0003);// j. HCLKMODE: 0x0, Mode 0i //*****!!!!!6/30 changing HCLKMODE=3                                     
+    sensor_write_register(0xc041  ,0x2000);   // H1 Phase                                                                                        
+    sensor_write_register(0xc042  ,0x4120);   // H2 Phase  //***** delay H2 rising and falling edge        0x0122                                      
+    sensor_write_register(0xc045  ,0x2000);   //0x2505                                                                                                   
+    sensor_write_register(0xc046  ,0x4a3d);   //0x1404                                                                                                   
+    sensor_write_register(0xc047  ,0x1323);   // SHP Phase *1620 0x1019                                                                                
+    sensor_write_register(0xc048  ,0x0003);   // SHD Phase      0x0000                                                                                 
+    sensor_write_register(0xC04a  ,0x2000);   // Dout phase Phase                                                                                
+    sensor_write_register(0xC04c  ,0x0e0f);   // enable H4 retime                                                                                
+    sensor_write_register(0xC04d  ,0x0040);   // Add one to H2/3/4                                                                               
+    sensor_write_register(0xc052  ,0x0002);// select HPAT, generated from TG                                                                     
+    sensor_write_register(0xc053  ,0x7777);// H1-clock drive strength    0x3323                                                                        
+    sensor_write_register(0xc054  ,0x5555);   // H2-clock drive strength    0x2323                                                                     
+    sensor_write_register(0xc055  ,0x5656);// H3-clock drive strength                                                                            
+    sensor_write_register(0xc056  ,0x5656);   // H4-clock drive strength                                                                         
+    sensor_write_register(0xc057  ,0x0043);  // RG driver strength  // ***** reduce RGDRV from 6 to 2 to remove the oblique line noise    0x0042       
+    sensor_write_register(0x7c7b  ,0x0008);   // set XSUBCK to high                                                                              
+    sensor_write_register(0x4000  ,0x0000);                                                                                                          
+    sensor_write_register(0x4001  ,0x0000);                                                                                                          
+    sensor_write_register(0x4002  ,0x000b);                                                                                                          
+    sensor_write_register(0x4003  ,0x0116);                                                                                                          
+    sensor_write_register(0x4004  ,0x0000);                                                                                                          
+    sensor_write_register(0x4005  ,0x012c);                                                                                                          
+    sensor_write_register(0x4006  ,0x0000);                                                                                                          
+    sensor_write_register(0x4007  ,0x0000);                                                                                                          
+    sensor_write_register(0x4008  ,0x0000);                                                                                                          
+    sensor_write_register(0x4009  ,0x0000);                                                                                                          
+    sensor_write_register(0x400a  ,0x0000);                                                                                                          
+    sensor_write_register(0x400b  ,0x0000);                                                                                                          
+    sensor_write_register(0x400c  ,0x0000);                                                                                                          
+    sensor_write_register(0x403e  ,0x0108);                                                                                                          
+    sensor_write_register(0x4040  ,0x0002);                                                                                                          
+    sensor_write_register(0x4041  ,0x0050);                                                                                                          
+    sensor_write_register(0x4042  ,0x0051);                                                                                                          
+    sensor_write_register(0x4043  ,0x0202);                                                                                                          
+    sensor_write_register(0x4044  ,0x1202);                                                                                                          
+    sensor_write_register(0x4045  ,0x0072);                                                                                                          
+    sensor_write_register(0x4046  ,0x0051);                                                                                                          
+    sensor_write_register(0x4047  ,0x0202);                                                                                                          
+    sensor_write_register(0x4048  ,0x0000);                                                                                                          
+    sensor_write_register(0x4049  ,0x00c2);                                                                                                          
+    sensor_write_register(0x404a  ,0x0648);                                                                                                          
+    sensor_write_register(0x404b  ,0x005a);                                                                                                          
+    sensor_write_register(0x404c  ,0x0051);                                                                                                          
+    sensor_write_register(0x404d  ,0x0202);                                                                                                          
+    sensor_write_register(0x404e  ,0x02eb);                                                                                                          
+    sensor_write_register(0x404f  ,0x0026);                                                                                                          
+    sensor_write_register(0x4050  ,0xff08);                                                                                                          
+    sensor_write_register(0x4051  ,0xffff);                                                                                                          
+    sensor_write_register(0x4052  ,0x0407);                                                                                                          
+    sensor_write_register(0x4053  ,0xffff);                                                                                                          
+    sensor_write_register(0x4054  ,0x1202);                                                                                                          
+    sensor_write_register(0x4055  ,0x0073);                                                                                                          
+    sensor_write_register(0x4056  ,0x0078);                                                                                                          
+    sensor_write_register(0x4057  ,0x0909);                                                                                                          
+    sensor_write_register(0x4058  ,0x0000);                                                                                                          
+    sensor_write_register(0x4059  ,0x00f6);                                                                                                          
+    sensor_write_register(0x405a  ,0x0648);                                                                                                          
+    sensor_write_register(0x405b  ,0x007d);                                                                                                          
+    sensor_write_register(0x405c  ,0x007f);                                                                                                          
+    sensor_write_register(0x405d  ,0x0404);                                                                                                          
+    sensor_write_register(0x405e  ,0x02eb);                                                                                                          
+    sensor_write_register(0x405f  ,0x0008);                                                                                                          
+    sensor_write_register(0x4060  ,0x0306);                                                                                                          
+    sensor_write_register(0x4061  ,0xffff);                                                                                                          
+    sensor_write_register(0x4062  ,0x1202);                                                                                                          
+    sensor_write_register(0x4063  ,0x005b);                                                                                                          
+    sensor_write_register(0x4064  ,0x0066);                                                                                                          
+    sensor_write_register(0x4065  ,0x1716);                                                                                                          
+    sensor_write_register(0x4066  ,0x0000);                                                                                                          
+    sensor_write_register(0x4067  ,0x00c2);                                                                                                          
+    sensor_write_register(0x4068  ,0x0648);                                                                                                          
+    sensor_write_register(0x4069  ,0x0052);                                                                                                          
+    sensor_write_register(0x406a  ,0x0056);                                                                                                          
+    sensor_write_register(0x406b  ,0x0807);                                                                                                          
+    sensor_write_register(0x406c  ,0x02eb);                                                                                                          
+    sensor_write_register(0x406d  ,0x0026);                                                                                                          
+    sensor_write_register(0x406e  ,0x0306);                                                                                                          
+    sensor_write_register(0x406f  ,0xffff);                                                                                                          
+    sensor_write_register(0x4070  ,0x0207);                                                                                                          
+    sensor_write_register(0x4071  ,0x2081);                                                                                                          
+    sensor_write_register(0x4072  ,0x0640);                                                                                                          
+    sensor_write_register(0x4073  ,0x0000);                                                                                                          
+    sensor_write_register(0x4074  ,0x0807);                                                                                                          
+    sensor_write_register(0x4075  ,0x2082);                                                                                                          
+    sensor_write_register(0x4076  ,0x0001);                                                                                                          
+    sensor_write_register(0x4077  ,0x0000);                                                                                                          
+    sensor_write_register(0x4078  ,0x0207);                                                                                                          
+    sensor_write_register(0x4079  ,0x2083);                                                                                                          
+    sensor_write_register(0x407a  ,0x0640);                                                                                                          
+    sensor_write_register(0x407b  ,0x0000);                                                                                                          
+    sensor_write_register(0x407c  ,0x8807);                                                                                                          
+    sensor_write_register(0x407d  ,0x2082);                                                                                                          
+    sensor_write_register(0x407e  ,0x02ea);                                                                                                          
+    sensor_write_register(0x407f  ,0x0000);                                                                                                          
+    sensor_write_register(0x4080  ,0x4207);                                                                                                          
+    sensor_write_register(0x4081  ,0x2082);                                                                                                          
+    sensor_write_register(0x4082  ,0x0640);                                                                                                          
+    sensor_write_register(0x4083  ,0x0000);                                                                                                          
+    sensor_write_register(0x4084  ,0x080a);                                                                                                          
+    sensor_write_register(0x4085  ,0x0406);                                                                                                          
+    sensor_write_register(0x4086  ,0xff02);                                                                                                          
+    sensor_write_register(0x4087  ,0xffff);                                                                                                          
+    sensor_write_register(0x40a0  ,0x000a);                                                                                                          
+    sensor_write_register(0x40a1  ,0x0028);                                                                                                          
+    sensor_write_register(0x40a2  ,0x0000);                                                                                                          
+    sensor_write_register(0x40a3  ,0x0000);                                                                                                          
+    sensor_write_register(0x40a4  ,0x0002);                                                                                                          
+    sensor_write_register(0x40a5  ,0x0016);                                                                                                          
+    sensor_write_register(0x40a6  ,0x0022);                                                                                                          
+    sensor_write_register(0x40a7  ,0x0022);                                                                                                          
+    sensor_write_register(0x40a8  ,0x0016);                                                                                                          
+    sensor_write_register(0x40a9  ,0x0022);                                                                                                          
+    sensor_write_register(0x40aa  ,0x0016);                                                                                                          
+    sensor_write_register(0x40ab  ,0x0000);                                                                                                          
+    sensor_write_register(0x40ac  ,0x0001);                                                                                                          
+    sensor_write_register(0x40ad  ,0x0004);                                                                                                          
+    sensor_write_register(0x40ae  ,0x0002);                                                                                                          
+    sensor_write_register(0x40af  ,0x0008);                                                                                                          
+    sensor_write_register(0x40b0  ,0x0004);                                                                                                          
+    sensor_write_register(0x40b1  ,0x0001);                                                                                                          
+    sensor_write_register(0x40b2  ,0x0008);                                                                                                          
+    sensor_write_register(0x40b3  ,0x0002);                                                                                                          
+    sensor_write_register(0x40b4  ,0x000a);                                                                                                          
+    sensor_write_register(0x40b5  ,0x00b6);                                                                                                          
+    sensor_write_register(0x40b6  ,0x0002);                                                                                                          
+    sensor_write_register(0x40b7  ,0x0016);                                                                                                          
+    sensor_write_register(0x40b8  ,0x0044);                                                                                                          
+    sensor_write_register(0x40b9  ,0x0016);                                                                                                          
+    sensor_write_register(0x40ba  ,0x04ae);                                                                                                          
+    sensor_write_register(0x40bb  ,0x00cc);                                                                                                          
+    sensor_write_register(0x40bc  ,0x0016);                                                                                                          
+    sensor_write_register(0x40bd  ,0x0022);                                                                                                          
+    sensor_write_register(0x40be  ,0x0016);                                                                                                          
+    sensor_write_register(0x40bf  ,0x0022);                                                                                                          
+    sensor_write_register(0x40c0  ,0x0022);                                                                                                          
+    sensor_write_register(0x40c1  ,0x0016);                                                                                                          
+    sensor_write_register(0x40c2  ,0x0022);                                                                                                          
+    sensor_write_register(0x40c3  ,0x0016);                                                                                                          
+    sensor_write_register(0x40c4  ,0x0016);                                                                                                          
+    sensor_write_register(0x40c5  ,0x0022);                                                                                                          
+    sensor_write_register(0x40c6  ,0x0016);                                                                                                          
+    sensor_write_register(0x40c7  ,0x0022);                                                                                                          
+    sensor_write_register(0x40c8  ,0x0022);                                                                                                          
+    sensor_write_register(0x40c9  ,0x0016);                                                                                                          
+    sensor_write_register(0x40ca  ,0x0022);                                                                                                          
+    sensor_write_register(0x40cb  ,0x0016);                                                                                                          
+    sensor_write_register(0x40cc  ,0x0001);                                                                                                          
+    sensor_write_register(0x40cd  ,0x0004);                                                                                                          
+    sensor_write_register(0x40ce  ,0x000a);                                                                                                          
+    sensor_write_register(0x40cf  ,0x0004);                                                                                                          
+    sensor_write_register(0x40d0  ,0x0001);                                                                                                          
+    sensor_write_register(0x40d1  ,0x0008);                                                                                                          
+    sensor_write_register(0x40d2  ,0x0002);                                                                                                          
+    sensor_write_register(0x40d3  ,0x0001);                                                                                                          
+    sensor_write_register(0x40d4  ,0x0004);                                                                                                          
+    sensor_write_register(0x40d5  ,0x0002);                                                                                                          
+    sensor_write_register(0x40d6  ,0x0008);                                                                                                          
+    sensor_write_register(0x40d7  ,0x0004);                                                                                                          
+    sensor_write_register(0x40d8  ,0x0001);                                                                                                          
+    sensor_write_register(0x40d9  ,0x0008);                                                                                                          
+    sensor_write_register(0x40da  ,0x0002);                                                                                                          
+    sensor_write_register(0x40db  ,0x0001);                                                                                                          
+    sensor_write_register(0x40dc  ,0x0004);                                                                                                          
+    sensor_write_register(0x40dd  ,0x0002);                                                                                                          
+    sensor_write_register(0x40de  ,0x0008);                                                                                                          
+    sensor_write_register(0x40df  ,0x0004);                                                                                                          
+    sensor_write_register(0x40e0  ,0x0001);                                                                                                          
+    sensor_write_register(0x40e1  ,0x0008);                                                                                                          
+    sensor_write_register(0x40e2  ,0x0002);                                                                                                          
+    sensor_write_register(0x40e3  ,0x0000);                                                                                                          
+    sensor_write_register(0x40e4  ,0x000a);                                                                                                          
+    sensor_write_register(0x40e5  ,0x07b8);                                                                                                          
+    sensor_write_register(0x40e6  ,0x0002);                                                                                                          
+    sensor_write_register(0x40e7  ,0x04b5);                                                                                                          
+    sensor_write_register(0x40e8  ,0x0010);                                                                                                          
+    sensor_write_register(0x40e9  ,0x004c);                                                                                                          
+    sensor_write_register(0x40ea  ,0x0010);                                                                                                          
+    sensor_write_register(0x40eb  ,0x0027);                                                                                                          
+    sensor_write_register(0x40ec  ,0x00f8);                                                                                                          
+    sensor_write_register(0x40ed  ,0x0548);                                                                                                          
+    sensor_write_register(0x40ee  ,0x00f8);                                                                                                          
+    sensor_write_register(0x40ef  ,0x0000);                                                                                                          
+    sensor_write_register(0x40f0  ,0x800c);                                                                                                          
+    sensor_write_register(0x40f1  ,0x0002);                                                                                                          
+    sensor_write_register(0x40f2  ,0x0004);                                                                                                          
+    sensor_write_register(0x40f3  ,0x0002);                                                                                                          
+    sensor_write_register(0x40f4  ,0x0004);                                                                                                          
+    sensor_write_register(0x40f5  ,0x800c);                                                                                                          
+    sensor_write_register(0x40f6  ,0x800c);                                                                                                          
+    sensor_write_register(0x40f7  ,0x800c);                                                                                                          
+    sensor_write_register(0x40f8  ,0x800c);                                                                                                          
+    sensor_write_register(0x40f9  ,0x0000);                                                                                                          
+    sensor_write_register(0x40fa  ,0x0002);                                                                                                          
+    sensor_write_register(0x40fb  ,0x0014);                                                                                                          
+    sensor_write_register(0x40fc  ,0x000a);                                                                                                          
+    sensor_write_register(0x40fd  ,0x00f0);                                                                                                          
+    sensor_write_register(0x40fe  ,0x8001);                                                                                                          
+    sensor_write_register(0x40ff  ,0x8001);                                                                                                          
+    sensor_write_register(0x4100  ,0x800c);                                                                                                          
+    sensor_write_register(0x4101  ,0x800c);                                                                                                          
+    sensor_write_register(0x4102  ,0xc000);                                                                                                          
+    sensor_write_register(0x4103  ,0x8064);                                                                                                          
+    sensor_write_register(0x4104  ,0x8000);                                                                                                          
+    sensor_write_register(0x4105  ,0x8064);                                                                                                          
+    sensor_write_register(0x4106  ,0xc000);                                                                                                          
+    sensor_write_register(0x4107  ,0x8064);                                                                                                          
+    sensor_write_register(0x4108  ,0x0000);                                                                                                          
+    sensor_write_register(0x4109  ,0x0003);                                                                                                          
+    sensor_write_register(0x410a  ,0x0000);                                                                                                          
+    sensor_write_register(0x410b  ,0x2030);                                                                                                          
+    sensor_write_register(0x410c  ,0x010d);                                                                                                          
+    sensor_write_register(0x410d  ,0x0109);                                                                                                          
+    sensor_write_register(0x410e  ,0x0042);                                                                                                          
+    sensor_write_register(0x410f  ,0x0037);                                                                                                          
+    sensor_write_register(0x4110  ,0x0029);                                                                                                          
+    sensor_write_register(0x4111  ,0x0030);                                                                                                          
+    sensor_write_register(0x4112  ,0xffff);                                                                                                          
+    sensor_write_register(0x4113  ,0xffff);                                                                                                          
+    sensor_write_register(0x4114  ,0xffff);                                                                                                          
+    sensor_write_register(0x4115  ,0xff6f);                                                                                                        
+    sensor_write_register(0x4116  ,0x1a06);                                                                                                        
+    sensor_write_register(0x4117  ,0x0126);                                                                                                        
+    sensor_write_register(0x4118  ,0x1b86);                                                                                                        
+    sensor_write_register(0x4119  ,0x0122);                                                                                                        
+    sensor_write_register(0x411a  ,0x001b);                                                                                                        
+    sensor_write_register(0x411b  ,0x0132);                                                                                                        
+    sensor_write_register(0x411c  ,0x0586);                                                                                                        
+    sensor_write_register(0x411d  ,0x00ff);                                                                                                        
+    sensor_write_register(0x411e  ,0x8086);                                                                                                        
+    sensor_write_register(0x411f  ,0x0001);                                                                                                        
+    sensor_write_register(0x4120  ,0x0015);                                                                                                        
+    sensor_write_register(0x4121  ,0x0025);                                                                                                        
+    sensor_write_register(0x4122  ,0x8186);                                                                                                        
+    sensor_write_register(0x4123  ,0x008f);                                                                                                        
+    sensor_write_register(0x4124  ,0x0035);                                                                                                        
+    sensor_write_register(0x4125  ,0x000d);                                                                                                          
+    sensor_write_register(0x4126  ,0x039c);                                                                                                        
+    sensor_write_register(0x4127  ,0x0001);                                                                                                        
+    sensor_write_register(0x4128  ,0x001c);                                                                                                        
+    sensor_write_register(0x4129  ,0x0000);                                                                                                        
+    sensor_write_register(0x412a  ,0x0003);                                                                                                        
+    sensor_write_register(0x412b  ,0x000d);                                                                                                          
+    sensor_write_register(0x412c  ,0x001b);                                                                                                        
+    sensor_write_register(0x412d  ,0x0132);                                                                                                        
+    sensor_write_register(0x412e  ,0x8086);                                                                                                        
+    sensor_write_register(0x412f  ,0x0002);                                                                                                        
+    sensor_write_register(0x4130  ,0x0035);                                                                                                        
+    sensor_write_register(0x4131  ,0x000d);                                                                                                          
+    sensor_write_register(0x4132  ,0x039c);                                                                                                        
+    sensor_write_register(0x4133  ,0x0000);                                                                                                        
+    sensor_write_register(0x4134  ,0x0086);                                                                                                        
+    sensor_write_register(0x4135  ,0x010c);                                                                                                        
+    sensor_write_register(0x4136  ,0x4400);                                                                                                        
+    sensor_write_register(0x4137  ,0x000d);                                                                                                          
+    sensor_write_register(0x4138  ,0x411c);                                                                                                        
+    sensor_write_register(0x4139  ,0x0000);                                                                                                        
+    sensor_write_register(0x413a  ,0x611c);                                                                                                        
+    sensor_write_register(0x413b  ,0x0001);                                                                                                        
+    sensor_write_register(0x413c  ,0x638c);                                                                                                        
+    sensor_write_register(0x413d  ,0x3d25);                                                                                                        
+    sensor_write_register(0x413e  ,0x611c);                                                                                                        
+    sensor_write_register(0x413f  ,0x0002);                                                                                                        
+    sensor_write_register(0x4140  ,0x638c);                                                                                                        
+    sensor_write_register(0x4141  ,0x3d40);                                                                                                        
+    sensor_write_register(0x4142  ,0x611c);                                                                                                        
+    sensor_write_register(0x4143  ,0x0003);                                                                                                        
+    sensor_write_register(0x4144  ,0x638c);                                                                                                        
+    sensor_write_register(0x4145  ,0x3d60);                                                                                                        
+    sensor_write_register(0x4146  ,0x611c);                                                                                                        
+    sensor_write_register(0x4147  ,0x0004);                                                                                                        
+    sensor_write_register(0x4148  ,0x638c);                                                                                                        
+    sensor_write_register(0x4149  ,0x3d80);                                                                                                        
+    sensor_write_register(0x414a  ,0x611c);                                                                                                        
+    sensor_write_register(0x414b  ,0x0005);                                                                                                        
+    sensor_write_register(0x414c  ,0x638c);                                                                                                        
+    sensor_write_register(0x414d  ,0x3c35);                                                                                                        
+    sensor_write_register(0x414e  ,0x611c);                                                                                                        
+    sensor_write_register(0x414f  ,0x0006);                                                                                                        
+    sensor_write_register(0x4150  ,0x638c);                                                                                                        
+    sensor_write_register(0x4151  ,0x3c36);                                                                                                        
+    sensor_write_register(0x4152  ,0x611c);                                                                                                        
+    sensor_write_register(0x4153  ,0x0008);                                                                                                        
+    sensor_write_register(0x4154  ,0x638c);                                                                                                        
+    sensor_write_register(0x4155  ,0x3c20);                                                                                                        
+    sensor_write_register(0x4156  ,0x611c);                                                                                                        
+    sensor_write_register(0x4157  ,0x0000);                                                                                                        
+    sensor_write_register(0x4158  ,0xa19c);                                                                                                        
+    sensor_write_register(0x4159  ,0x0000);                                                                                                        
+    sensor_write_register(0x415a  ,0xa38c);                                                                                                        
+    sensor_write_register(0x415b  ,0x3d42);                                                                                                        
+    sensor_write_register(0x415c  ,0xa19c);                                                                                                        
+    sensor_write_register(0x415d  ,0x0001);                                                                                                        
+    sensor_write_register(0x415e  ,0xa38c);                                                                                                        
+    sensor_write_register(0x415f  ,0x3d62);                                                                                                        
+    sensor_write_register(0x4160  ,0xa19c);                                                                                                        
+    sensor_write_register(0x4161  ,0x0002);                                                                                                        
+    sensor_write_register(0x4162  ,0xa38c);                                                                                                        
+    sensor_write_register(0x4163  ,0x3d83);                                                                                                        
+    sensor_write_register(0x4164  ,0x611c);                                                                                                        
+    sensor_write_register(0x4165  ,0x0007);                                                                                                        
+    sensor_write_register(0x4166  ,0xa19c);                                                                                                        
+    sensor_write_register(0x4167  ,0x0000);                                                                                                        
+    sensor_write_register(0x4168  ,0xa38c);                                                                                                        
+    sensor_write_register(0x4169  ,0x3c33);                                                                                                        
+    sensor_write_register(0x416a  ,0x0055);                                                                                                        
+    sensor_write_register(0x7DA0  ,0x0009);                                                                                                        
+    sensor_write_register(0x7D41  ,0x0044);                                                                                                        
+    sensor_write_register(0x7D05  ,0x0001);       //slave:0; master:1                                                                                
+    sensor_write_register(0x7D02  ,0x00FF);                                                                                                        
+    sensor_write_register(0x7C06  ,0x0001);                                                                                                        
+    sensor_write_register(0x7C07  ,0x0000);                                                                                                        
+    sensor_write_register(0x7D43  ,0x2000);                                                                                                        
+    sensor_write_register(0x7D63  ,0x0005);                                                                                                        
+    sensor_write_register(0x7D82  ,0x7FFF);                                                                                                        
+    sensor_write_register(0x7D83  ,0x203C);                                                                                                        
+    sensor_write_register(0x7d01  ,0x0004);        //Force initial value updated                                                                     
+    sensor_write_register(0xc028  ,0x00f1);       //VDR ENABLE                                                                                       
+    sensor_write_register(0xc020  ,0x02FF);   // Enable DCLK, DOUT, Hdrv                                                                         
+    sensor_write_register(0x7c25  ,0x7FFF);//                                                                                                    
+    sensor_write_register(0xc052  ,0x0000);                                                                                                      
+    sensor_write_register(0xc04c  ,0x1111);                                                                                                      
+    sensor_write_register(0xC080  ,0xFFFF);// Set outen_reg0 register to enabled.                                                                
+    sensor_write_register(0xC081  ,0xFFFF);// Set outen_reg1 register to enabled.                                                                
+    sensor_write_register(0xC082  ,0xFFFF);// Set outen_reg2 register to enabled.                                                                
+    sensor_write_register(0xC083  ,0xFFFF);// Set outen_reg3 register to enabled.                                                                
+    sensor_write_register(0xC084  ,0x1C03);// Set outstandby_reg0 register to polarities of TG outputs(XVSG1-XVSG3, VD, HD to 1, others to 0)    
+    sensor_write_register(0xC085  ,0x1FFF);// Set outstandby_reg1 register to polarities of TG outputs(XVSG4-XVSG16 to 1, others to 0)           
+    sensor_write_register(0xC086  ,0x0000);// Set outstandby_reg2 register to polarities of TG outputs(XV1-XV16:  all to 0)                      
+    sensor_write_register(0xC087  ,0x0000);// Set outstandby_reg3 register to polarities of TG outputs(XV1-XV16, RGBLK, SUBCK: all to 0)         
+    sensor_write_register(0x7c0f  ,0x0011);// enable memory compression mode                                                                     
+    sensor_write_register(0x7c34  ,0x0002);// b.Fixed start address at 0x4002 (SPI)                                                              
+    sensor_write_register(0x7c20  ,0xFFFF);// IMASK, disalbe all interrupt                                                                       
+    sensor_write_register(0x7d00  ,0x0002);//  c.TG running mode enable                                                                          
+    sensor_write_register(0x4000  ,0x0000);// mode Id:0                                                                                          
+    sensor_write_register(0x7c22  ,0x0000);// d.ILAT (CLEAR INTERRUPTS)                                                                          
+    sensor_write_register(0x7c21  ,0x0000);// clear the PMASK                                                                                    
+    sensor_write_register(0x7c20  ,0xffef);// e.IMASK to allow SYNC Interrupt                                                                    
+    sensor_write_register(0x7c22  ,0x0010);// f. ILAT to trigger SYNC ISR                                                                        
+    sensor_write_register(0x7C73  ,0x0001);   //SUBCK_AUTO                                                                                       
+    sensor_write_register(0x7C7B  ,0x0008);   //SUBCK_CTRL                                                                                       
+    sensor_write_register(0x7C90  ,0x00bd);//TOG1, 25                                                                                            
+    sensor_write_register(0x7C92  ,0x00ea);//TOG2, 52                                                                                            
+    sensor_write_register(0x7C94  ,0xffff);//HP_TOG1, disable                                                                                    
+    sensor_write_register(0x7C96  ,0xffff);//HP_TOG2, disable                                                                                    
+    sensor_write_register(0x7C72  ,0x0001);//SGLINE                                                                                              
+    sensor_write_register(0x7C13  ,0x0008);//subck startline from SGLINE                                                                         
+    sensor_write_register(0x7C14  ,0x0020);//subck endline from SGLINE                                                                           
+    sensor_write_register(0xc074  ,0x1110);// 9020 vdriver mux                                                                                   
+    sensor_write_register(0xc075  ,0x1312);                                                                                                      
+    sensor_write_register(0xc078  ,0x0908);                                                                                                      
+    sensor_write_register(0xc079  ,0x0b0a);    
 
-	printf("-------sensor ICX692 initial ok!----\n");
+    sensor_write_register(0xc0ae  ,0x8088); 
+
+    printf("-------sensor ICX692 initial ok!----\n");
 }
-
-
-
-
 

--- a/libraries/sensor/hi3516cv100/sony_imx104/imx104_cmos.c
+++ b/libraries/sensor/hi3516cv100/sony_imx104/imx104_cmos.c
@@ -5,10 +5,12 @@
 #include <string.h>
 #include <assert.h>
 #include "hi_comm_sns.h"
+#include "hi_comm_isp.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_isp_debug.h"
-#include "hi_comm_isp.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -23,190 +25,116 @@ extern "C"{
 #define PGC_ADDR (0x214)
 #define VMAX_ADDR (0x218)
 
+#define IMX104_ID 104
+/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker */
+/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance   */
+/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                     */
 #define CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE (1)
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
 HI_U8 gu8SensorMode = 0;
+#if CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
+static HI_BOOL gsbRegInit = HI_FALSE;
+#endif
+static HI_U32 gu32FullLinesStd = 750;
+static HI_U32 gu32FullLines = 750;
 
-static cmos_isp_default_t st_coms_isp_default_lin =
+static AWB_CCM_S g_stAwbCcm =
 {
-    // color correction matrix
+    5000,
     {
-        5000,
-    	{
-    		0x01D3, 0x80A0, 0x8033,
-    		0x8036, 0x0192, 0x805C,
-    		0x0023, 0x80CC, 0x01A9,
-    	},
-        3200,
-    	{
-    		0x01DA, 0x8094, 0x8046,
-    		0x8064, 0x01B0, 0x804C,
-    		0x0034, 0x8107, 0x01D3,
-    	},
-    	2600,
-    	{
-    		0x0231, 0x80E9, 0x8048,
-    		0x8019, 0x014D, 0x8034,
-    		0x0079, 0x81CA, 0x0251,
-    	}
+        0x01D3, 0x80A0, 0x8033,
+        0x8036, 0x0192, 0x805C,
+        0x0023, 0x80CC, 0x01A9,
     },
-
-	// black level for R, Gr, Gb, B channels
-	{0xF0,0xF0,0xF0,0xF0},
-
-	//calibration reference color temperature
-	5000,
-
-	//WB gain at 5000K, must keep consistent with calibration color temperature
-	{0x01D6, 0x100, 0x100, 0x01DA},
-
-	// WB curve parameters, must keep consistent with reference color temperature.
-	{19, 147, -89, 186629, 128, -137989},
-
-	// hist_thresh
-	{0xd,0x28,0x60,0x80},
-
-	0x00,	// iridix_balck
-	0x2,	// 0:rggb; 2: gbrg
-
-	// max again, max dgain
-	0x10,	0x10,
-
-	// iridix
-	0x04,	0x08,	0xa0, 	0xfff,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x8, 	// sinter threshold
-
-	0x1,  //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
-	0,    //nr0
-	455,  //nr1
-
-    2
+    3200,
+    {
+        0x01DA, 0x8094, 0x8046,
+        0x8064, 0x01B0, 0x804C,
+        0x0034, 0x8107, 0x01D3,
+    },
+    2600,
+    {
+        0x0231, 0x80E9, 0x8048,
+        0x8019, 0x014D, 0x8034,
+        0x0079, 0x81CA, 0x0251,
+    }
 };
 
-static cmos_isp_default_t st_coms_isp_default_wdr =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
-    // color correction matrix
-    {
-        5000,
-    	{
-    		0x01D3, 0x80A0, 0x8033,
-    		0x8036, 0x0192, 0x805C,
-    		0x0023, 0x80CC, 0x01A9,
-    	},
-        3200,
-    	{
-    		0x01DA, 0x8094, 0x8046,
-    		0x8064, 0x01B0, 0x804C,
-    		0x0034, 0x8107, 0x01D3,
-    	},
-    	2600,
-    	{
-    		0x0231, 0x80E9, 0x8048,
-    		0x8019, 0x014D, 0x8034,
-    		0x0079, 0x81CA, 0x0251,
-    	}
-    },
-
-
-	// black level(wdr)
-	{0x00,0x00,0x00,0x00},
-
-	//calibration reference color temperature
-	5000,
-
-	//WB gain at 5000K, must keep consistent with calibration color temperature
-	{0x01D6, 0x100, 0x100, 0x01DA},
-
-	// WB curve parameters, must keep consistent with reference color temperature.
-	{19, 147, -89, 186629, 128, -137989},
-
-	// hist_thresh
-	{0x20,0x40,0x60,0x80},
-
-	0x00,	// iridix_balck
-	0x2,	// rggb
-
-	// gain
-	0x1,	0x4,
-
-	//wdr_variance_space, wdr_variance_intensity, slope_max_write,  white_level_write
-	0x08,	0x01,	0x3c, 	0xFFF,
-
-	0x0, 	// balance_fe
-	0x80,	// ae compensation
-	0x9, 	// sinter threshold
-
-	0x0,     //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
-	0x0,
-	0x0,
-      2
-};
-
-
-static cmos_isp_agc_table_t st_isp_agc_table =
-{
-    //sharpen_alt_d
-    //{45,45,45,40,40,35,33,15},
-    {80,75,70,65,60,50,40,30},
-
-    //sharpen_alt_ud
-    //{30,30,30,28,28,25,22,10},
-    {75,70,65,60,50,40,30,20},
-
-    //snr_thresh
-    //{33,41,49,57,65,73,81,89},
-    {8,12,18,26,36,46,56,70},
-
-    //demosaic_lum_thresh
-    {0x50,0x50,0x40,0x40,0x30,0x30,0x20,0x20},
-
-    //demosaic_np_offset
-    {0,8,16,24,32,40,48,56},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
+    /* bvalid */
+    1,
 
     /* saturation */
     {0x80,0x80,0x6C,0x48,0x44,0x40,0x3C,0x38}
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
 {
-  //nosie_profile_weight_lut
+    /* bvalid */
+    1,
+
+    /* sharpen_alt_d */
+    {80,75,70,65,60,50,40,30},
+        
+    /* sharpen_alt_ud */
+    {75,70,65,60,50,40,30,20},
+        
+    /* snr_thresh */
+    {8,12,18,26,36,46,56,70},
+        
+    /* demosaic_lum_thresh */
+    {0x50,0x50,0x40,0x40,0x30,0x30,0x20,0x20},
+        
+    /* demosaic_np_offset */
+    {0,8,16,24,32,40,48,56},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
+};
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTableLin =
+{
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {
         0,0,0,0,0,0,0,15,25,29,31,33,32,35,36,37,37,38,39,39,40,40,40,41,41,41,42,42,42,43,43,43,43,44,44,44,44,44,45,45,45,45,45,45,45,46,46,46,46,46,46,47,47,47,47,47,47,47,47,48,48,48,48,48,48,48,48,48,49,49,49,49,49,49,49,49,49,49,49,49,50,50,50,50,50,50,50,50,50,50,50,50,50,50,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52
     },
 
-  //demosaic_weight_lut
+    /* demosaic_weight_lut */
     {
         0,15,25,29,31,33,34,35,36,37,37,38,39,39,40,40,40,41,41,41,42,42,42,43,43,43,43,44,44,44,44,44,45,45,45,45,45,45,46,46,46,46,46,46,46,47,47,47,47,47,47,47,47,48,48,48,48,48,48,48,48,48,49,49,49,49,49,49,49,49,49,49,49,49,49,50,50,50,50,50,50,50,50,50,50,50,50,50,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52,52
     }
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table_wdr =
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTableWdr =
 {
-    /*nosie_profile_weight_lut WDR*/
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {
         0,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,45,48,57,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64
     },
 
-  //demosaic_weight_lut
+    /* demosaic_weight_lut */
     {
         0,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,45,48,57,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64
     }
 };
 
 
-static cmos_isp_demosaic_t st_isp_demosaic =
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
+    /* bvalid */
+    1,
+    
     /*vh_slope*/
     0xc6,
 
@@ -243,752 +171,152 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     /*ac_thresh*/
     0x1b3,
 };
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
+
+static ISP_CMOS_GAMMAFE_S g_stGammafe = 
 {
-	cmos_inttime.full_lines_std = 750;
-	cmos_inttime.full_lines_std_30fps = 750;
-	cmos_inttime.full_lines = 750;
-	cmos_inttime.full_lines_limit = 65535;
-	cmos_inttime.max_lines_target = 748;
-	cmos_inttime.min_lines_target = 2;
-	cmos_inttime.vblanking_lines = 0;
+    /* bvalid */
+    1,
 
-	cmos_inttime.exposure_ashort = 0;
-
-	cmos_inttime.lines_per_500ms = 750*30/2; //
-	cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-    switch(gu8SensorMode)
     {
-        default:
-        case 0: //linear mode
-
-        break;
-        case 1: //WDR mode for short exposure, Exposure ratio = 16X
-            cmos_inttime.max_lines_target = 46;
-            cmos_inttime.min_lines_target = 5;
-        break;
+       0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  28,
+      70,  95, 114, 131, 146, 159, 172, 183, 195, 205, 215, 224, 233, 242, 250, 258,
+     266, 273, 281, 288, 295, 302, 309, 315, 322, 328, 334, 340, 346, 352, 358, 364,
+     369, 375, 380, 386, 391, 396, 401, 406, 411, 416, 421, 426, 431, 436, 440, 445,
+     450, 454, 459, 463, 467, 472, 476, 480, 485, 489, 493, 497, 502, 506, 510, 514,
+     518, 522, 525, 529, 533, 537, 541, 545, 548, 552, 556, 559, 563, 567, 571, 574,
+     578, 581, 585, 588, 592, 595, 599, 602, 605, 609, 612, 615, 619, 622, 625, 629,
+     632, 635, 638, 642, 645, 648, 651, 654, 657, 661, 664, 667, 670, 673, 676, 679,
+     682, 729, 772, 814, 853, 891, 927, 962, 995,1028,1060,1090,1120,1149,1177,1205,
+    1232,1258,1284,1309,1334,1359,1383,1406,1429,1452,1475,1497,1519,1540,1561,1582,
+    1603,1623,1643,1663,1683,1702,1721,1740,1759,1778,1796,1814,1832,1850,1868,1885,
+    1903,1920,1937,1954,1971,1987,2004,2020,2036,2100,2162,2222,2280,2337,2393,2447,
+    2500,2552,2603,2653,2702,2751,2798,2844,2890,2936,2980,3024,3067,3110,3151,3193,
+    3234,3274,3314,3354,3393,3431,3469,3507,3544,3581,3618,3654,3690,3725,3760,3795,
+    3830,3864,3898,3931,3965,3998,4030,4063,4095,4095,4095,4095,4095,4095,4095,4095,
+    4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095
     }
-
-	return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
-{
-    HI_U16 exp_time,current;
-
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0: //linear mode
-            //Integration time = (VMAX - (SHS1+1)) + tOFFSET
-            exp_time = p_inttime->full_lines - p_inttime->exposure_ashort - 1;
-            current = sensor_read_register(EXPOSURE_ADDR+2);
-#if CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE
-
-            ISP_SSP_DATA_S   stSspData;
-            stSspData.bDelayCfg = HI_FALSE;
-            stSspData.u32DevAddr = 0x02;
-            stSspData.u32DevAddrByteNum = 1;
-            stSspData.u32RegAddr = 0x20;
-            stSspData.u32RegAddrByteNum = 1;
-            stSspData.u32Data = (exp_time & 0xFF);
-            stSspData.u32DataByteNum = 1;
-            HI_MPI_ISP_SSPWrite(&stSspData);
-
-            stSspData.u32RegAddr = 0x21;
-            stSspData.u32RegAddrByteNum = 1;
-            stSspData.u32Data = ((exp_time & 0xFF00) >> 8);            
-            stSspData.u32DataByteNum = 1;
-            HI_MPI_ISP_SSPWrite(&stSspData);
-
-            stSspData.u32RegAddr = 0x22;
-            stSspData.u32RegAddrByteNum = 1;
-            stSspData.u32Data = (((exp_time & 0x10000) >> 16)+(current&0xFE));            
-            stSspData.u32DataByteNum = 1;            
-            HI_MPI_ISP_SSPWrite(&stSspData);
-
-
-
-#else   
-
-
-            sensor_write_register(EXPOSURE_ADDR, exp_time & 0xFF);
-            sensor_write_register(EXPOSURE_ADDR+1, (exp_time & 0xFF00) >> 8);
-            sensor_write_register(EXPOSURE_ADDR+2, (((exp_time & 0x10000) >> 16)+(current&0xFE)) );
-
-            
-#endif
-
-        break;
-        case 1: //WDR mode
-            //short exposure
-            if (p_inttime->exposure_ashort < p_inttime->min_lines_target)
-            {
-                p_inttime->exposure_ashort = p_inttime->min_lines_target;
-            }
-            if (p_inttime->exposure_ashort > p_inttime->max_lines_target)
-            {
-                p_inttime->exposure_ashort = p_inttime->max_lines_target;
-            }
-            exp_time = p_inttime->full_lines - p_inttime->exposure_ashort - 1;
-            current = sensor_read_register(EXPOSURE_ADDR+2);
-#if CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE
-
-            stSspData.bDelayCfg = HI_FALSE;
-            stSspData.u32DevAddr = 0x02;
-            stSspData.u32DevAddrByteNum = 1;
-            stSspData.u32RegAddr = 0x20;
-            stSspData.u32RegAddrByteNum = 1;
-            stSspData.u32Data = (exp_time & 0xFF);
-            stSspData.u32DataByteNum = 1;
-            HI_MPI_ISP_SSPWrite(&stSspData);
-
-            stSspData.u32RegAddr = 0x21;
-            stSspData.u32RegAddrByteNum = 1;
-            stSspData.u32Data = ((exp_time & 0xFF00) >> 8);
-            stSspData.u32DataByteNum = 1;
-            HI_MPI_ISP_SSPWrite(&stSspData);
-
-            stSspData.u32RegAddr = 0x22;
-            stSspData.u32RegAddrByteNum = 1;
-            stSspData.u32Data = (((exp_time & 0x10000) >> 16)+(current&0xFE));
-            stSspData.u32DataByteNum = 1;
-            HI_MPI_ISP_SSPWrite(&stSspData);
-
-            exp_time = p_inttime->full_lines - (p_inttime->exposure_ashort << 4) - 1;
-            current = sensor_read_register(LONG_EXPOSURE_ADDR+2);
-
-            stSspData.u32RegAddr = 0x23;
-            stSspData.u32RegAddrByteNum = 1;
-            stSspData.u32Data = (exp_time & 0xFF);
-            stSspData.u32DataByteNum = 1;
-            HI_MPI_ISP_SSPWrite(&stSspData);
-
-            stSspData.u32RegAddr = 0x24;
-            stSspData.u32RegAddrByteNum = 1;
-            stSspData.u32Data = ((exp_time & 0xFF00) >> 8);
-            stSspData.u32DataByteNum = 1;
-            HI_MPI_ISP_SSPWrite(&stSspData);
-
-            stSspData.u32RegAddr = 0x25;
-            stSspData.u32RegAddrByteNum = 1;
-            stSspData.u32Data = (((exp_time & 0x10000) >> 16)+(current&0xFE));
-            stSspData.u32DataByteNum = 1;
-            HI_MPI_ISP_SSPWrite(&stSspData);
-
-            
-            
-#else
-
-
-            sensor_write_register(EXPOSURE_ADDR, exp_time & 0xFF);
-            sensor_write_register(EXPOSURE_ADDR+1, (exp_time & 0xFF00) >> 8);
-            sensor_write_register(EXPOSURE_ADDR+2, (((exp_time & 0x10000) >> 16)+(current&0xFE)) );
-
-            //long exposure
-            exp_time = p_inttime->full_lines - (p_inttime->exposure_ashort << 4) - 1;
-            current = sensor_read_register(LONG_EXPOSURE_ADDR+2);
-
-            sensor_write_register(LONG_EXPOSURE_ADDR, exp_time & 0xFF);
-            sensor_write_register(LONG_EXPOSURE_ADDR+1, (exp_time & 0xFF00) >> 8);
-            sensor_write_register(LONG_EXPOSURE_ADDR+2, (((exp_time & 0x10000) >> 16)+(current&0xFE)) );
-
-            
-#endif
-
-
-
-        break;
-    }
-
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-	HI_U16 vmax = p_inttime->full_lines;
-    HI_U16  current;
-    current = sensor_read_register(VMAX_ADDR+2);
-
-	sensor_write_register(VMAX_ADDR, (vmax&0x00ff));
-	sensor_write_register(VMAX_ADDR+1, ((vmax&0xff00) >> 8));
-	sensor_write_register(VMAX_ADDR+2,(((vmax & 0x10000) >> 16)+(current&0xFE)));
-	return;
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-	if (p_inttime->exposure_ashort >= p_inttime->full_lines - 2)
-	{
-		p_inttime->exposure_ashort = p_inttime->full_lines - 2;
-	}
-
-	p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std;
-
-	return p_inttime->exposure_ashort;
-}
-
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-	switch(fps)
-	{
-		case 30:
-			// Change the frame rate via changing the vertical blanking
-			p_inttime->full_lines_std = 750;
-			sensor_write_register(VMAX_ADDR, 0xEE);
-			sensor_write_register(VMAX_ADDR+1, 0x02);
-			p_inttime->lines_per_500ms = 750 * 30 / 2;
-		break;
-
-		case 25:
-			// Change the frame rate via changing the vertical blanking
-			p_inttime->full_lines_std = 900;
-			sensor_write_register(VMAX_ADDR, 0x84);
-			sensor_write_register(VMAX_ADDR+1, 0x03);
-			p_inttime->lines_per_500ms = 900 * 25 / 2;
-		break;
-
-		default:
-		break;
-	}
-
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
-{
-    cmos_gains.again = 1;
-    cmos_gains.dgain = 1;
-    cmos_gains.isp_dgain = 1;
-    cmos_gains.again_db = 1;
-    cmos_gains.dgain_db = 1;
-	cmos_gains.again_shift = 10;
-	cmos_gains.dgain_shift = 10;
-	cmos_gains.dgain_fine_shift = 0;
-
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_TRUE;
-
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0: //linear mode
-            cmos_gains.max_again = 16229;
-            cmos_gains.max_dgain = 16229;
-            cmos_gains.max_again_target = 16229;
-            cmos_gains.max_dgain_target = 16229;
-            cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-        break;
-        case 1: //WDR mode
-            cmos_gains.max_again = 1 << cmos_gains.again_shift;
-            cmos_gains.max_dgain = 4077;
-            cmos_gains.max_again_target = 1 << cmos_gains.again_shift;
-            cmos_gains.max_dgain_target = 4077;
-            cmos_gains.max_isp_dgain_target = 32 << cmos_gains.isp_dgain_shift;
-        break;
-    }
-
-	return &cmos_gains;
-}
-
-static HI_U32 gain_table[81] =
-{
-    1024 , 1060 ,  1097 ,  1136 ,  1176,  1217 , 1260 ,  1304,  1350 ,  1397 ,  1446 ,  1497 , 1550 , 1604 ,  1661 ,  1719 , 
-    1780 , 1842 ,  1907 ,  1974 ,  2043,  2115 , 2189 ,  2266,  2346 ,  2428 ,  2514 ,  2602 , 2693 , 2788 ,  2886 ,  2987 , 
-    3092 , 3201 ,  3314 ,  3430 ,  3551,  3675 , 3805 ,  3938,  4077 ,  4220 ,  4368 ,  4522 , 4681 , 4845 ,  5015 ,  5192 , 
-    5374 , 5563 ,  5758 ,  5961 ,  6170,  6387 , 6611 ,  6844,  7084 ,  7333 ,  7591 ,  7858 , 8134 , 8420 ,  8716 ,  9022 , 
-    9339 , 9667 , 10007 , 10359 , 10723, 11099 ,11489 , 11893, 12311 , 12744 , 13192 , 13655 ,14135 ,14632 , 15146 , 15678 , 
-    16229     
 };
 
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-#if CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE 
+    if (HI_NULL == pstDef)
+    {
+        printf("null pointer when get isp default value!\n");
+        return -1;
+    }
 
-    ISP_SSP_DATA_S   stSspData;
-
-    switch(gu8SensorMode)
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
+    
+    switch (gu8SensorMode)
     {
         default:
-        case 0: /* linear mode */
-            /* analog gain = APGC * 0.3 db, APGC = [0x0,0x50], ag_db=[0db, 24db] */
-            /* digital gain = DPGC * 0.3 db, DPCG = [0x50,0xA0], dg_db=[0db, 24db] */
-            
-       
-            stSspData.bDelayCfg = HI_TRUE;
-            stSspData.u32DevAddr = 0x02;
-            stSspData.u32DevAddrByteNum = 1;
-            stSspData.u32RegAddr = 0x14;
-            stSspData.u32RegAddrByteNum = 1;
-            stSspData.u32Data = p_gains->again_db + p_gains->dgain_db;
-            stSspData.u32DataByteNum = 1;
+        case 0:
+            pstDef->stComm.u8Rggb           = 0x2;      //2: gbrg  
+            pstDef->stComm.u8BalanceFe      = 0x1;
 
-            if((p_gains->again_db + p_gains->dgain_db) <= 0xA0)
-            {
+            pstDef->stDenoise.u8SinterThresh= 0x8;
+            pstDef->stDenoise.u8NoiseProfile= 0x1;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+            pstDef->stDenoise.u16Nr0        = 0x0;
+            pstDef->stDenoise.u16Nr1        = 455;
 
+            pstDef->stDrc.u8DrcBlack        = 0x00;
+            pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+            pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+            pstDef->stDrc.u8DrcSm           = 0xa0;     // slope max
+            pstDef->stDrc.u16DrcWl          = 0x8ff;    // white level
 
-              HI_MPI_ISP_SSPWrite(&stSspData);
-            }
-            else
-            {
-
-              
-                stSspData.u32Data = 0xA0;
-                stSspData.u32DataByteNum = 1;
-                HI_MPI_ISP_SSPWrite(&stSspData);
-            }
-            
-
+            memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTableLin, sizeof(ISP_CMOS_NOISE_TABLE_S));            
         break;
-        case 1: //WDR mode
+        case 1:
+            pstDef->stComm.u8Rggb           = 0x2;      //2: gbrg  
+            pstDef->stComm.u8BalanceFe      = 0x0;
 
-            /* analog gain : 4.5dB fixed
-              * digital gain : 0 to 12dB  0.3dB step
-              * DPGC = [00h,28h];
-              * digital_gain = DPGC * 0.3 db. */
+            pstDef->stDenoise.u8SinterThresh= 0x9;
+            pstDef->stDenoise.u8NoiseProfile= 0x0;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+            pstDef->stDenoise.u16Nr0        = 0x0;
+            pstDef->stDenoise.u16Nr1        = 0x0;
 
-            stSspData.bDelayCfg = HI_TRUE;
-            stSspData.u32DevAddr = 0x02;
-            stSspData.u32DevAddrByteNum = 1;
-            stSspData.u32RegAddr = 0x14;
-            stSspData.u32RegAddrByteNum = 1;
-            stSspData.u32Data =  p_gains->dgain_db;
-            stSspData.u32DataByteNum = 1;
+            pstDef->stDrc.u8DrcBlack        = 0x00;
+            pstDef->stDrc.u8DrcVs           = 0x08;     // variance space
+            pstDef->stDrc.u8DrcVi           = 0x01;     // variance intensity
+            pstDef->stDrc.u8DrcSm           = 0x3C;     // slope max
+            pstDef->stDrc.u16DrcWl          = 0xFFF;    // white level
 
-            if(p_gains->dgain_db <= 40)
-            {
-             HI_MPI_ISP_SSPWrite(&stSspData);
-            }
-            else
-            {
-            stSspData.u32Data = 0x28;
-            stSspData.u32DataByteNum = 1;
-            HI_MPI_ISP_SSPWrite(&stSspData);
-            }
- 
+            memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTableWdr, sizeof(ISP_CMOS_NOISE_TABLE_S));
+
+            memcpy(&pstDef->stGammafe, &g_stGammafe, sizeof(ISP_CMOS_GAMMAFE_S));
         break;
     }
 
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
 
-#else
-
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0: /* linear mode */
-            /* analog gain = APGC * 0.3 db, APGC = [0x0,0x50], ag_db=[0db, 24db] */
-            /* digital gain = DPGC * 0.3 db, DPCG = [0x50,0xA0], dg_db=[0db, 24db] */            
-            if((p_gains->again_db + p_gains->dgain_db) <= 0xA0)
-            {
-                sensor_write_register(PGC_ADDR, p_gains->again_db + p_gains->dgain_db);
-            }
-            else
-            {
-                sensor_write_register(PGC_ADDR, 0xA0);
-            }
-            
-        break;
-        case 1: //WDR mode
-
-            /* analog gain : 4.5dB fixed
-              * digital gain : 0 to 12dB  0.3dB step
-              * DPGC = [00h,28h];
-              * digital_gain = DPGC * 0.3 db. */
-
-            if(p_gains->dgain_db <= 40)
-            {
-                sensor_write_register(PGC_ADDR, p_gains->dgain_db);
-            }
-            else
-            {
-                sensor_write_register(PGC_ADDR, 0x28);
-            }
-
-        break;
-    }
-
-#endif
-
+    return 0;
 }
 
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-    HI_U32 again = 1024;
-    HI_U32 step = 0;
-    HI_S32 shift = 0;
-    HI_S32 i = 0;
-
-    while (exposure > (1 << 20))
-    {
-        exposure     >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-
-    /*WDR mode, again 4.5dB fixed*/
-    if((1 != gu8SensorMode) && (exposure > exposure_max))
-    {
-        again = (exposure << 10) / exposure_max;
-        again = again < 1024? 1024: again;
-        again = again > p_gains->max_again_target? p_gains->max_again_target: again;
+    HI_S32  i;
     
-        if (again >= gain_table[80])
-        {
-             again = gain_table[80];
-             step = 80;
-        }
-        else
-        {
-            for(i = 1; i < 81; i++)
+    if (HI_NULL == pstBlackLevel)
+    {
+        printf("null pointer when get isp black level value!\n");
+        return -1;
+    }
+
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+
+    switch (gu8SensorMode)
+    {
+        default :
+        case 0 :
+            for (i=0; i<4; i++)
             {
-                if(again < gain_table[i])
-                {
-                    again = gain_table[i-1];
-                    step = i-1;
-                    break;
-                }
+                pstBlackLevel->au16BlackLevel[i] = 0xf0;
             }
-        }
-        
-        exposure = (exposure << 10) / again;
-    }
-
-    p_gains->again = again;
-    p_gains->again_db = step;
-    
-    return exposure << shift;
-}
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
-
-    while (exposure > (1 << 22))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target)? (p_gains->max_isp_dgain_target): isp_dgain;        
-    }
-    
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shift;
-}
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 dgain = 1024;
-    HI_U32 step = 0;
-    HI_S32 shift = 0;
-    HI_S32 i = 0;
-    HI_U32 u32MaxStep;
-    
-    while (exposure > (1 << 20))
-    {
-        exposure     >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-    
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0: /*linear mode, dgain: 0.3 to 24dB(step 0.3dB)*/
-            u32MaxStep = 81;
-        break;
-        case 1: /*WDR mode, dgain: 0.3 to 12dB(step 0.3dB), but now fixed to 0dB*/
-            u32MaxStep = 41;
-        break;
-    }
-    
-    if(exposure > exposure_max)
-    {
-        dgain = (exposure << 10) / exposure_max;
-        dgain = dgain < 1024? 1024: dgain;
-        dgain = dgain > p_gains->max_dgain_target? p_gains->max_dgain_target: dgain;
-    
-        if (dgain >= gain_table[u32MaxStep - 1])
-        {
-             dgain = gain_table[u32MaxStep - 1];
-             step = u32MaxStep - 1;
-        }
-        else
-        {
-            for(i = 1; i < u32MaxStep; i++)
+            break;
+        case 1 :
+            for (i=0; i<4; i++)
             {
-                if(dgain < gain_table[i])
-                {
-                    dgain = gain_table[i-1];
-                    step = i-1 ;
-                    break;
-                }
+                pstBlackLevel->au16BlackLevel[i] = 0x0;
             }
-        }
-        
-        exposure = (exposure << 10) / dgain;
+            break;
     }
- 
-    p_gains->dgain = dgain;
-    p_gains->dgain_db = step;
-    
-    return exposure << shift;
 
+    return 0;    
 }
 
-static void setup_sensor(int isp_mode)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-	if(0 == isp_mode) /* setup for ISP 'normal mode' */
-	{
-        sensor_write_register(VMAX_ADDR, 0xEE);
-        sensor_write_register(VMAX_ADDR + 1, 0x02);
-	}
-	else if(1 == isp_mode) /* setup for ISP pixel calibration mode */
-	{
+    if (bEnable) /* setup for ISP pixel calibration mode */
+    {
         /* Sensor must be programmed for slow frame rate (5 fps and below)*/
         /* change frame rate to 5 fps by setting 1 frame length = 750 * 30 / 5 */
         sensor_write_register(VMAX_ADDR, 0x94);
         sensor_write_register(VMAX_ADDR + 1, 0x11);
 
         /* max Exposure time */
-		sensor_write_register(EXPOSURE_ADDR, 0x00);
-		sensor_write_register(EXPOSURE_ADDR + 1, 0x00);
+        sensor_write_register(EXPOSURE_ADDR, 0x00);
+        sensor_write_register(EXPOSURE_ADDR + 1, 0x00);
 
         /* Analog and Digital gains both must be programmed for their minimum values */
-		sensor_write_register(PGC_ADDR, 0x00);
-
-	}
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-
-	HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-	HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _ispdgain = p_gains->isp_dgain == 0 ? 1 : p_gains->isp_dgain;
-
-		p_gains->iso =  (((HI_U64)_again * _dgain * _ispdgain * 100) 
-        >> (p_gains->again_shift + p_gains->dgain_shift 
-        + p_gains->isp_dgain_shift));
-
-	return p_gains->iso;
-}
-
-/* Note: The unit of return value is 1db.  */
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return (cmos_gains->again_db *  3 / 10);
-}
-
-/* Note: The unit of return value is 1db.  */
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return  (cmos_gains->dgain_db *  3 / 10);
-}
-
-/*
-static HI_U8 cmos_get_digital_fine_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return cmos_gains->dgain_fine;
-}
-*/
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-    if (NULL == p_coms_isp_default)
+        sensor_write_register(PGC_ADDR, 0x00);
+    }
+    else /* setup for ISP 'normal mode' */
     {
-        printf("null pointer when get isp default value!\n");
-        return -1;
+        sensor_write_register(VMAX_ADDR, 0xEE);
+        sensor_write_register(VMAX_ADDR + 1, 0x02);
     }
 
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0:
-            memcpy(p_coms_isp_default, &st_coms_isp_default_lin, sizeof(cmos_isp_default_t));
-        break;
-        case 1:
-            memcpy(p_coms_isp_default, &st_coms_isp_default_wdr, sizeof(cmos_isp_default_t));
-        break;
-    }
-    return 0;
+    return;
 }
 
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0:
-            memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-        break;
-        case 1:
-            memcpy(p_cmos_isp_noise_table, &st_isp_noise_table_wdr, sizeof(cmos_isp_noise_table_t));
-        break;
-    }
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
-{
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-HI_U32 cmos_get_sensor_mode(void)
-{
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0:
-            return isp_special_alg_imx104_lin;
-
-        break;
-        case 1:
-            return isp_special_alg_imx104_wdr;
-
-        break;
-    }
-}
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1280;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 720;
-
-    return 0;
-}
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-SENSOR_EXP_FUNC_S stSensorExpFuncs =
-{
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
-
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-
-	.pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-	.pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-	.pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-	.pfn_cmos_get_isp_default = cmos_get_isp_default,
-	.pfn_cmos_get_isp_special_alg = cmos_get_sensor_mode,
-	.pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-	.pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-	.pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-	.pfn_cmos_get_isp_shading_table = NULL,
-	.pfn_cmos_get_isp_gamma_table = NULL,
-	.pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-	.pfn_cmos_set_sensor_image_mode = NULL,
-
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-	return 0;
-}
-
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
-        //720P30 linear
+        //sensor mode 0
         case 0:
             gu8SensorMode = 0;
             sensor_write_register(0x20C, 0x00);
@@ -1004,11 +332,10 @@ int sensor_mode_set(HI_U8 u8Mode)
             sensor_write_register(0x461, 0x9B);
             sensor_write_register(0x466, 0xD0);
             sensor_write_register(0x467, 0x08);
-
+           
             printf("imx104 linear mode\n");
         break;
-
-        //720P30 wdr
+        //sensor mode 1
         case 1:
             gu8SensorMode = 1;
             sensor_write_register(0x20C, 0x02);
@@ -1030,12 +357,588 @@ int sensor_mode_set(HI_U8 u8Mode)
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+#if CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE
+    gsbRegInit = HI_FALSE;
+#endif
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 750;
+    
+    pstAeSnsDft->u32LinesPer500ms = 750*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 748;
+    pstAeSnsDft->u32MinIntTime = 2;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 0.3;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.3;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
+    switch(gu8SensorMode)
+    {
+        default:
+        case 0: //linear mode
+            pstAeSnsDft->au8HistThresh[0] = 0xd;
+            pstAeSnsDft->au8HistThresh[1] = 0x28;
+            pstAeSnsDft->au8HistThresh[2] = 0x60;
+            pstAeSnsDft->au8HistThresh[3] = 0x80;
+            
+            pstAeSnsDft->u8AeCompensation = 0x40;
+            
+            pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+            pstAeSnsDft->u32MinIntTimeTarget = 2;
+            
+            pstAeSnsDft->u32MaxAgain = 16229;  /* */
+            pstAeSnsDft->u32MinAgain = 1024;
+            pstAeSnsDft->u32MaxAgainTarget = 16229;
+            pstAeSnsDft->u32MinAgainTarget = 1024;
+            
+            pstAeSnsDft->u32MaxDgain = 16229;  /*  */
+            pstAeSnsDft->u32MinDgain = 1024;
+            pstAeSnsDft->u32MaxDgainTarget = 16229;
+            pstAeSnsDft->u32MinDgainTarget = 1024;
+            
+            pstAeSnsDft->u32MaxISPDgainTarget = 3 << pstAeSnsDft->u32ISPDgainShift;
+        break;
+        case 1: //WDR mode
+            pstAeSnsDft->au8HistThresh[0] = 0x20;
+            pstAeSnsDft->au8HistThresh[1] = 0x40;
+            pstAeSnsDft->au8HistThresh[2] = 0x60;
+            pstAeSnsDft->au8HistThresh[3] = 0x80;
+            
+            pstAeSnsDft->u8AeCompensation = 0x40;
+
+        
+            pstAeSnsDft->u32MaxIntTimeTarget = 46;  /* for short exposure, Exposure ratio = 16X */
+            pstAeSnsDft->u32MinIntTimeTarget = 5;
+
+            pstAeSnsDft->u32MaxAgain = 1024;  /* 4.5db fixed */
+            pstAeSnsDft->u32MinAgain = 1024;
+            pstAeSnsDft->u32MaxAgainTarget = 1024;
+            pstAeSnsDft->u32MinAgainTarget = 1024;
+            
+            pstAeSnsDft->u32MaxDgain = 4096;  /*  */
+            pstAeSnsDft->u32MinDgain = 1024;
+            pstAeSnsDft->u32MaxDgainTarget = 1024;
+            pstAeSnsDft->u32MinDgainTarget = 1024;
+            
+            pstAeSnsDft->u32MaxISPDgainTarget = 32 << pstAeSnsDft->u32ISPDgainShift;
+        break;
+    }
+
     return 0;
 }
 
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    switch(u8Fps)
+    {
+        case 30:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 750;
+            pstAeSnsDft->u32MaxIntTime = 748;
+            pstAeSnsDft->u32LinesPer500ms = 750 * 30 / 2;
+            sensor_write_register(VMAX_ADDR, 0xEE);
+            sensor_write_register(VMAX_ADDR+1, 0x02);
+        break;
+        
+        case 25:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 900;
+            pstAeSnsDft->u32MaxIntTime = 898;
+            pstAeSnsDft->u32LinesPer500ms = 900 * 25 / 2;
+            sensor_write_register(VMAX_ADDR, 0x84);
+            sensor_write_register(VMAX_ADDR+1, 0x03);
+        break;
+        
+        default:
+        break;
+    }
+
+    if(1 == gu8SensorMode)
+    {
+        pstAeSnsDft->u32MaxIntTime = 46;
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    gu32FullLines = gu32FullLinesStd;
+
+    return;
+}
+
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
+    return 0;
+}
+
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    HI_U16 u16Vmax = u16FullLines;
+    HI_U16 u16Current;
+    u16Current = sensor_read_register(VMAX_ADDR+2);
+    
+    sensor_write_register(VMAX_ADDR, (u16Vmax&0x00ff));
+    sensor_write_register(VMAX_ADDR+1, ((u16Vmax&0xff00) >> 8));
+    sensor_write_register(VMAX_ADDR+2,(((u16Vmax & 0x10000) >> 16)+(u16Current&0xFE)));
+
+    pstAeSnsDft->u32MaxIntTime = u16Vmax - 2;
+    gu32FullLines = u16Vmax;
+    
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+
+    if (HI_FALSE == gsbRegInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_SSP_TYPE;
+        for (i=0; i<7; i++)
+        {
+            g_stSnsRegsInfo.astSspData[i].u32DevAddr = 0x02;
+            g_stSnsRegsInfo.astSspData[i].u32DevAddrByteNum = 1;
+            g_stSnsRegsInfo.astSspData[i].u32RegAddrByteNum = 1;
+            g_stSnsRegsInfo.astSspData[i].u32DataByteNum = 1;
+        }
+        g_stSnsRegsInfo.astSspData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[0].u32RegAddr = 0x20;
+        g_stSnsRegsInfo.astSspData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[1].u32RegAddr = 0x21;
+        g_stSnsRegsInfo.astSspData[2].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[2].u32RegAddr = 0x22;
+        switch(gu8SensorMode)
+        {
+            default:
+            case 0: //linear mode
+            g_stSnsRegsInfo.u32RegNum = 4;
+            g_stSnsRegsInfo.astSspData[3].bDelayCfg = HI_TRUE;
+            g_stSnsRegsInfo.astSspData[3].u32RegAddr = 0x14;
+			
+            break;
+            case 1: //WDR mode
+            g_stSnsRegsInfo.u32RegNum = 7;
+            g_stSnsRegsInfo.astSspData[3].bDelayCfg = HI_FALSE;
+            g_stSnsRegsInfo.astSspData[3].u32RegAddr = 0x23;
+            g_stSnsRegsInfo.astSspData[4].bDelayCfg = HI_FALSE;
+            g_stSnsRegsInfo.astSspData[4].u32RegAddr = 0x24;
+            g_stSnsRegsInfo.astSspData[5].bDelayCfg = HI_FALSE;
+            g_stSnsRegsInfo.astSspData[5].u32RegAddr = 0x25;
+            g_stSnsRegsInfo.astSspData[6].bDelayCfg = HI_TRUE;
+            g_stSnsRegsInfo.astSspData[6].u32RegAddr = 0x14;
+			
+            break;
+        }
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_TRUE;
+
+        gsbRegInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+
+static  HI_U32   gain_table[81]={
+
+ 1024,   1060,   1097,   1136,   1176,   1217,   1260,   1304,   1350,   1397,   1446,   1497,   1550,   1604,   1661,   1719,   1780,
+ 1842,   1907,   1974,   2043,   2115,   2189,   2266,   2346,   2428,   2514,   2602,   2693,   2788,   2886,   2987,   3092,
+ 3201,   3314,   3430,   3551,   3675,   3805,   3938,   4077,   4220,   4368,   4522,   4681,   4845,   5015,   5192,   5374,
+ 5563,   5758,   5961,   6170,   6387,   6611,   6844,   7084,   7333,   7591,   7858,   8134,   8420,   8716,   9022,   9339,
+ 9667,  10007,  10359,  10723,  11099,  11489,  11893,  12311,  12744,  13192,  13655,  14135,  14632,  15146,  15678,   16229
+
+};
+
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+    HI_U16 u16ExpTime,u16Current;
+
+    switch(gu8SensorMode)
+    {
+        default:
+        case 0: //linear mode
+            //Integration time = (VMAX - (SHS1+1)) + tOFFSET
+            u16ExpTime = gu32FullLines - u32IntTime - 1;
+            u16Current = sensor_read_register(EXPOSURE_ADDR+2);
+			
+            #if CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE
+            cmos_init_regs_info();
+            g_stSnsRegsInfo.astSspData[0].u32Data = u16ExpTime & 0xFF;
+            g_stSnsRegsInfo.astSspData[1].u32Data = (u16ExpTime & 0xFF00) >> 8;
+            g_stSnsRegsInfo.astSspData[2].u32Data = (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE));
+            #else            
+            sensor_write_register(EXPOSURE_ADDR, u16ExpTime & 0xFF);
+            sensor_write_register(EXPOSURE_ADDR+1, (u16ExpTime & 0xFF00) >> 8);
+            sensor_write_register(EXPOSURE_ADDR+2, (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE)) );
+            #endif
+        break;
+        case 1: //WDR mode
+            #if CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE
+            //short exposure
+            u16ExpTime = gu32FullLines - u32IntTime - 1;
+            u16Current = sensor_read_register(EXPOSURE_ADDR+2);
+            
+            cmos_init_regs_info();
+            g_stSnsRegsInfo.astSspData[0].u32Data = u16ExpTime & 0xFF;
+            g_stSnsRegsInfo.astSspData[1].u32Data = (u16ExpTime & 0xFF00) >> 8;
+            g_stSnsRegsInfo.astSspData[2].u32Data = (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE));
+            
+            //long exposure
+            u16ExpTime = gu32FullLines - (u32IntTime << 4) - 1;
+            u16Current = sensor_read_register(LONG_EXPOSURE_ADDR+2);
+
+            g_stSnsRegsInfo.astSspData[3].u32Data = u16ExpTime & 0xFF;
+            g_stSnsRegsInfo.astSspData[4].u32Data = (u16ExpTime & 0xFF00) >> 8;
+            g_stSnsRegsInfo.astSspData[5].u32Data = (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE));
+            #else
+            //short exposure
+            u16ExpTime = gu32FullLines - u32IntTime - 1;
+            u16Current = sensor_read_register(EXPOSURE_ADDR+2);
+            
+            sensor_write_register(EXPOSURE_ADDR, u16ExpTime & 0xFF);
+            sensor_write_register(EXPOSURE_ADDR+1, (u16ExpTime & 0xFF00) >> 8);
+            sensor_write_register(EXPOSURE_ADDR+2, (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE)) );
+
+            //long exposure
+            u16ExpTime = gu32FullLines - (u32IntTime << 4) - 1;
+            u16Current = sensor_read_register(LONG_EXPOSURE_ADDR+2);
+            
+            sensor_write_register(LONG_EXPOSURE_ADDR, u16ExpTime & 0xFF);
+            sensor_write_register(LONG_EXPOSURE_ADDR+1, (u16ExpTime & 0xFF00) >> 8);
+            sensor_write_register(LONG_EXPOSURE_ADDR+2, (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE)) );
+            #endif
+        break;
+    }
+
+    return;
+}
+
+
+static HI_VOID cmos_again_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
+{
+    int i;
+
+    if(HI_NULL == pstAeSnsGainInfo)
+    {
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
+    }
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+    
+    if (u32InTimes >= gain_table[80])
+    {
+         pstAeSnsGainInfo->u32SnsTimes = gain_table[80];
+         pstAeSnsGainInfo->u32GainDb = 80;
+         return ;
+    }
+    
+    for(i = 1; i < 81; i++)
+    {
+        if(u32InTimes < gain_table[i])
+        {
+            pstAeSnsGainInfo->u32SnsTimes = gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
+
+    }
+          
+    return;
+}
+
+static HI_VOID cmos_dgain_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
+{
+    int i;
+
+    if(HI_NULL == pstAeSnsGainInfo)
+    {
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
+    }
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+    
+    if (u32InTimes >= gain_table[80])
+    {
+         pstAeSnsGainInfo->u32SnsTimes = gain_table[80];
+         pstAeSnsGainInfo->u32GainDb = 80;
+         return ;
+    }
+    
+    for(i = 1; i < 81; i++)
+    {
+        if(u32InTimes < gain_table[i])
+        {
+            pstAeSnsGainInfo->u32SnsTimes = gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
+
+    }
+          
+    return;
+
+}
+
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    switch(gu8SensorMode)
+    {
+        default:
+        case 0: /* linear mode */
+            /* analog gain = APGC * 0.3 db, APGC = [0x0,0x50], ag_db=[0db, 24db] */
+            /* digital gain = DPGC * 0.3 db, DPCG = [0x50,0xA0], dg_db=[0db, 24db] */
+            #if CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE
+            cmos_init_regs_info();
+		
+            if((u32Again + u32Dgain) <= 0xA0)
+            {
+                g_stSnsRegsInfo.astSspData[3].u32Data = u32Again + u32Dgain;
+            }
+            else
+            {
+                g_stSnsRegsInfo.astSspData[3].u32Data = 0xA0;
+            }
+            HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+            #else
+            if((u32Again + u32Dgain) <= 0xA0)
+            {
+                sensor_write_register(PGC_ADDR, u32Again + u32Dgain);
+            }
+            else
+            {
+                sensor_write_register(PGC_ADDR, 0xA0);
+            }
+            #endif
+        break;
+        case 1: //WDR mode
+        
+            /* analog gain : 4.5dB fixed
+              * digital gain : 0 to 12dB  0.3dB step
+              * DPGC = [00h,28h];
+              * digital_gain = DPGC * 0.3 db. */
+            #if CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE
+            cmos_init_regs_info();
+            if(u32Dgain <= 40)
+            {
+                g_stSnsRegsInfo.astSspData[6].u32Data = u32Dgain;
+            }
+            else
+            {
+                g_stSnsRegsInfo.astSspData[6].u32Data = 0x28;
+            }
+            HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+            #else
+            if(u32Dgain <= 40)
+            {
+                sensor_write_register(PGC_ADDR, u32Dgain);
+            }
+            else
+            {
+                sensor_write_register(PGC_ADDR, 0x28);
+            }
+            #endif
+        break;
+    }
+
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 5000;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x01D6;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x01DA;
+
+    pstAwbSnsDft->as32WbPara[0] = 19;
+    pstAwbSnsDft->as32WbPara[1] = 147;
+    pstAwbSnsDft->as32WbPara[2] = -89;
+    pstAwbSnsDft->as32WbPara[3] = 186629;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -137989;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+#if CMOS_IMX104_ISP_WRITE_SENSOR_ENABLE
+	gsbRegInit = HI_FALSE;
+#endif
+   
+}
+
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+    pstExpFuncs->pfn_cmos_again_calc_table  = cmos_again_calc_table;
+    pstExpFuncs->pfn_cmos_dgain_calc_table  = cmos_dgain_calc_table;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(IMX104_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, IMX104_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, IMX104_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(IMX104_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, IMX104_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, IMX104_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus

--- a/libraries/sensor/hi3516cv100/sony_imx104/imx104_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/sony_imx104/imx104_sensor_ctl.c
@@ -26,57 +26,57 @@
 
 int sony_sensor_write_packet(unsigned int data)
 {
-	int fd = -1;
-	int ret;
-	unsigned int value;
+    int fd = -1;
+    int ret;
+    unsigned int value;
 
-	fd = open("/dev/ssp", 0);
-	if(fd < 0)
-	{
-		printf("Open /dev/ssp error!\n");
-		return -1;
-	}
+    fd = open("/dev/ssp", 0);
+    if(fd < 0)
+    {
+        printf("Open /dev/ssp error!\n");
+        return -1;
+    }
 
-	value = data;
+    value = data;
 
-	ret = ioctl(fd, SSP_WRITE_ALT, &value);
+    ret = ioctl(fd, SSP_WRITE_ALT, &value);
 
-	close(fd);
-	return 0;
+    close(fd);
+    return 0;
 }
 
 int sony_sensor_read_packet(unsigned int data)
 {
-	unsigned int value;
-	int fd = -1;
-	int ret;
+    unsigned int value;
+    int fd = -1;
+    int ret;
 
-	fd = open("/dev/ssp", 0);
-	if(fd < 0)
-	{
-		printf("Open /dev/ssp error!\n");
-		return -1;
-	}
+    fd = open("/dev/ssp", 0);
+    if(fd < 0)
+    {
+        printf("Open /dev/ssp error!\n");
+        return -1;
+    }
 
-	value = data;
+    value = data;
 
-	ret = ioctl(fd, SSP_READ_ALT, &value);
+    ret = ioctl(fd, SSP_READ_ALT, &value);
 
-	close(fd);
-	return (value&0xff);
+    close(fd);
+    return (value&0xff);
 }
 
 int sensor_write_register(int addr, int data)
 {
-	unsigned int value = (unsigned int)(((addr&0xffff)<<8) | (data & 0xff));
-	//printf("write data = %#x\n", value);
+    unsigned int value = (unsigned int)(((addr&0xffff)<<8) | (data & 0xff));
+    //printf("write data = %#x\n", value);
     return sony_sensor_write_packet(value);
 }
 
 int sensor_read_register(int addr)
 {
-	unsigned int data = (unsigned int)(((addr&0xffff)<<8));
-	//printf("read data = %#x\n", data);
+    unsigned int data = (unsigned int)(((addr&0xffff)<<8));
+    //printf("read data = %#x\n", data);
     return sony_sensor_read_packet(data);
 }
 
@@ -90,15 +90,15 @@ void setup_sensor(int isp_mode)
 
 void sensor_init()
 {
-	sensor_write_register(0x200, 0x01); //Standby
-	usleep(200000);
+    sensor_write_register(0x200, 0x01); //Standby
+    usleep(200000);
 
-	// chip_id = 0x2
-	sensor_write_register(0x205, 0x01); //12bit
-	sensor_write_register(0x206, 0x00); //Drive mode:All-pix scan mode(720p mode)
-	sensor_write_register(0x207, 0x10); //Window mode:720p mode
-	sensor_write_register(0x209, 0x02); //30fps mode
-	sensor_write_register(0x20A, 0xF0); //black level
+    // chip_id = 0x2
+    sensor_write_register(0x205, 0x01); //12bit
+    sensor_write_register(0x206, 0x00); //Drive mode:All-pix scan mode(720p mode)
+    sensor_write_register(0x207, 0x10); //Window mode:720p mode
+    sensor_write_register(0x209, 0x02); //30fps mode
+    sensor_write_register(0x20A, 0xF0); //black level
 
     /*linear & WDR mode is different*/
     sensor_write_register(0x20C, 0x00);
@@ -106,29 +106,29 @@ void sensor_init()
     sensor_write_register(0x210, 0x39);
     sensor_write_register(0x212, 0x50);
 
-	sensor_write_register(0x217, 0x01);
-	sensor_write_register(0x218, 0xEE);
-	sensor_write_register(0x219, 0x02);
-	sensor_write_register(0x21A, 0x00);
-	sensor_write_register(0x21B, 0xC0);
-	sensor_write_register(0x21C, 0x19);
-	sensor_write_register(0x21D, 0xFF);
-	sensor_write_register(0x21E, 0x01);
-	sensor_write_register(0x236, 0x14); //VB size
-	sensor_write_register(0x238, 0x00); //cropping postion(Vertical position)
-	sensor_write_register(0x239, 0x00);
-	sensor_write_register(0x23A, 0x19); //cropping size(Vertical direction)
-	sensor_write_register(0x23B, 0x04);
-	sensor_write_register(0x23C, 0x00); //cropping postion(horizontal position)
-	sensor_write_register(0x23D, 0x00);
-	sensor_write_register(0x23E, 0x1C); //cropping size(horizontal direction)
-	sensor_write_register(0x23F, 0x05);
-	sensor_write_register(0x244, 0x01); //Parallel CMOS SDR output
-	sensor_write_register(0x254, 0x63);
-	sensor_write_register(0x25B, 0x00); //CLK 37.125MHz
-	sensor_write_register(0x25D, 0x00); //CLK 37.125MHz
-	sensor_write_register(0x25F, 0x10); //invalid
-	sensor_write_register(0x2BF, 0x1F);
+    sensor_write_register(0x217, 0x01);
+    sensor_write_register(0x218, 0xEE);
+    sensor_write_register(0x219, 0x02);
+    sensor_write_register(0x21A, 0x00);
+    sensor_write_register(0x21B, 0xC0);
+    sensor_write_register(0x21C, 0x19);
+    sensor_write_register(0x21D, 0xFF);
+    sensor_write_register(0x21E, 0x01);
+    sensor_write_register(0x236, 0x14); //VB size
+    sensor_write_register(0x238, 0x00); //cropping postion(Vertical position)
+    sensor_write_register(0x239, 0x00);
+    sensor_write_register(0x23A, 0x19); //cropping size(Vertical direction)
+    sensor_write_register(0x23B, 0x04);
+    sensor_write_register(0x23C, 0x00); //cropping postion(horizontal position)
+    sensor_write_register(0x23D, 0x00);
+    sensor_write_register(0x23E, 0x1C); //cropping size(horizontal direction)
+    sensor_write_register(0x23F, 0x05);
+    sensor_write_register(0x244, 0x01); //Parallel CMOS SDR output
+    sensor_write_register(0x254, 0x63);
+    sensor_write_register(0x25B, 0x00); //CLK 37.125MHz
+    sensor_write_register(0x25D, 0x00); //CLK 37.125MHz
+    sensor_write_register(0x25F, 0x10); //invalid
+    sensor_write_register(0x2BF, 0x1F);
 
     /*linear & WDR mode is different*/
     sensor_write_register(0x265, 0x20);
@@ -138,166 +138,166 @@ void sensor_init()
     sensor_write_register(0x2D2, 0x5F);
     sensor_write_register(0x2D3, 0x00);
 
-	// chip_id = 0x3
-	sensor_write_register(0x312, 0x00);
-	sensor_write_register(0x31D, 0x07);
-	sensor_write_register(0x323, 0x07);
-	sensor_write_register(0x326, 0xDF);
-	sensor_write_register(0x347, 0x87);
+    // chip_id = 0x3
+    sensor_write_register(0x312, 0x00);
+    sensor_write_register(0x31D, 0x07);
+    sensor_write_register(0x323, 0x07);
+    sensor_write_register(0x326, 0xDF);
+    sensor_write_register(0x347, 0x87);
 
-	// chip_id = 0x4
-	sensor_write_register(0x403, 0xCD);
-	sensor_write_register(0x407, 0x4B);
-	sensor_write_register(0x409, 0xE9);
-	sensor_write_register(0x413, 0x1B);
-	sensor_write_register(0x415, 0xED);
-	sensor_write_register(0x416, 0x01);
-	sensor_write_register(0x418, 0x09);
-	sensor_write_register(0x41A, 0x19);
-	sensor_write_register(0x41B, 0xA1);
-	sensor_write_register(0x41C, 0x11);
-	sensor_write_register(0x427, 0x00);
-	sensor_write_register(0x428, 0x05);
-	sensor_write_register(0x429, 0xEC);
-	sensor_write_register(0x42A, 0x40);
-	sensor_write_register(0x42B, 0x11);
-	sensor_write_register(0x42D, 0x22);
-	sensor_write_register(0x42E, 0x00);
-	sensor_write_register(0x42F, 0x05);
-	sensor_write_register(0x431, 0xEC);
-	sensor_write_register(0x432, 0x40);
-	sensor_write_register(0x433, 0x11);
-	sensor_write_register(0x435, 0x23);
-	sensor_write_register(0x436, 0xB0);
-	sensor_write_register(0x437, 0x04);
-	sensor_write_register(0x439, 0x24);
-	sensor_write_register(0x43A, 0x30);
-	sensor_write_register(0x43B, 0x04);
-	sensor_write_register(0x43C, 0xED);
-	sensor_write_register(0x43D, 0xC0);
-	sensor_write_register(0x43E, 0x10);
-	sensor_write_register(0x440, 0x44);
-	sensor_write_register(0x441, 0xA0);
-	sensor_write_register(0x442, 0x04);
-	sensor_write_register(0x443, 0x0D);
-	sensor_write_register(0x444, 0x31);
-	sensor_write_register(0x445, 0x11);
-	sensor_write_register(0x447, 0xEC);
-	sensor_write_register(0x448, 0xD0);
-	sensor_write_register(0x449, 0x1D);
-	sensor_write_register(0x455, 0x03);
-	sensor_write_register(0x456, 0x54);
-	sensor_write_register(0x457, 0x60);
-	sensor_write_register(0x458, 0x1F);
-	sensor_write_register(0x45A, 0xA9);
-	sensor_write_register(0x45B, 0x50);
-	sensor_write_register(0x45C, 0x0A);
-	sensor_write_register(0x45D, 0x25);
-	sensor_write_register(0x45E, 0x11);
-	sensor_write_register(0x45F, 0x12);
-	sensor_write_register(0x461, 0x9B);
-	sensor_write_register(0x466, 0xD0);
-	sensor_write_register(0x467, 0x08);
-	sensor_write_register(0x46A, 0x20);
-	sensor_write_register(0x46B, 0x0A);
-	sensor_write_register(0x46E, 0x20);
-	sensor_write_register(0x46F, 0x0A);
-	sensor_write_register(0x472, 0x20);
-	sensor_write_register(0x473, 0x0A);
-	sensor_write_register(0x475, 0xEC);
-	sensor_write_register(0x47D, 0xA5);
-	sensor_write_register(0x47E, 0x20);
-	sensor_write_register(0x47F, 0x0A);
-	sensor_write_register(0x481, 0xEF);
-	sensor_write_register(0x482, 0xC0);
-	sensor_write_register(0x483, 0x0E);
-	sensor_write_register(0x485, 0xF6);
-	sensor_write_register(0x48A, 0x60);
-	sensor_write_register(0x48B, 0x1F);
-	sensor_write_register(0x48D, 0xBB);
-	sensor_write_register(0x48E, 0x90);
-	sensor_write_register(0x48F, 0x0D);
-	sensor_write_register(0x490, 0x39);
-	sensor_write_register(0x491, 0xC1);
-	sensor_write_register(0x492, 0x1D);
-	sensor_write_register(0x494, 0xC9);
-	sensor_write_register(0x495, 0x70);
-	sensor_write_register(0x496, 0x0E);
-	sensor_write_register(0x497, 0x47);
-	sensor_write_register(0x498, 0xA1);
-	sensor_write_register(0x499, 0x1E);
-	sensor_write_register(0x49B, 0xC5);
-	sensor_write_register(0x49C, 0xB0);
-	sensor_write_register(0x49D, 0x0E);
-	sensor_write_register(0x49E, 0x43);
-	sensor_write_register(0x49F, 0xE1);
-	sensor_write_register(0x4A0, 0x1E);
-	sensor_write_register(0x4A2, 0xBB);
-	sensor_write_register(0x4A3, 0x10);
-	sensor_write_register(0x4A4, 0x0C);
-	sensor_write_register(0x4A6, 0xB3);
-	sensor_write_register(0x4A7, 0x30);
-	sensor_write_register(0x4A8, 0x0A);
-	sensor_write_register(0x4A9, 0x29);
-	sensor_write_register(0x4AA, 0x91);
-	sensor_write_register(0x4AB, 0x11);
-	sensor_write_register(0x4AD, 0xB4);
-	sensor_write_register(0x4AE, 0x40);
-	sensor_write_register(0x4AF, 0x0A);
-	sensor_write_register(0x4B0, 0x2A);
-	sensor_write_register(0x4B1, 0xA1);
-	sensor_write_register(0x4B2, 0x11);
-	sensor_write_register(0x4B4, 0xAB);
-	sensor_write_register(0x4B5, 0xB0);
-	sensor_write_register(0x4B6, 0x0B);
-	sensor_write_register(0x4B7, 0x21);
-	sensor_write_register(0x4B8, 0x11);
-	sensor_write_register(0x4B9, 0x13);
-	sensor_write_register(0x4BB, 0xAC);
-	sensor_write_register(0x4BC, 0xC0);
-	sensor_write_register(0x4BD, 0x0B);
-	sensor_write_register(0x4BE, 0x22);
-	sensor_write_register(0x4BF, 0x21);
-	sensor_write_register(0x4C0, 0x13);
-	sensor_write_register(0x4C2, 0xAD);
-	sensor_write_register(0x4C3, 0x10);
-	sensor_write_register(0x4C4, 0x0B);
-	sensor_write_register(0x4C5, 0x23);
-	sensor_write_register(0x4C6, 0x71);
-	sensor_write_register(0x4C7, 0x12);
-	sensor_write_register(0x4C9, 0xB5);
-	sensor_write_register(0x4CA, 0x90);
-	sensor_write_register(0x4CB, 0x0B);
-	sensor_write_register(0x4CC, 0x2B);
-	sensor_write_register(0x4CD, 0xF1);
-	sensor_write_register(0x4CE, 0x12);
-	sensor_write_register(0x4D0, 0xBB);
-	sensor_write_register(0x4D1, 0x10);
-	sensor_write_register(0x4D2, 0x0C);
-	sensor_write_register(0x4D4, 0xE7);
-	sensor_write_register(0x4D5, 0x90);
-	sensor_write_register(0x4D6, 0x0E);
-	sensor_write_register(0x4D8, 0x45);
-	sensor_write_register(0x4D9, 0x11);
-	sensor_write_register(0x4DA, 0x1F);
-	sensor_write_register(0x4EB, 0xA4);
-	sensor_write_register(0x4EC, 0x60);
-	sensor_write_register(0x4ED, 0x1F);
+    // chip_id = 0x4
+    sensor_write_register(0x403, 0xCD);
+    sensor_write_register(0x407, 0x4B);
+    sensor_write_register(0x409, 0xE9);
+    sensor_write_register(0x413, 0x1B);
+    sensor_write_register(0x415, 0xED);
+    sensor_write_register(0x416, 0x01);
+    sensor_write_register(0x418, 0x09);
+    sensor_write_register(0x41A, 0x19);
+    sensor_write_register(0x41B, 0xA1);
+    sensor_write_register(0x41C, 0x11);
+    sensor_write_register(0x427, 0x00);
+    sensor_write_register(0x428, 0x05);
+    sensor_write_register(0x429, 0xEC);
+    sensor_write_register(0x42A, 0x40);
+    sensor_write_register(0x42B, 0x11);
+    sensor_write_register(0x42D, 0x22);
+    sensor_write_register(0x42E, 0x00);
+    sensor_write_register(0x42F, 0x05);
+    sensor_write_register(0x431, 0xEC);
+    sensor_write_register(0x432, 0x40);
+    sensor_write_register(0x433, 0x11);
+    sensor_write_register(0x435, 0x23);
+    sensor_write_register(0x436, 0xB0);
+    sensor_write_register(0x437, 0x04);
+    sensor_write_register(0x439, 0x24);
+    sensor_write_register(0x43A, 0x30);
+    sensor_write_register(0x43B, 0x04);
+    sensor_write_register(0x43C, 0xED);
+    sensor_write_register(0x43D, 0xC0);
+    sensor_write_register(0x43E, 0x10);
+    sensor_write_register(0x440, 0x44);
+    sensor_write_register(0x441, 0xA0);
+    sensor_write_register(0x442, 0x04);
+    sensor_write_register(0x443, 0x0D);
+    sensor_write_register(0x444, 0x31);
+    sensor_write_register(0x445, 0x11);
+    sensor_write_register(0x447, 0xEC);
+    sensor_write_register(0x448, 0xD0);
+    sensor_write_register(0x449, 0x1D);
+    sensor_write_register(0x455, 0x03);
+    sensor_write_register(0x456, 0x54);
+    sensor_write_register(0x457, 0x60);
+    sensor_write_register(0x458, 0x1F);
+    sensor_write_register(0x45A, 0xA9);
+    sensor_write_register(0x45B, 0x50);
+    sensor_write_register(0x45C, 0x0A);
+    sensor_write_register(0x45D, 0x25);
+    sensor_write_register(0x45E, 0x11);
+    sensor_write_register(0x45F, 0x12);
+    sensor_write_register(0x461, 0x9B);
+    sensor_write_register(0x466, 0xD0);
+    sensor_write_register(0x467, 0x08);
+    sensor_write_register(0x46A, 0x20);
+    sensor_write_register(0x46B, 0x0A);
+    sensor_write_register(0x46E, 0x20);
+    sensor_write_register(0x46F, 0x0A);
+    sensor_write_register(0x472, 0x20);
+    sensor_write_register(0x473, 0x0A);
+    sensor_write_register(0x475, 0xEC);
+    sensor_write_register(0x47D, 0xA5);
+    sensor_write_register(0x47E, 0x20);
+    sensor_write_register(0x47F, 0x0A);
+    sensor_write_register(0x481, 0xEF);
+    sensor_write_register(0x482, 0xC0);
+    sensor_write_register(0x483, 0x0E);
+    sensor_write_register(0x485, 0xF6);
+    sensor_write_register(0x48A, 0x60);
+    sensor_write_register(0x48B, 0x1F);
+    sensor_write_register(0x48D, 0xBB);
+    sensor_write_register(0x48E, 0x90);
+    sensor_write_register(0x48F, 0x0D);
+    sensor_write_register(0x490, 0x39);
+    sensor_write_register(0x491, 0xC1);
+    sensor_write_register(0x492, 0x1D);
+    sensor_write_register(0x494, 0xC9);
+    sensor_write_register(0x495, 0x70);
+    sensor_write_register(0x496, 0x0E);
+    sensor_write_register(0x497, 0x47);
+    sensor_write_register(0x498, 0xA1);
+    sensor_write_register(0x499, 0x1E);
+    sensor_write_register(0x49B, 0xC5);
+    sensor_write_register(0x49C, 0xB0);
+    sensor_write_register(0x49D, 0x0E);
+    sensor_write_register(0x49E, 0x43);
+    sensor_write_register(0x49F, 0xE1);
+    sensor_write_register(0x4A0, 0x1E);
+    sensor_write_register(0x4A2, 0xBB);
+    sensor_write_register(0x4A3, 0x10);
+    sensor_write_register(0x4A4, 0x0C);
+    sensor_write_register(0x4A6, 0xB3);
+    sensor_write_register(0x4A7, 0x30);
+    sensor_write_register(0x4A8, 0x0A);
+    sensor_write_register(0x4A9, 0x29);
+    sensor_write_register(0x4AA, 0x91);
+    sensor_write_register(0x4AB, 0x11);
+    sensor_write_register(0x4AD, 0xB4);
+    sensor_write_register(0x4AE, 0x40);
+    sensor_write_register(0x4AF, 0x0A);
+    sensor_write_register(0x4B0, 0x2A);
+    sensor_write_register(0x4B1, 0xA1);
+    sensor_write_register(0x4B2, 0x11);
+    sensor_write_register(0x4B4, 0xAB);
+    sensor_write_register(0x4B5, 0xB0);
+    sensor_write_register(0x4B6, 0x0B);
+    sensor_write_register(0x4B7, 0x21);
+    sensor_write_register(0x4B8, 0x11);
+    sensor_write_register(0x4B9, 0x13);
+    sensor_write_register(0x4BB, 0xAC);
+    sensor_write_register(0x4BC, 0xC0);
+    sensor_write_register(0x4BD, 0x0B);
+    sensor_write_register(0x4BE, 0x22);
+    sensor_write_register(0x4BF, 0x21);
+    sensor_write_register(0x4C0, 0x13);
+    sensor_write_register(0x4C2, 0xAD);
+    sensor_write_register(0x4C3, 0x10);
+    sensor_write_register(0x4C4, 0x0B);
+    sensor_write_register(0x4C5, 0x23);
+    sensor_write_register(0x4C6, 0x71);
+    sensor_write_register(0x4C7, 0x12);
+    sensor_write_register(0x4C9, 0xB5);
+    sensor_write_register(0x4CA, 0x90);
+    sensor_write_register(0x4CB, 0x0B);
+    sensor_write_register(0x4CC, 0x2B);
+    sensor_write_register(0x4CD, 0xF1);
+    sensor_write_register(0x4CE, 0x12);
+    sensor_write_register(0x4D0, 0xBB);
+    sensor_write_register(0x4D1, 0x10);
+    sensor_write_register(0x4D2, 0x0C);
+    sensor_write_register(0x4D4, 0xE7);
+    sensor_write_register(0x4D5, 0x90);
+    sensor_write_register(0x4D6, 0x0E);
+    sensor_write_register(0x4D8, 0x45);
+    sensor_write_register(0x4D9, 0x11);
+    sensor_write_register(0x4DA, 0x1F);
+    sensor_write_register(0x4EB, 0xA4);
+    sensor_write_register(0x4EC, 0x60);
+    sensor_write_register(0x4ED, 0x1F);
 
     /*linear & WDR mode is different*/
     sensor_write_register(0x461, 0x9B);
     sensor_write_register(0x466, 0xD0);
     sensor_write_register(0x467, 0x08);
 
-	usleep(200000);
-	sensor_write_register(0x200, 0x00); //release standy
-	usleep(200000);
-	sensor_write_register(0x202, 0x00); //Master mose start
-	usleep(200000);
-	sensor_write_register(0x249, 0x0A); //XVS & XHS output
-	usleep(200000);
+    usleep(200000);
+    sensor_write_register(0x200, 0x00); //release standy
+    usleep(200000);
+    sensor_write_register(0x202, 0x00); //Master mose start
+    usleep(200000);
+    sensor_write_register(0x249, 0x0A); //XVS & XHS output
+    usleep(200000);
 
-	printf("-------Sony IMX104 Sensor Initial OK!-------\n");
+    printf("-------Sony IMX104 Sensor Initial OK!-------\n");
 }
 
 

--- a/libraries/sensor/hi3516cv100/sony_imx122/imx122_cmos.c
+++ b/libraries/sensor/hi3516cv100/sony_imx122/imx122_cmos.c
@@ -1,14 +1,14 @@
-#if !defined(__SONY_IMX122_H_)
-#define __SONY_IMX122_H_
+#if !defined(__IMX122_CMOS_H_)
+#define __IMX122_CMOS_H_
 
 #include <stdio.h>
-#include <unistd.h>		// usleep
 #include <string.h>
-
 #include "hi_comm_sns.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
-#include "hi_isp_debug.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -16,176 +16,122 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-
-#define CMOS_IMX122_ISP_WRITE_SENSOR_ENABLE (1)
-
-
-#define SENSOR_720P_30FPS_MODE   1
-#define SENSOR_720P_60FPS_MODE   2
-#define SENSOR_1080P_30FPS_MODE  3
-
-
 #define EXPOSURE_ADDR (0x208) //2:chip_id, 0C: reg addr.
 
 #define PGC_ADDR (0x21E)
 #define VMAX_ADDR (0x205)
+
+#define IMX122_ID 122
+
+#define CMOS_IMX122_ISP_WRITE_SENSOR_ENABLE  1
+#define SENSOR_720P_30FPS_MODE   1
+#define SENSOR_720P_60FPS_MODE   2
+#define SENSOR_1080P_30FPS_MODE  3
+
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
+
+
+
+#if CMOS_IMX122_ISP_WRITE_SENSOR_ENABLE
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
+static HI_BOOL gsbRegInit = HI_FALSE;
+#endif
+
+
+HI_U32 gu32FullLinesStd = 1125;
+HI_U32 gu32FullLines = 1125;
 HI_U8 gu8SensorMode = 0;
 
 HI_U8 gu8SensorImageMode = 3;
-
 
 extern void sensor_init_720p_60fps();
 
 extern void sensor_init_720p_30fps();
 
 
-
-static cmos_isp_default_t st_coms_isp_default =
+static AWB_CCM_S g_stAwbCcm =
 {
-    // color correction matrix
-    #if 0
-    {
-        5000,
-    	{	0x1b7,  0x8079, 0x803d,
-    		0x806d, 0x01f2, 0x8084,
-    		0x800a, 0x80b9, 0x01c4
-    	},
-    	3200,
-        {
-            0x01e7, 0x80cd, 0x801a,
-            0x808f, 0x01d3, 0x8044,
-            0x001b, 0x813b, 0x021f
-        },
-        2600,
-        {
-            0x020a, 0x80ed, 0x801d,
-            0x806e, 0x0196, 0x8028,
-            0x0015, 0x820f, 0x02f9
-        }
-    },
-    #else
-    {
-        5000,
-    	{	0x024d, 0x8140, 0x800d,
-    		0x8052, 0x01cf, 0x807d,
-    		0x0010, 0x80e0, 0x01d0
-    	},
-    	3200,
-        {
-            0x0213, 0x80e8, 0x802b,
-            0x8080, 0x01d3, 0x8053,
-            0x0012, 0x80ea, 0x01d8
-        },
-        2600,
-        {
-            0x0226, 0x80ea, 0x803c,
-            0x8067, 0x01d7, 0x8070,
-            0x000a, 0x810a, 0x0200
-        }
-    },
-    #endif
-
-	// black level for R, Gr, Gb, B channels
-	{0xf0,0xf0,0xf0,0xf0},
-
-    // calibration reference color temperature
-    5000,
-
-    //WB gain at 5000K, must keep consistent with calibration color temperature
-	{0x1c5, 0x100, 0x100, 0x1ec},
-
-    // WB curve parameters, must keep consistent with reference color temperature.
-	{22, 141, -84, 186260, 0x80, -134565},
-
-	// hist_thresh
-	{0xd,0x28,0x60,0x80},
-
-	0x00,	// iridix_balck
-	0x0,	// rggb
-
-	// gain
-	0x10,	0x8,
-
-	// iridix space, intensity, slope_max, white level
-	0x02,	0x08,	0x80, 	0x8ff,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x20, 	// sinter threshold
-
-	0x1,        //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
-	0,
-	1528,
-	
-#if CMOS_IMX122_ISP_WRITE_SENSOR_ENABLE 
-    2
-#else
-    1
-#endif
-
-};
-/*the default setting is more sharpen and the noise is bigger in low light mode*/
 #if 0
-static cmos_isp_agc_table_t st_isp_agc_table =
-{
-    //sharpen_alt_d
-    {0x88,0x85,0x80,0x7b,0x78,0x72,0x70,0x60},
-
-    //sharpen_alt_ud
-    {0xc8,0xc0,0xb8,0xb0,0xa8,0xa0,0x98,0x70},
-
-    //snr_thresh
-    {0x06,0x8,0xb,0x16,0x22,0x28,0x2e,0x35},
-
-    //demosaic_lum_thresh
-    {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
-
-    //demosaic_np_offset
-    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
-
-    /* saturation */
-    {0x80,0x80,0x6C,0x48,0x44,0x40,0x3C,0x38}
-};
+    5000,
+	{	0x1b7,  0x8079, 0x803d,
+		0x806d, 0x01f2, 0x8084,
+		0x800a, 0x80b9, 0x01c4
+	},
+	3200,
+    {
+        0x01e7, 0x80cd, 0x801a,
+        0x808f, 0x01d3, 0x8044,
+        0x001b, 0x813b, 0x021f
+    },
+    2600,
+    {
+        0x020a, 0x80ed, 0x801d,
+        0x806e, 0x0196, 0x8028,
+        0x0015, 0x820f, 0x02f9
+    }
+#else
+    5000,
+	{	0x024d, 0x8140, 0x800d,
+		0x8052, 0x01cf, 0x807d,
+		0x0010, 0x80e0, 0x01d0
+	},
+	3200,
+    {
+        0x0213, 0x80e8, 0x802b,
+        0x8080, 0x01d3, 0x8053,
+        0x0012, 0x80ea, 0x01d8
+    },
+    2600,
+    {
+        0x0226, 0x80ea, 0x803c,
+        0x8067, 0x01d7, 0x8070,
+        0x000a, 0x810a, 0x0200
+    }
 #endif
+};
 
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
-    //sharpen_alt_d
-    {0x50,0x4b,0x46,0x41,0x3c,0x32,0x28,0x1e},
-
-    //sharpen_alt_ud
-    {0x4b,0x46,0x41,0x3c,0x32,0x28,0x1e,0x14},
-
-    //snr_thresh
-    {0x06,0x8,0xb,0x16,0x22,0x28,0x32,0x54},
-
-    //demosaic_lum_thresh
-    {0x50,0x50,0x40,0x40,0x30,0x30,0x20,0x20},
-
-    //demosaic_np_offset
-    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
+    /* bvalid */
+    1,
 
     /* saturation */
     {0x80,0x80,0x80,0x80,0x68,0x48,0x35,0x30}
 };
 
-
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
 {
-  //nosie_profile_weight_lut
+    /* bvalid */
+    1,
 
+    /* sharpen_alt_d */
+    {0x50,0x4b,0x46,0x41,0x3c,0x32,0x28,0x1e},
+        
+    /* sharpen_alt_ud */
+    {0x4b,0x46,0x41,0x3c,0x32,0x28,0x1e,0x14},
+        
+    /* snr_thresh */
+    {0x8,0xe,0x14,0x1e,0x28,0x32,0x40,0x50},
+        
+    /* demosaic_lum_thresh */
+    {0x50,0x50,0x40,0x40,0x30,0x30,0x20,0x20},
+        
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37}
+};
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
+{
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {
     0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x04,0x0c,0x11,0x14,0x17,0x19,0x1b,0x1c,0x1e,0x1f,
     0x20,0x21,0x22,0x23,0x24,0x24,0x25,0x26,0x26,0x27,0x28,0x28,0x29,0x29,0x2a,0x2a,0x2a,
@@ -196,7 +142,8 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     0x39,0x39,0x39,0x39,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3b,0x3b,0x3b,0x3b,
     0x3b,0x3b,0x3b,0x3b,0x3b,0x3c,0x3c,0x3c,0x3c
     },
-  
+
+    /* demosaic_weight_lut */
     {
     0x04,0x0c,0x11,0x14,0x17,0x19,0x1b,0x1c,0x1e,0x1f,
     0x20,0x21,0x22,0x23,0x24,0x24,0x25,0x26,0x26,0x27,0x28,0x28,0x29,0x29,0x2a,0x2a,0x2a,
@@ -206,524 +153,25 @@ static cmos_isp_noise_table_t st_isp_noise_table =
     0x37,0x37,0x37,0x37,0x37,0x38,0x38,0x38,0x38,0x38,0x38,0x38,0x39,0x39,0x39,0x39,0x39,
     0x39,0x39,0x39,0x39,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3b,0x3b,0x3b,0x3b,
     0x3b,0x3b,0x3b,0x3b,0x3b,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c
-    },
-    
+    }
 };
 
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
-    switch( gu8SensorImageMode )
-    {
-        case 3:
-            cmos_inttime.full_lines_std = 1125;
-            cmos_inttime.full_lines_std_30fps = 1125;
-            cmos_inttime.full_lines = 1125;
-            cmos_inttime.full_lines_limit = 65535;
-            cmos_inttime.max_lines_target = 1123;
-            cmos_inttime.min_lines_target = 2;
-            cmos_inttime.vblanking_lines = 1125;
-            cmos_inttime.exposure_ashort = 0;
-            cmos_inttime.lines_per_500ms = 16874; // 500ms / 29.63us = 16874
-            cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-        break;
-        
-        case 2:
-            cmos_inttime.full_lines_std = 750;
-            cmos_inttime.full_lines_std_30fps = 750;
-            cmos_inttime.full_lines = 750;
-            cmos_inttime.full_lines_limit = 65535;
-            cmos_inttime.max_lines_target = 748;
-            cmos_inttime.min_lines_target = 2;
-            cmos_inttime.vblanking_lines = 750;
-
-            cmos_inttime.exposure_ashort = 0;
-
-            cmos_inttime.lines_per_500ms = 22500; // 500ms / 29.63us = 16874
-            cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-        break;
-
-        case 1:
-            cmos_inttime.full_lines_std = 750;
-            cmos_inttime.full_lines_std_30fps = 750;
-            cmos_inttime.full_lines = 750;
-            cmos_inttime.full_lines_limit = 65535;
-            cmos_inttime.max_lines_target = 748;
-            cmos_inttime.min_lines_target = 2;
-            cmos_inttime.vblanking_lines = 750;
-
-            cmos_inttime.exposure_ashort = 0;
-
-            cmos_inttime.lines_per_500ms = 22500; // 500ms / 29.63us = 16874
-            cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-        break;
-
-        default:
-        break;
-            
-    }
-
-	return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime) 
-{
-    HI_U16 exp_time;
-#if CMOS_IMX122_ISP_WRITE_SENSOR_ENABLE
-
-    exp_time = p_inttime->full_lines - p_inttime->exposure_ashort;
-
-  
+    /* bvalid */
+    1,
     
-    ISP_SSP_DATA_S   stSspData;
-    stSspData.bDelayCfg = HI_FALSE;
-    stSspData.u32DevAddr = 0x02;
-    stSspData.u32DevAddrByteNum = 1;
-    stSspData.u32RegAddr = 0x08;
-    stSspData.u32RegAddrByteNum = 1;
-    stSspData.u32Data = (exp_time & 0xFF);
-    stSspData.u32DataByteNum = 1;
-    HI_MPI_ISP_SSPWrite(&stSspData);
-
-    stSspData.u32RegAddr = 0x09;
-    stSspData.u32RegAddrByteNum = 1;
-    stSspData.u32Data = ((exp_time & 0xFF00) >> 8);            
-    stSspData.u32DataByteNum = 1;
-    HI_MPI_ISP_SSPWrite(&stSspData);
-
-#else
-    exp_time = p_inttime->full_lines - p_inttime->exposure_ashort;
-    sensor_write_register(EXPOSURE_ADDR, exp_time & 0xFF);
-    sensor_write_register(EXPOSURE_ADDR + 1, (exp_time & 0xFF00) >> 8);
-#endif
-
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-    
-	HI_U16 vmax = p_inttime->full_lines;
- //         printf("vmax=%d",vmax);
-	sensor_write_register(VMAX_ADDR, (vmax&0x00ff));
-	sensor_write_register(VMAX_ADDR+1, ((vmax&0xff00) >> 8));
-
-	return;
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-	if (p_inttime->exposure_ashort >= p_inttime->full_lines - 3)
-	{
-		p_inttime->exposure_ashort = p_inttime->full_lines - 3;
-	}
-
-	p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std;
-    
-//    printf("vblanking_lines=%d",p_inttime->vblanking_lines);
-
-	return p_inttime->exposure_ashort;
-}
-
-
-
-/* Set fps base */
-#if 1
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-
-    if(gu8SensorImageMode == 3)
-    {
-    	switch(fps)
-    	{
-    		case 30:
-    			// Change the frame rate via changing the vertical blanking
-    			p_inttime->full_lines_std = 1125;
-    			sensor_write_register(VMAX_ADDR, 0x65);
-    			sensor_write_register(VMAX_ADDR+1, 0x04);
-    			p_inttime->lines_per_500ms = 1125 * 30 / 2;
-    		break;
-    		
-    		case 25:
-    			// Change the frame rate via changing the vertical blanking
-    			p_inttime->full_lines_std = 1350;
-    			sensor_write_register(VMAX_ADDR, 0x46);
-    			sensor_write_register(VMAX_ADDR+1, 0x05);
-    			p_inttime->lines_per_500ms = 1350 * 25 / 2;
-    		break;
-    		
-    		default:
-    		break;
-    	}
-     }
-    else if(gu8SensorImageMode == 2)
-    {
-        switch(fps)
-        {
-            case 60:
-                // Change the frame rate via changing the vertical blanking
-                p_inttime->full_lines_std = 750;
-                p_inttime->lines_per_500ms = 750 * 60 / 2;
-    			sensor_write_register(VMAX_ADDR, 0xEE);
-    			sensor_write_register(VMAX_ADDR+1, 0x02);
-            break;
-            
-            case 50:
-                // Change the frame rate via changing the vertical blanking
-                p_inttime->full_lines_std = 900;
-                p_inttime->lines_per_500ms = 900 * 50 / 2;
-    			sensor_write_register(VMAX_ADDR, 0x84);
-    			sensor_write_register(VMAX_ADDR+1, 0x03);
-            break;
-            
-            default:
-            break;
-        }
-    
-
-    }
-    else if(gu8SensorImageMode == 1)
-    {
-        switch(fps)
-        {
-             case 30:
-                 // Change the frame rate via changing the vertical blanking
-                 p_inttime->full_lines_std = 750;
-                 p_inttime->lines_per_500ms = 750 * 30 / 2;
-                 sensor_write_register(VMAX_ADDR, 0xEE);
-                 sensor_write_register(VMAX_ADDR+1, 0x02);
-             break;
-             
-             case 25:
-                 // Change the frame rate via changing the vertical blanking
-                 p_inttime->full_lines_std = 900;
-                 p_inttime->lines_per_500ms = 900 * 25 / 2;
-                 sensor_write_register(VMAX_ADDR, 0x84);
-                 sensor_write_register(VMAX_ADDR+1, 0x03);
-             break;
-             
-             default:
-             break;
-        }
-
-    }
-    else
-    {
-
-    }
-
-    return;
-     
-}
-
-#endif
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
-{
-	cmos_gains.again_shift = 10;
-	cmos_gains.dgain_shift = 10;
-	cmos_gains.dgain_fine_shift = 0;
-    
-	cmos_gains.max_again = 16229;                       //10 bit shift
-	cmos_gains.max_dgain = 8134;                        //10 bit shift
-	
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_FALSE;
-
-	return &cmos_gains;
-}
-
-
-static HI_U32 gain_table[81] =
-{
-    1024 , 1060 ,  1097 ,  1136 ,  1176,  1217 , 1260 ,  1304,  1350 ,  1397 ,  1446 ,  1497 , 1550 , 1604 ,  1661 ,  1719 , 
-    1780 , 1842 ,  1907 ,  1974 ,  2043,  2115 , 2189 ,  2266,  2346 ,  2428 ,  2514 ,  2602 , 2693 , 2788 ,  2886 ,  2987 , 
-    3092 , 3201 ,  3314 ,  3430 ,  3551,  3675 , 3805 ,  3938,  4077 ,  4220 ,  4368 ,  4522 , 4681 , 4845 ,  5015 ,  5192 , 
-    5374 , 5563 ,  5758 ,  5961 ,  6170,  6387 , 6611 ,  6844,  7084 ,  7333 ,  7591 ,  7858 , 8134 , 8420 ,  8716 ,  9022 , 
-    9339 , 9667 , 10007 , 10359 , 10723, 11099 ,11489 , 11893, 12311 , 12744 , 13192 , 13655 ,14135 ,14632 , 15146 , 15678 , 
-    16229     
-};
-
-
-
-
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{
-    /* analog gain 
-      * analog gain = PGC * 0.3 db.
-      * APGC = [0,80];
-      * analog gain = [0db, 24db]. */
-
-        ISP_SSP_DATA_S   stSspData;
-#if  CMOS_IMX122_ISP_WRITE_SENSOR_ENABLE
-
-
-        stSspData.bDelayCfg = HI_FALSE;
-        stSspData.u32DevAddr = 0x02;
-        stSspData.u32DevAddrByteNum = 1;
-        stSspData.u32RegAddr = 0x1E;
-        stSspData.u32RegAddrByteNum = 1;
-        stSspData.u32Data = p_gains->again_db + p_gains->dgain_db;
-        stSspData.u32DataByteNum = 1;
-
-        if((p_gains->again_db + p_gains->dgain_db) < 0x8C)
-        {
-          HI_MPI_ISP_SSPWrite(&stSspData);
-        }
-        else
-        {
-           stSspData.u32Data = 0x8C;
-           stSspData.u32DataByteNum = 1;
-           HI_MPI_ISP_SSPWrite(&stSspData);
-        }
-
-#else
-	
-        if((p_gains->again_db + p_gains->dgain_db)< 0x8C)
-		{  
-		  sensor_write_register(PGC_ADDR, (p_gains->again_db + p_gains->dgain_db));
-        }
-
-        else
-        {
-          sensor_write_register(PGC_ADDR, 0x8C);
-        }
-
-#endif
-	
-}
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 again = 1024;
-    HI_U32 step = 0;
-    HI_S32 shift = 0;
-    HI_S32 i = 0;
-
-    while (exposure > (1 << 20))
-    {
-        exposure     >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-    
-    if(exposure > exposure_max)
-    {
-        again = (exposure << 10) / exposure_max;
-        again = again < 1024? 1024: again;
-        again = again > p_gains->max_again_target? p_gains->max_again_target: again;
-    
-        if (again >= gain_table[80])
-        {
-             again = gain_table[80];
-             step = 80;
-        }
-        else
-        {
-            for(i = 1; i < 81; i++)
-            {
-                if(again < gain_table[i])
-                {
-                    again = gain_table[i-1];
-                    step = i-1;
-                    break;
-                }
-            }
-        }
-        
-        exposure = (exposure << 10) / again;
-    }
-
-    p_gains->again = again;
-    p_gains->again_db = step;
-    
-    return (exposure << shift);
-}
-
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
-
-    while (exposure > (1 << 22))
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shift;
-}
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 dgain = 1024;
-    HI_U32 step = 0;
-    HI_S32 shift = 0;
-    HI_S32 i = 0;  
-    
-    while (exposure > (1 << 20))
-    {
-        exposure     >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-    
-    if(exposure > exposure_max)
-    {
-        dgain = (exposure << 10) / exposure_max;
-        dgain = dgain < 1024? 1024: dgain;
-        dgain = dgain > p_gains->max_dgain_target? p_gains->max_dgain_target: dgain;
-    
-        if (dgain >= gain_table[60])
-        {
-             dgain = gain_table[60];
-             step = 60;
-        }
-        else
-        {
-            for(i = 1; i < 61; i++)
-            {
-                if(dgain < gain_table[i])
-                {
-                    dgain = gain_table[i-1];
-                    step = i-1 ;
-                    break;
-                }
-            }
-        }
-        
-        exposure = (exposure << 10) / dgain;
-    }
- 
-    p_gains->dgain = dgain;
-    p_gains->dgain_db = step;
-
-    return exposure << shift;
-
-
-}
-
-static void setup_sensor(int isp_mode)
-{
-	if(0 == isp_mode) /* setup for ISP 'normal mode' */
-	{
-        sensor_write_register(VMAX_ADDR, 0x65);
-        sensor_write_register(VMAX_ADDR + 1, 0x04);
-	}
-	else if(1 == isp_mode) /* setup for ISP pixel calibration mode */
-	{
-        //TODO: finish this.
-        /* Sensor must be programmed for slow frame rate (5 fps and below)*/
-        /* change frame rate to 3 fps by setting 1 frame length = 1125 * (30/3) */
-        sensor_write_register(VMAX_ADDR, 0xF2);
-        sensor_write_register(VMAX_ADDR + 1, 0x2B);
-
-        /* Analog and Digital gains both must be programmed for their minimum values */
-		sensor_write_register(PGC_ADDR, 0x00);
-       // sensor_write_register(APGC_ADDR + 1, 0x00);
-	//	sensor_write_register(DPGC_ADDR, 0x00);
-	}
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-    HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-    HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _ispdgain = p_gains->isp_dgain == 0 ? 1 : p_gains->isp_dgain;
-    
-   	p_gains->iso =  (((HI_U64)_again * _dgain * _ispdgain * 100) 
-        >> (p_gains->again_shift + p_gains->dgain_shift 
-        + p_gains->isp_dgain_shift));
-
-	return p_gains->iso;
-}
-
-/* Note: The unit of return value is 1db.  */
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return (cmos_gains->again_db *  3 / 10); 
-}
-
-/* Note: The unit of return value is 1db.  */
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return  (cmos_gains->dgain_db *  3 / 10); 
-}
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-	if (NULL == p_coms_isp_default)
-	{
-	    printf("null pointer when get isp default value!\n");
-	    return -1;
-	}
-    memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
-    return 0;
-}
-
-
-HI_U32 cmos_get_isp_speical_alg(void)
-{
-    return isp_special_alg_awb;
-}
-
-static cmos_isp_demosaic_t st_isp_demosaic =
-{
     /*vh_slope*/
-    0xc6,
+    0xc5,
 
     /*aa_slope*/
-    0xc3,
+    0xbb,
 
     /*va_slope*/
-    0xc4,
+    0xc8,
 
     /*uu_slope*/
-    0xcd,
+    0xca,
 
     /*sat_slope*/
     0x5d,
@@ -741,7 +189,7 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x0,
 
     /*uu_thresh*/
-    0x8,
+    0x6,
 
     /*sat_thresh*/
     0x171,
@@ -750,199 +198,83 @@ static cmos_isp_demosaic_t st_isp_demosaic =
     0x1b3,
 };
 
-
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
-}
-
-
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-    return 0;
-}
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1920;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 1080;
-
-    return 0;
-}
-
-static HI_S32 isp_image_mode_get(cmos_sensor_image_mode_ptr_t p_cmos_sensor_image_mode)
-{
- 
- if(HI_NULL == p_cmos_sensor_image_mode)
-  {
-      printf("null pointer when set image mode111\n");
-      return -1;
-  }
- 
-  if((p_cmos_sensor_image_mode->u16Width == 1280)&&(p_cmos_sensor_image_mode->u16Height == 720))
-  {
-    if(p_cmos_sensor_image_mode->u16Fps== 30)
+    if (HI_NULL == pstDef)
     {
-      gu8SensorImageMode = SENSOR_720P_30FPS_MODE;
-    }
-    else if(p_cmos_sensor_image_mode->u16Fps== 60)
-    {
-       
-        gu8SensorImageMode = SENSOR_720P_60FPS_MODE;
-    }
-    else
-    {
-       return -1;
-    }
-  }
-  else if((p_cmos_sensor_image_mode->u16Width == 1920)&&(p_cmos_sensor_image_mode->u16Height == 1080))
-  {
-      if(p_cmos_sensor_image_mode->u16Fps == 30)
-      {
-        gu8SensorImageMode = SENSOR_1080P_30FPS_MODE;
-      }
-      else
-      {
-         return -1;
-      }
-  }
- 
-  return 0;
-
-}
-static HI_S32 cmos_set_sensor_image_mode(cmos_sensor_image_mode_ptr_t p_cmos_sensor_image_mode)
-{
-    HI_S32 s32Ret;
-
-    if(NULL == p_cmos_sensor_image_mode)
-    {
-        printf("null pointer when set sensor image mode!\n");
+        printf("null pointer when get isp default value!\n");
         return -1;
     }
 
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
 
-    s32Ret = isp_image_mode_get(p_cmos_sensor_image_mode);
+    pstDef->stComm.u8Rggb           = 0x0;      //1: rggb  
+    pstDef->stComm.u8BalanceFe      = 0x1;
 
-    if(s32Ret == -1 )
+    pstDef->stDenoise.u8SinterThresh= 0x20;
+    pstDef->stDenoise.u8NoiseProfile= 0x1;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 1528;
+
+    pstDef->stDrc.u8DrcBlack        = 0x00;
+    pstDef->stDrc.u8DrcVs           = 0x02;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0x80;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x8ff;    // white level
+
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+
+    return 0;
+}
+
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
+{
+    HI_S32  i;
+    
+    if (HI_NULL == pstBlackLevel)
     {
+        printf("null pointer when get isp black level value!\n");
         return -1;
     }
 
-    switch(gu8SensorImageMode)
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+            
+    for (i=0; i<4; i++)
     {
-        case SENSOR_720P_30FPS_MODE:
-
-        sensor_init_720p_30fps();
-
-        break;
-
-        case SENSOR_720P_60FPS_MODE:
-
-        sensor_init_720p_60fps();
-
-        break;
-
-        case SENSOR_1080P_30FPS_MODE:
-
-        sensor_init();
-
-        break;
-
-        default:
-
-        break;
-
+        pstBlackLevel->au16BlackLevel[i] = 0xf0;
     }
 
-    return 0;
-
+    return 0;    
 }
 
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-static SENSOR_EXP_FUNC_S stSensorExpFuncs =
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
+    if (bEnable) /* setup for ISP pixel calibration mode */
+    {
+        //TODO: finish this.
+        /* Sensor must be programmed for slow frame rate (5 fps and below)*/
+        /* change frame rate to 3 fps by setting 1 frame length = 1125 * (30/3) */
+        sensor_write_register(VMAX_ADDR, 0xF2);
+        sensor_write_register(VMAX_ADDR + 1, 0x2B);
 
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
+        /* Analog and Digital gains both must be programmed for their minimum values */
+		sensor_write_register(PGC_ADDR, 0x00);
+        //sensor_write_register(APGC_ADDR + 1, 0x00);
+	    //sensor_write_register(DPGC_ADDR, 0x00);
+    }
+    else /* setup for ISP 'normal mode' */
+    {
+        sensor_write_register(VMAX_ADDR, 0x65);
+        sensor_write_register(VMAX_ADDR + 1, 0x04);
+    }
 
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-
-    .pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-    .pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-    .pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-    .pfn_cmos_get_isp_default = cmos_get_isp_default,
-    .pfn_cmos_get_isp_special_alg = NULL,
-    .pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-	.pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-	.pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-	.pfn_cmos_get_isp_shading_table = NULL,
-	.pfn_cmos_get_isp_gamma_table = NULL,
-	.pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-	.pfn_cmos_set_sensor_image_mode = cmos_set_sensor_image_mode,
-
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-
-	return 0;
+    return;
 }
 
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
@@ -959,18 +291,626 @@ int sensor_mode_set(HI_U8 u8Mode)
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
-    return 0;
+    
+    return;
 }
 
 
+static HI_U32 digital_gain_table[61]=
+{
+    1024,  1060,  1097,  1136,  1176,  1217,  1260,  1304,  1350,  1397,  1446,   1497,  1550,   1604,  1661,   1719,  
+    1780,  1842,  1907,  1974,  2043,  2115,  2189,  2266,  2346,  2428,  2514,   2602,  2693,   2788,  2886,   2987,  
+    3092,  3201,  3314,  3430,  3551,  3675,  3805,  3938,  4077,  4220,  4368,   4522,  4681,   4845,  5015,   5192,  
+    5374,  5563,  5758,  5961,  6170,  6387,  6611,  6844,  7084,  7333,  7591,   7858,  8134  
+};
+
+
+static HI_U32 analog_gain_table[81] =
+{
+     1024 , 1060 ,  1097 ,  1136 ,  1176,  1217 , 1260 ,  1304,  1350 ,  1397 ,  1446 ,  1497 , 1550 , 1604 ,  1661 ,  1719 , 
+     1780 , 1842 ,  1907 ,  1974 ,  2043,  2115 , 2189 ,  2266,  2346 ,  2428 ,  2514 ,  2602 , 2693 , 2788 ,  2886 ,  2987 , 
+     3092 , 3201 ,  3314 ,  3430 ,  3551,  3675 , 3805 ,  3938,  4077 ,  4220 ,  4368 ,  4522 , 4681 , 4845 ,  5015 ,  5192 , 
+     5374 , 5563 ,  5758 ,  5961 ,  6170,  6387 , 6611 ,  6844,  7084 ,  7333 ,  7591 ,  7858 , 8134 , 8420 ,  8716 ,  9022 , 
+     9339 , 9667 , 10007 , 10359 , 10723, 11099 ,11489 , 11893, 12311 , 12744 , 13192 , 13655 ,14135 ,14632 , 15146 , 15678 , 
+    16229     
+
+};
+
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    switch(gu8SensorImageMode)
+    {
+      case SENSOR_720P_30FPS_MODE:
+        
+         pstAeSnsDft->u32MaxIntTime = 748;
+         pstAeSnsDft->u32LinesPer500ms = 750*30/2;
+         gu32FullLinesStd = 750;
+
+      break;
+      
+
+      case SENSOR_720P_60FPS_MODE:
+        
+         pstAeSnsDft->u32MaxIntTime = 748;
+         pstAeSnsDft->u32LinesPer500ms = 750*60/2;
+         gu32FullLinesStd = 750;
+        
+
+      break;
+      
+
+      case SENSOR_1080P_30FPS_MODE:
+
+         pstAeSnsDft->u32MaxIntTime = 1122;
+         pstAeSnsDft->u32LinesPer500ms = 1125*30/2;
+         gu32FullLinesStd = 1125;
+         
+      break;
+
+
+      default:
+      
+      break;
+        
+    }
+
+    
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32LinesPer500ms = 1125*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 1122;
+    pstAeSnsDft->u32MinIntTime = 2;    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 2;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 0.3;    
+    pstAeSnsDft->u32MaxAgain = 16229;  /*the max again value is 10bit precison, the same with the table*/
+    pstAeSnsDft->u32MinAgain = 1024;
+    pstAeSnsDft->u32MaxAgainTarget = 16229;
+    pstAeSnsDft->u32MinAgainTarget = 1024;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.3;    
+    pstAeSnsDft->u32MaxDgain = 8134;  /*the max again value is 10bit precison, the same with the table*/ 
+    pstAeSnsDft->u32MinDgain = 1024;
+    pstAeSnsDft->u32MaxDgainTarget = 8134;
+    pstAeSnsDft->u32MinDgainTarget = 1024;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
+    return 0;
+}
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if(gu8SensorImageMode == 3)
+    {
+        switch(u8Fps)
+        {
+            case 30:
+                // Change the frame rate via changing the vertical blanking
+                gu32FullLinesStd = 1125;
+    			pstAeSnsDft->u32MaxIntTime = 1122;
+                pstAeSnsDft->u32LinesPer500ms = 1125 * 30 / 2;
+    			sensor_write_register(VMAX_ADDR, 0x65);
+    			sensor_write_register(VMAX_ADDR+1, 0x04);
+            break;
+            
+            case 25:
+                // Change the frame rate via changing the vertical blanking
+                gu32FullLinesStd = 1350;
+                pstAeSnsDft->u32MaxIntTime = 1347;
+                pstAeSnsDft->u32LinesPer500ms = 1350 * 25 / 2;
+    			sensor_write_register(VMAX_ADDR, 0x46);
+    			sensor_write_register(VMAX_ADDR+1, 0x05);
+            break;
+            
+            default:
+            break;
+        }
+    }
+    else if(gu8SensorImageMode == 2)
+    {
+        switch(u8Fps)
+        {
+            case 60:
+                // Change the frame rate via changing the vertical blanking
+                gu32FullLinesStd = 750;
+    			pstAeSnsDft->u32MaxIntTime = 748;
+                pstAeSnsDft->u32LinesPer500ms = 750 * 60 / 2;
+    			sensor_write_register(VMAX_ADDR, 0xEE);
+    			sensor_write_register(VMAX_ADDR+1, 0x02);
+            break;
+            
+            case 50:
+                // Change the frame rate via changing the vertical blanking
+                gu32FullLinesStd = 900;
+                pstAeSnsDft->u32MaxIntTime = 897;
+                pstAeSnsDft->u32LinesPer500ms = 900 * 50 / 2;
+    			sensor_write_register(VMAX_ADDR, 0x84);
+    			sensor_write_register(VMAX_ADDR+1, 0x03);
+            break;
+            
+            default:
+            break;
+        }
+
+    }
+    else if(gu8SensorImageMode == 1)
+    {
+       switch(u8Fps)
+       {
+            case 30:
+                // Change the frame rate via changing the vertical blanking
+                gu32FullLinesStd = 750;
+                pstAeSnsDft->u32MaxIntTime = 748;
+                pstAeSnsDft->u32LinesPer500ms = 750 * 30 / 2;
+                sensor_write_register(VMAX_ADDR, 0xEE);
+                sensor_write_register(VMAX_ADDR+1, 0x02);
+            break;
+            
+            case 25:
+                // Change the frame rate via changing the vertical blanking
+                gu32FullLinesStd = 900;
+                pstAeSnsDft->u32MaxIntTime = 897;
+                pstAeSnsDft->u32LinesPer500ms = 900 * 25 / 2;
+                sensor_write_register(VMAX_ADDR, 0x84);
+                sensor_write_register(VMAX_ADDR+1, 0x03);
+            break;
+            
+            default:
+            break;
+       }
+
+
+    }
+    else
+    {
+
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    gu32FullLines = gu32FullLinesStd;
+        
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    gu32FullLines = u16FullLines;
+
+	sensor_write_register(VMAX_ADDR, (gu32FullLines & 0x00ff));
+	sensor_write_register(VMAX_ADDR+1, ((gu32FullLines & 0xff00) >> 8));
+    
+    pstAeSnsDft->u32MaxIntTime = gu32FullLines - 3;
+    
+    return;
+}
+
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_IMX122_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+
+    if (HI_FALSE == gsbRegInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_SSP_TYPE;
+        g_stSnsRegsInfo.u32RegNum = 3;
+        for (i=0; i<3; i++)
+        {
+            g_stSnsRegsInfo.astSspData[i].u32DevAddr = 0x02;
+            g_stSnsRegsInfo.astSspData[i].u32DevAddrByteNum = 1;
+            g_stSnsRegsInfo.astSspData[i].u32RegAddrByteNum = 1;
+            g_stSnsRegsInfo.astSspData[i].u32DataByteNum = 1;
+        }
+        g_stSnsRegsInfo.astSspData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[0].u32RegAddr = 0x08;
+        g_stSnsRegsInfo.astSspData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[1].u32RegAddr = 0x09;
+
+        g_stSnsRegsInfo.astSspData[2].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[2].u32RegAddr = 0x1E;
+        
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_FALSE;
+
+        gsbRegInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+    HI_U32 u32Value = gu32FullLines - u32IntTime;
+    
+#if CMOS_IMX122_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+
+    g_stSnsRegsInfo.astSspData[0].u32Data = (u32Value & 0xFF);
+    g_stSnsRegsInfo.astSspData[1].u32Data = (u32Value & 0xFF00) >> 8;
+
+#else
+    sensor_write_register(EXPOSURE_ADDR, u32Value & 0xFF);
+    sensor_write_register(EXPOSURE_ADDR + 1, (u32Value & 0xFF00) >> 8);
+#endif
+    return;
+}
+
+static HI_VOID cmos_again_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
+{
+    int i;
+
+    if(HI_NULL == pstAeSnsGainInfo)
+    {
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
+    }
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+
+    if (u32InTimes >= analog_gain_table[80])
+    {
+         pstAeSnsGainInfo->u32SnsTimes = analog_gain_table[80];
+         pstAeSnsGainInfo->u32GainDb = 80;
+         return ;
+    }
+    
+    for(i = 1; i < 81; i++)
+    {
+        if(u32InTimes < analog_gain_table[i])
+        {
+            pstAeSnsGainInfo->u32SnsTimes = analog_gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
+    }
+
+    return;
+}
+
+static HI_VOID cmos_dgain_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
+{
+
+    int i;
+
+    if(HI_NULL == pstAeSnsGainInfo)
+    {
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
+    }
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+    if (u32InTimes >= digital_gain_table[60])
+    {
+         pstAeSnsGainInfo->u32SnsTimes = digital_gain_table[60];
+         pstAeSnsGainInfo->u32GainDb = 60;
+         return;
+    }
+    
+    for(i = 1; i < 61; i++)
+    {
+        if(u32InTimes < digital_gain_table[i])
+        {
+            pstAeSnsGainInfo->u32SnsTimes = digital_gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
+    }
+
+    return;
+
+}
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    HI_U32 u32Tmp = u32Again + u32Dgain;
+    
+    u32Tmp = u32Tmp > 0x8C ? 0x8C : u32Tmp;
+    
+#if CMOS_IMX122_ISP_WRITE_SENSOR_ENABLE 
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astSspData[2].u32Data = u32Tmp;
+    HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+#else
+    sensor_write_register(PGC_ADDR, u32Tmp);
+#endif
+
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 5000;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x1c5;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x1ec;
+
+    pstAwbSnsDft->as32WbPara[0] = 22;
+    pstAwbSnsDft->as32WbPara[1] = 141;
+    pstAwbSnsDft->as32WbPara[2] = -84;
+    pstAwbSnsDft->as32WbPara[3] = 186260;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -134565;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1920;
+    pstSensorMaxResolution->u32MaxHeight = 1080;
+
+    return 0;
+}
+
+static HI_U8  isp_image_mode_get(ISP_CMOS_SENSOR_IMAGE_MODE *pstSensorImageMode)
+{
+    if(HI_NULL == pstSensorImageMode)
+    {
+        printf("null pointer when set image mode111\n");
+        return -1;
+    }
+
+    if((pstSensorImageMode->u16Width == 1280)&&(pstSensorImageMode->u16Height == 720))
+    {
+      if(pstSensorImageMode->u16Fps== 30)
+      {
+        
+        gu8SensorImageMode = SENSOR_720P_30FPS_MODE;
+      }
+      else if(pstSensorImageMode->u16Fps== 60)
+      {
+         
+          gu8SensorImageMode = SENSOR_720P_60FPS_MODE;
+      }
+      else
+      {
+         return -1;
+      }
+    }
+    else if((pstSensorImageMode->u16Width == 1920)&&(pstSensorImageMode->u16Height == 1080))
+    {
+        if(pstSensorImageMode->u16Fps == 30)
+        {
+          gu8SensorImageMode = SENSOR_1080P_30FPS_MODE;
+        }
+        else
+        {
+           return -1;
+        }
+    }
+
+    return 0;
+
+}
+
+static HI_S32 cmos_set_image_mode(ISP_CMOS_SENSOR_IMAGE_MODE *pstSensorImageMode)
+{
+   HI_S32 s32Ret;
+     
+    if (HI_NULL == pstSensorImageMode )
+    {
+        printf("null pointer when set image mode\n");
+        return -1;
+    }
+    
+    s32Ret = isp_image_mode_get(pstSensorImageMode);
+    if(s32Ret == -1 )
+    {
+     return -1;
+    }
+    
+    switch(gu8SensorImageMode)
+    {
+      case SENSOR_720P_30FPS_MODE:
+        
+          sensor_init_720p_30fps();
+
+      break;
+      
+      case SENSOR_720P_60FPS_MODE:
+        
+          sensor_init_720p_60fps();
+          
+      break;
+      
+      case SENSOR_1080P_30FPS_MODE:
+
+           sensor_init();
+          
+      break;
+
+      default:
+      
+      break;
+        
+    }
+
+    return 0;
+    
+    
+}
+
+HI_VOID sensor_global_init()
+{
+     gu32FullLinesStd = 1125;
+     gu32FullLines = 1125;
+     gu8SensorMode = 0;
+
+     gu8SensorImageMode = 3;
+
+}
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+    pstSensorExpFunc->pfn_cmos_set_image_mode = cmos_set_image_mode;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+    pstExpFuncs->pfn_cmos_again_calc_table  = cmos_again_calc_table;
+    pstExpFuncs->pfn_cmos_dgain_calc_table  = cmos_dgain_calc_table;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(IMX122_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, IMX122_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, IMX122_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(IMX122_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, IMX122_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, IMX122_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 #ifdef __cplusplus
 #if __cplusplus
 }
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-
-#endif // __SONY_ICX692_H_
+#endif // __IMX104_CMOS_H_

--- a/libraries/sensor/hi3516cv100/sony_imx122/imx122_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/sony_imx122/imx122_sensor_ctl.c
@@ -651,7 +651,7 @@ void sensor_init()
 	//sensor_write_register(0x229, 0xC0);
 
 	// waiting for image stabilization
-	usleep(200000);
+
 
 	printf("-------Sony IMX122 Sensor Initial OK!-------\n");
 }
@@ -1764,3 +1764,5 @@ void sensor_init_720p_60fps()
 
 	printf("-------Sony IMX122 Sensor Initial OK!-------\n");
 }
+
+    

--- a/libraries/sensor/hi3516cv100/sony_imx138/imx138_cmos.c
+++ b/libraries/sensor/hi3516cv100/sony_imx138/imx138_cmos.c
@@ -1,19 +1,14 @@
-/******************************************************************************
-  A driver program of panasonic IMX138 on HI3518A 
- ******************************************************************************
-    Modification:  2013-05  Created
-******************************************************************************/
-
-
 #if !defined(__IMX138_CMOS_H_)
 #define __IMX138_CMOS_H_
 
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 #include "hi_comm_sns.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -21,89 +16,66 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-
 #define CMOS_IMX138_ISP_WRITE_SENSOR_ENABLE (1)
 
-/* Note: format of address is special.
- * chip_id + reg_adddr */
-#define EXPOSURE_ADDR (0x220) //2:chip_id, 20: reg addr.
-#define LONG_EXPOSURE_ADDR (0x223)
+
+#if CMOS_IMX138_ISP_WRITE_SENSOR_ENABLE
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
+static HI_BOOL gsbRegInit = HI_FALSE;
+#endif
+
+#define EXPOSURE_ADDR (0x220) //2:chip_id, 0C: reg addr.
+
 #define PGC_ADDR (0x214)
 #define VMAX_ADDR (0x218)
 
+#define IMX138_ID 138
+
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
+HI_U32 gu32FullLinesStd = 750;
+HI_U32 gu32FullLines = 750;
 HI_U8 gu8SensorMode = 0;
-static cmos_isp_default_t st_coms_isp_default =
+
+static AWB_CCM_S g_stAwbCcm =
 {
-    // color correction matrix
+    5048,
     {
-        5048,
-    	{
-    		0x01f2, 0x80bd, 0x8035,
-    		0x8042, 0x01a3, 0x8061,
-    		0x0026, 0x80e0, 0x1b9,
-    	},
-        3200,
-    	{
-    		0x01dd, 0x807b, 0x8062,
-    		0x807b, 0x01d2, 0x8057,
-    		0x0036, 0x8110, 0x01d9,
-    	},
-    	2480,
-    	{
-    		0x01b1, 0x8066, 0x804b,
-    		0x8074, 0x01b2, 0x803e,
-    		0x001e, 0x81d9, 0x02ba,
-    	}
+        0x01f2, 0x80bd, 0x8035,
+        0x8042, 0x01a3, 0x8061,
+        0x0026, 0x80e0, 0x1b9,
     },
-
-	// black level for R, Gr, Gb, B channels
-	{0xF0,0xF0,0xF0,0xF0},
-
-	//calibration reference color temperature
-	5048,
-
-	//WB gain at 5000K, must keep consistent with calibration color temperature
-	{0x01ff, 0x100, 0x100, 0x01e4},
-
-	// WB curve parameters, must keep consistent with reference color temperature.
-	{40, 106, -110, 184787, 128, -134867},
-
-	// hist_thresh
-	{0xd,0x28,0x60,0x80},
-
-	0x00,	// iridix_balck
-	0x2,	// 0:rggb; 2: gbrg
-
-	// max again, max dgain
-	0x10,	0x10,
-
-	// iridix
-	0x04,	0x08,	0xa0, 	0x8ff,
-
-	0x1, 	// balance_fe
-	0x80,	// ae compensation
-	0x8, 	// sinter threshold
-
-	0x1,  //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
-	0,    //nr0
-	455,  //nr1
-
-#if  CMOS_IMX138_ISP_WRITE_SENSOR_ENABLE
-    2
-#else
-    1
-#endif
+    3200,
+    {
+        0x01dd, 0x807b, 0x8062,
+        0x807b, 0x01d2, 0x8057,
+        0x0036, 0x8110, 0x01d9,
+    },
+    2480,
+    {
+        0x01b1, 0x8066, 0x804b,
+        0x8074, 0x01b2, 0x803e,
+        0x001e, 0x81d9, 0x02ba,
+    }
 };
 
-
-static cmos_isp_agc_table_t st_isp_agc_table =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
+    /* bvalid */
+    1,
+
+    /* saturation */   
+    {0x80,0x80,0x80,0x75,0x60,0x55,0x50,0x48}
+
+};
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
+{
+    /* bvalid */
+    1,
+
     /* sharpen_alt_d */
    {48,48,40,35,30,30,20,15}, 
     
@@ -114,430 +86,147 @@ static cmos_isp_agc_table_t st_isp_agc_table =
    {10,16,24,34,39,44,49,54},  
     
     /*  demosaic_lum_thresh   */
-   {0x50,0x50,0x40,0x40,0x30,0x30,0x20,0x20}, 
+   {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80}, 
     
     /* demosaic_np_offset   */
-   {0,10,16,24,32,40,48,56},  
+   {0,0xa,16,24,32,40,48,56},  
     
     /* ge_strength    */
    {0x82,0x55,0x55,0x55,0x55,0x55,0x37,0x37}, 
     
-    /* saturation */   
-   {0x80,0x80,0x80,0x75,0x60,0x55,0x50,0x48}
+
 };
 
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
 {
-  //nosie_profile_weight_lut
-    {
-      0,  0,  0,  0,  0,  0,  0,  0,  5, 10, 15, 17, 20, 22, 25, 27, 
-     27, 30, 30, 32, 32, 35, 35, 35, 37, 37, 37, 40, 40, 40, 40, 42,
-     42, 42, 42, 42, 45, 45, 45, 45, 45, 45, 47, 47, 47, 47, 47, 47,
-     50, 50, 50, 50, 50, 50, 50, 50, 52, 52, 52, 52, 52, 52, 52, 52,
-     52, 52, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 57, 57, 57,
-     57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 60, 60, 60, 60, 60,
-     60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 62, 62, 62, 62, 62, 62,
-     62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 65, 65, 65
-    },
+    /* bvalid */
+    1,
+    
+    //nosie_profile_weight_lut
+   {
+     0,  0,  0,  0,  0,  0,  0,  0,  5, 10, 15, 17, 20, 22, 25, 27, 
+    27, 30, 30, 32, 32, 35, 35, 35, 37, 37, 37, 40, 40, 40, 40, 42,
+    42, 42, 42, 42, 45, 45, 45, 45, 45, 45, 47, 47, 47, 47, 47, 47,
+    50, 50, 50, 50, 50, 50, 50, 50, 52, 52, 52, 52, 52, 52, 52, 52,
+    52, 52, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 57, 57, 57,
+    57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 60, 60, 60, 60, 60,
+    60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 62, 62, 62, 62, 62, 62,
+    62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 65, 65, 65,
+   },
 
-  //demosaic_weight_lut
-    {
+    //demosaic_weight_lut
+   {
       0,  5, 10, 15, 17, 20, 22, 25, 27, 27, 30, 30, 32, 32, 35, 35,
-      35, 37, 37, 37, 40, 40, 40, 40, 42, 42, 42, 42, 42, 45, 45, 45,
-      45, 45, 45, 47, 47, 47, 47, 47, 47, 50, 50, 50, 50, 50, 50, 50,
-      50, 52, 52, 52, 52, 52, 52, 52, 52, 52, 52, 55, 55, 55, 55, 55,
-      55, 55, 55, 55, 55, 55, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57,
-      57, 57, 57, 57, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60,
-      60, 60, 60, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62,
-      62, 62, 62, 62, 62, 62, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65
-    }
+     35, 37, 37, 37, 40, 40, 40, 40, 42, 42, 42, 42, 42, 45, 45, 45,
+     45, 45, 45, 47, 47, 47, 47, 47, 47, 50, 50, 50, 50, 50, 50, 50,
+     50, 52, 52, 52, 52, 52, 52, 52, 52, 52, 52, 55, 55, 55, 55, 55,
+     55, 55, 55, 55, 55, 55, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57,
+     57, 57, 57, 57, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60,
+     60, 60, 60, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62,
+     62, 62, 62, 62, 62, 62, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65
+   }
+
 };
 
-
-
-
-static cmos_isp_demosaic_t st_isp_demosaic =
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
 {
-   /*vh_slope*/
-   220,
-   
-   /*aa_slope*/
-   200,
-   
-   /*va_slope*/
-   185,
-   
-   /*uu_slope*/
-   210,
-   
-   /*sat_slope*/
-   93,
-   
-   /*ac_slope*/
-   160,
-   
-   /*vh_thresh*/
-   0,
-   
-   /*aa_thresh*/
-   0,
-   
-   /*va_thresh*/
-   0,
-   
-   /*uu_thresh*/
-   8,
-   
-   /*sat_thresh*/
-   0,
-   
-   /*ac_thresh*/
-   0x1b3,
-   
-};
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
-{
-	cmos_inttime.full_lines_std = 752;
-	cmos_inttime.full_lines_std_30fps = 752;
-	cmos_inttime.full_lines = 752;
-	cmos_inttime.full_lines_limit = 65535;
-	cmos_inttime.max_lines_target = 752;
-	cmos_inttime.min_lines_target = 3;
-	cmos_inttime.vblanking_lines = 0;
-
-	cmos_inttime.exposure_ashort = 0;
-
-	cmos_inttime.lines_per_500ms = 752*30/2; //
-	cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-	return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime)
-{
-
-    HI_U16 exp_time;
-    exp_time = p_inttime->full_lines - p_inttime->exposure_ashort - 1;  
+     /* bvalid */
+     1,
     
-#if CMOS_IMX138_ISP_WRITE_SENSOR_ENABLE
+    /*vh_slope*/
+     220,
+     
+     /*aa_slope*/
+     200,
+     
+     /*va_slope*/
+     185,
+     
+     /*uu_slope*/
+     210,
+     
+     /*sat_slope*/
+     93,
+     
+     /*ac_slope*/
+     160,
+     
+     /*vh_thresh*/
+     0,
+     
+     /*aa_thresh*/
+     0,
+     
+     /*va_thresh*/
+     0,
+     
+     /*uu_thresh*/
+     8,
+     
+     /*sat_thresh*/
+     0,
+     
+     /*ac_thresh*/
+     0x1b3,
 
-    ISP_SSP_DATA_S   stSspData;
-    stSspData.bDelayCfg = HI_FALSE;
-    stSspData.u32DevAddr = 0x02;
-    stSspData.u32DevAddrByteNum = 1;
-    stSspData.u32RegAddr = 0x20;
-    stSspData.u32RegAddrByteNum = 1;
-    stSspData.u32Data = (exp_time & 0xFF);
-    stSspData.u32DataByteNum = 1;
-    HI_MPI_ISP_SSPWrite(&stSspData);
-
-    stSspData.u32RegAddr = 0x21;
-    stSspData.u32RegAddrByteNum = 1;
-    stSspData.u32Data = ((exp_time & 0xFF00) >> 8);            
-    stSspData.u32DataByteNum = 1;
-    HI_MPI_ISP_SSPWrite(&stSspData);
-    
-#else
-
-    sensor_write_register(EXPOSURE_ADDR, exp_time & 0xFF);
-    sensor_write_register(EXPOSURE_ADDR+1, (exp_time & 0xFF00) >> 8);
-
-#endif 
-
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-
-	HI_U16 vmax = p_inttime->full_lines;
-	sensor_write_register(VMAX_ADDR, (vmax&0x00ff));
-	sensor_write_register(VMAX_ADDR+1, ((vmax&0xff00) >> 8));
-	return;
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-	if (p_inttime->exposure_ashort >= p_inttime->full_lines - 2)
-	{
-		p_inttime->exposure_ashort = p_inttime->full_lines - 2;
-	}
-
-	p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std;
-	return p_inttime->exposure_ashort;
-}
-
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-
-	switch(fps)
-	{
-		case 30:
-			// Change the frame rate via changing the vertical blanking
-			p_inttime->full_lines_std = 752;
-			sensor_write_register(VMAX_ADDR, 0xF0);
-			sensor_write_register(VMAX_ADDR+1, 0x02);
-			p_inttime->lines_per_500ms = 752 * 30 / 2;
-		break;
-
-		case 25:
-			// Change the frame rate via changing the vertical blanking
-			p_inttime->full_lines_std = 902;
-			sensor_write_register(VMAX_ADDR, 0x86);
-			sensor_write_register(VMAX_ADDR+1, 0x03);
-			p_inttime->lines_per_500ms = 902 * 25 / 2;
-		break;
-
-		default:
-		break;
-	}
-
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
-{
-    cmos_gains.again = 1;
-    cmos_gains.dgain = 1;
-    cmos_gains.isp_dgain = 1;
-    cmos_gains.again_db = 1;
-    cmos_gains.dgain_db = 1;
-    cmos_gains.again_shift = 10;
-    cmos_gains.dgain_shift = 10;
-    cmos_gains.dgain_fine_shift = 0;
-
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-
-    
-    cmos_gains.max_again = 16229;
-    cmos_gains.max_dgain = 16229;
-    cmos_gains.max_again_target = 16229;
-    cmos_gains.max_dgain_target = 16229;
-    cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_TRUE;
-
-
-	return &cmos_gains;
-}
-
-static HI_U32 gain_table[81] =
-{
-    1024 , 1060 ,  1097 ,  1136 ,  1176,  1217 , 1260 ,  1304,  1350 ,  1397 ,  1446 ,  1497 , 1550 , 1604 ,  1661 ,  1719 , 
-    1780 , 1842 ,  1907 ,  1974 ,  2043,  2115 , 2189 ,  2266,  2346 ,  2428 ,  2514 ,  2602 , 2693 , 2788 ,  2886 ,  2987 , 
-    3092 , 3201 ,  3314 ,  3430 ,  3551,  3675 , 3805 ,  3938,  4077 ,  4220 ,  4368 ,  4522 , 4681 , 4845 ,  5015 ,  5192 , 
-    5374 , 5563 ,  5758 ,  5961 ,  6170,  6387 , 6611 ,  6844,  7084 ,  7333 ,  7591 ,  7858 , 8134 , 8420 ,  8716 ,  9022 , 
-    9339 , 9667 , 10007 , 10359 , 10723, 11099 ,11489 , 11893, 12311 , 12744 , 13192 , 13655 ,14135 ,14632 , 15146 , 15678 , 
-    16229     
 };
 
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
 {
-    /* analog gain = APGC * 0.3 db, APGC = [0x0,0x50], ag_db=[0db, 24db] */
-    /* digital gain = DPGC * 0.3 db, DPCG = [0x50,0xA0], dg_db=[0db, 24db] */
-
-     ISP_SSP_DATA_S   stSspData;
-    
-#if CMOS_IMX138_ISP_WRITE_SENSOR_ENABLE
-
-    stSspData.bDelayCfg = HI_TRUE;
-    stSspData.u32DevAddr = 0x02;
-    stSspData.u32DevAddrByteNum = 1;
-    stSspData.u32RegAddr = 0x14;
-    stSspData.u32RegAddrByteNum = 1;
-    stSspData.u32Data = p_gains->again_db + p_gains->dgain_db;
-    stSspData.u32DataByteNum = 1;
-
-    if((p_gains->again_db + p_gains->dgain_db) <= 0xA0)
+    if (HI_NULL == pstDef)
     {
-      HI_MPI_ISP_SSPWrite(&stSspData);
-    }
-    else
-    {
-       stSspData.u32Data = 0xA0;
-       stSspData.u32DataByteNum = 1;
-       HI_MPI_ISP_SSPWrite(&stSspData);
+        printf("null pointer when get isp default value!\n");
+        return -1;
     }
 
-#else
-    
-    if((p_gains->again_db + p_gains->dgain_db) <= 0xA0)
-    {
-        sensor_write_register(PGC_ADDR, p_gains->again_db + p_gains->dgain_db);
-    }
-    else
-    {
-        sensor_write_register(PGC_ADDR, 0xA0);
-    }
-    
- #endif
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
 
+    pstDef->stComm.u8Rggb           = 0x2;      //2: gbrg 
+    pstDef->stComm.u8BalanceFe      = 0x1;
+
+    pstDef->stDenoise.u8SinterThresh= 0x8;
+    pstDef->stDenoise.u8NoiseProfile= 0x1;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+    pstDef->stDenoise.u16Nr0        = 0x0;
+    pstDef->stDenoise.u16Nr1        = 455;
+
+    pstDef->stDrc.u8DrcBlack        = 0x00;
+    pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+    pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+    pstDef->stDrc.u8DrcSm           = 0xa0;     // slope max
+    pstDef->stDrc.u16DrcWl          = 0x8ff;    // white level
+
+    memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+
+    return 0;
 }
 
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
 {
-    HI_U32 again = 1024;
-    HI_U32 step = 0;
-    HI_S32 shift = 0;
-    HI_S32 i = 0;
-
-    while (exposure > (1 << 20))
-    {
-        exposure     >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
+    HI_S32  i;
     
-    if(exposure > exposure_max)
+    if (HI_NULL == pstBlackLevel)
     {
-        again = (exposure << 10) / exposure_max;
-        again = again < 1024? 1024: again;
-        again = again > p_gains->max_again_target? p_gains->max_again_target: again;
-    
-        if (again >= gain_table[80])
-        {
-             again = gain_table[80];
-             step = 80;
-        }
-        else
-        {
-            for(i = 1; i < 81; i++)
-            {
-                if(again < gain_table[i])
-                {
-                    again = gain_table[i-1];
-                    step = i-1;
-                    break;
-                }
-            }
-        }
-        
-        exposure = (exposure << 10) / again;
+        printf("null pointer when get isp black level value!\n");
+        return -1;
     }
 
-    p_gains->again = again;
-    p_gains->again_db = step;
-    
-    return (exposure << shift);
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+            
+    for (i=0; i<4; i++)
+    {
+        pstBlackLevel->au16BlackLevel[i] = 0xF0;
+    }
+
+    return 0;    
 }
 
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
-
-    while (exposure > (1 << 22))
+    if (bEnable) /* setup for ISP pixel calibration mode */
     {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-
-    if(exposure > exposure_max)
-    {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
-    }
-    
-    p_gains->isp_dgain = isp_dgain;
-
-    return exposure << shift;
-}
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    HI_U32 dgain = 1024;
-    HI_U32 step = 0;
-    HI_S32 shift = 0;
-    HI_S32 i = 0;  
-    
-    while (exposure > (1 << 20))
-    {
-        exposure     >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
-    
-    if(exposure > exposure_max)
-    {
-        dgain = (exposure << 10) / exposure_max;
-        dgain = dgain < 1024? 1024: dgain;
-        dgain = dgain > p_gains->max_dgain_target? p_gains->max_dgain_target: dgain;
-    
-        if (dgain >= gain_table[80])
-        {
-             dgain = gain_table[80];
-             step = 80;
-        }
-        else
-        {
-            for(i = 1; i < 81; i++)
-            {
-                if(dgain < gain_table[i])
-                {
-                    dgain = gain_table[i-1];
-                    step = i-1 ;
-                    break;
-                }
-            }
-        }
-        
-        exposure = (exposure << 10) / dgain;
-    }
- 
-    p_gains->dgain = dgain;
-    p_gains->dgain_db = step;
-
-    return exposure << shift;
-
-}
-
-static void setup_sensor(int isp_mode)
-{
-    printf("defect bad pixiel  \n");
-	if(0 == isp_mode) /* setup for ISP 'normal mode' */
-	{
-        sensor_write_register(VMAX_ADDR, 0xEE);
-        sensor_write_register(VMAX_ADDR + 1, 0x02);
-	}
-	else if(1 == isp_mode) /* setup for ISP pixel calibration mode */
-	{
         /* Sensor must be programmed for slow frame rate (5 fps and below)*/
         /* change frame rate to 5 fps by setting 1 frame length = 750 * 30 / 5 */
         sensor_write_register(VMAX_ADDR, 0x94);
@@ -549,158 +238,17 @@ static void setup_sensor(int isp_mode)
 
         /* Analog and Digital gains both must be programmed for their minimum values */
 		sensor_write_register(PGC_ADDR, 0x00);
-
-	}
-}
-
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
-{
-    HI_U32 _again = p_gains->again == 0 ? 1 : p_gains->again;
-	HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _ispdgain = p_gains->isp_dgain == 0 ? 1 : p_gains->isp_dgain;
-
-		p_gains->iso =  (((HI_U64)_again * _dgain * _ispdgain * 100) 
-        >> (p_gains->again_shift + p_gains->dgain_shift 
-        + p_gains->isp_dgain_shift));
-
-	return p_gains->iso;
-}
-
-/* Note: The unit of return value is 1db.  */
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return (cmos_gains->again_db *  3 / 10);
-}
-
-/* Note: The unit of return value is 1db.  */
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return  (cmos_gains->dgain_db *  3 / 10);
-}
-
-/*
-static HI_U8 cmos_get_digital_fine_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return cmos_gains->dgain_fine;
-}
-*/
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-    if (NULL == p_coms_isp_default)
-    {
-        printf("null pointer when get isp default value!\n");
-        return -1;
     }
-
-     memcpy(p_coms_isp_default, &st_coms_isp_default, sizeof(cmos_isp_default_t));
-
-    return 0;
+    else /* setup for ISP 'normal mode' */
+    {
+        sensor_write_register(VMAX_ADDR, 0xEE);
+        sensor_write_register(VMAX_ADDR + 1, 0x02);
+    }
+    
+    return;
 }
 
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-	if (NULL == p_cmos_isp_agc_table)
-	{
-	    printf("null pointer when get isp agc table value!\n");
-	    return -1;
-	}
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-
-     memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-
-
-    return 0;
-}
-
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
-{
-   if (NULL == p_cmos_isp_demosaic)
-   {
-	    printf("null pointer when get isp demosaic value!\n");
-	    return -1;
-   }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1280;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 720;
-
-    return 0;
-}
-
-
-/****************************************************************************
- * callback structure                                                       *
- ****************************************************************************/
-
-SENSOR_EXP_FUNC_S stSensorExpFuncs =
-{
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
-
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
-
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
-
-    .pfn_setup_sensor = setup_sensor,
-	.pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-	.pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-	.pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
-
-	.pfn_cmos_get_isp_default = cmos_get_isp_default,
-	.pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-	.pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-	.pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-	.pfn_cmos_get_isp_shading_table = NULL,
-	.pfn_cmos_get_isp_gamma_table = NULL,
-	.pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-	.pfn_cmos_set_sensor_image_mode = NULL,
-
-};
-
-int sensor_register_callback(void)
-{
-	int ret;
-	ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-	if (ret)
-	{
-	    printf("sensor register callback function failed!\n");
-	    return ret;
-	}
-	return 0;
-}
-
-int sensor_mode_set(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
@@ -717,13 +265,422 @@ int sensor_mode_set(HI_U8 u8Mode)
 
         default:
             printf("NOT support this mode!\n");
-            return -1;
+            return;
         break;
     }
+    
+    return;
+}
+
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 752;
+    
+    pstAeSnsDft->au8HistThresh[0] = 0xd;
+    pstAeSnsDft->au8HistThresh[1] = 0x28;
+    pstAeSnsDft->au8HistThresh[2] = 0x60;
+    pstAeSnsDft->au8HistThresh[3] = 0x80;
+    
+    pstAeSnsDft->u8AeCompensation = 0x40;
+    
+    pstAeSnsDft->u32LinesPer500ms = 752*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 749;
+    pstAeSnsDft->u32MinIntTime = 3;    
+    pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+    pstAeSnsDft->u32MinIntTimeTarget = 3;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 0.3;    
+    pstAeSnsDft->u32MaxAgain = 16229;  /**/
+    pstAeSnsDft->u32MinAgain = 1024;
+    pstAeSnsDft->u32MaxAgainTarget = 16229;
+    pstAeSnsDft->u32MinAgainTarget = 1024;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.3;    
+    pstAeSnsDft->u32MaxDgain = 16229;  /*  */
+    pstAeSnsDft->u32MinDgain = 1024;
+    pstAeSnsDft->u32MaxDgainTarget = 16229;
+    pstAeSnsDft->u32MinDgainTarget = 1024;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
+    return 0;
+}
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    switch(u8Fps)
+    {
+        case 30:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 752;
+			pstAeSnsDft->u32MaxIntTime = 749;
+            pstAeSnsDft->u32LinesPer500ms = 752 * 30 / 2;
+			sensor_write_register(VMAX_ADDR, 0xF0);
+			sensor_write_register(VMAX_ADDR+1, 0x02);
+        break;
+        
+        case 25:
+            // Change the frame rate via changing the vertical blanking
+            gu32FullLinesStd = 902;
+            pstAeSnsDft->u32MaxIntTime = 899;
+            pstAeSnsDft->u32LinesPer500ms = 902 * 25 / 2;
+			sensor_write_register(VMAX_ADDR, 0x86);
+			sensor_write_register(VMAX_ADDR+1, 0x03);
+        break;
+        
+        default:
+        break;
+    }
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    gu32FullLines = gu32FullLinesStd;
+
+    return;
+}
+
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1280;
+    pstSensorMaxResolution->u32MaxHeight = 720;
+
     return 0;
 }
 
 
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    gu32FullLines = u16FullLines;
+
+	sensor_write_register(VMAX_ADDR, (gu32FullLines & 0x00ff));
+	sensor_write_register(VMAX_ADDR+1, ((gu32FullLines & 0xff00) >> 8));
+    
+    pstAeSnsDft->u32MaxIntTime = gu32FullLines - 3;
+    
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_IMX138_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+
+    if (HI_FALSE == gsbRegInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_SSP_TYPE;
+        for (i=0; i<3; i++)
+        {
+            g_stSnsRegsInfo.astSspData[i].u32DevAddr = 0x02;
+            g_stSnsRegsInfo.astSspData[i].u32DevAddrByteNum = 1;
+            g_stSnsRegsInfo.astSspData[i].u32RegAddrByteNum = 1;
+            g_stSnsRegsInfo.astSspData[i].u32DataByteNum = 1;
+        }
+        g_stSnsRegsInfo.u32RegNum = 3;
+        g_stSnsRegsInfo.astSspData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[0].u32RegAddr = 0x20;
+        g_stSnsRegsInfo.astSspData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astSspData[1].u32RegAddr = 0x21;
+        g_stSnsRegsInfo.astSspData[2].bDelayCfg = HI_TRUE;
+        g_stSnsRegsInfo.astSspData[2].u32RegAddr = 0x14;
+    
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_TRUE;
+
+        gsbRegInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+static  HI_U32   gain_table[81]={
+
+ 1024,   1060,   1097,   1136,   1176,   1217,   1260,   1304,   1350,   1397,   1446,   1497,   1550,   1604,   1661,   1719,   1780,
+ 1842,   1907,   1974,   2043,   2115,   2189,   2266,   2346,   2428,   2514,   2602,   2693,   2788,   2886,   2987,   3092,
+ 3201,   3314,   3430,   3551,   3675,   3805,   3938,   4077,   4220,   4368,   4522,   4681,   4845,   5015,   5192,   5374,
+ 5563,   5758,   5961,   6170,   6387,   6611,   6844,   7084,   7333,   7591,   7858,   8134,   8420,   8716,   9022,   9339,
+ 9667,  10007,  10359,  10723,  11099,  11489,  11893,  12311,  12744,  13192,  13655,  14135,  14632,  15146,  15678,   16229
+
+};
+
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+    HI_U32 u32Value = gu32FullLines - u32IntTime - 1;
+
+#if CMOS_IMX138_ISP_WRITE_SENSOR_ENABLE
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astSspData[0].u32Data = (u32Value & 0xFF);
+    g_stSnsRegsInfo.astSspData[1].u32Data = ((u32Value & 0xFF00) >> 8);
+   
+#else
+    sensor_write_register(EXPOSURE_ADDR, u32Value & 0xFF);
+    sensor_write_register(EXPOSURE_ADDR + 1, (u32Value & 0xFF00) >> 8);
+
+#endif
+    return;
+}
+
+static HI_VOID cmos_again_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
+{
+    int i;
+
+    if(HI_NULL == pstAeSnsGainInfo)
+    {
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
+    }
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+   
+    if (u32InTimes >= gain_table[80])
+    {
+         pstAeSnsGainInfo->u32SnsTimes = gain_table[80];
+         pstAeSnsGainInfo->u32GainDb = 80;
+         return ;
+    }
+    
+    for(i = 1; i < 81; i++)
+    {
+        if(u32InTimes < gain_table[i])
+        {
+            pstAeSnsGainInfo->u32SnsTimes = gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
+
+    }
+          
+    return;
+
+}
+
+static HI_VOID cmos_dgain_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
+{
+    int i;
+
+    if(HI_NULL == pstAeSnsGainInfo)
+    {
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
+    }
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+
+    if (u32InTimes >= gain_table[80])
+    {
+        pstAeSnsGainInfo->u32SnsTimes = gain_table[80];
+        pstAeSnsGainInfo->u32GainDb = 80;
+        return ;
+    }
+
+    for(i = 1; i < 81; i++)
+    {
+        if(u32InTimes < gain_table[i])
+        {
+            pstAeSnsGainInfo->u32SnsTimes = gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
+
+    }
+       
+    return;
+
+}
+
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    HI_U32 u32Tmp = u32Again + u32Dgain;
+    u32Tmp = u32Tmp > 0xA0 ? 0xA0 : u32Tmp;
+#if CMOS_IMX138_ISP_WRITE_SENSOR_ENABLE   
+    cmos_init_regs_info();
+    g_stSnsRegsInfo.astSspData[2].u32Data = u32Tmp;
+    
+    HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+#else
+    sensor_write_register(PGC_ADDR, u32Tmp);
+#endif
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 5048;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x1ff;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x1e4;
+
+    pstAwbSnsDft->as32WbPara[0] = 40;
+    pstAwbSnsDft->as32WbPara[1] = 106;
+    pstAwbSnsDft->as32WbPara[2] = -110;
+    pstAwbSnsDft->as32WbPara[3] = 184787;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -134867;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+    
+    return 0;
+}
+
+HI_VOID sensor_global_init()
+{
+
+   gu8SensorMode = 0;
+   
+}
+
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
+
+    return 0;
+}
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+    pstExpFuncs->pfn_cmos_again_calc_table  = cmos_again_calc_table;
+    pstExpFuncs->pfn_cmos_dgain_calc_table  = cmos_dgain_calc_table;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+int sensor_register_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(IMX138_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, IMX138_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, IMX138_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(void)
+{
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(IMX138_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, IMX138_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, IMX138_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -731,4 +688,4 @@ int sensor_mode_set(HI_U8 u8Mode)
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-#endif // __IMX138_CMOS_H_
+#endif // __IMX104_CMOS_H_

--- a/libraries/sensor/hi3516cv100/sony_imx138/imx138_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/sony_imx138/imx138_sensor_ctl.c
@@ -1,9 +1,19 @@
 /******************************************************************************
-  A driver program of panasonic IMX138 on HI3518A 
- ******************************************************************************
-    Modification:  2013-05  Created
-******************************************************************************/
 
+  Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : sony138_sensor_ctl.c
+  Version       : Initial Draft
+  Author        : Hisilicon multimedia software group
+  Created       : 2011/09/09
+  Description   : Sony IMX138 sensor driver
+  History       :
+  1.Date        : 2011/09/09
+    Author      : MPP
+    Modification: Created file
+
+******************************************************************************/
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -58,14 +68,12 @@ int sony_sensor_read_packet(unsigned int data)
 int sensor_write_register(int addr, int data)
 {
 	unsigned int value = (unsigned int)(((addr&0xffff)<<8) | (data & 0xff));
-	//printf("write data = %#x\n", value);
     return sony_sensor_write_packet(value);
 }
 
 int sensor_read_register(int addr)
 {
 	unsigned int data = (unsigned int)(((addr&0xffff)<<8));
-	//printf("read data = %#x\n", data);
     return sony_sensor_read_packet(data);
 }
 
@@ -293,3 +301,4 @@ void sensor_init()
 
 	printf("-------Sony IMX138 Sensor Initial OK!-------\n");
 }
+

--- a/libraries/sensor/hi3516cv100/sony_imx236/imx236_cmos.c
+++ b/libraries/sensor/hi3516cv100/sony_imx236/imx236_cmos.c
@@ -2,13 +2,15 @@
 #define __IMX236_CMOS_H_
 
 #include <stdio.h>
-#include <unistd.h>		
 #include <string.h>
 #include <assert.h>
 #include "hi_comm_sns.h"
 #include "hi_comm_isp.h"
 #include "hi_sns_ctrl.h"
 #include "mpi_isp.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -16,178 +18,95 @@ extern "C"{
 #endif
 #endif /* End of #ifdef __cplusplus */
 
-
-#define EXPOSURE_ADDR (0x220) 
+/* Note: format of address is special.
+ * chip_id + reg_adddr */
+#define EXPOSURE_ADDR (0x220) //2:chip_id, 20: reg addr.
 #define LONG_EXPOSURE_ADDR (0x223)
 #define PGC_ADDR (0x214)
 #define VMAX_ADDR (0x218)
 #define HMAX_ADDR (0x21B)
+
+#define IMX236_ID 236
+/*set Frame End Update Mode 2 with HI_MPI_ISP_SetAEAttr and set this value 1 to avoid flicker */
+/*when use Frame End Update Mode 2, the speed of i2c will affect whole system's performance   */
+/*increase I2C_DFT_RATE in Hii2c.c to 400000 to increase the speed of i2c                     */
 #define CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE (1)
 /****************************************************************************
- * local variables															*
+ * local variables                                                            *
  ****************************************************************************/
 extern const unsigned int sensor_i2c_addr;
 extern const unsigned int sensor_addr_byte;
 extern const unsigned int sensor_data_byte;
 
-static cmos_inttime_t cmos_inttime;
-static cmos_gains_t cmos_gains;
 HI_U8 gu8SensorMode = 0;
-
-
-static cmos_isp_default_t st_coms_isp_default_lin =
-{
-    // color correction matrix
-    {
-        4850,
-        {
-            0x01f7, 0x80ef, 0x8008,
-            0x804b, 0x019d, 0x8052,
-            0x0015, 0x8133, 0x021d
-        },
-        3140,
-        {
-            0x0199, 0x8080, 0x8019,
-            0x808e, 0x01b3, 0x8025,
-            0x000f, 0x817c, 0x026c
-        },
-        2470,
-        {
-            0x0147, 0x8025, 0x8022,
-            0x8086, 0x018b, 0x8005,
-            0x801e, 0x8228, 0x0346
-        }
-    },
-	// black level for R, Gr, Gb, B channels
-    {0xf0,0xf0,0xf0,0xf0},
-
-    // calibration reference color temperature
-    4850,
-
-    //WB gain at 5000K, must keep consistent with calibration color temperature
-    
-	{0x190, 0x100, 0x100, 0x204},
-
-    // WB curve parameters, must keep consistent with reference color temperature.
-	//{63, 65, -127, 201983, 128, -151034},
-	{62, 68, -125, 201189, 128, -150451},
-	// hist_thresh
-    {0xd,0x28,0x60,0x80},
-
-    0x00,	// iridix_balck
-    0x0,	// 0:rggb; 2: gbrg
-
-    // gain
-    0xFB,	0x1,
-
-    // iridix space, intensity, slope_max, white level
-    0x02,	0x08,	0x80, 	0x8ff,
-
-    0x1, 	// balance_fe
-    0x80,	// ae compensation
-    0x20, 	// sinter threshold
-
-    0x1,        //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
-    0,
-    1528,
 #if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
-    2
-#else
-    1
+ISP_SNS_REGS_INFO_S g_stSnsRegsInfo = {0};
+static HI_BOOL gsbRegInit = HI_FALSE;
 #endif
+static HI_U32 gu32FullLinesStd = 1125;
+static HI_U32 gu32FullLines = 1125;
+
+static AWB_CCM_S g_stAwbCcm =
+{
+    4850,
+    {
+        0x01f7, 0x80ef, 0x8008,
+        0x804b, 0x019d, 0x8052,
+        0x0015, 0x8133, 0x021d
+    },
+    3140,
+    {
+        0x0199, 0x8080, 0x8019,
+        0x808e, 0x01b3, 0x8025,
+        0x000f, 0x817c, 0x026c
+    },
+    2470,
+    {
+        0x0147, 0x8025, 0x8022,
+        0x8086, 0x018b, 0x8005,
+        0x801e, 0x8228, 0x0346
+    }
 };
 
-static cmos_isp_default_t st_coms_isp_default_wdr =
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
 {
-    // color correction matrix
-    {
-        4850,
-        {
-            0x022d, 0x80fc, 0x8031,
-            0x803a, 0x01a9, 0x806f,
-            0x002e, 0x8130, 0x0201
-        },
-        3140,
-        {
-            0x01dc, 0x808e, 0x804e,
-            0x809f, 0x01f5, 0x8056,
-            0x0013, 0x8186, 0x0272
-        },
-        2470,
-        {
-            0x018d, 0x807d, 0x8010,
-            0x8072, 0x016f, 0x2,
-            0x8006, 0x8235, 0x033b
-        }
-    },
-
-	// black level for R, Gr, Gb, B channels
-    {0x0,0x0,0x0,0x0},
-
-    // calibration reference color temperature
-    4850,
-
-    //WB gain at 5000K, must keep consistent with calibration color temperature
-	{0x190, 0x100, 0x100, 0x206},
-	
-    // WB curve parameters, must keep consistent with reference color temperature.
-    {63, 65, -127, 201983, 128, -151034},
-	
-    // hist_thresh
-    {0x20,0x40,0x60,0x80},
-   
-    0x00,   // iridix_balck
-    0x0,    // 0:rggb; 2: gbrg
-
-    // gain
-    0x4,    0x1,
-
-    // iridix space, intensity, slope_max, white level
-    0x08,   0x01,   0x20,   0xfff,
-
-    0x0,    // balance_fe
-    0x80,   // ae compensation
-    0x9,    // sinter threshold
-    
-    0x0,     //noise profile=0, use the default noise profile lut, don't need to set nr0 and nr1
-    0x0,
-    0x0,
-#if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
-    2
-#else
-    1
-#endif
-};
-
-static cmos_isp_agc_table_t st_isp_agc_table =
-{
-    //sharpen_alt_d
-    {0x88,0x85,0x80,0x7b,0x78,0x72,0x70,0x60},
-
-    //sharpen_alt_ud
-    {0xc8,0xc0,0xb8,0xb0,0xa8,0xa0,0x72,0x4b},
-
-    //snr_thresh
-    {0x06,0x8,0xb,0x16,0x22,0x28,0x32,0x54},
-
-    //demosaic_lum_thresh
-    {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
-
-    //demosaic_np_offset
-    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
-
-    //ge_strength
-    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
+    /* bvalid */
+    1,
 
     /* saturation */
-    {0x80,0x80,0x80,0x80,0x68,0x48,0x35,0x30}
+     {0x80,0x80,0x80,0x80,0x68,0x48,0x35,0x30}
 };
 
-
-static cmos_isp_noise_table_t st_isp_noise_table =
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
 {
-  //nosie_profile_weight_lut
+    /* bvalid */
+    1,
 
+    /* sharpen_alt_d */
+    {0x88,0x85,0x80,0x7b,0x78,0x72,0x70,0x60},
+        
+    /* sharpen_alt_ud */
+    {0xc8,0xc0,0xb8,0xb0,0xa8,0xa0,0x72,0x4b},
+        
+    /* snr_thresh */
+    {0x06,0x8,0xb,0x16,0x22,0x28,0x32,0x54},
+        
+    /* demosaic_lum_thresh */
+    {0x60,0x60,0x80,0x80,0x80,0x80,0x80,0x80},
+        
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37},
+};
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTableLin =
+{
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
     {
         0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x04,0x0c,0x11,0x14,0x17,0x19,0x1b,0x1c,0x1e,0x1f,
         0x20,0x21,0x22,0x23,0x24,0x24,0x25,0x26,0x26,0x27,0x28,0x28,0x29,0x29,0x2a,0x2a,0x2a,
@@ -198,7 +117,8 @@ static cmos_isp_noise_table_t st_isp_noise_table =
         0x39,0x39,0x39,0x39,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3b,0x3b,0x3b,0x3b,
         0x3b,0x3b,0x3b,0x3b,0x3b,0x3c,0x3c,0x3c,0x3c
     },
-  
+
+    /* demosaic_weight_lut */
     {
         0x04,0x0c,0x11,0x14,0x17,0x19,0x1b,0x1c,0x1e,0x1f,
         0x20,0x21,0x22,0x23,0x24,0x24,0x25,0x26,0x26,0x27,0x28,0x28,0x29,0x29,0x2a,0x2a,0x2a,
@@ -208,33 +128,40 @@ static cmos_isp_noise_table_t st_isp_noise_table =
         0x37,0x37,0x37,0x37,0x37,0x38,0x38,0x38,0x38,0x38,0x38,0x38,0x39,0x39,0x39,0x39,0x39,
         0x39,0x39,0x39,0x39,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3a,0x3b,0x3b,0x3b,0x3b,
         0x3b,0x3b,0x3b,0x3b,0x3b,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c,0x3c
-    },
-};
-
-static cmos_isp_noise_table_t st_isp_noise_table_wdr =
-{
-    /*nosie_profile_weight_lut WDR*/
-    {
-        0,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,45,48,57,
-            63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,
-            63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,
-            63,63,63,63,63,63,63,63,63,63,63,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,
-            64,64,64,64,64,64,64,64,64,64,64,64,64,64,64
-    },
-
-  //demosaic_weight_lut
-    {
-        0,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,45,48,57,
-            63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,
-            63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,
-            63,63,63,63,63,63,63,63,63,63,63,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,
-            64,64,64,64,64,64,64,64,64,64,64,64,64,64,64
     }
 };
 
-static cmos_isp_demosaic_t st_isp_demosaic =
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTableWdr =
 {
-    /*vh_slope*/
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
+    {
+        0,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,45,48,57,
+        63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,
+        63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,
+        63,63,63,63,63,63,63,63,63,63,63,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,
+        64,64,64,64,64,64,64,64,64,64,64,64,64,64,64
+    },
+
+    /* demosaic_weight_lut */
+    {
+        0,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,37,45,48,57,
+        63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,
+        63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,
+        63,63,63,63,63,63,63,63,63,63,63,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,
+        64,64,64,64,64,64,64,64,64,64,64,64,64,64,64
+    }
+};
+
+
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
+{
+    /* bvalid */
+    1,
+    
+     /*vh_slope*/
     0xd8,
 
     /*aa_slope*/
@@ -269,285 +196,7 @@ static cmos_isp_demosaic_t st_isp_demosaic =
 
     /*ac_thresh*/
     0x1b3,
-
 };
-
-extern void sensor_linner_init();
-extern void sensor_wdr_init();
-
-/*
- * This function initialises an instance of cmos_inttime_t.
- */
-static __inline cmos_inttime_const_ptr_t cmos_inttime_initialize()
-{
-    cmos_inttime.full_lines_std = 1125;
-    cmos_inttime.full_lines_std_30fps = 1125;
-    cmos_inttime.full_lines_std_25fps = 1350;    
-    
-    //cmos_inttime.full_lines = 1125;
-    //cmos_inttime.full_lines_limit = 65535;
-    cmos_inttime.max_lines_target = 1123;
-    cmos_inttime.min_lines_target = 2;
-    cmos_inttime.exposure_shift = 0;
-    //cmos_inttime.vblanking_lines = 1125;
-
-   //cmos_inttime.exposure_ashort = 0;
-
-    cmos_inttime.lines_per_500ms = 16875; // 500ms / 29.63us = 16874
-    cmos_inttime.flicker_freq = 0;//60*256;//50*256;
-
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0: //linear mode
-
-        break;
-        case 1: //WDR mode for short exposure, Exposure ratio = 16X
-            cmos_inttime.max_lines_target = 70;
-            cmos_inttime.min_lines_target = 8;
-        break;
-    }
-    return &cmos_inttime;
-}
-
-/*
- * This function applies the new integration time to the ISP registers.
- */
-static __inline void cmos_inttime_update(cmos_inttime_ptr_t p_inttime) 
-{
-
-    HI_U16 exp_time,current;
-    ISP_I2C_DATA_S stI2cData;
-    static HI_U32 _last_exposure_time = 0xFFFFFFFF;
-    
-    if(_last_exposure_time == p_inttime->exposure_ashort)
-    {
-        return;
-    }else
-    {
-        _last_exposure_time = p_inttime->exposure_ashort;
-    }
-    
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0: //linear mode
-            exp_time = p_inttime->full_lines - p_inttime->exposure_ashort;  
-            current = sensor_read_register(EXPOSURE_ADDR+2);
-#if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
-            
-            stI2cData.bDelayCfg = HI_FALSE;
-            stI2cData.u8DevAddr = sensor_i2c_addr;
-            stI2cData.u32AddrByteNum = sensor_addr_byte;
-            stI2cData.u32DataByteNum = sensor_data_byte;
-            
-            stI2cData.u32RegAddr = 0x3020;
-            stI2cData.u32Data = (exp_time & 0xFF);
-            HI_MPI_ISP_I2cWrite(&stI2cData);  
-
-            stI2cData.u32RegAddr = 0x3020+1;
-            stI2cData.u32Data = ((exp_time & 0xFF00) >> 8);
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-
-            
-            stI2cData.u32RegAddr = 0x3020+2;
-            stI2cData.u32Data = ((((exp_time & 0x10000) >> 16)+(current&0xFE)) );
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-            
-#else   
-            sensor_write_register(EXPOSURE_ADDR, exp_time & 0xFF);
-            sensor_write_register(EXPOSURE_ADDR + 1, (exp_time & 0xFF00) >> 8);
-            current = sensor_read_register(EXPOSURE_ADDR+2);
-            sensor_write_register(EXPOSURE_ADDR+2, (((exp_time & 0x10000) >> 16)+(current&0xFE)) );
-#endif
-
-        break;
-        
-        case 1: //WDR mode
-            //short exposure
-            if (p_inttime->exposure_ashort < p_inttime->min_lines_target)
-            {
-                p_inttime->exposure_ashort = p_inttime->min_lines_target;
-            }
-            if (p_inttime->exposure_ashort > p_inttime->max_lines_target)
-            {
-                p_inttime->exposure_ashort = p_inttime->max_lines_target;
-            }
-            
-            exp_time = p_inttime->full_lines - p_inttime->exposure_ashort;
-            current = sensor_read_register(EXPOSURE_ADDR+2);
-#if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
-
-            stI2cData.bDelayCfg = HI_FALSE;
-            stI2cData.u8DevAddr = sensor_i2c_addr;
-            stI2cData.u32AddrByteNum = sensor_addr_byte;
-            stI2cData.u32DataByteNum = sensor_data_byte;
-
-            stI2cData.u32RegAddr = 0x3020;
-            stI2cData.u32Data = exp_time & 0xFF;
-            HI_MPI_ISP_I2cWrite(&stI2cData);  
-
-            stI2cData.u32RegAddr = 0x3020+1;
-            stI2cData.u32Data = ((exp_time & 0xFF00) >> 8);
-            HI_MPI_ISP_I2cWrite(&stI2cData);  
-
-            
-            stI2cData.u32RegAddr = 0x3020+2;
-            stI2cData.u32Data = (((exp_time & 0x10000) >> 16)+(current&0xFE));
-            HI_MPI_ISP_I2cWrite(&stI2cData);  
-
-            //long exposure
-            exp_time = p_inttime->full_lines - (p_inttime->exposure_ashort << 4);
-            stI2cData.u32RegAddr = 0x3023;
-            stI2cData.u32Data = (exp_time & 0xFF);
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-
-            stI2cData.u32RegAddr = 0x3023+1;
-            stI2cData.u32Data = ( (exp_time & 0xFF00) >> 8);
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-
-            current = sensor_read_register(LONG_EXPOSURE_ADDR+2);
-            stI2cData.u32RegAddr = 0x3023+2;
-            stI2cData.u32Data = (((exp_time & 0x10000) >> 16)+(current&0xFE));
-            HI_MPI_ISP_I2cWrite(&stI2cData);
-#else
-            sensor_write_register(EXPOSURE_ADDR, exp_time & 0xFF);
-            sensor_write_register(EXPOSURE_ADDR+1, (exp_time & 0xFF00) >> 8);
-            current = sensor_read_register(EXPOSURE_ADDR+2);
-            sensor_write_register(EXPOSURE_ADDR+2, (((exp_time & 0x10000) >> 16)+(current&0xFE)) );
-
-            //long exposure
-            exp_time = p_inttime->full_lines - (p_inttime->exposure_ashort << 4);
-            
-            sensor_write_register(LONG_EXPOSURE_ADDR, exp_time & 0xFF);
-            sensor_write_register(LONG_EXPOSURE_ADDR+1, (exp_time & 0xFF00) >> 8);
-            //current = sensor_read_register(LONG_EXPOSURE_ADDR+2);
-            sensor_write_register(LONG_EXPOSURE_ADDR+2, (((exp_time & 0x10000) >> 16)+(current&0xFE)) );
-#endif
-        break;
-    }
-
-}
-
-/*
- * This function applies the new vert blanking porch to the ISP registers.
- */
-static __inline void cmos_vblanking_update(cmos_inttime_const_ptr_t p_inttime)
-{
-    HI_U16 vmax = p_inttime->full_lines;
-    static HI_U16 last_vblanking_lines = 0xFFFF;
-    
-    if(vmax != last_vblanking_lines)
-    {
-        sensor_write_register(VMAX_ADDR, (vmax&0x00ff));
-        sensor_write_register(VMAX_ADDR+1, ((vmax&0xff00) >> 8));
-        last_vblanking_lines = vmax;
-    }else
-    {
-
-    }
-    return;
-}
-
-static __inline HI_U16 vblanking_calculate(
-		cmos_inttime_ptr_t p_inttime)
-{
-    if (p_inttime->exposure_ashort >= p_inttime->full_lines - 2)
-    {
-        p_inttime->exposure_ashort = p_inttime->full_lines - 2;
-    }
-    else if(p_inttime->exposure_ashort < 1)
-    {
-        p_inttime->exposure_ashort = 1;
-    }
-
-    p_inttime->vblanking_lines = p_inttime->full_lines - p_inttime->full_lines_std;
-    return p_inttime->exposure_ashort;
-}
-
-
-/* Set fps base */
-static __inline void cmos_fps_set(
-		cmos_inttime_ptr_t p_inttime,
-		const HI_U8 fps
-		)
-{
-    if (0 == gu8SensorMode) /*linear mode*/
-    {
-        switch(fps)
-        {
-            case 30:
-                // Change the frame rate via changing the vertical blanking
-                p_inttime->full_lines_std = p_inttime->full_lines_std_30fps;
-                //p_inttime->max_lines = 1123;
-                sensor_write_register(VMAX_ADDR, 0x65);
-                sensor_write_register(VMAX_ADDR+1, 0x04);
-                p_inttime->lines_per_500ms = p_inttime->full_lines_std_30fps * 30 / 2;
-            break;
-            
-            case 25:
-                // Change the frame rate via changing the vertical blanking
-                p_inttime->full_lines_std = p_inttime->full_lines_std_25fps;
-                //p_inttime->max_lines = 1348;
-                sensor_write_register(VMAX_ADDR, 0x46);
-                sensor_write_register(VMAX_ADDR+1, 0x05);
-                p_inttime->lines_per_500ms = p_inttime->full_lines_std_25fps * 25 / 2;
-            break;
-            default:
-                break;
-    	}
-    }
-    else if (1 == gu8SensorMode)   /* Built-in WDR */
-    {
-        switch(fps)
-        {
-            case 30:
-                sensor_write_register(HMAX_ADDR, 0x30);
-                sensor_write_register(HMAX_ADDR+1, 0x11);
-            break;
-            case 25:
-                sensor_write_register(HMAX_ADDR, 0xA0);
-                sensor_write_register(HMAX_ADDR+1, 0x14);
-            break;
-            default:
-                break;
-    	}
-    }
-}
-
-/*
- * This function initialises an instance of cmos_gains_t.
- */
-static __inline cmos_gains_ptr_t cmos_gains_initialize()
-{
-    cmos_gains.again_shift = 10;
-    cmos_gains.dgain_shift = 0;
-
-    cmos_gains.isp_dgain_shift = 8;
-    cmos_gains.isp_dgain = 1 << cmos_gains.isp_dgain_shift;
-    cmos_gains.isp_dgain_delay_cfg = HI_FALSE;
-
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0: //linear mode
-            cmos_gains.max_again = 257217;
-            cmos_gains.max_dgain = 1;
-            cmos_gains.max_again_target = 257217;
-            cmos_gains.max_dgain_target = 1;
-            cmos_gains.max_isp_dgain_target = 4 << cmos_gains.isp_dgain_shift;
-        break;
-        case 1: //WDR mode
-            cmos_gains.max_again = 4076;
-            cmos_gains.max_dgain = 1;
-            cmos_gains.max_again_target = 4076;
-            cmos_gains.max_dgain_target = 1;
-            cmos_gains.max_isp_dgain_target = 32 << cmos_gains.isp_dgain_shift;
-        break;
-    }
-
-	return &cmos_gains;
-}
 
 
 static HI_U32 gain_table[481]=
@@ -577,177 +226,166 @@ static HI_U32 gain_table[481]=
     162293, 164172, 166073, 167996, 169941, 171909, 173900, 175913, 177950, 180011, 182095, 184204, 186337, 188495, 190677, 192885, 195119, 197378, 199664, 201976, 
     204314, 206680, 209073, 211494, 213943, 216421, 218927, 221462, 224026, 226620, 229244, 231899, 234584, 237301, 240048, 242828, 245640, 248484, 251362, 254272, 
     257217
+
 };
 
+extern void sensor_linner_init();
+extern void sensor_wdr_init();
 
-/*
- * This function applies the new gains to the ISP registers.
- */
-static __inline void cmos_gains_update(cmos_gains_const_ptr_t p_gains)
-{    
-    HI_U32 u32Tmp = p_gains->again_db + p_gains->dgain_db;
-
-    u32Tmp = u32Tmp > 0x1E0 ? 0x1E0 : u32Tmp;
-
-    static HI_U32 _last_gain = 0xFFFFFFFF;
-    if(_last_gain == u32Tmp)
-    {
-        return;
-    }else
-    {
-        _last_gain = u32Tmp;
-    }
-
-#if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
-    
-    ISP_I2C_DATA_S stI2cData;
-    stI2cData.bDelayCfg = HI_FALSE;
-    stI2cData.u8DevAddr = sensor_i2c_addr;
-    stI2cData.u32AddrByteNum = sensor_addr_byte;
-    stI2cData.u32DataByteNum = sensor_data_byte;
-
-    stI2cData.u32RegAddr = 0x3014;
-    stI2cData.u32Data = (u32Tmp & 0xff);
-    HI_MPI_ISP_I2cWrite(&stI2cData);  
-
-    stI2cData.u32RegAddr = 0x3014+1;
-    stI2cData.u32Data = ((u32Tmp & 0x100) >> 8);
-    HI_MPI_ISP_I2cWrite(&stI2cData);  
-#else
-    sensor_write_register(PGC_ADDR, u32Tmp & 0xff);
-    sensor_write_register(PGC_ADDR + 1, (u32Tmp & 0x100) >> 8);
-#endif
-}
-
-static __inline HI_U32 analog_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
+static ISP_CMOS_GAMMAFE_S g_stGammafe = 
 {
-    HI_U32 again = 1024;
-    HI_U32 step = 0;
-    HI_S32 shift = 0;
-    HI_S32 i = 0;
-    HI_U32 u32MaxStep;
+    /* bvalid */
+    1,
 
-    while (exposure > (1 << 20))
     {
-        exposure     >>= 1;
-        exposure_max >>= 1;
-        ++shift;
+       0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  28,
+      70,  95, 114, 131, 146, 159, 172, 183, 195, 205, 215, 224, 233, 242, 250, 258,
+     266, 273, 281, 288, 295, 302, 309, 315, 322, 328, 334, 340, 346, 352, 358, 364,
+     369, 375, 380, 386, 391, 396, 401, 406, 411, 416, 421, 426, 431, 436, 440, 445,
+     450, 454, 459, 463, 467, 472, 476, 480, 485, 489, 493, 497, 502, 506, 510, 514,
+     518, 522, 525, 529, 533, 537, 541, 545, 548, 552, 556, 559, 563, 567, 571, 574,
+     578, 581, 585, 588, 592, 595, 599, 602, 605, 609, 612, 615, 619, 622, 625, 629,
+     632, 635, 638, 642, 645, 648, 651, 654, 657, 661, 664, 667, 670, 673, 676, 679,
+     682, 729, 772, 814, 853, 891, 927, 962, 995,1028,1060,1090,1120,1149,1177,1205,
+    1232,1258,1284,1309,1334,1359,1383,1406,1429,1452,1475,1497,1519,1540,1561,1582,
+    1603,1623,1643,1663,1683,1702,1721,1740,1759,1778,1796,1814,1832,1850,1868,1885,
+    1903,1920,1937,1954,1971,1987,2004,2020,2036,2100,2162,2222,2280,2337,2393,2447,
+    2500,2552,2603,2653,2702,2751,2798,2844,2890,2936,2980,3024,3067,3110,3151,3193,
+    3234,3274,3314,3354,3393,3431,3469,3507,3544,3581,3618,3654,3690,3725,3760,3795,
+    3830,3864,3898,3931,3965,3998,4030,4063,4095,4095,4095,4095,4095,4095,4095,4095,
+    4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095,4095
     }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
+};
 
-    switch(gu8SensorMode)
+HI_U32 cmos_get_isp_default(ISP_CMOS_DEFAULT_S *pstDef)
+{
+    if (HI_NULL == pstDef)
+    {
+        printf("null pointer when get isp default value!\n");
+        return -1;
+    }
+
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
+    
+    switch (gu8SensorMode)
     {
         default:
         case 0:
-            u32MaxStep = 481;
+            pstDef->stComm.u8Rggb           = 0x0;      //2: gbrg  
+            pstDef->stComm.u8BalanceFe      = 0x1;
+
+            pstDef->stDenoise.u8SinterThresh= 0x20;
+            pstDef->stDenoise.u8NoiseProfile= 0x1;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+            pstDef->stDenoise.u16Nr0        = 0x0;
+            pstDef->stDenoise.u16Nr1        = 455;
+
+            pstDef->stDrc.u8DrcBlack        = 0x00;
+            pstDef->stDrc.u8DrcVs           = 0x04;     // variance space
+            pstDef->stDrc.u8DrcVi           = 0x08;     // variance intensity
+            pstDef->stDrc.u8DrcSm           = 0xa0;     // slope max
+            pstDef->stDrc.u16DrcWl          = 0x8ff;    // white level
+
+            memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTableLin, sizeof(ISP_CMOS_NOISE_TABLE_S));            
         break;
         case 1:
-            u32MaxStep = 121;
+            pstDef->stComm.u8Rggb           = 0x0;      //2: gbrg  
+            pstDef->stComm.u8BalanceFe      = 0x0;
+
+            pstDef->stDenoise.u8SinterThresh= 0x9;
+            pstDef->stDenoise.u8NoiseProfile= 0x0;      //0: use default profile table; 1: use calibrated profile lut, the setting for nr0 and nr1 must be correct.
+            pstDef->stDenoise.u16Nr0        = 0x0;
+            pstDef->stDenoise.u16Nr1        = 0x0;
+
+            pstDef->stDrc.u8DrcBlack        = 0x00;
+            pstDef->stDrc.u8DrcVs           = 0x08;     // variance space
+            pstDef->stDrc.u8DrcVi           = 0x01;     // variance intensity
+            pstDef->stDrc.u8DrcSm           = 0x3C;     // slope max
+            pstDef->stDrc.u16DrcWl          = 0xFFF;    // white level
+
+            memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTableWdr, sizeof(ISP_CMOS_NOISE_TABLE_S));
+
+            memcpy(&pstDef->stGammafe, &g_stGammafe, sizeof(ISP_CMOS_GAMMAFE_S));
         break;
     }
-    
-    if(exposure > exposure_max)
 
-    {
-        again = (exposure << 10) / exposure_max;
-        again = again < 1024? 1024: again;
-        again = again > p_gains->max_again_target? p_gains->max_again_target: again;
+    memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+    memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+
+    return 0;
+}
+
+HI_U32 cmos_get_isp_black_level(ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
+{
+    HI_S32  i;
     
-        if (again >= gain_table[u32MaxStep - 1])
-        {
-             again = gain_table[u32MaxStep - 1];
-             step = u32MaxStep - 1;
-        }
-        else
-        {
-            for(i = 1; i < u32MaxStep; i++)
+    if (HI_NULL == pstBlackLevel)
+    {
+        printf("null pointer when get isp black level value!\n");
+        return -1;
+    }
+
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+
+    switch (gu8SensorMode)
+    {
+        default :
+        case 0 :
+            for (i=0; i<4; i++)
             {
-                if(again < gain_table[i])
-                {
-                    again = gain_table[i-1];
-                    step = i-1 ;
-                    break;
-                }
+                pstBlackLevel->au16BlackLevel[i] = 0xf0;
             }
-        }
-        
-        exposure = (exposure << 10) / again;
+            break;
+        case 1 :
+            for (i=0; i<4; i++)
+            {
+                pstBlackLevel->au16BlackLevel[i] = 0x0;
+            }
+            break;
     }
 
-    p_gains->again = again;
-    p_gains->again_db = step;
-    
-    return exposure << shift;
+    return 0;    
 }
 
-static __inline HI_U32 isp_digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
+HI_VOID cmos_set_pixel_detect(HI_BOOL bEnable)
 {
-    HI_U32 isp_dgain = (1 << p_gains->isp_dgain_shift);
-    HI_S32 shift = 0;
-
-    while (exposure > (1 << 22))
+    if (bEnable) /* setup for ISP pixel calibration mode */
     {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shift;
-    }
-    exposure_max = (exposure_max == 0)? 1: exposure_max;
+        /* Sensor must be programmed for slow frame rate (5 fps and below)*/
+        /* change frame rate to 5 fps by setting 1 frame length = 750 * 30 / 5 */
+        sensor_write_register(VMAX_ADDR, 0x5E);
+        sensor_write_register(VMAX_ADDR + 1, 0x1A);
 
-    if(exposure > exposure_max)
+        /* max Exposure time */
+        sensor_write_register(EXPOSURE_ADDR, 0x00);
+        sensor_write_register(EXPOSURE_ADDR + 1, 0x00);
+
+        /* Analog and Digital gains both must be programmed for their minimum values */
+        sensor_write_register(PGC_ADDR, 0x00);
+        sensor_write_register(PGC_ADDR + 1, 0x00); 
+    }
+    else /* setup for ISP 'normal mode' */
     {
-        isp_dgain = ((exposure << p_gains->isp_dgain_shift) + (exposure_max >> 1)) / exposure_max;
-        exposure = exposure_max;
-        isp_dgain = (isp_dgain > p_gains->max_isp_dgain_target) ? (p_gains->max_isp_dgain_target) : isp_dgain;        
+        sensor_write_register(VMAX_ADDR, 0x65);
+        sensor_write_register(VMAX_ADDR + 1, 0x04);      
     }
-    
-    p_gains->isp_dgain = isp_dgain;
 
-    return exposure << shift;
+    return;
 }
 
-
-static __inline HI_U32 digital_gain_from_exposure_calculate(
-        cmos_gains_ptr_t p_gains,
-        HI_U32 exposure,
-        HI_U32 exposure_max,
-        HI_U32 exposure_shift)
-{
-    int shft = 0;
-    
-    while (exposure > (1<<20)) /* analog use (1<<22) for analog exposure is bigger. */
-    {
-        exposure >>= 1;
-        exposure_max >>= 1;
-        ++shft;
-    }
-
-    p_gains->dgain = 1<<p_gains->dgain_shift;
-    p_gains->dgain_db = 0;
-  
-    return exposure << shft;
-}
-
-void cmos_set_wdr_mode(HI_U8 u8Mode)
+HI_VOID cmos_set_wdr_mode(HI_U8 u8Mode)
 {
     switch(u8Mode)
     {
-        //LINE MODE
         case 0:
             gu8SensorMode = 0;
             sensor_linner_init();
+            printf("imx236 linear mode\n");
         break;
-        //WDR MODE
         case 1:
             gu8SensorMode = 1;
             sensor_wdr_init();
+            printf("imx236 wdr mode\n");
         break;
 
         default:
@@ -755,231 +393,588 @@ void cmos_set_wdr_mode(HI_U8 u8Mode)
             return;
         break;
     }
-    
+#if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
+    gsbRegInit = HI_FALSE;
+#endif
     return;
 }
 
-void setup_sensor(int isp_mode)
+static HI_S32 cmos_get_ae_default(AE_SENSOR_DEFAULT_S *pstAeSnsDft)
 {
-    if(0 == isp_mode) /* setup for ISP 'normal mode' */
+    if (HI_NULL == pstAeSnsDft)
     {
+        printf("null pointer when get ae default value!\n");
+        return -1;
+    }
+
+    gu32FullLinesStd = 1125;
+    
+    pstAeSnsDft->u32LinesPer500ms = 1125*30/2;
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    pstAeSnsDft->u32FlickerFreq = 0;//60*256;//50*256;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->u32MaxIntTime = 1123;
+    pstAeSnsDft->u32MinIntTime = 2;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 0.1;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 0.1;
+
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+
+    switch(gu8SensorMode)
+    {
+        default:
+        case 0: //linear mode
+            pstAeSnsDft->au8HistThresh[0] = 0xd;
+            pstAeSnsDft->au8HistThresh[1] = 0x28;
+            pstAeSnsDft->au8HistThresh[2] = 0x60;
+            pstAeSnsDft->au8HistThresh[3] = 0x80;
+            
+            pstAeSnsDft->u8AeCompensation = 0x50;
+            
+            pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+            pstAeSnsDft->u32MinIntTimeTarget = 2;
+            
+            pstAeSnsDft->u32MaxAgain = 257217;  /*10bit precision */
+            pstAeSnsDft->u32MinAgain = 1024;
+            pstAeSnsDft->u32MaxAgainTarget = 257217;
+            pstAeSnsDft->u32MinAgainTarget = 1024;
+            
+            pstAeSnsDft->u32MaxDgain = 1024;  /* 24db / 0.1db = 240 */
+            pstAeSnsDft->u32MinDgain = 1024;
+            pstAeSnsDft->u32MaxDgainTarget = 1024;
+            pstAeSnsDft->u32MinDgainTarget = 1024;
+            
+            pstAeSnsDft->u32MaxISPDgainTarget = 4 << pstAeSnsDft->u32ISPDgainShift;
+        break;
+        case 1: //WDR mode
+            pstAeSnsDft->au8HistThresh[0] = 0x20;
+            pstAeSnsDft->au8HistThresh[1] = 0x40;
+            pstAeSnsDft->au8HistThresh[2] = 0x60;
+            pstAeSnsDft->au8HistThresh[3] = 0x80;
+            
+            pstAeSnsDft->u8AeCompensation = 0x50;
+
+        
+            pstAeSnsDft->u32MaxIntTimeTarget = 70;  /* for short exposure, Exposure ratio = 16X */
+            pstAeSnsDft->u32MinIntTimeTarget = 8;
+
+            pstAeSnsDft->u32MaxAgain = 1024;  /* 4.5db fixed */
+            pstAeSnsDft->u32MinAgain = 1024;
+            pstAeSnsDft->u32MaxAgainTarget = 1024;
+            pstAeSnsDft->u32MinAgainTarget = 1024;
+            
+            pstAeSnsDft->u32MaxDgain = 4076;  /* 10bit shift */
+            pstAeSnsDft->u32MinDgain = 1024;
+            pstAeSnsDft->u32MaxDgainTarget = 4076;
+            pstAeSnsDft->u32MinDgainTarget = 1024;
+            
+            pstAeSnsDft->u32MaxISPDgainTarget = 32 << pstAeSnsDft->u32ISPDgainShift;
+        break;
+    }
+
+    return 0;
+}
+
+static HI_S32 cmos_get_sensor_max_resolution(ISP_CMOS_SENSOR_MAX_RESOLUTION *pstSensorMaxResolution)
+{
+    if (HI_NULL == pstSensorMaxResolution)
+    {
+        printf("null pointer when get sensor max resolution \n");
+        return -1;
+    }
+
+    memset(pstSensorMaxResolution, 0, sizeof(ISP_CMOS_SENSOR_MAX_RESOLUTION));
+
+    pstSensorMaxResolution->u32MaxWidth  = 1920;
+    pstSensorMaxResolution->u32MaxHeight = 1080;
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+static HI_VOID cmos_fps_set(HI_U8 u8Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if(0 == gu8SensorMode)
+    {
+        sensor_write_register(HMAX_ADDR,  0x30);
+        sensor_write_register(HMAX_ADDR+1, 0x11);
+        switch(u8Fps)
+        {
+            case 30:
+                // Change the frame rate via changing the vertical blanking
+                gu32FullLinesStd = 1125;
+                pstAeSnsDft->u32MaxIntTime = 1123;
+                pstAeSnsDft->u32LinesPer500ms = 1125 * 30 / 2;
+                sensor_write_register(VMAX_ADDR, 0x65);
+                sensor_write_register(VMAX_ADDR+1, 0x4);
+            break;
+            
+            case 25:
+                // Change the frame rate via changing the vertical blanking
+                gu32FullLinesStd = 1350;
+                pstAeSnsDft->u32MaxIntTime = 1348;
+                pstAeSnsDft->u32LinesPer500ms = 1350 * 25 / 2;
+                sensor_write_register(VMAX_ADDR, 0x46);
+                sensor_write_register(VMAX_ADDR+1, 0x05);
+            break;
+            
+            default:
+            break;
+        }
+    }
+    else if (1 == gu8SensorMode)   /* Built-in WDR */
+    {
+        gu32FullLinesStd = 1125;
+        pstAeSnsDft->u32LinesPer500ms = 1125 * 30 / 2;
+        pstAeSnsDft->u32MaxIntTime = 70;
         sensor_write_register(VMAX_ADDR, 0x65);
-        sensor_write_register(VMAX_ADDR + 1, 0x04);       
+        sensor_write_register(VMAX_ADDR+1, 0x4);
+        switch(u8Fps)
+        {
+            case 30:
+                sensor_write_register(HMAX_ADDR, 0x30);
+                sensor_write_register(HMAX_ADDR+1, 0x11);
+            break;
+            case 25:
+                sensor_write_register(HMAX_ADDR, 0xA0);
+                sensor_write_register(HMAX_ADDR+1, 0x14);
+            break;
+            default:
+                break;
+    	}
     }
-    else if(1 == isp_mode) /* setup for ISP pixel calibration mode */
-    {
-        /* Sensor must be programmed for slow frame rate (5 fps and below) */
-        /* change frame rate to 5 fps by setting 1 frame length = 1125 * (30/5) */
-        sensor_write_register(VMAX_ADDR, 0x5E);
-        sensor_write_register(VMAX_ADDR + 1, 0x1A);
 
-        /* Analog and Digital gains both must be programmed for their minimum values */
-        sensor_write_register(PGC_ADDR, 0x00);
-        sensor_write_register(PGC_ADDR + 1, 0x00);
+
+    pstAeSnsDft->u32FullLinesStd = gu32FullLinesStd;
+    gu32FullLines = gu32FullLinesStd;
+
+    return;
+}
+
+static HI_VOID cmos_slow_framerate_set(HI_U16 u16FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    HI_U16 u16Vmax = u16FullLines;
+    HI_U16 u16Current;
+    u16Current = sensor_read_register(VMAX_ADDR+2);
+    
+    sensor_write_register(VMAX_ADDR, (u16Vmax&0x00ff));
+    sensor_write_register(VMAX_ADDR+1, ((u16Vmax&0xff00) >> 8));
+    //sensor_write_register(VMAX_ADDR+2,(((u16Vmax & 0x10000) >> 16)+(u16Current&0xFE)));
+
+    pstAeSnsDft->u32MaxIntTime = u16Vmax - 2;
+    gu32FullLines = u16Vmax;
+
+    return;
+}
+
+static HI_VOID cmos_init_regs_info(HI_VOID)
+{
+#if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
+    HI_S32 i;
+
+    if (HI_FALSE == gsbRegInit)
+    {
+        g_stSnsRegsInfo.enSnsType = ISP_SNS_I2C_TYPE;
+        for (i=0; i<8; i++)
+        {
+            g_stSnsRegsInfo.astI2cData[i].u8DevAddr = sensor_i2c_addr;
+            g_stSnsRegsInfo.astI2cData[i].u32AddrByteNum = sensor_addr_byte;
+            g_stSnsRegsInfo.astI2cData[i].u32DataByteNum = sensor_data_byte;
+        }
+        g_stSnsRegsInfo.astI2cData[0].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[0].u32RegAddr = 0x3020;
+        g_stSnsRegsInfo.astI2cData[1].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[1].u32RegAddr = 0x3021;
+        g_stSnsRegsInfo.astI2cData[2].bDelayCfg = HI_FALSE;
+        g_stSnsRegsInfo.astI2cData[2].u32RegAddr = 0x3022;
+        switch(gu8SensorMode)
+        {
+            default:
+            case 0: //linear mode
+            g_stSnsRegsInfo.u32RegNum = 5;
+            g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_TRUE;
+            g_stSnsRegsInfo.astI2cData[3].u32RegAddr = 0x3014;
+            g_stSnsRegsInfo.astI2cData[4].bDelayCfg = HI_TRUE;
+            g_stSnsRegsInfo.astI2cData[4].u32RegAddr = 0x3015;
+            break;
+            case 1: //WDR mode
+            g_stSnsRegsInfo.u32RegNum = 8;
+            g_stSnsRegsInfo.astI2cData[3].bDelayCfg = HI_FALSE;
+            g_stSnsRegsInfo.astI2cData[3].u32RegAddr = 0x3023;
+            g_stSnsRegsInfo.astI2cData[4].bDelayCfg = HI_FALSE;
+            g_stSnsRegsInfo.astI2cData[4].u32RegAddr = 0x3024;
+            g_stSnsRegsInfo.astI2cData[5].bDelayCfg = HI_FALSE;
+            g_stSnsRegsInfo.astI2cData[5].u32RegAddr = 0x3025;
+            
+            g_stSnsRegsInfo.astI2cData[6].bDelayCfg = HI_TRUE;
+            g_stSnsRegsInfo.astI2cData[6].u32RegAddr = 0x3014;
+            g_stSnsRegsInfo.astI2cData[7].bDelayCfg = HI_TRUE;
+            g_stSnsRegsInfo.astI2cData[7].u32RegAddr = 0x3015;
+            break;
+        }
+        g_stSnsRegsInfo.bDelayCfgIspDgain = HI_TRUE;
+        gsbRegInit = HI_TRUE;
+    }
+#endif
+    return;
+}
+
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+static HI_VOID cmos_inttime_update(HI_U32 u32IntTime)
+{
+    HI_U16 u16ExpTime,u16Current;
+
+    switch(gu8SensorMode)
+    {
+        default:
+        case 0: //linear mode
+            //Integration time = (VMAX - (SHS1)) + tOFFSET
+            u16ExpTime = gu32FullLines - u32IntTime;
+            u16Current = sensor_read_register(EXPOSURE_ADDR+2);
+
+            #if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
+            cmos_init_regs_info();
+            g_stSnsRegsInfo.astI2cData[0].u32Data = u16ExpTime & 0xFF;
+            g_stSnsRegsInfo.astI2cData[1].u32Data = (u16ExpTime & 0xFF00) >> 8;
+            g_stSnsRegsInfo.astI2cData[2].u32Data = (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE));
+            #else            
+            sensor_write_register(EXPOSURE_ADDR, u16ExpTime & 0xFF);
+            sensor_write_register(EXPOSURE_ADDR+1, (u16ExpTime & 0xFF00) >> 8);
+            sensor_write_register(EXPOSURE_ADDR+2, (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE)) );
+            #endif
+        break;
+        case 1: //WDR mode
+            #if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
+            //short exposure
+            u16ExpTime = gu32FullLines - u32IntTime;
+            u16Current = sensor_read_register(EXPOSURE_ADDR+2);
+            
+            cmos_init_regs_info();
+            g_stSnsRegsInfo.astI2cData[0].u32Data = u16ExpTime & 0xFF;
+            g_stSnsRegsInfo.astI2cData[1].u32Data = (u16ExpTime & 0xFF00) >> 8;
+            g_stSnsRegsInfo.astI2cData[2].u32Data = (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE));
+            
+            //long exposure
+            u16ExpTime = gu32FullLines - (u32IntTime << 4);
+            u16Current = sensor_read_register(LONG_EXPOSURE_ADDR+2);
+
+            g_stSnsRegsInfo.astI2cData[3].u32Data = u16ExpTime & 0xFF;
+            g_stSnsRegsInfo.astI2cData[4].u32Data = (u16ExpTime & 0xFF00) >> 8;
+            g_stSnsRegsInfo.astI2cData[5].u32Data = (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE));
+            #else
+            //short exposure
+            u16ExpTime = gu32FullLines - u32IntTime;
+            u16Current = sensor_read_register(EXPOSURE_ADDR+2);
+            
+            sensor_write_register(EXPOSURE_ADDR, u16ExpTime & 0xFF);
+            sensor_write_register(EXPOSURE_ADDR+1, (u16ExpTime & 0xFF00) >> 8);
+            sensor_write_register(EXPOSURE_ADDR+2, (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE)) );
+
+            //long exposure
+            u16ExpTime = gu32FullLines - (u32IntTime << 4);
+            u16Current = sensor_read_register(LONG_EXPOSURE_ADDR+2);
+            
+            sensor_write_register(LONG_EXPOSURE_ADDR, u16ExpTime & 0xFF);
+            sensor_write_register(LONG_EXPOSURE_ADDR+1, (u16ExpTime & 0xFF00) >> 8);
+            sensor_write_register(LONG_EXPOSURE_ADDR+2, (((u16ExpTime & 0x10000) >> 16)+(u16Current&0xFE)) );
+            #endif
+        break;
     }
 
     return;
 }
 
-static __inline HI_U32 cmos_get_ISO(cmos_gains_ptr_t p_gains)
+static HI_VOID cmos_again_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
 {
-    HI_U32  _again = p_gains->again == 0 ? 1 : p_gains->again;
-    HI_U32 _dgain = p_gains->dgain == 0 ? 1 : p_gains->dgain;
-    HI_U32 _isp_dgain = p_gains->isp_dgain == 0 ? 1 : p_gains->isp_dgain;
+    int i;
 
-    p_gains->iso =  (((HI_U64)_again * _dgain * _isp_dgain * 100) 
-        >> (p_gains->again_shift + p_gains->dgain_shift + p_gains->isp_dgain_shift));
-
-    return p_gains->iso;
-}
-
-/* Note: The unit of return value is 1db.  */
-static HI_U8 cmos_get_analog_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return (cmos_gains->again_db *  3 / 10); 
-}
-
-/* Note: The unit of return value is 1db.  */
-static HI_U8 cmos_get_digital_gain(cmos_gains_ptr_t cmos_gains)
-{
-    return  (cmos_gains->dgain_db *  3 / 10); 
-}
-
-static HI_U32 cmos_get_isp_default(cmos_isp_default_ptr_t p_coms_isp_default)
-{
-    if (NULL == p_coms_isp_default)
+    if(HI_NULL == pstAeSnsGainInfo)
     {
-        printf("null pointer when get isp default value!\n");
-        return -1;
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
     }
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+   
+    if (u32InTimes >= gain_table[480])
+    {
+         pstAeSnsGainInfo->u32SnsTimes = gain_table[480];
+         pstAeSnsGainInfo->u32GainDb = 480;
+         return ;
+    }
+    
+    for(i = 1; i < 481; i++)
+    {
+        if(u32InTimes < gain_table[i])
+        {
+            pstAeSnsGainInfo->u32SnsTimes = gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
 
+    }
+          
+    return;
+
+}
+
+static HI_VOID cmos_dgain_calc_table(HI_U32 u32InTimes,AE_SENSOR_GAININFO_S *pstAeSnsGainInfo)
+{
+    int i;
+
+    if(HI_NULL == pstAeSnsGainInfo)
+    {
+        printf("null pointer when get ae sensor gain info  value!\n");
+        return;
+    }
+ 
+    pstAeSnsGainInfo->u32GainDb = 0;
+    pstAeSnsGainInfo->u32SnsTimes = 1024;
+   
+    if (u32InTimes >= gain_table[480])
+    {
+         pstAeSnsGainInfo->u32SnsTimes = gain_table[480];
+         pstAeSnsGainInfo->u32GainDb = 480;
+         return ;
+    }
+    
+    for(i = 1; i < 481; i++)
+    {
+        if(u32InTimes < gain_table[i])
+        {
+            pstAeSnsGainInfo->u32SnsTimes = gain_table[i - 1];
+            pstAeSnsGainInfo->u32GainDb = i - 1;
+            break;
+        }
+
+    }
+          
+    return;
+
+}
+
+
+static HI_VOID cmos_gains_update(HI_U32 u32Again, HI_U32 u32Dgain)
+{
+    HI_U32 u32Tmp = u32Again + u32Dgain;
     switch(gu8SensorMode)
     {
         default:
-        case 0:
-            memcpy(p_coms_isp_default, &st_coms_isp_default_lin, sizeof(cmos_isp_default_t));
+        case 0: /* linear mode */
+            if( u32Tmp > 0x1E0)
+            {
+                u32Tmp = 0x1E0;
+            }
+            #if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
+            cmos_init_regs_info();
+
+            g_stSnsRegsInfo.astI2cData[3].u32Data = (u32Tmp & 0xff);
+            g_stSnsRegsInfo.astI2cData[4].u32Data = ((u32Tmp & 0x100)>>8);
+
+            HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+            #else
+            sensor_write_register(PGC_ADDR, u32Tmp & 0xff);
+            sensor_write_register(PGC_ADDR + 1, (u32Tmp & 0x100) >> 8);
+            #endif
         break;
-        case 1:
-            memcpy(p_coms_isp_default, &st_coms_isp_default_wdr, sizeof(cmos_isp_default_t));
+        case 1: //WDR mode      
+            #if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
+            cmos_init_regs_info();
+            if(u32Dgain <= 120)
+            {
+                g_stSnsRegsInfo.astI2cData[6].u32Data = (u32Dgain & 0xff);
+            }
+            else
+            {
+                g_stSnsRegsInfo.astI2cData[6].u32Data = 0x78;
+            }
+            HI_MPI_ISP_SnsRegsCfg(&g_stSnsRegsInfo);
+            #else
+            if(u32Dgain <= 120)
+            {
+                sensor_write_register(PGC_ADDR, u32Dgain);
+            }
+            else
+            {
+                sensor_write_register(PGC_ADDR, 0x78);
+            }
+            #endif
         break;
     }
+
+    return;
+}
+
+static HI_S32 cmos_get_awb_default(AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+
+    pstAwbSnsDft->u16WbRefTemp = 4850;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x190;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x204;
+
+    pstAwbSnsDft->as32WbPara[0] = 62;
+    pstAwbSnsDft->as32WbPara[1] = 68;
+    pstAwbSnsDft->as32WbPara[2] = -125;
+    pstAwbSnsDft->as32WbPara[3] = 201189;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -150451;
+
+    memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+    memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
     
     return 0;
 }
 
-
-HI_U32 cmos_get_isp_speical_alg(void)
+HI_VOID sensor_global_init()
 {
-    return isp_special_alg_awb;
-}
 
-static HI_U32 cmos_get_isp_demosaic(cmos_isp_demosaic_ptr_t p_cmos_isp_demosaic)
-{
-   if (NULL == p_cmos_isp_demosaic)
-    {
-        printf("null pointer when get isp demosaic value!\n");
-        return -1;
-    }
-   memcpy(p_cmos_isp_demosaic, &st_isp_demosaic,sizeof(cmos_isp_demosaic_t));
-   return 0;
-
-}
-
-
-static HI_U32 cmos_get_isp_agc_table(cmos_isp_agc_table_ptr_t p_cmos_isp_agc_table)
-{
-    if (NULL == p_cmos_isp_agc_table)
-    {
-        printf("null pointer when get isp agc table value!\n");
-        return -1;
-    }
-    memcpy(p_cmos_isp_agc_table, &st_isp_agc_table, sizeof(cmos_isp_agc_table_t));
-    return 0;
-}
-
-
-static HI_U32 cmos_get_isp_noise_table(cmos_isp_noise_table_ptr_t p_cmos_isp_noise_table)
-{
-	if (NULL == p_cmos_isp_noise_table)
-	{
-	    printf("null pointer when get isp noise table value!\n");
-	    return -1;
-	}
-
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0:
-            memcpy(p_cmos_isp_noise_table, &st_isp_noise_table, sizeof(cmos_isp_noise_table_t));
-        break;
-        case 1:
-            memcpy(p_cmos_isp_noise_table, &st_isp_noise_table_wdr, sizeof(cmos_isp_noise_table_t));
-        break;
-    }
-    return 0;
-}
-
-HI_U32 cmos_get_sensor_mode(void)
-{
-    switch(gu8SensorMode)
-    {
-        default:
-        case 0:
-            return isp_special_alg_imx104_lin;
-
-        break;
-        case 1:
-            return isp_special_alg_imx104_wdr;
-
-        break;
-    }
-}
-
-static HI_S32 cmos_get_sensor_max_resolution(cmos_sensor_max_resolution_ptr_t p_cmos_sensor_max_resolution)
-{
-     if(NULL == p_cmos_sensor_max_resolution)
-     {
-       printf("null pointer when get sensor max resolution value!\n");
-       return -1;
-     }
-
-     p_cmos_sensor_max_resolution->u32MaxWidth  = 1920;
-     p_cmos_sensor_max_resolution->u32MaxHeight = 1080;
-
-    return 0;
+   gu8SensorMode = 0;
+   
+#if CMOS_IMX236_ISP_WRITE_SENSOR_ENABLE
+	gsbRegInit = HI_FALSE;
+#endif
 }
 
 
 /****************************************************************************
  * callback structure                                                       *
  ****************************************************************************/
-
-SENSOR_EXP_FUNC_S stSensorExpFuncs =
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
 {
-    .pfn_cmos_inttime_initialize = cmos_inttime_initialize,
-    .pfn_cmos_inttime_update = cmos_inttime_update,
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
 
-    .pfn_cmos_gains_initialize = cmos_gains_initialize,
-    .pfn_cmos_gains_update = cmos_gains_update,
-    .pfn_cmos_gains_update2 = NULL,
-    .pfn_analog_gain_from_exposure_calculate = analog_gain_from_exposure_calculate,
-    .pfn_digital_gain_from_exposure_calculate = digital_gain_from_exposure_calculate,
-    .pfn_isp_digital_gain_from_exposure_calculate = isp_digital_gain_from_exposure_calculate,
+    pstSensorExpFunc->pfn_cmos_sensor_init = sensor_init;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    pstSensorExpFunc->pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution;
 
-    .pfn_cmos_fps_set = cmos_fps_set,
-    .pfn_vblanking_calculate = vblanking_calculate,
-    .pfn_cmos_vblanking_front_update = cmos_vblanking_update,
+    return 0;
+}
 
-    .pfn_setup_sensor = setup_sensor,
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
 
-    .pfn_cmos_get_analog_gain = cmos_get_analog_gain,
-    .pfn_cmos_get_digital_gain = cmos_get_digital_gain,
-    .pfn_cmos_get_digital_fine_gain = NULL,
-    .pfn_cmos_get_iso = cmos_get_ISO,
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+    pstExpFuncs->pfn_cmos_again_calc_table  = cmos_again_calc_table;
+    pstExpFuncs->pfn_cmos_dgain_calc_table  = cmos_dgain_calc_table;
 
-    .pfn_cmos_get_isp_default = cmos_get_isp_default,
-    .pfn_cmos_get_isp_special_alg = cmos_get_sensor_mode,
-    .pfn_cmos_get_isp_agc_table = cmos_get_isp_agc_table,
-    .pfn_cmos_get_isp_noise_table = cmos_get_isp_noise_table,
-    .pfn_cmos_get_isp_demosaic = cmos_get_isp_demosaic,
-    .pfn_cmos_get_isp_shading_table = NULL,
-    .pfn_cmos_get_isp_gamma_table = NULL,    
-	.pfn_cmos_get_sensor_max_resolution = cmos_get_sensor_max_resolution,
-	.pfn_cmos_set_sensor_image_mode = NULL,
-};
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
 
 int sensor_register_callback(void)
 {
-    int ret;
-    ret = HI_MPI_ISP_SensorRegCallBack(&stSensorExpFuncs);
-    if (ret)
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(IMX236_ID, &stIspRegister);
+    if (s32Ret)
     {
         printf("sensor register callback function failed!\n");
-        return ret;
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(&stLib, IMX236_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
     }
 
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(&stLib, IMX236_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
     return 0;
 }
-
-//chang sensor mode
-int sensor_mode_set(HI_U8 u8Mode)
+int sensor_unregister_callback(void)
 {
-    cmos_set_wdr_mode(u8Mode);
+    HI_S32 s32Ret;
+    ALG_LIB_S stLib;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(IMX236_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AE_LIB_NAME);
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(&stLib, IMX236_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    stLib.s32Id = 0;
+    strcpy(stLib.acLibName, HI_AWB_LIB_NAME);
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(&stLib, IMX236_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+    
+    gu8SensorMode = 0;
     return 0;
-
 }
-
-int  sensor_mode_get()
-{
-    return (int)gu8SensorMode;
-}
-
 
 #ifdef __cplusplus
 #if __cplusplus
 }
 #endif
 #endif /* End of #ifdef __cplusplus */
-
 
 #endif // __IMX236_CMOS_H_

--- a/libraries/sensor/hi3516cv100/sony_imx236/imx236_sensor_ctl.c
+++ b/libraries/sensor/hi3516cv100/sony_imx236/imx236_sensor_ctl.c
@@ -5,10 +5,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-
 #include "hi_comm_isp.h"
 
-#if 1
+
 #ifdef HI_GPIO_I2C
 #include "gpioi2c_32.h"
 #include "gpio_i2c.h"
@@ -115,128 +114,10 @@ int sensor_write_register(int addr, int data)
 #endif
 	return 0;
 }
-/*
-
-int sony_sensor_write_packet(unsigned int data)
-{
-	int fd = -1;
-	int ret;
-	unsigned int value;
-
-	fd = open("/dev/ssp", 0);
-	if(fd < 0)
-	{
-		printf("Open /dev/ssp error!\n");
-		return -1;
-	}
-
-	value = data;
-
-	ret = ioctl(fd, SSP_WRITE_ALT, &value);
-
-	close(fd);
-	return 0;
-}
-
-int sony_sensor_read_packet(unsigned int data)
-{
-	unsigned int value;
-	int fd = -1;
-	int ret;
-
-	fd = open("/dev/ssp", 0);
-	if(fd < 0)
-	{
-		printf("Open /dev/ssp error!\n");
-		return -1;
-	}
-
-	value = data;
-
-	ret = ioctl(fd, SSP_READ_ALT, &value);
-
-	close(fd);
-	return (value&0xff);
-}
-*/
-#else
-int sensor_write_register(int addr, int data)
-{
-	unsigned int value = (unsigned int)(((addr&0xffff)<<8) | (data & 0xff));
-	//printf("write data = %#x\n", value);
-    return sony_sensor_write_packet(value);
-}
-
-int sensor_read_register(int addr)
-{
-	unsigned int data = (unsigned int)(((addr&0xffff)<<8));
-	//printf("read data = %#x\n", data);
-    return sony_sensor_read_packet(data);
-}
-#endif
 
 void sensor_prog(int* rom) 
 {
     return;
-}
-
-void sensor_init()
-{
-    sensor_write_register(0x200, 0x01);     /* Standby */
-    usleep(200000);
-
-    sensor_write_register(0x202, 0x01);     /* master mode stop */
-    sensor_write_register(0x205, 0x01);     /* 12 bit */
-    sensor_write_register(0x206, 0x00);     /* All-pix scan mode */
-    sensor_write_register(0x207, 0x10);     /* 1080p mode */
-    sensor_write_register(0x209, 0x02);     /* Frame rate (data rate) setting: 30fps */
-    sensor_write_register(0x20A, 0xF0);     /* Black level offset */
-    sensor_write_register(0x20B, 0x00);     /* Black level offset */
-    sensor_write_register(0x20B, 0x00);     /* Black level offset */
-    sensor_write_register(0x214, 0x0C);     /* AGC min gain 1.2dB; */
-    sensor_write_register(0x218, 0x65);     /* Vertical span[7:0] */
-    sensor_write_register(0x219, 0x04);     /* Vertical span[15:8] */
-    sensor_write_register(0x21A, 0x00);     /* Vertical span[15:8] */
-    sensor_write_register(0x21B, 0x30);     /* Horizontal span[7:0] */
-    sensor_write_register(0x21C, 0x11);     /* Horizontal span[15:8] */
-    sensor_write_register(0x220, 0xC0);     /* Shutter[7:0] */
-    sensor_write_register(0x221, 0x03);     /* Shutter[15:8] */
-    sensor_write_register(0x244, 0x01);     /* cmos parallel output, 12bit */
-    sensor_write_register(0x246, 0x01);     
-    sensor_write_register(0x247, 0x01);    
-    sensor_write_register(0x248, 0x01);    
-    sensor_write_register(0x249, 0x0A);     /* HSYNC,VSYNC output */
-    sensor_write_register(0x254, 0x63);     
-    sensor_write_register(0x25B, 0x00);     /* INCK setting0 */
-    sensor_write_register(0x25C, 0x20);     /* INCK setting1 */
-    sensor_write_register(0x25D, 0x06);     /* INCK setting2 */
-    sensor_write_register(0x25E, 0x30);     /* INCK setting3 */
-    sensor_write_register(0x25F, 0x04);     /* INCK setting4 */
-
-    sensor_write_register(0x30F, 0x0E);     /* */
-    sensor_write_register(0x316, 0x02);     /* */
-
-    sensor_write_register(0x436, 0x71);     /* */
-    sensor_write_register(0x439, 0xF1);     /* */
-    sensor_write_register(0x441, 0xF2);     /* */
-    sensor_write_register(0x442, 0x21);     /* */
-    sensor_write_register(0x443, 0x21);     /* */
-    sensor_write_register(0x448, 0xF2);     /* */
-    sensor_write_register(0x449, 0x21);     /* */
-    sensor_write_register(0x44A, 0x21);     /* */
-    sensor_write_register(0x452, 0x01);     /* */
-    sensor_write_register(0x454, 0xB1);     /* */
-    
-    /* waiting for image stabilization */
-    usleep(200000);
-    sensor_write_register(0x200, 0x00);     /* release standy */
-    usleep(200000);
-    sensor_write_register(0x202, 0x00);     /* Master mode operation start */
-    usleep(200000);
-    sensor_write_register(0x249, 0x0A);     /* HSYNC and VSYNC output */
-    usleep(200000);
-    
-
 }
 
 void sensor_linner_init()
@@ -304,5 +185,62 @@ void sensor_wdr_init()
     usleep(200000);
     
     return;
+}
+void sensor_init()
+{
+    sensor_write_register(0x200, 0x01);     /* Standby */
+    usleep(200000);
+
+    sensor_write_register(0x202, 0x01);     /* master mode stop */
+    sensor_write_register(0x205, 0x01);     /* 12 bit */
+    sensor_write_register(0x206, 0x00);     /* All-pix scan mode */
+    sensor_write_register(0x207, 0x10);     /* 1080p mode */
+    sensor_write_register(0x209, 0x02);     /* Frame rate (data rate) setting: 30fps */
+    sensor_write_register(0x20A, 0xF0);     /* Black level offset */
+    sensor_write_register(0x20B, 0x00);     /* Black level offset */
+    sensor_write_register(0x20B, 0x00);     /* Black level offset */
+    sensor_write_register(0x214, 0x0C);     /* AGC min gain 1.2dB; */
+    sensor_write_register(0x218, 0x65);     /* Vertical span[7:0] */
+    sensor_write_register(0x219, 0x04);     /* Vertical span[15:8] */
+    sensor_write_register(0x21A, 0x00);     /* Vertical span[15:8] */
+    sensor_write_register(0x21B, 0x30);     /* Horizontal span[7:0] */
+    sensor_write_register(0x21C, 0x11);     /* Horizontal span[15:8] */
+    sensor_write_register(0x220, 0xC0);     /* Shutter[7:0] */
+    sensor_write_register(0x221, 0x03);     /* Shutter[15:8] */
+    sensor_write_register(0x244, 0x01);     /* cmos parallel output, 12bit */
+    sensor_write_register(0x246, 0x01);     
+    sensor_write_register(0x247, 0x01);    
+    sensor_write_register(0x248, 0x01);    
+    sensor_write_register(0x249, 0x0A);     /* HSYNC,VSYNC output */
+    sensor_write_register(0x254, 0x63);     
+    sensor_write_register(0x25B, 0x00);     /* INCK setting0 */
+    sensor_write_register(0x25C, 0x20);     /* INCK setting1 */
+    sensor_write_register(0x25D, 0x06);     /* INCK setting2 */
+    sensor_write_register(0x25E, 0x30);     /* INCK setting3 */
+    sensor_write_register(0x25F, 0x04);     /* INCK setting4 */
+
+    sensor_write_register(0x30F, 0x0E);     /* */
+    sensor_write_register(0x316, 0x02);     /* */
+
+    sensor_write_register(0x436, 0x71);     /* */
+    sensor_write_register(0x439, 0xF1);     /* */
+    sensor_write_register(0x441, 0xF2);     /* */
+    sensor_write_register(0x442, 0x21);     /* */
+    sensor_write_register(0x443, 0x21);     /* */
+    sensor_write_register(0x448, 0xF2);     /* */
+    sensor_write_register(0x449, 0x21);     /* */
+    sensor_write_register(0x44A, 0x21);     /* */
+    sensor_write_register(0x452, 0x01);     /* */
+    sensor_write_register(0x454, 0xB1);     /* */
+    
+    /* waiting for image stabilization */
+    usleep(200000);
+    sensor_write_register(0x200, 0x00);     /* release standy */
+    usleep(200000);
+    sensor_write_register(0x202, 0x00);     /* Master mode operation start */
+    usleep(200000);
+    sensor_write_register(0x249, 0x0A);     /* HSYNC and VSYNC output */
+    usleep(200000);
+    sensor_linner_init();
 }
 

--- a/libraries/sensor/hi3519v101/sony_imx327/Makefile
+++ b/libraries/sensor/hi3519v101/sony_imx327/Makefile
@@ -1,0 +1,19 @@
+LIB_NAME := libsns_imx327
+
+override CFLAGS += -fPIC \
+	-I$(CURDIR)/../../../../kernel/include/hi3519v101 \
+	-I$(CURDIR)/../../../../kernel/isp/arch/hi3519v101/include
+
+SRCS := $(wildcard *.c)
+OBJS := $(SRCS:%.c=%.o)
+
+all: $(LIB_NAME).so $(LIB_NAME).a
+
+$(LIB_NAME).so: $(OBJS)
+	$(CC) -shared -o $@ $(OBJS)
+
+$(LIB_NAME).a: $(OBJS)
+	$(AR) -rcs $(LIB_NAME).a $(OBJS)
+
+clean:
+	-rm -f $(OBJS) $(LIB_NAME).so $(LIB_NAME).a

--- a/libraries/sensor/hi3519v101/sony_imx327/imx327_cmos.c
+++ b/libraries/sensor/hi3519v101/sony_imx327/imx327_cmos.c
@@ -1,0 +1,1967 @@
+#if !defined(__IMX327_CMOS_H_)
+#define __IMX327_CMOS_H_
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "hi_comm_sns.h"
+#include "hi_comm_video.h"
+#include "hi_sns_ctrl.h"
+#include "mpi_isp.h"
+#include "mpi_ae.h"
+#include "mpi_awb.h"
+#include "mpi_af.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+
+#define IMX327_ID 327
+
+/****************************************************************************
+ * global variables                                                            *
+ ****************************************************************************/
+ISP_SNS_STATE_S             g_astimx327[ISP_MAX_DEV_NUM] = {{0}};
+static ISP_SNS_STATE_S     *g_apstSnsState[ISP_MAX_DEV_NUM] = {&g_astimx327[0], &g_astimx327[1]};
+ISP_SNS_COMMBUS_U     g_aunImx327BusInfo[ISP_MAX_DEV_NUM] = {
+    [0] = { .s8I2cDev = 0},
+    [1] = { .s8I2cDev = 1}
+}; 
+static ISP_FSWDR_MODE_E genFSWDRMode[ISP_MAX_DEV_NUM] = {ISP_FSWDR_NORMAL_MODE,ISP_FSWDR_NORMAL_MODE};
+static HI_U32 gu32MaxTimeGetCnt[ISP_MAX_DEV_NUM] = {0,0};
+
+static HI_U32 g_au32InitExposure[ISP_MAX_DEV_NUM]  = {0};
+static HI_U32 g_au32LinesPer500ms[ISP_MAX_DEV_NUM] = {0};
+static HI_U16 g_au16InitWBGain[ISP_MAX_DEV_NUM][3] = {{0}};
+static HI_U16 g_au16SampleRgain[ISP_MAX_DEV_NUM] = {0};
+static HI_U16 g_au16SampleBgain[ISP_MAX_DEV_NUM] = {0};
+
+extern const unsigned int imx327_i2c_addr;
+extern unsigned int imx327_addr_byte;
+extern unsigned int imx327_data_byte;
+
+typedef struct hiIMX327_STATE_S
+{
+    HI_U8       u8Hcg;
+    HI_U32      u32BRL;
+    HI_U32      u32RHS1_MAX;
+    HI_U32      u32RHS2_MAX;
+} IMX327_STATE_S;
+
+IMX327_STATE_S g_astimx327State[ISP_MAX_DEV_NUM] = {{0}};
+
+extern void imx327_init(ISP_DEV IspDev);
+extern void imx327_exit(ISP_DEV IspDev);
+extern void imx327_standby(ISP_DEV IspDev);
+extern void imx327_restart(ISP_DEV IspDev);
+extern int imx327_write_register(ISP_DEV IspDev, int addr, int data);
+extern int imx327_read_register(ISP_DEV IspDev, int addr);
+
+#define IMX327_FULL_LINES_MAX  (0x3FFFF)
+#define IMX327_FULL_LINES_MAX_2TO1_WDR  (0x8AA)    // considering the YOUT_SIZE and bad frame
+#define IMX327_FULL_LINES_MAX_3TO1_WDR  (0x7FC)
+
+/*****Imx327 Register Address*****/
+#define IMX327_SHS1_ADDR (0x3020) 
+#define IMX327_SHS2_ADDR (0x3024) 
+#define IMX327_SHS3_ADDR (0x3028) 
+#define IMX327_GAIN_ADDR (0x3014)
+#define IMX327_HCG_ADDR  (0x3009)
+#define IMX327_VMAX_ADDR (0x3018)
+#define IMX327_HMAX_ADDR (0x301c)
+#define IMX327_RHS1_ADDR (0x3030) 
+#define IMX327_RHS2_ADDR (0x3034)
+#define IMX327_Y_OUT_SIZE_ADDR (0x3418)
+
+#define IMX327_INCREASE_LINES (1) /* make real fps less than stand fps because NVR require*/
+
+#define IMX327_VMAX_1080P30_LINEAR  (1125+IMX327_INCREASE_LINES)
+#define IMX327_VMAX_1080P60TO30_WDR (1125+IMX327_INCREASE_LINES)
+#define IMX327_VMAX_1080P120TO30_WDR (1125+IMX327_INCREASE_LINES)
+
+//sensor fps mode
+#define IMX327_SENSOR_1080P_30FPS_LINEAR_MODE      (1)
+#define IMX327_SENSOR_1080P_30FPS_3t1_WDR_MODE     (2)
+#define IMX327_SENSOR_1080P_30FPS_2t1_WDR_MODE     (3)
+
+HI_S32 cmos_get_ae_default(ISP_DEV IspDev,AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if (HI_NULL == pstAeSnsDft)
+    {
+        printf("null pointer when get ae default value!\n");
+        return - 1;
+    }
+
+    memset(&pstAeSnsDft->stAERouteAttr, 0, sizeof(ISP_AE_ROUTE_S));
+      
+    pstAeSnsDft->u32FullLinesStd = g_apstSnsState[IspDev]->u32FLStd;
+    pstAeSnsDft->u32FlickerFreq = 50*256;
+    pstAeSnsDft->u32FullLinesMax = IMX327_FULL_LINES_MAX;
+
+    pstAeSnsDft->stIntTimeAccu.enAccuType = AE_ACCURACY_LINEAR;
+    pstAeSnsDft->stIntTimeAccu.f32Accuracy = 1;
+    pstAeSnsDft->stIntTimeAccu.f32Offset = 0;
+
+    pstAeSnsDft->stAgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stAgainAccu.f32Accuracy = 1;
+
+    pstAeSnsDft->stDgainAccu.enAccuType = AE_ACCURACY_TABLE;
+    pstAeSnsDft->stDgainAccu.f32Accuracy = 1;
+    
+    pstAeSnsDft->u32ISPDgainShift = 8;
+    pstAeSnsDft->u32MinISPDgainTarget = 1 << pstAeSnsDft->u32ISPDgainShift;
+    pstAeSnsDft->u32MaxISPDgainTarget = 2 << pstAeSnsDft->u32ISPDgainShift;
+
+    if(g_au32LinesPer500ms[IspDev] == 0)
+	{
+		pstAeSnsDft->u32LinesPer500ms = g_apstSnsState[IspDev]->u32FLStd*30/2;
+	}
+	else
+	{
+		pstAeSnsDft->u32LinesPer500ms = g_au32LinesPer500ms[IspDev];
+	}
+
+
+    pstAeSnsDft->enMaxIrisFNO = ISP_IRIS_F_NO_1_0;
+    pstAeSnsDft->enMinIrisFNO = ISP_IRIS_F_NO_32_0;
+
+    pstAeSnsDft->bAERouteExValid = HI_FALSE;
+    pstAeSnsDft->stAERouteAttr.u32TotalNum = 0;
+    pstAeSnsDft->stAERouteAttrEx.u32TotalNum = 0;
+
+    switch(g_apstSnsState[IspDev]->enWDRMode)
+    {
+        default:
+        case WDR_MODE_NONE:   /*linear mode*/
+            pstAeSnsDft->au8HistThresh[0] = 0xd;
+            pstAeSnsDft->au8HistThresh[1] = 0x28;
+            pstAeSnsDft->au8HistThresh[2] = 0x60;
+            pstAeSnsDft->au8HistThresh[3] = 0x80;
+
+            pstAeSnsDft->u32MaxAgain = 62564; 
+            pstAeSnsDft->u32MinAgain = 1024;
+            pstAeSnsDft->u32MaxAgainTarget = pstAeSnsDft->u32MaxAgain;
+            pstAeSnsDft->u32MinAgainTarget = pstAeSnsDft->u32MinAgain;
+
+            pstAeSnsDft->u32MaxDgain = 38577;  
+            pstAeSnsDft->u32MinDgain = 1024;
+            pstAeSnsDft->u32MaxDgainTarget = 20013;
+            pstAeSnsDft->u32MinDgainTarget = pstAeSnsDft->u32MinDgain;
+            
+            pstAeSnsDft->u8AeCompensation = 0x38;
+            pstAeSnsDft->enAeExpMode = AE_EXP_HIGHLIGHT_PRIOR; 
+
+            pstAeSnsDft->u32InitExposure = g_au32InitExposure[IspDev] ? g_au32InitExposure[IspDev] : 148859;
+            
+            pstAeSnsDft->u32MaxIntTime = g_apstSnsState[IspDev]->u32FLStd - 2;
+            pstAeSnsDft->u32MinIntTime = 1;
+            pstAeSnsDft->u32MaxIntTimeTarget = 65535;
+            pstAeSnsDft->u32MinIntTimeTarget = 1;
+        break;
+
+        case WDR_MODE_2To1_LINE:                                                                      
+            pstAeSnsDft->au8HistThresh[0] = 0xC;                                                      
+            pstAeSnsDft->au8HistThresh[1] = 0x18;                                                     
+            pstAeSnsDft->au8HistThresh[2] = 0x60;                                                     
+            pstAeSnsDft->au8HistThresh[3] = 0x80;                                                     
+                                                                                                   
+                                 
+            pstAeSnsDft->u32MaxIntTime = g_apstSnsState[IspDev]->u32FLStd - 2;                                                           
+            pstAeSnsDft->u32MinIntTime = 2;                                                           
+                                                                                       
+            pstAeSnsDft->u32MaxIntTimeTarget = 65535;                                                 
+            pstAeSnsDft->u32MinIntTimeTarget = pstAeSnsDft->u32MinIntTime;                            
+                                                                                                   
+            pstAeSnsDft->u32MaxAgain = 62564; 
+            pstAeSnsDft->u32MinAgain = 1024;                                                          
+            pstAeSnsDft->u32MaxAgainTarget = 62564;                                                 
+            pstAeSnsDft->u32MinAgainTarget = pstAeSnsDft->u32MinAgain; 
+
+            pstAeSnsDft->u32MaxDgain = 38577;  
+            pstAeSnsDft->u32MinDgain = 1024;
+            pstAeSnsDft->u32MaxDgainTarget = 20013;
+            pstAeSnsDft->u32MinDgainTarget = pstAeSnsDft->u32MinDgain;
+
+            pstAeSnsDft->u32InitExposure = g_au32InitExposure[IspDev] ? g_au32InitExposure[IspDev] : 16462;
+
+            if(ISP_FSWDR_LONG_FRAME_MODE == genFSWDRMode[IspDev])
+            {
+                pstAeSnsDft->u8AeCompensation = 56; 
+                pstAeSnsDft->enAeExpMode = AE_EXP_HIGHLIGHT_PRIOR; 
+            }
+            else
+            {
+                pstAeSnsDft->u32MaxDgainTarget = 8153;
+                pstAeSnsDft->u32MaxISPDgainTarget = 267;
+                pstAeSnsDft->u8AeCompensation = 24;  
+                pstAeSnsDft->enAeExpMode = AE_EXP_LOWLIGHT_PRIOR; 
+                pstAeSnsDft->u16ManRatioEnable = HI_TRUE;                                                 
+                pstAeSnsDft->au32Ratio[0] = 0x400;  
+                pstAeSnsDft->au32Ratio[1] = 0x40; 
+                pstAeSnsDft->au32Ratio[2] = 0x40; 
+            }
+       break;
+
+      case WDR_MODE_3To1_LINE:                                                                      
+            pstAeSnsDft->au8HistThresh[0] = 0xC;                                                      
+            pstAeSnsDft->au8HistThresh[1] = 0x18;                                                     
+            pstAeSnsDft->au8HistThresh[2] = 0x60;                                                     
+            pstAeSnsDft->au8HistThresh[3] = 0x80;                                                     
+                                 
+            pstAeSnsDft->u32MaxIntTime = g_apstSnsState[IspDev]->u32FLStd - 2;                                                           
+            pstAeSnsDft->u32MinIntTime = 3;                                                           
+            pstAeSnsDft->u32MaxIntTimeTarget = 65535;                                                 
+            pstAeSnsDft->u32MinIntTimeTarget = pstAeSnsDft->u32MinIntTime;                            
+                                                                                                   
+            pstAeSnsDft->u32MaxAgain = 62564; 
+            pstAeSnsDft->u32MinAgain = 1024;                                                          
+            pstAeSnsDft->u32MaxAgainTarget = 62564;                                                 
+            pstAeSnsDft->u32MinAgainTarget = pstAeSnsDft->u32MinAgain; 
+
+            pstAeSnsDft->u32MaxDgain = 38577;  
+            pstAeSnsDft->u32MinDgain = 1024;
+            pstAeSnsDft->u32MaxDgainTarget = 20013;
+            pstAeSnsDft->u32MinDgainTarget = pstAeSnsDft->u32MinDgain;
+
+            pstAeSnsDft->u32InitExposure = g_au32InitExposure[IspDev] ? g_au32InitExposure[IspDev] : 7436;
+
+            if(ISP_FSWDR_LONG_FRAME_MODE == genFSWDRMode[IspDev])
+            {
+                pstAeSnsDft->u8AeCompensation = 56; 
+                pstAeSnsDft->enAeExpMode = AE_EXP_HIGHLIGHT_PRIOR;
+            }
+            else
+            {
+                pstAeSnsDft->u32MaxDgainTarget = 8153;
+                pstAeSnsDft->u32MaxISPDgainTarget = 267;
+                pstAeSnsDft->u8AeCompensation = 24;  
+                pstAeSnsDft->enAeExpMode = AE_EXP_LOWLIGHT_PRIOR; 
+                pstAeSnsDft->u16ManRatioEnable = HI_TRUE;                                                 
+                pstAeSnsDft->au32Ratio[0] = 0x200;  
+                pstAeSnsDft->au32Ratio[1] = 0x200; 
+                pstAeSnsDft->au32Ratio[2] = 0x40;
+            }
+       break; 
+    
+    }
+
+    return 0;
+}
+
+
+/* the function of sensor set fps */
+HI_VOID cmos_fps_set(ISP_DEV IspDev, HI_FLOAT f32Fps, AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+
+    HI_U32 u32VMAX = IMX327_VMAX_1080P30_LINEAR;                                                                            
+                                                                                                                          
+    switch (g_apstSnsState[IspDev]->u8ImgMode)                                                                                           
+    {
+      case IMX327_SENSOR_1080P_30FPS_2t1_WDR_MODE:
+           if ((f32Fps <= 30) && (f32Fps >= 16.5))                                                                            
+           {
+               u32VMAX = IMX327_VMAX_1080P60TO30_WDR * 30 / f32Fps;  
+           }
+           else                                                                                                              
+           {                                                                                                                 
+               printf("Not support Fps: %f\n", f32Fps);                                                                      
+               return;                                                                                                       
+           }
+           u32VMAX = (u32VMAX > IMX327_FULL_LINES_MAX_2TO1_WDR) ? IMX327_FULL_LINES_MAX_2TO1_WDR : u32VMAX; 
+           break;
+
+     case IMX327_SENSOR_1080P_30FPS_3t1_WDR_MODE:                                                                                  
+           if ((f32Fps <= 30) && (f32Fps >= 16.5))                                                                            
+           {
+               u32VMAX = IMX327_VMAX_1080P120TO30_WDR * 30 / f32Fps;  
+           }
+           else                                                                                                              
+           {                                                                                                                 
+               printf("Not support Fps: %f\n", f32Fps);                                                                      
+               return;                                                                                                       
+           }
+           u32VMAX = (u32VMAX > IMX327_FULL_LINES_MAX_3TO1_WDR) ? IMX327_FULL_LINES_MAX_3TO1_WDR : u32VMAX; 
+           break;
+                
+      case IMX327_SENSOR_1080P_30FPS_LINEAR_MODE:
+           if ((f32Fps <= 30) && (f32Fps >= 0.5))                                                                            
+           {
+               u32VMAX = IMX327_VMAX_1080P30_LINEAR * 30 / f32Fps;  
+           }
+           else                                                                                                              
+           {                                                                                                                 
+               printf("Not support Fps: %f\n", f32Fps);                                                                      
+               return;                                                                                                       
+           } 
+           u32VMAX = (u32VMAX > IMX327_FULL_LINES_MAX) ? IMX327_FULL_LINES_MAX : u32VMAX;   
+           break;
+                                                                                                       
+      default:                                                                                                              
+          return;
+          break;                                                                                                            
+    }                                                                                                                                                                                          
+                                                                                                                          
+    if (WDR_MODE_NONE == g_apstSnsState[IspDev]->enWDRMode)                                                                                   
+    {                                                                                                                     
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[5].u32Data = (u32VMAX & 0xFF);                                                         
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[6].u32Data = ((u32VMAX & 0xFF00) >> 8);                                                
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[7].u32Data = ((u32VMAX & 0xF0000) >> 16);                                              
+    }                                                                                                                     
+    else                                                                                                                  
+    {                                                                                                                     
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[8].u32Data = (u32VMAX & 0xFF);                                                         
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[9].u32Data = ((u32VMAX & 0xFF00) >> 8);                                                
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[10].u32Data = ((u32VMAX & 0xF0000) >> 16);                                             
+    }                                                                                                                     
+                                                                                                                          
+    if (WDR_MODE_2To1_LINE == g_apstSnsState[IspDev]->enWDRMode)                                                                              
+    {                                                                                                                     
+        g_apstSnsState[IspDev]->u32FLStd = u32VMAX * 2;
+        //printf("gu32FullLinesStd:%d\n",g_apstSnsState[IspDev]->u32FLStd);
+                                                                                                                          
+        /*                                                                                                                
+            RHS1 limitation:                                                                                              
+            2n + 5                                                                                                        
+            RHS1 <= FSC - BRL*2 -21                                                                                       
+            (2 * VMAX_IMX327_1080P30_WDR - 2 * gu32BRL - 21) - (((2 * VMAX_IMX327_1080P30_WDR - 2 * 1109 - 21) - 5) %2)   
+        */                                                                                                                
+
+        g_astimx327State[IspDev].u32RHS1_MAX = (u32VMAX - g_astimx327State[IspDev].u32BRL) * 2 - 21;
+                                                                                                                      
+    }
+
+    else if (WDR_MODE_3To1_LINE == g_apstSnsState[IspDev]->enWDRMode)                                                                              
+    {                                                                                                                     
+        g_apstSnsState[IspDev]->u32FLStd = u32VMAX * 4;
+        
+        //printf("u32VMAX:%d gu32FullLinesStd:%d\n",u32VMAX,g_apstSnsState[IspDev]->u32FLStd);
+                                                                                                                          
+        /*                                                                                                                
+            RHS2 limitation:                                                                                              
+            3n + 14                                                                                                        
+            RHS2 <= FSC - BRL*3 -25                                                                                       
+        */                                                                                                                
+        g_astimx327State[IspDev].u32RHS2_MAX = u32VMAX*4 - g_astimx327State[IspDev].u32BRL * 3 - 25;                                                                                                                                    
+                                                                                                                         
+    }
+    else                                                                                                                  
+    {                                                                                                                     
+        g_apstSnsState[IspDev]->u32FLStd = u32VMAX;                                                                                       
+    }                                                                                                                     
+                                                                                                                          
+    pstAeSnsDft->f32Fps = f32Fps;                                    
+    pstAeSnsDft->u32LinesPer500ms = g_apstSnsState[IspDev]->u32FLStd * f32Fps / 2;                                                        
+    pstAeSnsDft->u32FullLinesStd = g_apstSnsState[IspDev]->u32FLStd;  
+    pstAeSnsDft->u32MaxIntTime = g_apstSnsState[IspDev]->u32FLStd - 2;   
+    g_apstSnsState[IspDev]->au32FL[0] = g_apstSnsState[IspDev]->u32FLStd;
+    pstAeSnsDft->u32FullLines = g_apstSnsState[IspDev]->au32FL[0];
+                                                                                                                          
+    return;                                                                                                               
+
+}
+
+HI_VOID cmos_slow_framerate_set(ISP_DEV IspDev,HI_U32 u32FullLines,
+    AE_SENSOR_DEFAULT_S *pstAeSnsDft)
+{
+    if(WDR_MODE_2To1_LINE == g_apstSnsState[IspDev]->enWDRMode)
+    {
+    	u32FullLines = (u32FullLines > 2*IMX327_FULL_LINES_MAX_2TO1_WDR) ? 2*IMX327_FULL_LINES_MAX_2TO1_WDR : u32FullLines;
+        g_apstSnsState[IspDev]->au32FL[0] = (u32FullLines >> 1) << 1;
+		g_astimx327State[IspDev].u32RHS1_MAX = g_apstSnsState[IspDev]->au32FL[0] - g_astimx327State[IspDev].u32BRL * 2 - 21;
+    }
+    else if(WDR_MODE_3To1_LINE == g_apstSnsState[IspDev]->enWDRMode)
+    {
+    	u32FullLines = (u32FullLines > 4*IMX327_FULL_LINES_MAX_3TO1_WDR) ? 4*IMX327_FULL_LINES_MAX_3TO1_WDR : u32FullLines;
+        g_apstSnsState[IspDev]->au32FL[0] = (u32FullLines >> 2) << 2;
+        g_astimx327State[IspDev].u32RHS2_MAX = g_apstSnsState[IspDev]->au32FL[0] - g_astimx327State[IspDev].u32BRL * 3 - 25; 
+    }
+    else
+    {
+    	u32FullLines = (u32FullLines > IMX327_FULL_LINES_MAX) ? IMX327_FULL_LINES_MAX : u32FullLines;
+        g_apstSnsState[IspDev]->au32FL[0] = u32FullLines;  
+    }
+
+    if(WDR_MODE_NONE == g_apstSnsState[IspDev]->enWDRMode)
+    {
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[5].u32Data = (g_apstSnsState[IspDev]->au32FL[0] & 0xFF);
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[6].u32Data = ((g_apstSnsState[IspDev]->au32FL[0] & 0xFF00) >> 8);
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[7].u32Data = ((g_apstSnsState[IspDev]->au32FL[0] & 0xF0000) >> 16);
+    }
+    else if(WDR_MODE_2To1_LINE == g_apstSnsState[IspDev]->enWDRMode)                                                                                     
+    {                                                                                         
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[8].u32Data = ((g_apstSnsState[IspDev]->au32FL[0]>>1) & 0xFF);                       
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[9].u32Data = (((g_apstSnsState[IspDev]->au32FL[0]>>1) & 0xFF00) >> 8);              
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[10].u32Data = (((g_apstSnsState[IspDev]->au32FL[0]>>1) & 0xF0000) >> 16);           
+    }
+    else if(WDR_MODE_3To1_LINE == g_apstSnsState[IspDev]->enWDRMode)                                                                                     
+    {                                                                                         
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[8].u32Data = ((g_apstSnsState[IspDev]->au32FL[0]>>2) & 0xFF);                       
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[9].u32Data = (((g_apstSnsState[IspDev]->au32FL[0]>>2) & 0xFF00) >> 8);              
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[10].u32Data = (((g_apstSnsState[IspDev]->au32FL[0]>>2) & 0xF0000) >> 16);           
+    }
+    else                                                                                      
+    {                                                                                         
+    }   
+
+    pstAeSnsDft->u32FullLines = g_apstSnsState[IspDev]->au32FL[0];
+    pstAeSnsDft->u32MaxIntTime = g_apstSnsState[IspDev]->au32FL[0] - 2; 
+
+    return;
+}
+
+/* while isp notify ae to update sensor regs, ae call these funcs. */
+HI_VOID cmos_inttime_update(ISP_DEV IspDev,HI_U32 u32IntTime)
+{
+    static HI_BOOL bFirst[ISP_MAX_DEV_NUM] ={1, 1}; 
+    HI_U32 u32Value = 0;
+
+    static HI_U8 u8Count[ISP_MAX_DEV_NUM] = {0};
+
+    static HI_U32 u32ShortIntTime[ISP_MAX_DEV_NUM] = {0};
+    static HI_U32 u32ShortIntTime1[ISP_MAX_DEV_NUM] = {0}; 
+    static HI_U32 u32ShortIntTime2[ISP_MAX_DEV_NUM] = {0};
+    static HI_U32 u32LongIntTime[ISP_MAX_DEV_NUM] = {0};         
+
+    static HI_U32 u32RHS1[ISP_MAX_DEV_NUM]  = {0}; 
+    static HI_U32 u32RHS2[ISP_MAX_DEV_NUM]  = {0};  
+
+    static HI_U32 u32SHS1[ISP_MAX_DEV_NUM]  = {0};                      
+    static HI_U32 u32SHS2[ISP_MAX_DEV_NUM]  = {0};
+    static HI_U32 u32SHS3[ISP_MAX_DEV_NUM]  = {0};
+
+    HI_U32 u32YOUTSIZE;
+
+    if (WDR_MODE_2To1_LINE == g_apstSnsState[IspDev]->enWDRMode)                                                          
+    {
+      //printf("bFirst = %d\n",bFirst[IspDev]);
+      if (bFirst[IspDev]) /* short exposure */                                                              
+      {
+           g_apstSnsState[IspDev]->au32WDRIntTime[0] = u32IntTime;
+           u32ShortIntTime[IspDev] = u32IntTime;
+            //printf("u32ShortIntTime = %d \n",u32ShortIntTime[IspDev]);
+           bFirst[IspDev] = HI_FALSE;  
+       }                                                                                             
+
+       else   /* long exposure */                                                                      
+       {                                                                                             
+           g_apstSnsState[IspDev]->au32WDRIntTime[1] = u32IntTime;  
+           u32LongIntTime[IspDev] = u32IntTime;                                                              
+           
+           u32SHS2[IspDev] = g_apstSnsState[IspDev]->au32FL[1] - u32LongIntTime[IspDev] - 1; 
+                                                                                                    
+           //allocate the RHS1                                                                       
+           u32SHS1[IspDev] = (u32ShortIntTime[IspDev] % 2) + 2;
+		   u32RHS1[IspDev] = u32ShortIntTime[IspDev] + u32SHS1[IspDev] + 1; 
+                                                     
+
+           u32YOUTSIZE=(1097+(u32RHS1[IspDev]-1)/2+7)*2;
+           u32YOUTSIZE=(u32YOUTSIZE>=0x1FFF)?0x1FFF:u32YOUTSIZE;
+           //printf("u32ShortIntTime = %d u32SHS1 = %d \n",u32ShortIntTime[IspDev],u32SHS1);
+           //printf("IspDev = %d RHS1 = %d u32YOUTSIZE = %d \n",IspDev,u32RHS1[IspDev], u32YOUTSIZE);
+                                                                                     
+           g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[0].u32Data = (u32SHS1[IspDev] & 0xFF);                                 
+           g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[1].u32Data = ((u32SHS1[IspDev] & 0xFF00) >> 8);                        
+           g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[2].u32Data = ((u32SHS1[IspDev] & 0xF0000) >> 16);                      
+                                                                                                     
+           g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[5].u32Data = (u32SHS2[IspDev] & 0xFF);                                 
+           g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[6].u32Data = ((u32SHS2[IspDev] & 0xFF00) >> 8);                        
+           g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[7].u32Data = ((u32SHS2[IspDev] & 0xF0000) >> 16); 
+                                                                                                      
+           g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[11].u32Data = (u32RHS1[IspDev] & 0xFF);                                
+           g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[12].u32Data = ((u32RHS1[IspDev] & 0xFF00) >> 8);                       
+           g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[13].u32Data = ((u32RHS1[IspDev] & 0xF0000) >> 16);  
+
+           g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[14].u32Data = (u32YOUTSIZE & 0xFF);                                
+           g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[15].u32Data = ((u32YOUTSIZE & 0x1F00) >> 8);
+                                                                                              
+           bFirst[IspDev] = HI_TRUE;                                                                         
+        }                                                                                             
+     }   
+    
+
+     else if(WDR_MODE_3To1_LINE == g_apstSnsState[IspDev]->enWDRMode)
+     {
+           if (0 == u8Count[IspDev])        /* short exposure */
+           {
+               g_apstSnsState[IspDev]->au32WDRIntTime[0] = u32IntTime; 
+               u32ShortIntTime1[IspDev] = u32IntTime;
+               u8Count[IspDev]++;
+           }
+           else if (1 == u8Count[IspDev])  /* short short exposure */
+           {
+               g_apstSnsState[IspDev]->au32WDRIntTime[1] = u32IntTime; 
+               u32ShortIntTime2[IspDev] = u32IntTime;
+               u8Count[IspDev]++;
+           }
+           else                    /* long exposure */
+           {
+              g_apstSnsState[IspDev]->au32WDRIntTime[2] = u32IntTime; 
+              u32LongIntTime[IspDev] = u32IntTime;
+              u32SHS3[IspDev] = g_apstSnsState[IspDev]->au32FL[1] - u32LongIntTime[IspDev] -1;
+   
+              //allocate the RHS1 and RHS2  
+              u32SHS1[IspDev] = (3 - (u32ShortIntTime2[IspDev] % 3)) + 3;
+              u32RHS1[IspDev] = u32ShortIntTime2[IspDev] + u32SHS1[IspDev] + 1;
+              u32SHS2[IspDev] = u32RHS1[IspDev] + (3 - (u32ShortIntTime1[IspDev] % 3)) + 3;
+              u32RHS2[IspDev] = u32ShortIntTime1[IspDev] + u32SHS2[IspDev] + 1;
+
+              u32YOUTSIZE=(1097+(u32RHS2[IspDev]-2)/3+9)*3;
+              u32YOUTSIZE=(u32YOUTSIZE>=0x1FFF)?0x1FFF:u32YOUTSIZE;
+   
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[0].u32Data = (u32SHS1[IspDev] & 0xFF);                                 
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[1].u32Data = ((u32SHS1[IspDev] & 0xFF00) >> 8);                        
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[2].u32Data = ((u32SHS1[IspDev] & 0xF0000) >> 16);                      
+                                                                                                        
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[5].u32Data = (u32SHS2[IspDev] & 0xFF);                                 
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[6].u32Data = ((u32SHS2[IspDev] & 0xFF00) >> 8);                        
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[7].u32Data = ((u32SHS2[IspDev] & 0xF0000) >> 16); 
+                                                                                                       
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[11].u32Data = (u32RHS1[IspDev] & 0xFF);                                
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[12].u32Data = ((u32RHS1[IspDev] & 0xFF00) >> 8);                       
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[13].u32Data = ((u32RHS1[IspDev] & 0xF0000) >> 16);
+    
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[14].u32Data = (u32RHS2[IspDev] & 0xFF);                                
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[15].u32Data = ((u32RHS2[IspDev] & 0xFF00) >> 8);                       
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[16].u32Data = ((u32RHS2[IspDev] & 0xF0000) >> 16);
+    
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[17].u32Data = (u32SHS3[IspDev] & 0xFF);                                
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[18].u32Data = ((u32SHS3[IspDev] & 0xFF00) >> 8);                       
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[19].u32Data = ((u32SHS3[IspDev] & 0xF0000) >> 16);
+    
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[20].u32Data = (u32YOUTSIZE & 0xFF);                                
+              g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[21].u32Data = ((u32YOUTSIZE & 0x1F00) >> 8);
+                
+              u8Count[IspDev] = 0;
+           }
+     }
+     else                                                                                             
+     {                                                                                                 
+         u32Value = g_apstSnsState[IspDev]->au32FL[0] - u32IntTime - 1; 
+                                                                                                       
+         g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[0].u32Data = (u32Value & 0xFF);                                    
+         g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[1].u32Data = ((u32Value & 0xFF00) >> 8);                           
+         g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[2].u32Data = ((u32Value & 0x30000) >> 16); 
+         
+         bFirst[IspDev] = HI_TRUE;                                                                             
+     }                                                                                                 
+                                                                                                    
+  return;                                                                                           
+
+}
+
+static HI_U32 gain_table[262]=
+{
+    1024,1059,1097,1135,1175,1217,1259,1304,1349,1397,1446,1497,1549,1604,1660,1719,1779,1842,1906,
+    1973,2043,2048,2119,2194,2271,2351,2434,2519,2608,2699,2794,2892,2994,3099,3208,3321,3438,3559,
+    3684,3813,3947,4086,4229,4378,4532,4691,4856,5027,5203,5386,5576,5772,5974,6184,6402,6627,6860,
+    7101,7350,7609,7876,8153,8439,8736,9043,9361,9690,10030,10383,10748,11125,11516,11921,12340,12774,
+    13222,13687,14168,14666,15182,15715,16267,16839,17431,18043,18677,19334,20013,20717,21445,22198,
+    22978,23786,24622,25487,26383,27310,28270,29263,30292,31356,32458,33599,34780,36002,37267,38577,
+    39932,41336,42788,44292,45849,47460,49128,50854,52641,54491,56406,58388,60440,62564,64763,67039,
+    69395,71833,74358,76971,79676,82476,85374,88375,91480,94695,98023,101468,105034,108725,112545,
+    116501,120595,124833,129220,133761,138461,143327,148364,153578,158975,164562,170345,176331,182528,
+    188942,195582,202455,209570,216935,224558,232450,240619,249074,257827,266888,276267,285976,296026,
+    306429,317197,328344,339883,351827,364191,376990,390238,403952,418147,432842,448053,463799,480098,
+    496969,514434,532512,551226,570597,590649,611406,632892,655133,678156,701988,726657,752194,778627,
+    805990,834314,863634,893984,925400,957921,991585,1026431,1062502,1099841,1138491,1178500,1219916,
+    1262786,1307163,1353100,1400651,1449872,1500824,1553566,1608162,1664676,1723177,1783733,1846417,
+    1911304,1978472,2048000,2119971,2194471,2271590,2351418,2434052,2519590,2608134,2699789,2794666,
+    2892876,2994538,3099773,3208706,3321467,3438190,3559016,3684087,3813554,3947571,4086297,4229898,
+    4378546,4532417,4691696,4856573,5027243,5203912,5386788,5576092,5772048,5974890,6184861,6402210,
+    6627198,6860092,7101170,7350721,7609041,7876439,8153234
+};
+
+HI_VOID cmos_again_calc_table(ISP_DEV IspDev,HI_U32 *pu32AgainLin, HI_U32 *pu32AgainDb)
+{
+    int i;
+
+    if (*pu32AgainLin >= gain_table[120])
+    {
+         *pu32AgainLin = gain_table[120];
+         *pu32AgainDb = 120;
+         return ;
+    }
+    
+    for (i = 1; i < 121; i++)
+    {
+        if (*pu32AgainLin < gain_table[i])
+        {
+            *pu32AgainLin = gain_table[i - 1];
+            *pu32AgainDb = i - 1;
+            break;
+        }
+    }
+    return;
+}
+
+HI_VOID cmos_dgain_calc_table(ISP_DEV IspDev,HI_U32 *pu32DgainLin, HI_U32 *pu32DgainDb)
+{
+    int i;
+
+    if((HI_NULL == pu32DgainLin) ||(HI_NULL == pu32DgainDb))
+    {
+        printf("null pointer when get ae sensor gain info value!\n");
+        return;
+    }
+
+    if (*pu32DgainLin >= gain_table[106])
+    {
+         *pu32DgainLin = gain_table[106];
+         *pu32DgainDb = 106;
+         return ;
+    }
+    
+    for (i = 1; i < 106; i++)
+    {
+        if (*pu32DgainLin < gain_table[i])
+        {
+            *pu32DgainLin = gain_table[i - 1];
+            *pu32DgainDb = i - 1;
+            break;
+        }
+    }
+
+    return;
+}
+
+HI_VOID cmos_gains_update(ISP_DEV IspDev,HI_U32 u32Again, HI_U32 u32Dgain)
+{  
+    HI_U32 u32HCG = g_astimx327State[IspDev].u8Hcg;
+    HI_U32 u32Tmp;
+    
+    if(u32Again >= 21)
+    {
+        u32HCG = u32HCG | 0x10;  // bit[4] HCG  .Reg0x3009[7:0]
+        u32Again = u32Again - 21;
+    }
+
+    u32Tmp=u32Again+u32Dgain;
+        
+    g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[3].u32Data = (u32Tmp & 0xFF);
+    g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[4].u32Data = (u32HCG & 0xFF);
+    
+
+    return;
+}
+
+HI_VOID cmos_get_inttime_max(ISP_DEV IspDev,HI_U16 u16ManRatioEnable, HI_U32 *au32Ratio, HI_U32 *au32IntTimeMax, HI_U32 *au32IntTimeMin, HI_U32 *pu32LFMaxIntTime)
+{
+    HI_U32 i = 0;
+    HI_U32 u32IntTimeMaxTmp0 = 0;
+    HI_U32 u32IntTimeMaxTmp  = 0;
+    HI_U32 u32RHS2_Max=0;
+    HI_U32 u32RatioTmp = 0x40;
+    HI_U32 u32ShortTimeMinLimit = 0;
+
+    u32ShortTimeMinLimit = (WDR_MODE_2To1_LINE == g_apstSnsState[IspDev]->enWDRMode) ? 2 : ((WDR_MODE_3To1_LINE == g_apstSnsState[IspDev]->enWDRMode) ? 3 : 2);
+        
+    if((HI_NULL == au32Ratio) || (HI_NULL == au32IntTimeMax) || (HI_NULL == au32IntTimeMin))
+    {
+        printf("null pointer when get ae sensor ExpRatio/IntTimeMax/IntTimeMin value!\n");
+        return;
+    }                                                                                                                       
+    
+    if(WDR_MODE_2To1_LINE == g_apstSnsState[IspDev]->enWDRMode)                                                                             
+    {                                                                                                                        
+        /*  limitation for line base WDR                                                                                     
+                                                                                                                             
+            SHS1 limitation:                                                                                                 
+            2 or more                                                                                                        
+            RHS1 - 2 or less                                                                                                 
+                                                                                                                             
+            SHS2 limitation:                                                                                                 
+            RHS1 + 2 or more                                                                                                 
+            FSC - 2 or less                                                                                                  
+                                                                                                                             
+            RHS1 Limitation                                                                                                  
+            2n + 5 (n = 0,1,2...)                                                                                            
+            RHS1 <= FSC - BRL * 2 - 21                                                                                       
+                                                                                                                             
+            short exposure time = RHS1 - (SHS1 + 1) <= RHS1 - 3                                                              
+            long exposure time = FSC - (SHS2 + 1) <= FSC - (RHS1 + 3)                                                        
+            ExposureShort + ExposureLong <= FSC - 6                                                                          
+            short exposure time <= (FSC - 6) / (ratio + 1)                                                                   
+        */
+        if(ISP_FSWDR_LONG_FRAME_MODE == genFSWDRMode[IspDev])
+        {
+            u32IntTimeMaxTmp0 = g_apstSnsState[IspDev]->au32FL[1] - 6 - g_apstSnsState[IspDev]->au32WDRIntTime[0];
+            u32IntTimeMaxTmp = g_apstSnsState[IspDev]->au32FL[0] - 10;
+            u32IntTimeMaxTmp = (u32IntTimeMaxTmp0 < u32IntTimeMaxTmp) ? u32IntTimeMaxTmp0 : u32IntTimeMaxTmp;
+            au32IntTimeMax[0] = u32IntTimeMaxTmp;
+            au32IntTimeMin[0] = u32ShortTimeMinLimit;
+            return;
+        }
+        else
+        {
+            u32IntTimeMaxTmp0 = ((g_apstSnsState[IspDev]->au32FL[1] - 6 - g_apstSnsState[IspDev]->au32WDRIntTime[0]) * 0x40)  / DIV_0_TO_1(au32Ratio[0]);                                                                                                                     
+            u32IntTimeMaxTmp = ((g_apstSnsState[IspDev]->au32FL[0] - 6) * 0x40)  / DIV_0_TO_1(au32Ratio[0] + 0x40); 
+            u32IntTimeMaxTmp = (u32IntTimeMaxTmp0 < u32IntTimeMaxTmp) ? u32IntTimeMaxTmp0 : u32IntTimeMaxTmp;
+            u32IntTimeMaxTmp = (u32IntTimeMaxTmp > (g_astimx327State[IspDev].u32RHS1_MAX- 3))? (g_astimx327State[IspDev].u32RHS1_MAX - 3) : u32IntTimeMaxTmp; 
+            u32IntTimeMaxTmp = (0 == u32IntTimeMaxTmp)? 1: u32IntTimeMaxTmp;  
+        }
+        
+    } 
+    else if(WDR_MODE_3To1_LINE == g_apstSnsState[IspDev]->enWDRMode)                                                                             
+    {                                                                                                                        
+        /*  limitation for DOL 3t1                                                                                     
+                                                                                                                             
+            SHS1 limitation:                                                                                                 
+            3 or more                                                                                                        
+            RHS1 - 2 or less 
+
+            RHS1 Limitation                                                                                                  
+            3n + 7 (n = 0,1,2...)                                                                                            
+                                                                                                                            
+            SHS2 limitation:                                                                                                 
+            RHS1 + 3 or more                                                                                                 
+            RHS2 - 2 or less 
+                                                                                                                             
+            RHS2 Limitation                                                                                                  
+            3n + 14 (n = 0,1,2...)                                                                                            
+            RHS2 <= FSC - BRL * 3 - 25  
+            
+            SHS3 limitation:                                                                                                 
+            RHS2 + 3 or more                                                                                                 
+            FSC - 2 or less 
+                                                                                                                             
+            short exposure time 1 = RHS1 - (SHS1 + 1) <= RHS1 - 4
+            short exposure time 2 = RHS2 - (SHS2 + 1) <= RHS2 - (RHS1 + 4) 
+            short exposure time 2 <= (RHS2 - 8) / (ratio[0] + 1)
+            long exposure time = FSC - (SHS3 + 1) <= FSC - (RHS2 + 4)                                                        
+            short exposure time 1 + short exposure time 2 + long exposure time <= FSC -12                                                                         
+            short exposure time 2 <= (FSC - 12) / (ratio[0]*ratio[1] + ratio[0] + 1)                                                                   
+        */
+        if(ISP_FSWDR_LONG_FRAME_MODE == genFSWDRMode[IspDev])
+        {
+            /* when change LongFrameMode, the first 2 frames must limit the MaxIntTime to avoid flicker */
+            if(gu32MaxTimeGetCnt[IspDev] < 2)
+            {
+                u32IntTimeMaxTmp0 = g_apstSnsState[IspDev]->au32FL[1] - 100 - g_apstSnsState[IspDev]->au32WDRIntTime[0] - g_apstSnsState[IspDev]->au32WDRIntTime[1];
+            }
+            else
+            {
+                u32IntTimeMaxTmp0 = g_apstSnsState[IspDev]->au32FL[1] - 16 - g_apstSnsState[IspDev]->au32WDRIntTime[0] - g_apstSnsState[IspDev]->au32WDRIntTime[1];
+            }
+            u32IntTimeMaxTmp = g_apstSnsState[IspDev]->au32FL[0] - 24;
+            u32IntTimeMaxTmp = (u32IntTimeMaxTmp0 < u32IntTimeMaxTmp) ? u32IntTimeMaxTmp0 : u32IntTimeMaxTmp;
+            au32IntTimeMax[0] = u32IntTimeMaxTmp;
+            au32IntTimeMin[0] = u32ShortTimeMinLimit;
+            gu32MaxTimeGetCnt[IspDev]++;
+            return;
+        }
+        else
+        {
+            u32IntTimeMaxTmp0 = ((g_apstSnsState[IspDev]->au32FL[1] - 16 - g_apstSnsState[IspDev]->au32WDRIntTime[0] - g_apstSnsState[IspDev]->au32WDRIntTime[1]) * 0x40*0x40)  / (au32Ratio[0]*au32Ratio[1]);                                                                                                                      
+            u32IntTimeMaxTmp = ((g_apstSnsState[IspDev]->au32FL[0] - 16) * 0x40*0x40)  / (au32Ratio[0]*au32Ratio[1] + au32Ratio[0]*0x40 + 0x40*0x40); 
+            u32IntTimeMaxTmp = (u32IntTimeMaxTmp0 < u32IntTimeMaxTmp) ? u32IntTimeMaxTmp0 : u32IntTimeMaxTmp;
+            u32RHS2_Max = ((g_astimx327State[IspDev].u32RHS2_MAX-8)*0x40)/(au32Ratio[0]+0x40);
+            u32IntTimeMaxTmp = (u32IntTimeMaxTmp > u32RHS2_Max)? (u32RHS2_Max) : u32IntTimeMaxTmp; 
+            u32IntTimeMaxTmp = (0 == u32IntTimeMaxTmp)? 1: u32IntTimeMaxTmp; 
+        }
+
+    }
+    else
+    {
+    }
+
+    if(u32IntTimeMaxTmp >= u32ShortTimeMinLimit)
+    {
+        if (IS_LINE_WDR_MODE(g_apstSnsState[IspDev]->enWDRMode))
+        {
+            au32IntTimeMax[0] = u32IntTimeMaxTmp;
+            au32IntTimeMax[1] = au32IntTimeMax[0] * au32Ratio[0] >> 6;
+            au32IntTimeMax[2] = au32IntTimeMax[1] * au32Ratio[1] >> 6;
+            au32IntTimeMax[3] = au32IntTimeMax[2] * au32Ratio[2] >> 6;
+            au32IntTimeMin[0] = u32ShortTimeMinLimit;
+            au32IntTimeMin[1] = au32IntTimeMin[0] * au32Ratio[0] >> 6;
+            au32IntTimeMin[2] = au32IntTimeMin[1] * au32Ratio[1] >> 6;
+            au32IntTimeMin[3] = au32IntTimeMin[2] * au32Ratio[2] >> 6;
+        }
+        else
+        {
+        }
+    }
+    else
+    {
+        if(1 == u16ManRatioEnable)
+        {
+            printf("Manaul ExpRatio is too large!\n");
+            return;
+        }
+        else
+        {
+            u32IntTimeMaxTmp = u32ShortTimeMinLimit; 
+
+            if (WDR_MODE_2To1_LINE == g_apstSnsState[IspDev]->enWDRMode)
+            {
+                u32RatioTmp = 0xFFF;
+                au32IntTimeMax[0] = u32IntTimeMaxTmp;
+                au32IntTimeMax[1] = au32IntTimeMax[0] * u32RatioTmp >> 6;
+            }
+            else if (WDR_MODE_3To1_LINE == g_apstSnsState[IspDev]->enWDRMode)
+            {
+                for(i = 0x40; i <= 0xFFF; i++)
+                {
+                    if((u32IntTimeMaxTmp + (u32IntTimeMaxTmp*i >> 6) + (u32IntTimeMaxTmp*i*i >> 12)) > (g_apstSnsState[IspDev]->au32FL[0] - 12))
+                    {
+                        u32RatioTmp = i - 1;
+                        break;
+                    }
+                }
+                au32IntTimeMax[0] = u32IntTimeMaxTmp;
+                au32IntTimeMax[1] = au32IntTimeMax[0] * u32RatioTmp >> 6;
+                au32IntTimeMax[2] = au32IntTimeMax[1] * u32RatioTmp >> 6;
+            }
+            else
+            {
+            }
+            au32IntTimeMin[0] = au32IntTimeMax[0];
+            au32IntTimeMin[1] = au32IntTimeMax[1];
+            au32IntTimeMin[2] = au32IntTimeMax[2];
+            au32IntTimeMin[3] = au32IntTimeMax[3];
+        }
+    }
+
+    return;
+                                                                                                                
+}
+
+/* Only used in LINE_WDR mode */
+HI_VOID cmos_ae_fswdr_attr_set(ISP_DEV IspDev,AE_FSWDR_ATTR_S *pstAeFSWDRAttr)
+{
+    genFSWDRMode[IspDev] = pstAeFSWDRAttr->enFSWDRMode;
+    gu32MaxTimeGetCnt[IspDev] = 0;
+}
+
+
+HI_S32 cmos_init_ae_exp_function(AE_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AE_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_ae_default    = cmos_get_ae_default;
+    pstExpFuncs->pfn_cmos_fps_set           = cmos_fps_set;
+    pstExpFuncs->pfn_cmos_slow_framerate_set= cmos_slow_framerate_set;    
+    pstExpFuncs->pfn_cmos_inttime_update    = cmos_inttime_update;
+    pstExpFuncs->pfn_cmos_gains_update      = cmos_gains_update;
+    pstExpFuncs->pfn_cmos_again_calc_table  = cmos_again_calc_table;
+    pstExpFuncs->pfn_cmos_dgain_calc_table  = cmos_dgain_calc_table;
+    pstExpFuncs->pfn_cmos_get_inttime_max   = cmos_get_inttime_max; 
+    pstExpFuncs->pfn_cmos_ae_fswdr_attr_set = cmos_ae_fswdr_attr_set; 
+
+    return 0;
+}
+
+static AWB_CCM_S g_stAwbCcm =
+{  
+   4900,
+   {
+      0x1CE, 0x80BF, 0x800F,
+      0x8052,0x184,  0x8032,
+      0x5,   0x80D1, 0x1CC
+   },
+   3770,
+   {
+      0x1CB,  0x80AF, 0x801C,
+      0x806D, 0x18C,  0x801F,
+      0x11,   0x80EE, 0x1DD
+   }, 
+   2640,
+   {     
+      0x1B4,  0x80AA, 0x800A,
+      0x8091, 0x1A1,  0x8010,
+      0x0,    0x80DB, 0x1DB
+   }     
+};
+
+static AWB_CCM_S g_stAwbCcmWDR =
+{  
+   4900,
+   {
+      0x1CE, 0x80BF, 0x800F,
+      0x8052,0x184,  0x8032,
+      0x5,   0x80D1, 0x1CC
+   },
+   3770,
+   {
+      0x1CB,  0x80AF, 0x801C,
+      0x806D, 0x18C,  0x801F,
+      0x11,   0x80EE, 0x1DD
+   }, 
+   2640,
+   {     
+      0x1B4,  0x80AA, 0x800A,
+      0x8091, 0x1A1,  0x8010,
+      0x0,    0x80DB, 0x1DB
+   }     
+};
+
+static AWB_AGC_TABLE_S g_stAwbAgcTable =
+{
+    /* bvalid */
+    1,
+    
+    /*1,  2,  4,  8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768*/
+    /* saturation */   
+    {0x80,0x7a,0x78,0x74,0x68,0x60,0x58,0x50,0x48,0x40,0x38,0x38,0x38,0x38,0x38,0x38}
+};
+
+static AWB_AGC_TABLE_S g_stAwbAgcTableFSWDR =
+{
+    /* bvalid */
+    1,
+
+    /* saturation */ 
+    {0x78,0x78,0x6e,0x64,0x5E,0x58,0x50,0x48,0x40,0x38,0x38,0x38,0x38,0x38,0x38,0x38}
+};
+
+/* Rgain and Bgain of the golden sample */
+#define GOLDEN_RGAIN 0   
+#define GOLDEN_BGAIN 0  
+
+HI_S32 cmos_get_awb_default(ISP_DEV IspDev,AWB_SENSOR_DEFAULT_S *pstAwbSnsDft)
+{
+    if (HI_NULL == pstAwbSnsDft)
+    {
+        printf("null pointer when get awb default value!\n");
+        return -1;
+    }
+
+    memset(pstAwbSnsDft, 0, sizeof(AWB_SENSOR_DEFAULT_S));
+    pstAwbSnsDft->u16WbRefTemp = 4900;
+
+    pstAwbSnsDft->au16GainOffset[0] = 0x1C3;
+    pstAwbSnsDft->au16GainOffset[1] = 0x100;
+    pstAwbSnsDft->au16GainOffset[2] = 0x100;
+    pstAwbSnsDft->au16GainOffset[3] = 0x1D4;
+
+    pstAwbSnsDft->as32WbPara[0] = -37;
+    pstAwbSnsDft->as32WbPara[1] = 293;
+    pstAwbSnsDft->as32WbPara[2] = 0;
+    pstAwbSnsDft->as32WbPara[3] = 179537;
+    pstAwbSnsDft->as32WbPara[4] = 128;
+    pstAwbSnsDft->as32WbPara[5] = -123691;
+   
+    pstAwbSnsDft->u16GoldenRgain = GOLDEN_RGAIN;
+    pstAwbSnsDft->u16GoldenBgain = GOLDEN_BGAIN;
+    
+    switch (g_apstSnsState[IspDev]->enWDRMode)
+    {
+        default:
+        case WDR_MODE_NONE:
+            memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTable, sizeof(AWB_AGC_TABLE_S));
+            memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcm, sizeof(AWB_CCM_S));
+        break;
+        case WDR_MODE_2To1_LINE:
+        case WDR_MODE_3To1_LINE:
+            memcpy(&pstAwbSnsDft->stAgcTbl, &g_stAwbAgcTableFSWDR, sizeof(AWB_AGC_TABLE_S));
+            memcpy(&pstAwbSnsDft->stCcm, &g_stAwbCcmWDR, sizeof(AWB_CCM_S));
+        break;
+    }
+
+    pstAwbSnsDft->u16SampleRgain = g_au16SampleRgain[IspDev];
+    pstAwbSnsDft->u16SampleBgain = g_au16SampleBgain[IspDev];
+    pstAwbSnsDft->u16InitRgain = g_au16InitWBGain[IspDev][0];
+    pstAwbSnsDft->u16InitGgain = g_au16InitWBGain[IspDev][1];
+    pstAwbSnsDft->u16InitBgain = g_au16InitWBGain[IspDev][2];
+
+    pstAwbSnsDft->u8AWBRunInterval = 2;
+
+    return 0;
+}
+
+HI_S32 cmos_init_awb_exp_function(AWB_SENSOR_EXP_FUNC_S *pstExpFuncs)
+{
+    memset(pstExpFuncs, 0, sizeof(AWB_SENSOR_EXP_FUNC_S));
+
+    pstExpFuncs->pfn_cmos_get_awb_default = cmos_get_awb_default;
+
+    return 0;
+}
+
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTable =
+{
+    /* bvalid */
+    1,
+
+    /* snr_thresh */
+    {0x08,0x0c,0x10,0x14,0x18,0x20,0x28,0x30,0x30,0x30,0x30,0x30,0x30,0x30,0x30,0x30},
+               
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30,0x30,0x30,0x30,0x30,0x30,0x30,0x30,0x30},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37,0x37,0x37,0x37,0x37,0x37,0x37,0x37,0x37}
+    
+};
+
+static ISP_CMOS_BAYER_SHARPEN_S g_stIspBayerSharpen = 
+{
+    /* bvalid */
+    1,
+
+    /* ShpAlgSel = 1 is Demosaic SharpenEx, else Demosaic sharpen. */ 
+    0,
+    
+    /* sharpen_alt_d to Sharpen */
+    {0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x40,0x30,0x20,0x10},
+        
+    /* sharpen_alt_ud to Sharpen */
+    {0x3a,0x36,0x32,0x30,0x2c,0x30,0x30,0x30,0x28,0x24,0x24,0x20,0x20,0x20,0x10,0x10},
+        
+    /* demosaic_lum_thresh to Sharpen */
+    {0x50,0x50,0x50,0x50,0x50,0x50,0x50,0x50,0x40,0x30,0x20,0x20,0x20,0x20,0x20,0x20},
+        
+    /* SharpenHF to SharpenEx */
+    {0x30,0x30,0x30,0x30,0x30,0x30,0x2c,0x28,0x20,0x18,0x14,0x10,0x10,0x10,0x10,0x10},
+        
+    /* SharpenMF to SharpenEx */
+    {0x30,0x30,0x30,0x30,0x28,0x20,0x20,0x20,0x20,0x20,0x10,0x10,0x10,0x10,0x10,0x10},
+        
+    /* SharpenLF to SharpenEx */
+    {0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18},
+
+    /* SadAmplifier to SharpenEx */
+    {0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10}   
+
+};
+
+
+static ISP_CMOS_BAYER_SHARPEN_S g_stIspBayerSharpenFSWDR = 
+{
+    /* bvalid */
+    1,
+
+    /* ShpAlgSel = 1 is Demosaic SharpenEx, else Demosaic sharpen. */ 
+    0,
+    
+    /* sharpen_alt_d to Sharpen */
+    {0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x40,0x30,0x20,0x10},
+        
+    /* sharpen_alt_ud to Sharpen */
+    {0x48,0x46,0x42,0x40,0x40,0x40,0x40,0x40,0x40,0x3c,0x38,0x32,0x28,0x20,0x10,0x10},
+        
+    /* demosaic_lum_thresh to Sharpen */
+    {0x50,0x50,0x50,0x50,0x50,0x50,0x50,0x50,0x40,0x30,0x20,0x20,0x20,0x20,0x20,0x20},
+        
+    /* SharpenHF to SharpenEx */
+    {0x30,0x30,0x30,0x30,0x30,0x30,0x2c,0x28,0x20,0x18,0x14,0x10,0x10,0x10,0x10,0x10},
+        
+    /* SharpenMF to SharpenEx */
+    {0x30,0x30,0x30,0x30,0x28,0x20,0x20,0x20,0x20,0x20,0x10,0x10,0x10,0x10,0x10,0x10},
+        
+    /* SharpenLF to SharpenEx */
+    {0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18},
+
+    /* SadAmplifier to SharpenEx */
+    {0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10}   
+
+};
+
+
+static ISP_CMOS_YUV_SHARPEN_S g_stIspYuvSharpen = 
+{
+     /* bvalid */
+     1,
+
+     /* 100,  200,    400,     800,    1600,    3200,    6400,    12800,    25600,   51200,  102400,  204800,   409600,   819200,   1638400,  3276800 */
+    
+     /* bEnLowLumaShoot */ 
+     {0,     0,     0,     0,     0,     0,      0,      0,      0,     1,     1,      1,      1,      1,      1,     1},
+     
+     /* TextureSt */
+     {50,   48,    46,    44,    48,    56,     56,     56,     48,    36,    20,      8,      4,      4,      4,     4},
+         
+     /* EdgeSt */
+     {64,	64,	   64,	  64,	 64,	64,	    56,		56,		56,	   48,	  48,	  48,	  48,	  32,	  20,    20},
+         
+     /* OverShoot */
+     {64,   64,    64,    64,    72,    72,     72,     72,     72,    64,    64,     56,     50,     40,     30,    30},
+        
+     /* UnderShoot */
+     {64,   64,    64,    64,    72,    72,     72,     72,     72,    64,    64,     56,     50,     40,     30,    30},
+         
+     /* TextureThd */
+     {80,   80,    80,    80,    80,    80,     90,     90,     90,   100,   100,    100,    100,    100,    110,   110},
+         
+     /* EdgeThd */
+     {0,     0,     5,    10,    10,    10,     16,     20,     30,   40,     50,    50,      60,    60,     60,    60},
+    
+     /* JagCtrl */
+     {63,   38,    20,    18,    16,    12,     10,      8,      8,     4,     4,      4,      2,      2,      2,     2},
+    
+     /* SaltCtrl */
+     {50,   50,     50,     90,     90,     90,     90,     90,     90,     90,     90,     90,     90,     50,     50,    50},
+    
+     /* PepperCtrl */
+     {0,    0,       0,     20,     60,     60,     60,     80,    120,    160,    180,     180,   180,     180,   180,   180},
+    
+     /* DetailCtrl */
+     {150,  150,   135,    135,    130,    130,    130,    130,    120,    120,    120,     120,    100,     50,    50,    50}, 
+    
+     /* LumaThd */
+     {
+         {20,    20,     20,     20,     20,     20,     20,     20,     20,     20,     20,     20,     20,     20,     20,     20}, /* LumaThd0 */
+         {40,    40,     40,     40,     40,     40,     40,     40,     40,     40,     40,     40,     40,     40,     40,     40}, /* LumaThd1 */
+         {65,    65,     65,     65,     65,     65,     65,     65,     65,     65,     65,     65,     65,     65,     65,     65}, /* LumaThd2 */
+         {90,    90,     90,     90,     90,     90,     90,     90,     90,     90,     90,     90,     90,     90,     90,     90}  /* LumaThd3 */  
+     }, 
+    
+     /* LumaWgt */
+     {
+         {160,   160,    160,    150,    140,    130,    120,    110,    100,    100,     90,     90,     80,     80,     80,     80},
+         {200,   200,    200,    180,    170,    160,    150,    150,    150,    150,    120,    120,    120,    120,    120,    120},
+         {240,   240,    240,    200,    200,    190,    180,    180,    180,    180,    160,    160,    160,    160,    160,    160},
+         {255,   255,    255,    255,    255,    255,    255,    255,    255,    255,    255,    255,    255,    255,    255,    255},
+     } 
+};
+
+
+static ISP_CMOS_YUV_SHARPEN_S g_stIspYuvSharpenFSWDR = 
+{
+     /* bvalid */
+     1,
+
+     /* 100,  200,    400,     800,    1600,    3200,    6400,    12800,    25600,   51200,  102400,  204800,   409600,   819200,   1638400,  3276800 */
+    
+     /* bEnLowLumaShoot */ 
+     {0,     0,     0,     0,     0,     0,      0,      0,      0,     1,     1,      1,      1,      1,      1,     1},
+     
+     /* TextureSt */
+     {50,   48,    46,    44,    48,    56,     56,     56,     48,    36,    20,      8,      4,      4,      4,     4},
+         
+     /* EdgeSt */
+     {64,	64,	   64,	  64,	 64,	64,	    56,		56,		56,	   48,	  48,	  48,	  48,	  32,	  20,    20},
+         
+     /* OverShoot */
+     {32,   36,    40,    48,    48,    48,     44,     40,     40,    32,    32,     28,     25,     20,     20,    20},
+        
+     /* UnderShoot */
+     {32,   36,    40,    48,    48,    48,     44,     40,     40,    32,    32,     28,     25,     20,     20,    20},
+         
+     /* TextureThd */
+     {20,   24,    28,    32,    36,    40,     48,     56,     64,   128,   156,    156,    156,    160,    160,   160},
+         
+     /* EdgeThd */
+     {0,     0,     0,    10,    10,    10,     16,     32,     64,   128,   156,    156,    156,    160,    160,   160},
+    
+     /* JagCtrl */
+     {24,   22,    20,    18,    16,    12,     10,      8,      8,     4,     4,      4,      2,      2,      2,     2},
+    
+     /* SaltCtrl */
+     {50,   50,     50,     90,     90,     90,     90,     90,     90,     90,     90,     90,     90,     50,     50,    50},
+    
+     /* PepperCtrl */
+     {0,    0,       0,     20,     60,     60,     60,     80,    120,    160,    180,     180,   180,     180,   180,   180},
+    
+     /* DetailCtrl */
+     {140,  140,   135,    135,    130,    130,    130,    130,    120,    120,    120,     120,    100,     50,    50,    50}, 
+    
+     /* LumaThd */
+     {
+         {20,    20,     20,     20,     20,     20,     20,     20,     20,     20,     20,     20,     20,     20,     20,     20}, /* LumaThd0 */
+         {40,    40,     40,     40,     40,     40,     40,     40,     40,     40,     40,     40,     40,     40,     40,     40}, /* LumaThd1 */
+         {65,    65,     65,     65,     65,     65,     70,     75,     80,     80,     80,     80,     80,     80,     80,     80}, /* LumaThd2 */
+         {90,    90,     90,     90,     90,     90,     100,   110,    120,    120,    120,    120,    120,    120,    120,    120}  /* LumaThd3 */  
+     }, 
+    
+     /* LumaWgt */
+     {
+         {160,   160,    160,    150,    120,     80,     40,     20,     10,    10,     10,     10,     10,     10,     10,     10},
+         {200,   200,    200,    180,    160,    120,     80,     60,     40,    40,     40,     40,     40,     40,     40,     40},
+         {240,   240,    240,    200,    200,    180,    160,    140,    128,   128,    128,    128,    128,    128,    128,    128},
+         {255,   255,    255,    255,    255,    255,    255,    255,    255,   255,    255,    255,    255,    255,    255,    255},
+     } 
+};
+
+
+static ISP_CMOS_AGC_TABLE_S g_stIspAgcTableFSWDR =
+{
+    /* bvalid */
+    1,
+        
+    /* snr_thresh */
+    {0x8,0xC,0x10,0x14,0x18,0x20,0x28,0x30,0x30,0x30,0x30,0x30,0x30,0x30,0x30,0x30},
+        
+    /* demosaic_np_offset */
+    {0x0,0xa,0x12,0x1a,0x20,0x28,0x30,0x30,0x30,0x30,0x30,0x30,0x30,0x30,0x30,0x30},
+        
+    /* ge_strength */
+    {0x55,0x55,0x55,0x55,0x55,0x55,0x37,0x37,0x37,0x37,0x37,0x37,0x37,0x37,0x37,0x37},
+};
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTable =
+{
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
+    {
+      0,0,0,0,0,0,0,8,14,18,21,24,26,27,28,30,31,32,33,34,34,36,36,37,38,38,39,39,
+      40,40,41,41,42,42,42,43,43,44,44,44,45,45,45,46,46,46,46,47,47,47,48,48,48,48,49,49,49,
+      49,49,50,50,50,50,51,51,51,51,51,51,52,52,52,52,52,53,53,53,53,53,53,53,54,54,54,54,54,
+      54,55,55,55,55,55,55,55,55,56,56,56,56,56,56,56,56,57,57,57,57,57,57,57,57,57,58,58,58,
+      58,58,58,58,58,58,59,59,59,59,59,59,59
+    },
+
+    /* demosaic_weight_lut */
+    {
+      0,8,14,18,21,24,26,27,28,30,31,32,33,34,34,36,36,37,38,38,39,39,40,40,41,41,42,42,42,
+      43,43,44,44,44,45,45,45,46,46,46,46,47,47,47,48,48,48,48,49,49,49,49,49,50,50,50,50,
+      51,51,51,51,51,51,52,52,52,52,52,53,53,53,53,53,53,53,54,54,54,54,54,54,55,55,55,55,
+      55,55,55,55,56,56,56,56,56,56,56,56,57,57,57,57,57,57,57,57,57,58,58,58,58,58,58,58,
+      58,58,59,59,59,59,59,59,59,59,59,59,59,59,59
+    }
+};
+
+static ISP_CMOS_NOISE_TABLE_S g_stIspNoiseTableFSWDR =
+{
+    /* bvalid */
+    1,
+    
+    /* nosie_profile_weight_lut */
+    {
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,5,7,10,13,15,18,21,23,26,29,31,34,37,39,42,45
+    },
+
+    /* demosaic_weight_lut */
+    {
+        0,2,15,20,24,27,30,32,33,35,36,37,38,39,40,41,42,42,43,44,44,45,45,46,
+        46,47,47,48,48,49,49,49,50,50,50,51,51,51,52,52,52,53,53,53,53,54,54,54,54,55,55,
+        55,55,56,56,56,56,56,57,57,57,57,57,58,58,58,58,58,59,59,59,59,59,59,59,60,60,60,
+        60,60,60,61,61,61,61,61,61,61,62,62,62,62,62,62,62,62,63,63,63,63,63,63,63,63,63,
+        64,64,64,64,64,64,64,64,64,65,65,65,65,65,65,65,65,65,65,65,65,65,65
+    }
+};
+
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaic =
+{
+    /* bvalid */
+    1,
+    
+    /*vh_slope*/
+    0xac,
+
+    /*aa_slope*/
+    0xaa,
+
+    /*va_slope*/
+    0xa8,
+
+    /*uu_slope*/
+    0x55,
+
+    /*sat_slope*/
+    0x5d,
+
+    /*ac_slope*/
+    0xa0,
+    
+    /*fc_slope*/
+    0x80,
+
+    /*vh_thresh*/
+    0x00,
+
+    /*aa_thresh*/
+    0x00,
+
+    /*va_thresh*/
+    0x00,
+
+    /*uu_thresh*/
+    0x08,
+
+    /*sat_thresh*/
+    0x00,
+
+    /*ac_thresh*/
+    0x1b3
+
+};
+
+static ISP_CMOS_DEMOSAIC_S g_stIspDemosaicFSWDR =
+{
+    /* bvalid */
+    1,
+    
+    /*vh_slope*/
+    0xac,
+
+    /*aa_slope*/
+    0xaa,
+
+    /*va_slope*/
+    0xa8,
+
+    /*uu_slope*/
+    0x55,
+
+    /*sat_slope*/
+    0x5d,
+
+    /*ac_slope*/
+    0xa0,
+    
+    /*fc_slope*/
+    0x80,
+
+    /*vh_thresh*/
+    0x00,
+
+    /*aa_thresh*/
+    0x00,
+
+    /*va_thresh*/
+    0x00,
+
+    /*uu_thresh*/
+    0x00,
+
+    /*sat_thresh*/
+    0x00,
+
+    /*ac_thresh*/
+    0x1b3
+};
+
+static ISP_CMOS_GAMMA_S g_stIspGamma =
+{
+    /* bvalid */
+    1,
+    
+    {0   ,120 ,220 ,310 ,390 ,470 ,540 ,610 ,670 ,730 ,786 ,842 ,894 ,944 ,994 ,1050,    
+    1096,1138,1178,1218,1254,1280,1314,1346,1378,1408,1438,1467,1493,1519,1543,1568,    
+    1592,1615,1638,1661,1683,1705,1726,1748,1769,1789,1810,1830,1849,1869,1888,1907,    
+    1926,1945,1963,1981,1999,2017,2034,2052,2069,2086,2102,2119,2136,2152,2168,2184,    
+    2200,2216,2231,2247,2262,2277,2292,2307,2322,2337,2351,2366,2380,2394,2408,2422,    
+    2436,2450,2464,2477,2491,2504,2518,2531,2544,2557,2570,2583,2596,2609,2621,2634,    
+    2646,2659,2671,2683,2696,2708,2720,2732,2744,2756,2767,2779,2791,2802,2814,2825,    
+    2837,2848,2859,2871,2882,2893,2904,2915,2926,2937,2948,2959,2969,2980,2991,3001,    
+    3012,3023,3033,3043,3054,3064,3074,3085,3095,3105,3115,3125,3135,3145,3155,3165,    
+    3175,3185,3194,3204,3214,3224,3233,3243,3252,3262,3271,3281,3290,3300,3309,3318,    
+    3327,3337,3346,3355,3364,3373,3382,3391,3400,3409,3418,3427,3436,3445,3454,3463,    
+    3471,3480,3489,3498,3506,3515,3523,3532,3540,3549,3557,3566,3574,3583,3591,3600,    
+    3608,3616,3624,3633,3641,3649,3657,3665,3674,3682,3690,3698,3706,3714,3722,3730,    
+    3738,3746,3754,3762,3769,3777,3785,3793,3801,3808,3816,3824,3832,3839,3847,3855,    
+    3862,3870,3877,3885,3892,3900,3907,3915,3922,3930,3937,3945,3952,3959,3967,3974,    
+    3981,3989,3996,4003,4010,4018,4025,4032,4039,4046,4054,4061,4068,4075,4082,4089,4095}
+};
+
+static ISP_CMOS_GAMMA_S g_stIspGammaFSWDR =
+{
+    /* bvalid */
+    1,
+    
+    {0   ,120 ,220 ,310 ,390 ,470 ,540 ,610 ,670 ,730 ,786 ,842 ,894 ,944 ,994 ,1050,    
+    1096,1138,1178,1218,1254,1280,1314,1346,1378,1408,1438,1467,1493,1519,1543,1568,    
+    1592,1615,1638,1661,1683,1705,1726,1748,1769,1789,1810,1830,1849,1869,1888,1907,    
+    1926,1945,1963,1981,1999,2017,2034,2052,2069,2086,2102,2119,2136,2152,2168,2184,    
+    2200,2216,2231,2247,2262,2277,2292,2307,2322,2337,2351,2366,2380,2394,2408,2422,    
+    2436,2450,2464,2477,2491,2504,2518,2531,2544,2557,2570,2583,2596,2609,2621,2634,    
+    2646,2659,2671,2683,2696,2708,2720,2732,2744,2756,2767,2779,2791,2802,2814,2825,    
+    2837,2848,2859,2871,2882,2893,2904,2915,2926,2937,2948,2959,2969,2980,2991,3001,    
+    3012,3023,3033,3043,3054,3064,3074,3085,3095,3105,3115,3125,3135,3145,3155,3165,    
+    3175,3185,3194,3204,3214,3224,3233,3243,3252,3262,3271,3281,3290,3300,3309,3318,    
+    3327,3337,3346,3355,3364,3373,3382,3391,3400,3409,3418,3427,3436,3445,3454,3463,    
+    3471,3480,3489,3498,3506,3515,3523,3532,3540,3549,3557,3566,3574,3583,3591,3600,    
+    3608,3616,3624,3633,3641,3649,3657,3665,3674,3682,3690,3698,3706,3714,3722,3730,    
+    3738,3746,3754,3762,3769,3777,3785,3793,3801,3808,3816,3824,3832,3839,3847,3855,    
+    3862,3870,3877,3885,3892,3900,3907,3915,3922,3930,3937,3945,3952,3959,3967,3974,    
+    3981,3989,3996,4003,4010,4018,4025,4032,4039,4046,4054,4061,4068,4075,4082,4089,4095}
+
+};
+
+HI_U32 cmos_get_isp_default(ISP_DEV IspDev,ISP_CMOS_DEFAULT_S *pstDef)
+{
+    if (HI_NULL == pstDef)
+    {
+        printf("null pointer when get isp default value!\n");
+        return -1;
+    }
+
+    memset(pstDef, 0, sizeof(ISP_CMOS_DEFAULT_S));
+    
+    switch (g_apstSnsState[IspDev]->enWDRMode)
+    {
+        default:
+        case WDR_MODE_NONE:
+            pstDef->stDrc.bEnable               = HI_FALSE;
+            pstDef->stDrc.u32BlackLevel         = 0x00;
+            pstDef->stDrc.u32WhiteLevel         = 0xD0000; 
+            pstDef->stDrc.u32SlopeMax           = 0x30;
+            pstDef->stDrc.u32SlopeMin           = 0x0;
+            pstDef->stDrc.u32VarianceSpace      = 0x4;
+            pstDef->stDrc.u32VarianceIntensity  = 0x2;
+            pstDef->stDrc.u32Asymmetry          = 0x08;
+            pstDef->stDrc.u32BrightEnhance      = 0xE6;     
+            pstDef->stDrc.bFilterMux            = 0x1;
+            pstDef->stDrc.u32Svariance          = 0x6;
+            pstDef->stDrc.u32BrightPr           = 0xA0;
+            pstDef->stDrc.u32Contrast           = 0xA0;
+            pstDef->stDrc.u32DarkEnhance        = 0x9000;
+            
+            memcpy(&pstDef->stAgcTbl, &g_stIspAgcTable, sizeof(ISP_CMOS_AGC_TABLE_S));
+            memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTable, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+            memcpy(&pstDef->stDemosaic, &g_stIspDemosaic, sizeof(ISP_CMOS_DEMOSAIC_S));
+            memcpy(&pstDef->stBayerSharpen, &g_stIspBayerSharpen, sizeof(ISP_CMOS_BAYER_SHARPEN_S));
+            memcpy(&pstDef->stYuvSharpen, &g_stIspYuvSharpen, sizeof(ISP_CMOS_YUV_SHARPEN_S));
+            memcpy(&pstDef->stGamma, &g_stIspGamma, sizeof(ISP_CMOS_GAMMA_S));
+        break;
+
+        case WDR_MODE_2To1_LINE:
+            pstDef->stDrc.bEnable               = HI_TRUE;
+            pstDef->stDrc.u32BlackLevel         = 0x00;
+            pstDef->stDrc.u32WhiteLevel         = 0xB0000; 
+            pstDef->stDrc.u32SlopeMax           = 0x60;
+            pstDef->stDrc.u32SlopeMin           = 0xD0;
+            pstDef->stDrc.u32VarianceSpace      = 0x06;
+            pstDef->stDrc.u32VarianceIntensity  = 0x08;
+            pstDef->stDrc.u32Asymmetry          = 0x08;
+            pstDef->stDrc.u32BrightEnhance      = 0xE6;     
+            pstDef->stDrc.bFilterMux            = 0x1;
+            pstDef->stDrc.u32Svariance          = 0xC;
+            pstDef->stDrc.u32BrightPr           = 0x94;
+            pstDef->stDrc.u32Contrast           = 0x80;
+            pstDef->stDrc.u32DarkEnhance        = 0x6000;
+
+            pstDef->stWDRAttr.au32ExpRatio[0]   = 0x400;
+            pstDef->stWDRAttr.au32ExpRatio[1]   = 0x40;
+            pstDef->stWDRAttr.au32ExpRatio[2]   = 0x40;
+
+            memcpy(&pstDef->stAgcTbl, &g_stIspAgcTableFSWDR, sizeof(ISP_CMOS_AGC_TABLE_S));
+            memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTableFSWDR, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+            memcpy(&pstDef->stDemosaic, &g_stIspDemosaicFSWDR, sizeof(ISP_CMOS_DEMOSAIC_S));
+            memcpy(&pstDef->stBayerSharpen, &g_stIspBayerSharpenFSWDR, sizeof(ISP_CMOS_BAYER_SHARPEN_S));
+            memcpy(&pstDef->stYuvSharpen, &g_stIspYuvSharpenFSWDR, sizeof(ISP_CMOS_YUV_SHARPEN_S));          
+            memcpy(&pstDef->stGamma, &g_stIspGammaFSWDR, sizeof(ISP_CMOS_GAMMA_S));
+        break;
+
+        case WDR_MODE_3To1_LINE:
+            pstDef->stDrc.bEnable               = HI_TRUE;
+            pstDef->stDrc.u32BlackLevel         = 0x00;
+            pstDef->stDrc.u32WhiteLevel         = 0xB0000; 
+            pstDef->stDrc.u32SlopeMax           = 0x60;
+            pstDef->stDrc.u32SlopeMin           = 0xD0;
+            pstDef->stDrc.u32VarianceSpace      = 0x06;
+            pstDef->stDrc.u32VarianceIntensity  = 0x08;
+            pstDef->stDrc.u32Asymmetry          = 0x08;
+            pstDef->stDrc.u32BrightEnhance      = 0xE6;     
+            pstDef->stDrc.bFilterMux            = 0x1;
+            pstDef->stDrc.u32Svariance          = 0xC;
+            pstDef->stDrc.u32BrightPr           = 0x94;
+            pstDef->stDrc.u32Contrast           = 0x80;
+            pstDef->stDrc.u32DarkEnhance        = 0x6000;
+
+            pstDef->stWDRAttr.au32ExpRatio[0]   = 0x200;
+            pstDef->stWDRAttr.au32ExpRatio[1]   = 0x200;
+            pstDef->stWDRAttr.au32ExpRatio[2]   = 0x40;
+
+            memcpy(&pstDef->stAgcTbl, &g_stIspAgcTableFSWDR, sizeof(ISP_CMOS_AGC_TABLE_S));
+            memcpy(&pstDef->stNoiseTbl, &g_stIspNoiseTableFSWDR, sizeof(ISP_CMOS_NOISE_TABLE_S));            
+            memcpy(&pstDef->stDemosaic, &g_stIspDemosaicFSWDR, sizeof(ISP_CMOS_DEMOSAIC_S));
+            memcpy(&pstDef->stBayerSharpen, &g_stIspBayerSharpenFSWDR, sizeof(ISP_CMOS_BAYER_SHARPEN_S));
+            memcpy(&pstDef->stYuvSharpen, &g_stIspYuvSharpenFSWDR, sizeof(ISP_CMOS_YUV_SHARPEN_S));          
+            memcpy(&pstDef->stGamma, &g_stIspGammaFSWDR, sizeof(ISP_CMOS_GAMMA_S));
+        break;
+
+    }
+
+    pstDef->stSensorMaxResolution.u32MaxWidth  = 1920;
+    pstDef->stSensorMaxResolution.u32MaxHeight = 1080;
+    pstDef->stSensorMode.u32SensorID = IMX327_ID;
+    pstDef->stSensorMode.u8SensorMode = g_apstSnsState[IspDev]->u8ImgMode;
+
+    return 0;
+}
+
+HI_U32 cmos_get_isp_black_level(ISP_DEV IspDev,ISP_CMOS_BLACK_LEVEL_S *pstBlackLevel)
+{
+    HI_S32  i;
+    
+    if (HI_NULL == pstBlackLevel)
+    {
+        printf("null pointer when get isp black level value!\n");
+        return -1;
+    }
+
+    /* Don't need to update black level when iso change */
+    pstBlackLevel->bUpdate = HI_FALSE;
+
+    /* black level of linear mode */
+    if (WDR_MODE_NONE == g_apstSnsState[IspDev]->enWDRMode)
+    {
+        for (i=0; i<4; i++)
+        {
+            pstBlackLevel->au16BlackLevel[i] = 0x3c;    // 240
+        }
+    }
+
+    /* black level of DOL mode */
+    else
+    {
+        pstBlackLevel->au16BlackLevel[0] = 0xF0;
+        pstBlackLevel->au16BlackLevel[1] = 0xF0;
+        pstBlackLevel->au16BlackLevel[2] = 0xF0;
+        pstBlackLevel->au16BlackLevel[3] = 0xF0;
+    }
+          
+
+    return 0;  
+    
+}
+
+HI_VOID cmos_set_pixel_detect(ISP_DEV IspDev,HI_BOOL bEnable)
+{
+    
+    HI_U32 u32FullLines_5Fps, u32MaxIntTime_5Fps;
+    
+    if (WDR_MODE_2To1_LINE == g_apstSnsState[IspDev]->enWDRMode)
+    {
+        return;
+    }
+
+    else if(WDR_MODE_3To1_LINE == g_apstSnsState[IspDev]->enWDRMode)
+    {
+        return;
+    }
+
+    else
+    {
+        if (IMX327_SENSOR_1080P_30FPS_LINEAR_MODE == g_apstSnsState[IspDev]->u8ImgMode)
+        {
+            u32FullLines_5Fps = (IMX327_VMAX_1080P30_LINEAR * 30) / 5;
+        }
+        
+        else
+        {
+            return;
+        }
+    }
+
+    //u32FullLines_5Fps = (u32FullLines_5Fps > IMX327_FULL_LINES_MAX) ? IMX327_FULL_LINES_MAX : u32FullLines_5Fps;
+    u32MaxIntTime_5Fps = 4;
+
+    if (bEnable) /* setup for ISP pixel calibration mode */
+    {
+        imx327_write_register (IspDev,IMX327_GAIN_ADDR,0x00);
+        
+        imx327_write_register (IspDev,IMX327_VMAX_ADDR, u32FullLines_5Fps & 0xFF); 
+        imx327_write_register (IspDev,IMX327_VMAX_ADDR + 1, (u32FullLines_5Fps & 0xFF00) >> 8); 
+        imx327_write_register (IspDev,IMX327_VMAX_ADDR + 2, (u32FullLines_5Fps & 0xF0000) >> 16);
+
+        imx327_write_register (IspDev,IMX327_SHS1_ADDR, u32MaxIntTime_5Fps & 0xFF);
+        imx327_write_register (IspDev,IMX327_SHS1_ADDR + 1,  (u32MaxIntTime_5Fps & 0xFF00) >> 8); 
+        imx327_write_register (IspDev,IMX327_SHS1_ADDR + 2, (u32MaxIntTime_5Fps & 0xF0000) >> 16); 
+          
+    }
+    else /* setup for ISP 'normal mode' */
+    {
+        g_apstSnsState[IspDev]->u32FLStd = (g_apstSnsState[IspDev]->u32FLStd > 0x1FFFF) ? 0x1FFFF : g_apstSnsState[IspDev]->u32FLStd;
+        imx327_write_register (IspDev,IMX327_VMAX_ADDR, g_apstSnsState[IspDev]->u32FLStd & 0xFF); 
+        imx327_write_register (IspDev,IMX327_VMAX_ADDR + 1, (g_apstSnsState[IspDev]->u32FLStd & 0xFF00) >> 8); 
+        imx327_write_register (IspDev,IMX327_VMAX_ADDR + 2, (g_apstSnsState[IspDev]->u32FLStd & 0xF0000) >> 16);
+        g_apstSnsState[IspDev]->bSyncInit = HI_FALSE;
+    }
+
+    return;
+}
+
+HI_VOID cmos_set_wdr_mode(ISP_DEV IspDev,HI_U8 u8Mode)                                          
+{                                                                                
+    g_apstSnsState[IspDev]->bSyncInit = HI_FALSE;                                                          
+                                                                                 
+    switch(u8Mode)                                                               
+    {                                                                            
+        case WDR_MODE_NONE:                                                      
+            g_apstSnsState[IspDev]->enWDRMode = WDR_MODE_NONE;                                       
+            g_apstSnsState[IspDev]->u32FLStd = IMX327_VMAX_1080P30_LINEAR;
+            g_apstSnsState[IspDev]->u8ImgMode = IMX327_SENSOR_1080P_30FPS_LINEAR_MODE;
+            g_astimx327State[IspDev].u8Hcg = 0x2;
+            printf("linear mode\n");                                             
+        break;                                                                   
+                                                                                 
+        case WDR_MODE_2To1_LINE:                                                 
+            g_apstSnsState[IspDev]->enWDRMode = WDR_MODE_2To1_LINE;                                  
+            g_apstSnsState[IspDev]->u32FLStd = (IMX327_VMAX_1080P60TO30_WDR * 60) / 25;
+            g_apstSnsState[IspDev]->u8ImgMode = IMX327_SENSOR_1080P_30FPS_2t1_WDR_MODE;
+            g_astimx327State[IspDev].u32BRL = 1109;
+            g_astimx327State[IspDev].u8Hcg = 0x1;
+            printf("2to1 line WDR 1080p mode(60fps->30fps)\n");
+       break;                                                                   
+
+
+        case WDR_MODE_3To1_LINE:                                                 
+            g_apstSnsState[IspDev]->enWDRMode = WDR_MODE_3To1_LINE;                                  
+            g_apstSnsState[IspDev]->u32FLStd = (IMX327_VMAX_1080P120TO30_WDR * 120) / 25; 
+            g_apstSnsState[IspDev]->u8ImgMode = IMX327_SENSOR_1080P_30FPS_3t1_WDR_MODE;
+            g_astimx327State[IspDev].u32BRL = 1109;
+            g_astimx327State[IspDev].u8Hcg = 0x0;
+            printf("3to1 line WDR 1080p mode(120fps->30fps)\n");
+        break; 
+                                                                                 
+        default:                                                                 
+            printf("NOT support this mode!\n");                                  
+            return;                                                              
+        break;                                                                   
+    }  
+
+    g_apstSnsState[IspDev]->au32FL[0]= g_apstSnsState[IspDev]->u32FLStd;
+    g_apstSnsState[IspDev]->au32FL[1] = g_apstSnsState[IspDev]->au32FL[0];
+    memset(g_apstSnsState[IspDev]->au32WDRIntTime, 0, sizeof(g_apstSnsState[IspDev]->au32WDRIntTime));
+    
+    return;                                                                      
+}                                                                                
+
+HI_U32 cmos_get_sns_regs_info(ISP_DEV IspDev,ISP_SNS_REGS_INFO_S *pstSnsRegsInfo)
+{
+    HI_S32 i;
+
+    if (HI_NULL == pstSnsRegsInfo)
+    {
+        printf("null pointer when get sns reg info!\n");
+        return -1;
+    }
+
+    if ((HI_FALSE == g_apstSnsState[IspDev]->bSyncInit) || (HI_FALSE == pstSnsRegsInfo->bConfig))
+    {
+        g_apstSnsState[IspDev]->astRegsInfo[0].enSnsType = ISP_SNS_I2C_TYPE;
+        g_apstSnsState[IspDev]->astRegsInfo[0].unComBus.s8I2cDev = g_aunImx327BusInfo[IspDev].s8I2cDev;        
+        g_apstSnsState[IspDev]->astRegsInfo[0].u8Cfg2ValidDelayMax = 2;
+        g_apstSnsState[IspDev]->astRegsInfo[0].u32RegNum = 8;
+
+        if (WDR_MODE_2To1_LINE == g_apstSnsState[IspDev]->enWDRMode)                                                                
+        {                                                                                                       
+           g_apstSnsState[IspDev]->astRegsInfo[0].u32RegNum += 8; 
+           g_apstSnsState[IspDev]->astRegsInfo[0].u8Cfg2ValidDelayMax = 2;                                                            
+        }                                                                                                       
+
+        else if ((WDR_MODE_2To1_FRAME_FULL_RATE == g_apstSnsState[IspDev]->enWDRMode) || (WDR_MODE_2To1_FRAME == g_apstSnsState[IspDev]->enWDRMode))    
+        {                                                                                                       
+           g_apstSnsState[IspDev]->astRegsInfo[0].u32RegNum += 3;                                                                     
+           g_apstSnsState[IspDev]->astRegsInfo[0].u8Cfg2ValidDelayMax = 2;                                                            
+        }
+
+        else if (WDR_MODE_3To1_LINE == g_apstSnsState[IspDev]->enWDRMode)                                                                
+        {                                                                                                       
+           g_apstSnsState[IspDev]->astRegsInfo[0].u32RegNum += 14;
+           g_apstSnsState[IspDev]->astRegsInfo[0].u8Cfg2ValidDelayMax = 2;                                                            
+        } 
+
+
+        for (i=0; i<g_apstSnsState[IspDev]->astRegsInfo[0].u32RegNum; i++)
+        {
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[i].bUpdate = HI_TRUE;
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[i].u8DevAddr = imx327_i2c_addr;
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[i].u32AddrByteNum = imx327_addr_byte;
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[i].u32DataByteNum = imx327_data_byte;
+        }
+
+        //Linear Mode Regs
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[0].u8DelayFrmNum = 0;
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[0].u32RegAddr = IMX327_SHS1_ADDR;       
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[1].u8DelayFrmNum = 0;
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[1].u32RegAddr = IMX327_SHS1_ADDR + 1;        
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[2].u8DelayFrmNum = 0;
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[2].u32RegAddr = IMX327_SHS1_ADDR + 2;   
+     
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[3].u8DelayFrmNum = 0;       //make shutter and gain effective at the same time
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[3].u32RegAddr = IMX327_GAIN_ADDR;  //gain     
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[4].u8DelayFrmNum = 1;       
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[4].u32RegAddr = IMX327_HCG_ADDR;    
+        
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[5].u8DelayFrmNum = 0;
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[5].u32RegAddr = IMX327_VMAX_ADDR;
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[6].u8DelayFrmNum = 0;
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[6].u32RegAddr = IMX327_VMAX_ADDR + 1;
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[7].u8DelayFrmNum = 0;
+        g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[7].u32RegAddr = IMX327_VMAX_ADDR + 2;
+
+        //DOL 2t1 Mode Regs
+        if (WDR_MODE_2To1_LINE == g_apstSnsState[IspDev]->enWDRMode)                                                               
+        {
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[0].u8DelayFrmNum = 0;
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[1].u8DelayFrmNum = 0;
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[2].u8DelayFrmNum = 0;
+            
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[5].u8DelayFrmNum = 0;                                                   
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[5].u32RegAddr = IMX327_SHS2_ADDR;                                              
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[6].u8DelayFrmNum = 0;                                                   
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[6].u32RegAddr = IMX327_SHS2_ADDR + 1;                                          
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[7].u8DelayFrmNum = 0;                                                   
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[7].u32RegAddr = IMX327_SHS2_ADDR + 2; 
+                                                                          
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[8].u8DelayFrmNum = 1;                                                   
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[8].u32RegAddr = IMX327_VMAX_ADDR;                                              
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[9].u8DelayFrmNum = 1;                                                   
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[9].u32RegAddr = IMX327_VMAX_ADDR + 1;                                          
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[10].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[10].u32RegAddr = IMX327_VMAX_ADDR + 2; 
+                                                                                          
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[11].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[11].u32RegAddr = IMX327_RHS1_ADDR;                                             
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[12].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[12].u32RegAddr = IMX327_RHS1_ADDR + 1;                                         
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[13].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[13].u32RegAddr = IMX327_RHS1_ADDR + 2; 
+
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[14].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[14].u32RegAddr = IMX327_Y_OUT_SIZE_ADDR;                                             
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[15].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[15].u32RegAddr = IMX327_Y_OUT_SIZE_ADDR + 1; 
+
+         }  
+
+        //DOL 3t1 Mode Regs
+        else if (WDR_MODE_3To1_LINE == g_apstSnsState[IspDev]->enWDRMode)                                                               
+        {
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[0].u8DelayFrmNum = 0;
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[1].u8DelayFrmNum = 0;
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[2].u8DelayFrmNum = 0;
+                       
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[5].u8DelayFrmNum = 0;                                                   
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[5].u32RegAddr = IMX327_SHS2_ADDR;                                              
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[6].u8DelayFrmNum = 0;                                                   
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[6].u32RegAddr = IMX327_SHS2_ADDR + 1;                                          
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[7].u8DelayFrmNum = 0;                                                   
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[7].u32RegAddr = IMX327_SHS2_ADDR + 2; 
+                                                                          
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[8].u8DelayFrmNum = 1;                                                   
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[8].u32RegAddr = IMX327_VMAX_ADDR;                                              
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[9].u8DelayFrmNum = 1;                                                   
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[9].u32RegAddr = IMX327_VMAX_ADDR + 1;                                          
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[10].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[10].u32RegAddr = IMX327_VMAX_ADDR + 2; 
+                                                                                   
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[11].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[11].u32RegAddr = IMX327_RHS1_ADDR;                                             
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[12].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[12].u32RegAddr = IMX327_RHS1_ADDR + 1;                                         
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[13].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[13].u32RegAddr = IMX327_RHS1_ADDR + 2; 
+
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[14].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[14].u32RegAddr = IMX327_RHS2_ADDR;                                             
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[15].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[15].u32RegAddr = IMX327_RHS2_ADDR + 1;                                         
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[16].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[16].u32RegAddr = IMX327_RHS2_ADDR + 2; 
+
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[17].u8DelayFrmNum = 0;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[17].u32RegAddr = IMX327_SHS3_ADDR;                                             
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[18].u8DelayFrmNum = 0;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[18].u32RegAddr = IMX327_SHS3_ADDR + 1;                                         
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[19].u8DelayFrmNum = 0;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[19].u32RegAddr = IMX327_SHS3_ADDR + 2; 
+
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[20].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[20].u32RegAddr = IMX327_Y_OUT_SIZE_ADDR;                                             
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[21].u8DelayFrmNum = 1;                                                  
+            g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[21].u32RegAddr = IMX327_Y_OUT_SIZE_ADDR + 1; 
+
+         } 
+        
+         g_apstSnsState[IspDev]->bSyncInit = HI_TRUE;                                                                                                       
+                                                                       
+
+    }
+    else
+    {
+        for (i=0; i<g_apstSnsState[IspDev]->astRegsInfo[0].u32RegNum; i++)
+        {
+            if (g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[i].u32Data == g_apstSnsState[IspDev]->astRegsInfo[1].astI2cData[i].u32Data)
+            {
+                g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[i].bUpdate = HI_FALSE;
+            }
+            
+            else
+            {
+                g_apstSnsState[IspDev]->astRegsInfo[0].astI2cData[i].bUpdate = HI_TRUE;
+            }
+        }
+    }
+
+    pstSnsRegsInfo->bConfig = HI_FALSE;
+    memcpy(pstSnsRegsInfo, &g_apstSnsState[IspDev]->astRegsInfo[0], sizeof(ISP_SNS_REGS_INFO_S)); 
+    memcpy(&g_apstSnsState[IspDev]->astRegsInfo[1], &g_apstSnsState[IspDev]->astRegsInfo[0], sizeof(ISP_SNS_REGS_INFO_S)); 
+
+    g_apstSnsState[IspDev]->au32FL[1] = g_apstSnsState[IspDev]->au32FL[0];
+
+    return 0;
+}
+
+HI_S32 cmos_set_image_mode(ISP_DEV IspDev,ISP_CMOS_SENSOR_IMAGE_MODE_S *pstSensorImageMode)
+{
+    HI_U8 u8SensorImageMode = g_apstSnsState[IspDev]->u8ImgMode;
+    
+    g_apstSnsState[IspDev]->bSyncInit = HI_FALSE; 
+        
+    if (HI_NULL == pstSensorImageMode )
+    {
+        printf("null pointer when set image mode\n");
+        return -1;
+    }
+
+    if ((pstSensorImageMode->u16Width <= 1920) && (pstSensorImageMode->u16Height <= 1080)) 
+    {
+    }  
+    else
+    {
+        printf("Not support! Width:%d, Height:%d, Fps:%f, WDRMode:%d\n", 
+            pstSensorImageMode->u16Width, 
+            pstSensorImageMode->u16Height,
+            pstSensorImageMode->f32Fps,
+            g_apstSnsState[IspDev]->enWDRMode);
+
+        return -1;
+    }
+
+    if ((HI_TRUE == g_apstSnsState[IspDev]->bInit) && (u8SensorImageMode == g_apstSnsState[IspDev]->u8ImgMode))     
+    {                                                                              
+        /* Don't need to switch SensorImageMode */                                 
+        return -1;                                                                 
+    }                                                                              
+
+    return 0;
+}
+
+HI_VOID sensor_global_init(ISP_DEV IspDev)
+{     
+    g_apstSnsState[IspDev]->bInit = HI_FALSE; 
+    g_apstSnsState[IspDev]->bSyncInit = HI_FALSE;
+    g_apstSnsState[IspDev]->u8ImgMode = IMX327_SENSOR_1080P_30FPS_LINEAR_MODE;
+    g_apstSnsState[IspDev]->enWDRMode = WDR_MODE_NONE;
+    g_apstSnsState[IspDev]->u32FLStd = IMX327_VMAX_1080P30_LINEAR;
+    g_apstSnsState[IspDev]->au32FL[0] = IMX327_VMAX_1080P30_LINEAR;
+    g_apstSnsState[IspDev]->au32FL[1] = IMX327_VMAX_1080P30_LINEAR;
+
+    memset(&g_apstSnsState[IspDev]->astRegsInfo[0], 0, sizeof(ISP_SNS_REGS_INFO_S));
+    memset(&g_apstSnsState[IspDev]->astRegsInfo[1], 0, sizeof(ISP_SNS_REGS_INFO_S));
+}
+
+HI_S32 cmos_init_sensor_exp_function(ISP_SENSOR_EXP_FUNC_S *pstSensorExpFunc)
+{
+    memset(pstSensorExpFunc, 0, sizeof(ISP_SENSOR_EXP_FUNC_S));
+
+    pstSensorExpFunc->pfn_cmos_sensor_init = imx327_init;
+    pstSensorExpFunc->pfn_cmos_sensor_exit = imx327_exit;
+    pstSensorExpFunc->pfn_cmos_sensor_global_init = sensor_global_init;
+    pstSensorExpFunc->pfn_cmos_set_image_mode = cmos_set_image_mode;
+    pstSensorExpFunc->pfn_cmos_set_wdr_mode = cmos_set_wdr_mode;
+    
+    pstSensorExpFunc->pfn_cmos_get_isp_default = cmos_get_isp_default;
+    pstSensorExpFunc->pfn_cmos_get_isp_black_level = cmos_get_isp_black_level;
+    pstSensorExpFunc->pfn_cmos_set_pixel_detect = cmos_set_pixel_detect;
+    pstSensorExpFunc->pfn_cmos_get_sns_reg_info = cmos_get_sns_regs_info;
+
+    return 0;
+}
+
+/****************************************************************************
+ * callback structure                                                       *
+ ****************************************************************************/
+
+int imx327_set_bus_info(ISP_DEV IspDev, ISP_SNS_COMMBUS_U unSNSBusInfo)
+{
+    g_aunImx327BusInfo[IspDev].s8I2cDev = unSNSBusInfo.s8I2cDev;
+
+    return 0;
+}
+
+int sensor_register_callback(ISP_DEV IspDev, ALG_LIB_S *pstAeLib, ALG_LIB_S *pstAwbLib)
+{
+    HI_S32 s32Ret;
+    ISP_SENSOR_REGISTER_S stIspRegister;
+    AE_SENSOR_REGISTER_S  stAeRegister;
+    AWB_SENSOR_REGISTER_S stAwbRegister;
+
+    cmos_init_sensor_exp_function(&stIspRegister.stSnsExp);
+    s32Ret = HI_MPI_ISP_SensorRegCallBack(IspDev, IMX327_ID, &stIspRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function failed!\n");
+        return s32Ret;
+    }
+    
+    cmos_init_ae_exp_function(&stAeRegister.stSnsExp);
+    s32Ret = HI_MPI_AE_SensorRegCallBack(IspDev, pstAeLib, IMX327_ID, &stAeRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    cmos_init_awb_exp_function(&stAwbRegister.stSnsExp);
+    s32Ret = HI_MPI_AWB_SensorRegCallBack(IspDev, pstAwbLib, IMX327_ID, &stAwbRegister);
+    if (s32Ret)
+    {
+        printf("sensor register callback function to awb lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_unregister_callback(ISP_DEV IspDev, ALG_LIB_S *pstAeLib, ALG_LIB_S *pstAwbLib)
+{
+    HI_S32 s32Ret;
+
+    s32Ret = HI_MPI_ISP_SensorUnRegCallBack(IspDev, IMX327_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function failed!\n");
+        return s32Ret;
+    }
+    
+    s32Ret = HI_MPI_AE_SensorUnRegCallBack(IspDev, pstAeLib, IMX327_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to ae lib failed!\n");
+        return s32Ret;
+    }
+
+    s32Ret = HI_MPI_AWB_SensorUnRegCallBack(IspDev, pstAwbLib, IMX327_ID);
+    if (s32Ret)
+    {
+        printf("sensor unregister callback function to awb lib failed!\n");
+        return s32Ret;
+    }
+    
+    return 0;
+}
+
+int sensor_set_init(ISP_DEV IspDev, ISP_INIT_ATTR_S *pstInitAttr)
+{
+    g_au32InitExposure[IspDev] = pstInitAttr->u32Exposure;
+    g_au32LinesPer500ms[IspDev] = pstInitAttr->u32LinesPer500ms;
+    g_au16InitWBGain[IspDev][0] = pstInitAttr->u16WBRgain;
+    g_au16InitWBGain[IspDev][1] = pstInitAttr->u16WBGgain;
+    g_au16InitWBGain[IspDev][2] = pstInitAttr->u16WBBgain;
+    g_au16SampleRgain[IspDev] = pstInitAttr->u16SampleRgain;
+    g_au16SampleBgain[IspDev] = pstInitAttr->u16SampleBgain;
+    
+    return 0;
+}
+
+ISP_SNS_OBJ_S stSnsImx327Obj = 
+{
+    .pfnRegisterCallback    = sensor_register_callback,
+    .pfnUnRegisterCallback  = sensor_unregister_callback,
+    .pfnStandby             = imx327_standby,
+    .pfnRestart             = imx327_restart,
+    .pfnWriteReg            = imx327_write_register,
+    .pfnReadReg             = imx327_read_register,
+    .pfnSetBusInfo          = imx327_set_bus_info,
+    .pfnSetInit             = sensor_set_init
+};
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#endif /* __IMX327_CMOS_H_ */

--- a/libraries/sensor/hi3519v101/sony_imx327/imx327_sensor_ctl.c
+++ b/libraries/sensor/hi3519v101/sony_imx327/imx327_sensor_ctl.c
@@ -1,0 +1,1364 @@
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "hi_comm_video.h"
+#include "hi_sns_ctrl.h"
+
+#ifdef HI_GPIO_I2C
+#include "gpioi2c_ex.h"
+#else
+#include "hi_i2c.h"
+#endif
+
+const unsigned char imx327_i2c_addr     =    0x34;        /* I2C Address of IMX327 */
+const unsigned int  imx327_addr_byte    =    2;
+const unsigned int  imx327_data_byte    =    1;
+static int g_fd[ISP_MAX_DEV_NUM] = {-1, -1};
+
+extern ISP_SNS_STATE_S              g_astimx327[ISP_MAX_DEV_NUM];
+extern ISP_SNS_COMMBUS_U      g_aunImx327BusInfo[];
+
+
+//sensor fps mode
+#define IMX327_SENSOR_1080P_30FPS_LINEAR_MODE      (1)
+#define IMX327_SENSOR_1080P_30FPS_3t1_WDR_MODE     (2)
+#define IMX327_SENSOR_1080P_30FPS_2t1_WDR_MODE     (3)
+
+int imx327_i2c_init(ISP_DEV IspDev)
+{
+    char acDevFile[16] = {0};
+    HI_U8 u8DevNum;
+    
+    if(g_fd[IspDev] >= 0)
+    {
+        return 0;
+    }    
+#ifdef HI_GPIO_I2C
+    int ret;
+
+    g_fd[IspDev] = open("/dev/gpioi2c_ex", 0);
+    if(g_fd[IspDev] < 0)
+    {
+        printf("Open gpioi2c_ex error!\n");
+        return -1;
+    }
+#else
+    int ret;
+
+    u8DevNum = g_aunImx327BusInfo[IspDev].s8I2cDev;
+    snprintf_s(acDevFile, sizeof(acDevFile), sizeof(acDevFile)-1, "/dev/i2c-%d", u8DevNum);
+    
+    g_fd[IspDev] = open(acDevFile, O_RDWR);
+    if(g_fd[IspDev] < 0)
+    {
+        printf("Open /dev/i2c-%d error!\n", IspDev);
+        return -1;
+    }
+
+    ret = ioctl(g_fd[IspDev], I2C_SLAVE_FORCE, (imx327_i2c_addr>>1));
+    if (ret < 0)
+    {
+        printf("CMD_SET_DEV error!\n");
+        return ret;
+    }
+#endif
+
+    return 0;
+}
+
+int imx327_i2c_exit(ISP_DEV IspDev)
+{
+    if (g_fd[IspDev] >= 0)
+    {
+        close(g_fd[IspDev]);
+        g_fd[IspDev] = -1;
+        return 0;
+    }
+    return -1;
+}
+
+int imx327_read_register(ISP_DEV IspDev,int addr)
+{
+    // TODO: 
+    
+    return 0;
+}
+
+#ifdef __HuaweiLite__
+int imx327_write_register(ISP_DEV IspDev,int addr, int data)
+{
+    if (0 > g_fd[IspDev])
+    {
+        return 0;
+    }
+#ifdef HI_GPIO_I2C
+    i2c_data.dev_addr = imx327_i2c_addr;
+    i2c_data.reg_addr = addr;
+    i2c_data.addr_byte_num = imx327_addr_byte;
+    i2c_data.data = data;
+    i2c_data.data_byte_num = imx327_data_byte;
+    ret = ioctl(g_fd[IspDev], GPIO_I2C_WRITE, &i2c_data);
+    if (ret)
+    {
+        printf("GPIO-I2C write faild!\n");
+        return ret;
+    }
+#else
+    int idx = 0;
+    int ret;
+    char buf[8];
+    buf[idx++] = addr & 0xff;
+    if (imx327_addr_byte == 2)
+    {
+        ret = ioctl(g_fd[IspDev], I2C_16BIT_REG, 1);
+        buf[idx++] = (addr >> 8) & 0xff;
+    }
+    else
+    {
+        //ret = ioctl(g_fd[IspDev], I2C_16BIT_REG, 0);
+    }
+    buf[idx++] = data & 0xff;
+    if (imx327_data_byte == 2)
+    {
+        //ret = ioctl(g_fd[IspDev], I2C_16BIT_DATA, 1);
+        //buf[idx++] = (data >> 8) & 0xff;
+    }
+    else
+    {
+        ret = ioctl(g_fd[IspDev], I2C_16BIT_DATA, 0);
+    }
+    ret = write(g_fd[IspDev], buf, imx327_addr_byte + imx327_data_byte);
+    if(ret < 0)
+    {
+        printf("I2C_WRITE error!\n");
+        return -1;
+    }
+#endif
+    return 0;
+}
+#else
+int imx327_write_register(ISP_DEV IspDev,int addr, int data)
+{
+    if (0 > g_fd[IspDev])
+    {
+        return 0;
+    }
+
+#ifdef HI_GPIO_I2C
+    i2c_data.dev_addr = imx327_i2c_addr;
+    i2c_data.reg_addr = addr;
+    i2c_data.addr_byte_num = imx327_addr_byte;
+    i2c_data.data = data;
+    i2c_data.data_byte_num = imx327_data_byte;
+
+    ret = ioctl(g_fd[IspDev], GPIO_I2C_WRITE, &i2c_data);
+
+    if (ret)
+    {
+        printf("GPIO-I2C write faild!\n");
+        return ret;
+    }
+#else
+    int idx = 0;
+    int ret;
+    char buf[8];
+
+    if (imx327_addr_byte == 2)
+    {
+        buf[idx] = (addr >> 8) & 0xff;
+        idx++;
+        buf[idx] = addr & 0xff;
+        idx++;
+    }
+    else
+    {
+        //buf[idx] = addr & 0xff;
+        //idx++;
+    }
+
+    if (imx327_data_byte == 2)
+    {
+        //buf[idx] = (data >> 8) & 0xff;
+        //idx++;
+        //buf[idx] = data & 0xff;
+        //idx++;
+    }
+    else
+    {
+        buf[idx] = data & 0xff;
+        idx++;
+    }
+    
+    ret = write(g_fd[IspDev], buf, imx327_addr_byte + imx327_data_byte);
+    if(ret < 0)
+    {
+        printf("I2C_WRITE error!\n");
+        return -1;
+    }
+
+#endif
+    return 0;
+}
+#endif
+
+static void delay_ms(int ms) { 
+    hi_usleep(ms*1000);
+}
+
+void imx327_prog(ISP_DEV IspDev,int* rom) 
+{
+    int i = 0;
+    while (1) {
+        int lookup = rom[i++];
+        int addr = (lookup >> 16) & 0xFFFF;
+        int data = lookup & 0xFFFF;
+        if (addr == 0xFFFE) {
+            delay_ms(data);
+        } else if (addr == 0xFFFF) {
+            return;
+        } else {
+            imx327_write_register(IspDev,addr, data);
+        }
+    }
+}
+
+void imx327_standby(ISP_DEV IspDev)
+{
+    // TODO:
+    return;
+}
+
+void imx327_restart(ISP_DEV IspDev)
+{
+    // TODO:
+    return;
+}
+
+void imx327_wdr_1080p30_2to1_init(ISP_DEV IspDev);
+void imx327_wdr_1080p60_2to1_init(ISP_DEV IspDev);
+void imx327_wdr_1080p120_2to1_init(ISP_DEV IspDev);
+void imx327_wdr_720p60_2to1_init(ISP_DEV IspDev);
+void imx327_wdr_1080p30_3to1_init(ISP_DEV IspDev);
+void imx327_wdr_1080p120_3to1_init(ISP_DEV IspDev);
+void imx327_wdr_720p60_3to1_init(ISP_DEV IspDev);
+void imx327_linear_1080p30_init(ISP_DEV IspDev);
+
+
+void imx327_init(ISP_DEV IspDev)
+{
+	HI_U32           i;
+    WDR_MODE_E       enWDRMode;
+    HI_BOOL          bInit;
+
+    bInit       = g_astimx327[IspDev].bInit;
+    enWDRMode   = g_astimx327[IspDev].enWDRMode;
+    imx327_i2c_init(IspDev);
+    
+    /* When sensor first init, config all registers */
+    if (HI_FALSE == bInit) 
+    {
+        if (WDR_MODE_2To1_LINE == enWDRMode)
+        {
+            imx327_wdr_1080p60_2to1_init(IspDev);
+        }
+        else if (WDR_MODE_3To1_LINE == enWDRMode)
+        {
+            imx327_wdr_1080p120_3to1_init(IspDev);
+        }
+        else
+        {
+            imx327_linear_1080p30_init(IspDev);
+        }
+    }
+    /* When sensor switch mode(linear<->WDR or resolution), config different registers(if possible) */
+    else 
+    {
+        if(WDR_MODE_2To1_LINE == enWDRMode)
+        {
+            imx327_wdr_1080p60_2to1_init(IspDev);
+        }
+        
+        else if(WDR_MODE_3To1_LINE == enWDRMode)
+        {
+            imx327_wdr_1080p120_3to1_init(IspDev);
+        }
+        
+        else
+        {
+            imx327_linear_1080p30_init(IspDev);
+        }       
+    }
+
+	for (i=0; i<g_astimx327[IspDev].astRegsInfo[0].u32RegNum; i++)
+	{
+		imx327_write_register(IspDev, g_astimx327[IspDev].astRegsInfo[0].astI2cData[i].u32RegAddr, g_astimx327[IspDev].astRegsInfo[0].astI2cData[i].u32Data);
+	}
+	
+    g_astimx327[IspDev].bInit = HI_TRUE;
+    return ;
+}
+
+void imx327_exit(ISP_DEV IspDev)
+{
+    imx327_i2c_exit(IspDev);
+
+    return;
+}
+
+
+/* 1080P30 and 1080P25 */
+void imx327_linear_1080p30_init(ISP_DEV IspDev)
+{
+    imx327_write_register (IspDev,0x3000, 0x01); /* standby */
+    imx327_write_register (IspDev,0x3002, 0x01); /* XTMSTA */
+    
+    imx327_write_register (IspDev,0x3005, 0x01); //ADBIT
+    imx327_write_register (IspDev,0x3129, 0x00); //ADBIT1
+    imx327_write_register (IspDev,0x317c, 0x00); //ADBIT2
+    imx327_write_register (IspDev,0x31ec, 0x0e); //ADBIT3
+    imx327_write_register (IspDev,0x3441, 0x0c); //CSI_DT_FMT
+    imx327_write_register (IspDev,0x3442, 0x0c); //CSI_DT_FMT
+    
+    imx327_write_register (IspDev,0x3007, 0x00);
+    imx327_write_register (IspDev,0x3009, 0x02);
+    imx327_write_register (IspDev,0x300a, 0x3C);
+    imx327_write_register (IspDev,0x300c, 0x00);
+    imx327_write_register (IspDev,0x300f, 0x00);
+    imx327_write_register (IspDev,0x3010, 0x21);
+    imx327_write_register (IspDev,0x3011, 0x02);
+    imx327_write_register (IspDev,0x3012, 0x64);
+    imx327_write_register (IspDev,0x3016, 0x09);
+    imx327_write_register (IspDev,0x3017, 0x00);
+
+    imx327_write_register (IspDev,0x3018, 0x65);
+    imx327_write_register (IspDev,0x3019, 0x04);
+
+    imx327_write_register (IspDev,0x301c, 0x30);
+    imx327_write_register (IspDev,0x301d, 0x11);
+
+#if 1
+    imx327_write_register (IspDev,0x3020, 0x01);  /* SHS1 */
+    imx327_write_register (IspDev,0x3021, 0x00);
+    imx327_write_register (IspDev,0x3024, 0x00);  /* SHS2 */ 
+    imx327_write_register (IspDev,0x3025, 0x00);
+    imx327_write_register (IspDev,0x3028, 0x00);  /* SHS3 */
+    imx327_write_register (IspDev,0x3029, 0x00);
+    imx327_write_register (IspDev,0x3030, 0x00);  /* RHS1 */
+    imx327_write_register (IspDev,0x3031, 0x00);
+    imx327_write_register (IspDev,0x3034, 0x00);  /* RHS2 */ 
+    imx327_write_register (IspDev,0x3035, 0x00);
+#else
+    imx327_write_register (IspDev,0x3020, 0x02);
+#endif
+
+    imx327_write_register (IspDev,0x3046, 0x01);
+
+    imx327_write_register (IspDev,0x305c, 0x18);
+    imx327_write_register (IspDev,0x305d, 0x03); 
+    imx327_write_register (IspDev,0x305e, 0x20); 
+    imx327_write_register (IspDev,0x305f, 0x01);
+    imx327_write_register (IspDev,0x3070, 0x02);
+    imx327_write_register (IspDev,0x3071, 0x11);
+    imx327_write_register (IspDev,0x309b, 0x10);
+    imx327_write_register (IspDev,0x309c, 0x22);
+    imx327_write_register (IspDev,0x309e, 0x4a);
+    imx327_write_register (IspDev,0x309f, 0x4a);
+    imx327_write_register (IspDev,0x30a2, 0x02);
+    imx327_write_register (IspDev,0x30a6, 0x20);
+    imx327_write_register (IspDev,0x30a8, 0x20);
+    imx327_write_register (IspDev,0x30aa, 0x20);
+    imx327_write_register (IspDev,0x30ac, 0x20);
+    
+    imx327_write_register (IspDev,0x30b0, 0x43);
+    imx327_write_register (IspDev,0x30d2, 0x19);
+    imx327_write_register (IspDev,0x30d7, 0x03);
+    imx327_write_register (IspDev,0x3119, 0x9e);
+    imx327_write_register (IspDev,0x311c, 0x1e);
+    imx327_write_register (IspDev,0x311e, 0x08);
+    imx327_write_register (IspDev,0x3128, 0x05);
+    imx327_write_register (IspDev,0x313b, 0x61);
+    imx327_write_register (IspDev,0x313d, 0x83);
+    imx327_write_register (IspDev,0x3150, 0x02); //03
+
+    imx327_write_register (IspDev,0x317e, 0x00);
+    imx327_write_register (IspDev,0x315e, 0x1a);
+    imx327_write_register (IspDev,0x3164, 0x1a);
+    //imx327_write_register (IspDev,0x32b8, 0x50);
+
+    //imx327_write_register (IspDev,0x32b9, 0x10);
+    //imx327_write_register (IspDev,0x32ba, 0x00);
+    //imx327_write_register (IspDev,0x32bb, 0x04);
+    //imx327_write_register (IspDev,0x32c8, 0x50);
+    //imx327_write_register (IspDev,0x32c9, 0x10);
+    //imx327_write_register (IspDev,0x32ca, 0x00);
+    //imx327_write_register (IspDev,0x32cb, 0x04);
+    //imx327_write_register (IspDev,0x332c, 0xd3);
+    //imx327_write_register (IspDev,0x332d, 0x10);
+    //imx327_write_register (IspDev,0x332e, 0x0d);
+    //imx327_write_register (IspDev,0x3358, 0x06);
+    //imx327_write_register (IspDev,0x3359, 0xe1);
+    //imx327_write_register (IspDev,0x335a, 0x11);
+    //imx327_write_register (IspDev,0x3360, 0x1e);
+    
+    //imx327_write_register (IspDev,0x3361, 0x61);
+    //imx327_write_register (IspDev,0x3362, 0x10);
+    //imx327_write_register (IspDev,0x33b0, 0x50);
+    //imx327_write_register (IspDev,0x33b2, 0x1a);
+    //imx327_write_register (IspDev,0x33b3, 0x04);
+    imx327_write_register (IspDev,0x3414, 0x0a);
+    imx327_write_register (IspDev,0x3418, 0x49);
+    imx327_write_register (IspDev,0x3419, 0x04);
+    imx327_write_register (IspDev,0x3444, 0x20);
+    imx327_write_register (IspDev,0x3445, 0x25);
+
+    imx327_write_register (IspDev,0x3446, 0x47);
+    imx327_write_register (IspDev,0x3447, 0x0);
+    imx327_write_register (IspDev,0x3448, 0x1f);
+    imx327_write_register (IspDev,0x3449, 0x0);
+    imx327_write_register (IspDev,0x344a, 0x17);
+    imx327_write_register (IspDev,0x344b, 0x0);
+    imx327_write_register (IspDev,0x344c, 0x0f);
+    imx327_write_register (IspDev,0x344d, 0x0);
+    imx327_write_register (IspDev,0x344e, 0x17);
+    imx327_write_register (IspDev,0x344f, 0x0);
+    imx327_write_register (IspDev,0x3450, 0x47);
+    imx327_write_register (IspDev,0x3451, 0x0);
+    imx327_write_register (IspDev,0x3452, 0x0f);
+    imx327_write_register (IspDev,0x3453, 0x0);
+    imx327_write_register (IspDev,0x3454, 0x0f);
+    imx327_write_register (IspDev,0x3455, 0x0);
+    imx327_write_register (IspDev,0x3472, 0xa0);
+    imx327_write_register (IspDev,0x3473, 0x07);
+    imx327_write_register (IspDev,0x347b, 0x23);
+    imx327_write_register (IspDev,0x3480, 0x49);
+
+    imx327_write_register (IspDev,0x3000, 0x00); /* standby */
+    delay_ms(20);
+    imx327_write_register (IspDev,0x3002, 0x00); /* master mode start */
+    imx327_write_register (IspDev,0x304b, 0x00); /* XVSOUTSEL XHSOUTSEL */
+    
+    printf("===IMX327 1080P 30fps 12bit LINE Init OK!===\n");    
+    return;
+}
+
+
+void imx327_wdr_1080p30_2to1_init(ISP_DEV IspDev)
+{
+    imx327_write_register (IspDev,0x3000, 0x01); /* standby */
+    imx327_write_register (IspDev,0x3002, 0x01); /* XTMSTA */
+
+    //10bit
+    imx327_write_register (IspDev,0x3005, 0x00);
+    imx327_write_register (IspDev,0x3007, 0x00);
+    imx327_write_register (IspDev,0x300a, 0x3c);
+    imx327_write_register (IspDev,0x300c, 0x11);
+    imx327_write_register (IspDev,0x300f, 0x00);
+    imx327_write_register (IspDev,0x3010, 0x21);
+    imx327_write_register (IspDev,0x3012, 0x64);
+    imx327_write_register (IspDev,0x3016, 0x09);
+
+    imx327_write_register (IspDev,0x3018, 0xA6);   /**** VMAX ****/
+    imx327_write_register (IspDev,0x3019, 0x04);
+    imx327_write_register (IspDev,0x301A, 0x00);
+
+    imx327_write_register (IspDev,0x301C, 0xD8);  /***** HMAX ****/
+    imx327_write_register (IspDev,0x301D, 0x0F);
+    
+    imx327_write_register (IspDev,0x3020, 0x02);
+    imx327_write_register (IspDev,0x3024, 0xc9);
+    imx327_write_register (IspDev,0x3030, 0x0b);
+    imx327_write_register (IspDev,0x3045, 0x05);
+    imx327_write_register (IspDev,0x3046, 0x00);
+    imx327_write_register (IspDev,0x304b, 0x0a);
+    imx327_write_register (IspDev,0x305c, 0x18);
+    imx327_write_register (IspDev,0x305d, 0x03);
+    imx327_write_register (IspDev,0x305e, 0x20);
+    imx327_write_register (IspDev,0x305f, 0x01);
+    imx327_write_register (IspDev,0x3070, 0x02);
+    imx327_write_register (IspDev,0x3071, 0x11);
+    imx327_write_register (IspDev,0x309b, 0x10);
+    imx327_write_register (IspDev,0x309c, 0x22);
+    imx327_write_register (IspDev,0x30a2, 0x02);
+    imx327_write_register (IspDev,0x30a6, 0x20);
+    imx327_write_register (IspDev,0x30a8, 0x20);
+    imx327_write_register (IspDev,0x30aa, 0x20);
+    imx327_write_register (IspDev,0x30ac, 0x20);
+    imx327_write_register (IspDev,0x30b0, 0x43);
+    imx327_write_register (IspDev,0x3106, 0x11);
+    imx327_write_register (IspDev,0x3119, 0x9e);
+    imx327_write_register (IspDev,0x311c, 0x1e);
+    imx327_write_register (IspDev,0x311e, 0x08);
+    imx327_write_register (IspDev,0x3128, 0x05);
+    imx327_write_register (IspDev,0x3129, 0x1d);
+    imx327_write_register (IspDev,0x313d, 0x83);
+    imx327_write_register (IspDev,0x3150, 0x03);
+    imx327_write_register (IspDev,0x315e, 0x1a);
+    imx327_write_register (IspDev,0x3164, 0x1a);
+    imx327_write_register (IspDev,0x317c, 0x12);
+    imx327_write_register (IspDev,0x317e, 0x00);
+    imx327_write_register (IspDev,0x31ec, 0x37);
+    imx327_write_register (IspDev,0x32b8, 0x50);
+    imx327_write_register (IspDev,0x32b9, 0x10);
+    imx327_write_register (IspDev,0x32ba, 0x00);
+    imx327_write_register (IspDev,0x32bb, 0x04);
+    imx327_write_register (IspDev,0x32c8, 0x50);
+    imx327_write_register (IspDev,0x32c9, 0x10);
+    imx327_write_register (IspDev,0x32ca, 0x00);
+    imx327_write_register (IspDev,0x32cb, 0x04);
+    imx327_write_register (IspDev,0x332c, 0xd3);
+    imx327_write_register (IspDev,0x332d, 0x10);
+    imx327_write_register (IspDev,0x332e, 0x0d);
+    imx327_write_register (IspDev,0x3358, 0x06);
+    imx327_write_register (IspDev,0x3359, 0xe1);
+    imx327_write_register (IspDev,0x335a, 0x11);
+    imx327_write_register (IspDev,0x3360, 0x1e);
+    imx327_write_register (IspDev,0x3361, 0x61);
+    imx327_write_register (IspDev,0x3362, 0x10);
+    imx327_write_register (IspDev,0x33b0, 0x50);
+    imx327_write_register (IspDev,0x33b2, 0x1a);
+    imx327_write_register (IspDev,0x33b3, 0x04);
+
+    imx327_write_register (IspDev,0x3418, 0xb2); /**** Y_OUT_SIZE *****/ 
+    imx327_write_register (IspDev,0x3419, 0x08);
+   
+    imx327_write_register (IspDev,0x3441, 0x0a);
+    imx327_write_register (IspDev,0x3442, 0x0a);
+    imx327_write_register (IspDev,0x3444, 0x20);
+    imx327_write_register (IspDev,0x3445, 0x25);
+    imx327_write_register (IspDev,0x3480, 0x49);
+ 
+    imx327_write_register (IspDev,0x3000, 0x00); /* standby */
+    delay_ms(20); 
+    imx327_write_register (IspDev,0x3002, 0x00); /* master mode start */
+ 
+    printf("===Imx327 sensor 1080P15fps 10bit 2to1 WDR(30fps->15fps) init success!=====\n");
+
+    return;
+    
+}
+
+void imx327_wdr_1080p60_2to1_init(ISP_DEV IspDev)
+{
+ #if 0   
+    imx327_write_register (IspDev,0x3000, 0x01); /* standby */
+    imx327_write_register (IspDev,0x3002, 0x00); /* XTMSTA */
+
+    imx327_write_register (IspDev,0x3005, 0x01);
+    imx327_write_register (IspDev,0x3007, 0x00);
+    imx327_write_register (IspDev,0x3009, 0x01);
+    imx327_write_register (IspDev,0x300a, 0xf0);
+    imx327_write_register (IspDev,0x300c, 0x11);
+    imx327_write_register (IspDev,0x300f, 0x00);
+    imx327_write_register (IspDev,0x3010, 0x21);
+    imx327_write_register (IspDev,0x3012, 0x64);
+    imx327_write_register (IspDev,0x3016, 0x09);
+    imx327_write_register (IspDev,0x3018, 0x65);
+    imx327_write_register (IspDev,0x3019, 0x04);
+
+    imx327_write_register (IspDev,0x301c, 0x98); /* HMAX */
+    imx327_write_register (IspDev,0x301d, 0x08); /* HMAX */
+
+    imx327_write_register (IspDev,0x3045, 0x05);
+    imx327_write_register (IspDev,0x3046, 0x01);
+    imx327_write_register (IspDev,0x304b, 0x0a);
+    
+    imx327_write_register (IspDev,0x305c, 0x18);
+    imx327_write_register (IspDev,0x305d, 0x03);
+    imx327_write_register (IspDev,0x305e, 0x20);
+    imx327_write_register (IspDev,0x305f, 0x01);
+    
+    imx327_write_register (IspDev,0x3070, 0x02);
+    imx327_write_register (IspDev,0x3071, 0x11);
+    
+    imx327_write_register (IspDev,0x309b, 0x10);
+    imx327_write_register (IspDev,0x309c, 0x22);
+    
+    imx327_write_register (IspDev,0x30a2, 0x02);
+    imx327_write_register (IspDev,0x30a6, 0x20);
+    imx327_write_register (IspDev,0x30a8, 0x20);
+    
+    imx327_write_register (IspDev,0x30aa, 0x20);
+    imx327_write_register (IspDev,0x30ac, 0x20);
+    imx327_write_register (IspDev,0x30b0, 0x43);
+
+    imx327_write_register (IspDev,0x3106, 0x11);
+    imx327_write_register (IspDev,0x3119, 0x9e);
+    imx327_write_register (IspDev,0x311c, 0x1e);
+    imx327_write_register (IspDev,0x311e, 0x08);
+    
+    imx327_write_register (IspDev,0x3128, 0x05);
+    imx327_write_register (IspDev,0x3129, 0x00);
+    imx327_write_register (IspDev,0x313d, 0x83);
+    imx327_write_register (IspDev,0x3150, 0x03);
+    
+    imx327_write_register (IspDev,0x315e, 0x1a);
+    imx327_write_register (IspDev,0x3164, 0x1a);
+    imx327_write_register (IspDev,0x317c, 0x00);
+    imx327_write_register (IspDev,0x317e, 0x00);
+    imx327_write_register (IspDev,0x31ec, 0x00);
+                                         
+    imx327_write_register (IspDev,0x32b8, 0x50);
+    imx327_write_register (IspDev,0x32b9, 0x10);
+    imx327_write_register (IspDev,0x32ba, 0x00);
+    imx327_write_register (IspDev,0x32bb, 0x04);
+    
+    imx327_write_register (IspDev,0x32c8, 0x50);
+    imx327_write_register (IspDev,0x32c9, 0x10);
+    imx327_write_register (IspDev,0x32ca, 0x00);
+    imx327_write_register (IspDev,0x32cb, 0x04);
+                                        
+    imx327_write_register (IspDev,0x332c, 0xd3);
+    imx327_write_register (IspDev,0x332d, 0x10);
+    imx327_write_register (IspDev,0x332e, 0x0d);
+    
+    imx327_write_register (IspDev,0x3358, 0x06);
+    imx327_write_register (IspDev,0x3359, 0xe1);
+    imx327_write_register (IspDev,0x335a, 0x11);
+    
+    imx327_write_register (IspDev,0x3360, 0x1e);
+    imx327_write_register (IspDev,0x3361, 0x61);
+    imx327_write_register (IspDev,0x3362, 0x10);
+    
+    imx327_write_register (IspDev,0x33b0, 0x50);
+    imx327_write_register (IspDev,0x33b2, 0x1a);
+    imx327_write_register (IspDev,0x33b3, 0x04);
+                                         
+    imx327_write_register (IspDev,0x3405, 0x10);
+    imx327_write_register (IspDev,0x3407, 0x03);
+    imx327_write_register (IspDev,0x3414, 0x0a);
+    imx327_write_register (IspDev,0x3415, 0x00);
+    imx327_write_register (IspDev,0x3418, 0xb2);
+    imx327_write_register (IspDev,0x3419, 0x08);
+    
+    imx327_write_register (IspDev,0x3441, 0x0c);
+    imx327_write_register (IspDev,0x3442, 0x0c);
+    imx327_write_register (IspDev,0x3443, 0x03);
+    imx327_write_register (IspDev,0x3444, 0x20);
+    imx327_write_register (IspDev,0x3445, 0x25);
+    imx327_write_register (IspDev,0x3446, 0x57);
+    imx327_write_register (IspDev,0x3447, 0x00);
+    imx327_write_register (IspDev,0x3448, 0x37);
+    imx327_write_register (IspDev,0x3449, 0x00);
+    imx327_write_register (IspDev,0x344a, 0x1f);
+    
+    imx327_write_register (IspDev,0x344b, 0x00);
+    imx327_write_register (IspDev,0x344c, 0x1f);
+    imx327_write_register (IspDev,0x344d, 0x00);
+    imx327_write_register (IspDev,0x344e, 0x1f);
+    imx327_write_register (IspDev,0x344f, 0x00);
+    imx327_write_register (IspDev,0x3450, 0x77);
+    imx327_write_register (IspDev,0x3451, 0x00);
+    imx327_write_register (IspDev,0x3452, 0x1f);
+    imx327_write_register (IspDev,0x3453, 0x00);
+    imx327_write_register (IspDev,0x3454, 0x17);
+    imx327_write_register (IspDev,0x3455, 0x00);
+    imx327_write_register (IspDev,0x3472, 0x9c);
+    imx327_write_register (IspDev,0x3473, 0x07);
+    imx327_write_register (IspDev,0x3480, 0x49);
+
+    imx327_write_register (IspDev,0x3000, 0x00); /* standby */
+    delay_ms(20); 
+    imx327_write_register (IspDev,0x3002, 0x00); /* master mode start */
+ 
+    printf("===Imx327 sensor 1080P30fps 12bit 2to1 WDR(60fps->30fps) init success!=====\n");
+
+    bSensorInit = HI_TRUE;
+
+    return;
+ #endif
+    imx327_write_register (IspDev,0x3000, 0x01); /* standby */
+    imx327_write_register (IspDev,0x3002, 0x01); /* XTMSTA */
+
+    imx327_write_register (IspDev,0x3005, 0x00);
+    imx327_write_register (IspDev,0x3007, 0x00);
+    imx327_write_register (IspDev,0x3009, 0x01);
+    imx327_write_register (IspDev,0x300a, 0x3c);
+    imx327_write_register (IspDev,0x300c, 0x11);
+    imx327_write_register (IspDev,0x300f, 0x00);
+    imx327_write_register (IspDev,0x3010, 0x21);
+    imx327_write_register (IspDev,0x3012, 0x64);
+    imx327_write_register (IspDev,0x3016, 0x09);
+    imx327_write_register (IspDev,0x3018, 0xC4); /* VMAX */
+    imx327_write_register (IspDev,0x3019, 0x04); /* VMAX */
+    imx327_write_register (IspDev,0x301c, 0xEC); /* HMAX */
+    imx327_write_register (IspDev,0x301d, 0x07); /* HMAX */
+
+#if 1
+    imx327_write_register (IspDev,0x3020, 0x03);  /* SHS1 */
+    imx327_write_register (IspDev,0x3021, 0x00);
+    //imx327_write_register (IspDev,0x3022, 0x00);
+    imx327_write_register (IspDev,0x3024, 0x99);  /* SHS2 */ 
+    imx327_write_register (IspDev,0x3025, 0x00);
+    //imx327_write_register (IspDev,0x3025, 0x00);
+    imx327_write_register (IspDev,0x3028, 0x00);  /* SHS3 */
+    imx327_write_register (IspDev,0x3029, 0x00);
+    //imx327_write_register (IspDev,0x302A, 0x00);
+    imx327_write_register (IspDev,0x3030, 0x93);  /* RHS1 */
+    imx327_write_register (IspDev,0x3031, 0x00);
+    imx327_write_register (IspDev,0x3034, 0x00);  /* RHS2 */ 
+    imx327_write_register (IspDev,0x3035, 0x00);
+#endif
+    
+    imx327_write_register (IspDev,0x3045, 0x05);
+    imx327_write_register (IspDev,0x3046, 0x00);
+    imx327_write_register (IspDev,0x304b, 0x0a);
+    imx327_write_register (IspDev,0x305c, 0x18);
+    imx327_write_register (IspDev,0x305d, 0x03);
+    imx327_write_register (IspDev,0x305e, 0x20);
+    imx327_write_register (IspDev,0x305f, 0x01);
+    imx327_write_register (IspDev,0x3070, 0x02);
+    imx327_write_register (IspDev,0x3071, 0x11);
+    imx327_write_register (IspDev,0x309b, 0x10);
+    imx327_write_register (IspDev,0x309c, 0x22);
+    imx327_write_register (IspDev,0x30a2, 0x02);
+    imx327_write_register (IspDev,0x30a6, 0x20);
+    imx327_write_register (IspDev,0x30a8, 0x20);
+    imx327_write_register (IspDev,0x30aa, 0x20);
+    imx327_write_register (IspDev,0x30ac, 0x20);
+    imx327_write_register (IspDev,0x30b0, 0x43);
+
+    imx327_write_register (IspDev,0x3106, 0x11); 
+    imx327_write_register (IspDev,0x3119, 0x9e);
+    imx327_write_register (IspDev,0x311c, 0x1e);
+    imx327_write_register (IspDev,0x311e, 0x08);
+    imx327_write_register (IspDev,0x3128, 0x05);
+    imx327_write_register (IspDev,0x3129, 0x1d);
+    imx327_write_register (IspDev,0x313d, 0x83);
+    imx327_write_register (IspDev,0x3150, 0x03);
+    imx327_write_register (IspDev,0x315e, 0x1a);
+    imx327_write_register (IspDev,0x3164, 0x1a);
+    imx327_write_register (IspDev,0x317c, 0x12);
+    imx327_write_register (IspDev,0x317e, 0x00);
+    imx327_write_register (IspDev,0x31ec, 0x37);
+                                         
+    imx327_write_register (IspDev,0x32b8, 0x50);
+    imx327_write_register (IspDev,0x32b9, 0x10);
+    imx327_write_register (IspDev,0x32ba, 0x00);
+    imx327_write_register (IspDev,0x32bb, 0x04);
+    imx327_write_register (IspDev,0x32c8, 0x50);
+    imx327_write_register (IspDev,0x32c9, 0x10);
+    imx327_write_register (IspDev,0x32ca, 0x00);
+    imx327_write_register (IspDev,0x32cb, 0x04);
+                                        
+    imx327_write_register (IspDev,0x332c, 0xd3);
+    imx327_write_register (IspDev,0x332d, 0x10);
+    imx327_write_register (IspDev,0x332e, 0x0d);
+    imx327_write_register (IspDev,0x3358, 0x06);
+    imx327_write_register (IspDev,0x3359, 0xe1);
+    imx327_write_register (IspDev,0x335a, 0x11);
+    imx327_write_register (IspDev,0x3360, 0x1e);
+    imx327_write_register (IspDev,0x3361, 0x61);
+    imx327_write_register (IspDev,0x3362, 0x10);
+    imx327_write_register (IspDev,0x33b0, 0x50);
+    imx327_write_register (IspDev,0x33b2, 0x1a);
+    imx327_write_register (IspDev,0x33b3, 0x04);
+                                         
+    imx327_write_register (IspDev,0x3405, 0x10);
+    imx327_write_register (IspDev,0x3407, 0x03);
+    imx327_write_register (IspDev,0x3414, 0x0a);
+    imx327_write_register (IspDev,0x3415, 0x00);
+    imx327_write_register (IspDev,0x3418, 0x32);  /* Y_OUT_SIZE */
+    imx327_write_register (IspDev,0x3419, 0x09);  /* Y_OUT_SIZE */
+    imx327_write_register (IspDev,0x3441, 0x0a);
+    imx327_write_register (IspDev,0x3442, 0x0a);
+    imx327_write_register (IspDev,0x3443, 0x03);
+    imx327_write_register (IspDev,0x3444, 0x20);
+    imx327_write_register (IspDev,0x3445, 0x25);
+    imx327_write_register (IspDev,0x3446, 0x57);
+    imx327_write_register (IspDev,0x3447, 0x00);
+    imx327_write_register (IspDev,0x3448, 0x37);
+    imx327_write_register (IspDev,0x3449, 0x00);
+    imx327_write_register (IspDev,0x344a, 0x1f);
+    imx327_write_register (IspDev,0x344b, 0x00);
+    imx327_write_register (IspDev,0x344c, 0x1f);
+    imx327_write_register (IspDev,0x344d, 0x00);
+    imx327_write_register (IspDev,0x344e, 0x1f);
+    imx327_write_register (IspDev,0x344f, 0x00);
+    imx327_write_register (IspDev,0x3450, 0x77);
+    imx327_write_register (IspDev,0x3451, 0x00);
+    imx327_write_register (IspDev,0x3452, 0x1f);
+    imx327_write_register (IspDev,0x3453, 0x00);
+    imx327_write_register (IspDev,0x3454, 0x17);
+    imx327_write_register (IspDev,0x3455, 0x00);
+    imx327_write_register (IspDev,0x3472, 0x9c);
+    imx327_write_register (IspDev,0x3473, 0x07);
+    imx327_write_register (IspDev,0x3480, 0x49);
+
+    imx327_write_register (IspDev,0x3000, 0x00); /* standby */
+    delay_ms(20); 
+    imx327_write_register (IspDev,0x3002, 0x00); /* master mode start */
+ 
+    printf("===Imx327 sensor 1080P30fps 10bit 2to1 WDR(60fps->30fps) init success!=====\n");
+
+    return;
+
+}
+
+void imx327_wdr_1080p30_3to1_init(ISP_DEV IspDev)
+{
+    imx327_write_register (IspDev,0x3000, 0x01); /* standby */
+    imx327_write_register (IspDev,0x3002, 0x01); /* XTMSTA */
+
+    //12bit
+    imx327_write_register (IspDev,0x3007, 0x00);
+    imx327_write_register (IspDev,0x300c, 0x21);
+    imx327_write_register (IspDev,0x300f, 0x00);
+    imx327_write_register (IspDev,0x3010, 0x21);
+    imx327_write_register (IspDev,0x3012, 0x64);
+    imx327_write_register (IspDev,0x3016, 0x09);
+    imx327_write_register (IspDev,0x3020, 0x04);
+    imx327_write_register (IspDev,0x3021, 0x00);
+    imx327_write_register (IspDev,0x3024, 0xF2);
+    imx327_write_register (IspDev,0x3025, 0x01);
+    imx327_write_register (IspDev,0x3028, 0x57);
+    imx327_write_register (IspDev,0x3029, 0x02);
+    imx327_write_register (IspDev,0x3030, 0xED);
+    imx327_write_register (IspDev,0x3031, 0x01);
+    imx327_write_register (IspDev,0x3034, 0x30);
+    imx327_write_register (IspDev,0x3035, 0x02);
+    imx327_write_register (IspDev,0x3045, 0x05);
+    imx327_write_register (IspDev,0x304b, 0x0a);
+    imx327_write_register (IspDev,0x305c, 0x18);
+    imx327_write_register (IspDev,0x305d, 0x03);
+    imx327_write_register (IspDev,0x305e, 0x20);
+    imx327_write_register (IspDev,0x305f, 0x01);
+    imx327_write_register (IspDev,0x3070, 0x02);
+    imx327_write_register (IspDev,0x3071, 0x11);
+    imx327_write_register (IspDev,0x309b, 0x10);
+    imx327_write_register (IspDev,0x309c, 0x22);
+    imx327_write_register (IspDev,0x30a2, 0x02);
+    imx327_write_register (IspDev,0x30a6, 0x20);
+    imx327_write_register (IspDev,0x30a8, 0x20);
+    imx327_write_register (IspDev,0x30aa, 0x20);
+    imx327_write_register (IspDev,0x30ac, 0x20);
+    imx327_write_register (IspDev,0x30b0, 0x43);
+    imx327_write_register (IspDev,0x3106, 0x33);
+    imx327_write_register (IspDev,0x3119, 0x9e);
+    imx327_write_register (IspDev,0x311c, 0x1e);
+    imx327_write_register (IspDev,0x311e, 0x08);
+    imx327_write_register (IspDev,0x3128, 0x05);
+    imx327_write_register (IspDev,0x313d, 0x83);
+    imx327_write_register (IspDev,0x3150, 0x03);
+    imx327_write_register (IspDev,0x315e, 0x1a);
+    imx327_write_register (IspDev,0x3164, 0x1a);
+    imx327_write_register (IspDev,0x317e, 0x00);
+    imx327_write_register (IspDev,0x32b8, 0x50);
+    imx327_write_register (IspDev,0x32b9, 0x10);
+    imx327_write_register (IspDev,0x32ba, 0x00);
+    imx327_write_register (IspDev,0x32bb, 0x04);
+    imx327_write_register (IspDev,0x32c8, 0x50);
+    imx327_write_register (IspDev,0x32c9, 0x10);
+    imx327_write_register (IspDev,0x32ca, 0x00);
+    imx327_write_register (IspDev,0x32cb, 0x04);
+    imx327_write_register (IspDev,0x332c, 0xd3);
+    imx327_write_register (IspDev,0x332d, 0x10);
+    imx327_write_register (IspDev,0x332e, 0x0d);
+    imx327_write_register (IspDev,0x3358, 0x06);
+    imx327_write_register (IspDev,0x3359, 0xe1);
+    imx327_write_register (IspDev,0x335a, 0x11);
+    imx327_write_register (IspDev,0x3360, 0x1e);
+    imx327_write_register (IspDev,0x3361, 0x61);
+    imx327_write_register (IspDev,0x3362, 0x10);
+    imx327_write_register (IspDev,0x33b0, 0x50);
+    imx327_write_register (IspDev,0x33b2, 0x1a);
+    imx327_write_register (IspDev,0x33b3, 0x04);
+
+    imx327_write_register (IspDev,0x3418, 0x24); /**** Y_OUT_SIZE *****/ 
+    imx327_write_register (IspDev,0x3419, 0x0F);
+    
+    imx327_write_register (IspDev,0x3444, 0x20);
+    imx327_write_register (IspDev,0x3445, 0x25);
+    imx327_write_register (IspDev,0x3480, 0x49);
+
+    imx327_write_register (IspDev,0x3000, 0x00); /* standby */
+    delay_ms(20); 
+    imx327_write_register (IspDev,0x3002, 0x00); /* master mode start */
+ 
+    printf("===Imx327 imx327 1080P15fps 12bit 3to1 WDR(30fps->7p5fps) init success!=====\n");
+
+    return;
+    
+}
+
+void imx327_wdr_720p60_2to1_init(ISP_DEV IspDev)
+{
+    imx327_write_register (IspDev,0x3000, 0x01); /* standby */
+    imx327_write_register (IspDev,0x3002, 0x01); /* XTMSTA */
+
+    //12bit
+    imx327_write_register (IspDev,0x3005, 0x01);
+    imx327_write_register (IspDev,0x3007, 0x10);
+    imx327_write_register (IspDev,0x3009, 0x01);
+    imx327_write_register (IspDev,0x300a, 0xf0);
+    imx327_write_register (IspDev,0x300c, 0x11);
+    imx327_write_register (IspDev,0x300f, 0x00);
+    imx327_write_register (IspDev,0x3010, 0x21);
+    imx327_write_register (IspDev,0x3012, 0x64);
+    imx327_write_register (IspDev,0x3016, 0x09);
+    imx327_write_register (IspDev,0x3018, 0xee);
+    imx327_write_register (IspDev,0x3019, 0x02);
+    imx327_write_register (IspDev,0x301c, 0xe4);
+    imx327_write_register (IspDev,0x301d, 0x0c);
+    imx327_write_register (IspDev,0x3045, 0x05);
+    imx327_write_register (IspDev,0x3046, 0x01);
+    imx327_write_register (IspDev,0x304b, 0x0a);
+
+    imx327_write_register (IspDev,0x305c, 0x20); //INCKSEL1
+    imx327_write_register (IspDev,0x305d, 0x03); //INCKSEL2
+    imx327_write_register (IspDev,0x305e, 0x20); //INCKSEL3
+    imx327_write_register (IspDev,0x305f, 0x01); //INCKSEL4
+
+    imx327_write_register (IspDev,0x3070, 0x02);
+    imx327_write_register (IspDev,0x3071, 0x11);
+    imx327_write_register (IspDev,0x309b, 0x10);
+    imx327_write_register (IspDev,0x309c, 0x22);
+    imx327_write_register (IspDev,0x30a2, 0x02);
+    imx327_write_register (IspDev,0x30a6, 0x20);
+    imx327_write_register (IspDev,0x30a8, 0x20);
+    imx327_write_register (IspDev,0x30aa, 0x20);
+    imx327_write_register (IspDev,0x30ac, 0x20);
+    imx327_write_register (IspDev,0x30b0, 0x43);
+
+    //Add 
+    imx327_write_register (IspDev,0x3106, 0x11);
+    
+    imx327_write_register (IspDev,0x3119, 0x9e);
+    imx327_write_register (IspDev,0x311c, 0x1e);
+    imx327_write_register (IspDev,0x311e, 0x08);
+    imx327_write_register (IspDev,0x3128, 0x05);
+    imx327_write_register (IspDev,0x3129, 0x00);
+    imx327_write_register (IspDev,0x313d, 0x83);
+    imx327_write_register (IspDev,0x3150, 0x03);
+    imx327_write_register (IspDev,0x315e, 0x1a);
+    imx327_write_register (IspDev,0x3164, 0x1a);
+    imx327_write_register (IspDev,0x317c, 0x00);
+    imx327_write_register (IspDev,0x317e, 0x00);
+    imx327_write_register (IspDev,0x31ec, 0x00);
+    
+    imx327_write_register (IspDev,0x32b8, 0x50);
+    imx327_write_register (IspDev,0x32b9, 0x10);
+    imx327_write_register (IspDev,0x32ba, 0x00);
+    imx327_write_register (IspDev,0x32bb, 0x04);
+    imx327_write_register (IspDev,0x32c8, 0x50);
+    imx327_write_register (IspDev,0x32c9, 0x10);
+    imx327_write_register (IspDev,0x32ca, 0x00);
+    imx327_write_register (IspDev,0x32cb, 0x04);
+    
+    imx327_write_register (IspDev,0x332c, 0xd3);
+    imx327_write_register (IspDev,0x332d, 0x10);
+    imx327_write_register (IspDev,0x332e, 0x0d);
+    imx327_write_register (IspDev,0x3358, 0x06);
+    imx327_write_register (IspDev,0x3359, 0xe1);
+    imx327_write_register (IspDev,0x335a, 0x11);
+    imx327_write_register (IspDev,0x3360, 0x1e);
+    imx327_write_register (IspDev,0x3361, 0x61);
+    imx327_write_register (IspDev,0x3362, 0x10);
+    imx327_write_register (IspDev,0x33b0, 0x50);
+    imx327_write_register (IspDev,0x33b2, 0x1a);
+    imx327_write_register (IspDev,0x33b3, 0x04);
+    
+    imx327_write_register (IspDev,0x3405, 0x10);
+    imx327_write_register (IspDev,0x3407, 0x03);
+    imx327_write_register (IspDev,0x3414, 0x04);
+    imx327_write_register (IspDev,0x3418, 0xc6);
+    imx327_write_register (IspDev,0x3419, 0x05);
+    imx327_write_register (IspDev,0x3441, 0x0c);
+    imx327_write_register (IspDev,0x3442, 0x0c);
+    imx327_write_register (IspDev,0x3443, 0x03);
+    imx327_write_register (IspDev,0x3444, 0x20);
+    imx327_write_register (IspDev,0x3445, 0x25);
+    imx327_write_register (IspDev,0x3446, 0x4f);
+    imx327_write_register (IspDev,0x3447, 0x00);
+    imx327_write_register (IspDev,0x3448, 0x2f);
+    imx327_write_register (IspDev,0x3449, 0x00);
+    imx327_write_register (IspDev,0x344a, 0x17);
+    imx327_write_register (IspDev,0x344b, 0x00);
+    imx327_write_register (IspDev,0x344c, 0x17);
+    imx327_write_register (IspDev,0x344d, 0x00);
+    imx327_write_register (IspDev,0x344e, 0x17);
+    imx327_write_register (IspDev,0x344f, 0x00);
+    imx327_write_register (IspDev,0x3450, 0x57);
+    imx327_write_register (IspDev,0x3451, 0x00);
+    imx327_write_register (IspDev,0x3452, 0x17);
+    imx327_write_register (IspDev,0x3453, 0x00);
+    imx327_write_register (IspDev,0x3454, 0x17);
+    imx327_write_register (IspDev,0x3455, 0x00);
+    imx327_write_register (IspDev,0x3472, 0x1c);
+    imx327_write_register (IspDev,0x3473, 0x05);
+    imx327_write_register (IspDev,0x3480, 0x49);
+
+    imx327_write_register (IspDev,0x3000, 0x00); /* standby */
+    delay_ms(20); 
+    imx327_write_register (IspDev,0x3002, 0x00); /* master mode start */
+ 
+    printf("===Imx327 imx327 720P30fps 12bit 2to1 WDR(60fps->30fps) init success!=====\n");
+
+    return;
+}
+
+void imx327_wdr_720p60_3to1_init(ISP_DEV IspDev)
+{
+    imx327_write_register (IspDev,0x3000, 0x01); /* standby */
+    imx327_write_register (IspDev,0x3002, 0x01); /* XTMSTA */
+    
+    //12bit
+    imx327_write_register (IspDev,0x3005, 0x01);
+    imx327_write_register (IspDev,0x3007, 0x10);
+    imx327_write_register (IspDev,0x3009, 0x01);
+    imx327_write_register (IspDev,0x300a, 0xf0);
+    imx327_write_register (IspDev,0x300c, 0x31);
+    imx327_write_register (IspDev,0x300f, 0x00);
+    imx327_write_register (IspDev,0x3010, 0x21);
+    imx327_write_register (IspDev,0x3012, 0x64);
+    imx327_write_register (IspDev,0x3016, 0x09);
+    imx327_write_register (IspDev,0x3018, 0xee);
+    imx327_write_register (IspDev,0x3019, 0x02);
+    imx327_write_register (IspDev,0x301c, 0xe4);
+    imx327_write_register (IspDev,0x301d, 0x0c);
+    imx327_write_register (IspDev,0x3045, 0x05);
+    imx327_write_register (IspDev,0x3046, 0x01);
+    imx327_write_register (IspDev,0x304b, 0x0a);
+
+    imx327_write_register (IspDev,0x305c, 0x20); //INCKSEL1
+    imx327_write_register (IspDev,0x305d, 0x03); //INCKSEL2
+    imx327_write_register (IspDev,0x305e, 0x20); //INCKSEL3
+    imx327_write_register (IspDev,0x305f, 0x01); //INCKSEL4
+    
+    imx327_write_register (IspDev,0x3070, 0x02);
+    imx327_write_register (IspDev,0x3071, 0x11);
+    imx327_write_register (IspDev,0x309b, 0x10);
+    imx327_write_register (IspDev,0x309c, 0x22);
+    imx327_write_register (IspDev,0x30a2, 0x02);
+    imx327_write_register (IspDev,0x30a6, 0x20);
+    imx327_write_register (IspDev,0x30a8, 0x20);
+    imx327_write_register (IspDev,0x30aa, 0x20);
+    imx327_write_register (IspDev,0x30ac, 0x20);
+    imx327_write_register (IspDev,0x30b0, 0x43);
+
+    //Add 
+    imx327_write_register (IspDev,0x3106, 0x33);
+    
+    imx327_write_register (IspDev,0x3119, 0x9e);
+    imx327_write_register (IspDev,0x311c, 0x1e);
+    imx327_write_register (IspDev,0x311e, 0x08);
+    imx327_write_register (IspDev,0x3128, 0x05);
+    imx327_write_register (IspDev,0x3129, 0x00);
+    imx327_write_register (IspDev,0x313d, 0x83);
+    imx327_write_register (IspDev,0x3150, 0x03);
+    imx327_write_register (IspDev,0x315e, 0x1a);
+    imx327_write_register (IspDev,0x3164, 0x1a);
+    imx327_write_register (IspDev,0x317c, 0x00);
+    imx327_write_register (IspDev,0x317e, 0x00);
+    imx327_write_register (IspDev,0x31ec, 0x00);
+    
+    imx327_write_register (IspDev,0x32b8, 0x50);
+    imx327_write_register (IspDev,0x32b9, 0x10);
+    imx327_write_register (IspDev,0x32ba, 0x00);
+    imx327_write_register (IspDev,0x32bb, 0x04);
+    imx327_write_register (IspDev,0x32c8, 0x50);
+    imx327_write_register (IspDev,0x32c9, 0x10);
+    imx327_write_register (IspDev,0x32ca, 0x00);
+    imx327_write_register (IspDev,0x32cb, 0x04);
+    
+    imx327_write_register (IspDev,0x332c, 0xd3);
+    imx327_write_register (IspDev,0x332d, 0x10);
+    imx327_write_register (IspDev,0x332e, 0x0d);
+    imx327_write_register (IspDev,0x3358, 0x06);
+    imx327_write_register (IspDev,0x3359, 0xe1);
+    imx327_write_register (IspDev,0x335a, 0x11);
+    imx327_write_register (IspDev,0x3360, 0x1e);
+    imx327_write_register (IspDev,0x3361, 0x61);
+    imx327_write_register (IspDev,0x3362, 0x10);
+    imx327_write_register (IspDev,0x33b0, 0x50);
+    imx327_write_register (IspDev,0x33b2, 0x1a);
+    imx327_write_register (IspDev,0x33b3, 0x04);
+    
+    imx327_write_register (IspDev,0x3405, 0x10);
+    imx327_write_register (IspDev,0x3407, 0x03);
+    imx327_write_register (IspDev,0x3414, 0x04);
+    imx327_write_register (IspDev,0x3418, 0xb5);
+    imx327_write_register (IspDev,0x3419, 0x08);
+    imx327_write_register (IspDev,0x3441, 0x0c);
+    imx327_write_register (IspDev,0x3442, 0x0c);
+    imx327_write_register (IspDev,0x3443, 0x03);
+    imx327_write_register (IspDev,0x3444, 0x20);
+    imx327_write_register (IspDev,0x3445, 0x25);
+    imx327_write_register (IspDev,0x3446, 0x4f);
+    imx327_write_register (IspDev,0x3447, 0x00);
+    imx327_write_register (IspDev,0x3448, 0x2f);
+    imx327_write_register (IspDev,0x3449, 0x00);
+    imx327_write_register (IspDev,0x344a, 0x17);
+    imx327_write_register (IspDev,0x344b, 0x00);
+    imx327_write_register (IspDev,0x344c, 0x17);
+    imx327_write_register (IspDev,0x344d, 0x00);
+    imx327_write_register (IspDev,0x344e, 0x17);
+    imx327_write_register (IspDev,0x344f, 0x00);
+    imx327_write_register (IspDev,0x3450, 0x57);
+    imx327_write_register (IspDev,0x3451, 0x00);
+    imx327_write_register (IspDev,0x3452, 0x17);
+    imx327_write_register (IspDev,0x3453, 0x00);
+    imx327_write_register (IspDev,0x3454, 0x17);
+    imx327_write_register (IspDev,0x3455, 0x00);
+    imx327_write_register (IspDev,0x3472, 0x1c);
+    imx327_write_register (IspDev,0x3473, 0x05);
+    imx327_write_register (IspDev,0x3480, 0x49);
+
+    imx327_write_register (IspDev,0x3000, 0x00); /* standby */
+    delay_ms(20); 
+    imx327_write_register (IspDev,0x3002, 0x00); /* master mode start */
+ 
+    printf("===Imx327 imx327 720P15fps 12bit 3to1 WDR(60fps->15fps) init success!=====\n");
+    return;
+}
+
+void imx327_wdr_1080p120_2to1_init(ISP_DEV IspDev)
+{
+    imx327_write_register (IspDev,0x3000, 0x01); /* standby */
+    imx327_write_register (IspDev,0x3002, 0x01); /* XTMSTA */
+
+    imx327_write_register (IspDev,0x3005, 0x00);
+    imx327_write_register (IspDev,0x3007, 0x00);
+    imx327_write_register (IspDev,0x3009, 0x00);
+    imx327_write_register (IspDev,0x300a, 0x3c);
+    imx327_write_register (IspDev,0x300c, 0x11);
+    imx327_write_register (IspDev,0x300f, 0x00);
+    imx327_write_register (IspDev,0x3010, 0x21);
+    imx327_write_register (IspDev,0x3012, 0x64);
+    imx327_write_register (IspDev,0x3016, 0x09);
+    imx327_write_register (IspDev,0x3018, 0x65);
+    imx327_write_register (IspDev,0x3019, 0x04);
+    imx327_write_register (IspDev,0x301c, 0xF6);
+    imx327_write_register (IspDev,0x301d, 0x03);
+    imx327_write_register (IspDev,0x3020, 0x02);
+    imx327_write_register (IspDev,0x3024, 0xc9);
+    imx327_write_register (IspDev,0x3030, 0x0b);
+    imx327_write_register (IspDev,0x3045, 0x05);
+    imx327_write_register (IspDev,0x3046, 0x00);
+    imx327_write_register (IspDev,0x304b, 0x0a);
+    imx327_write_register (IspDev,0x305c, 0x18);
+    imx327_write_register (IspDev,0x305d, 0x03);
+    imx327_write_register (IspDev,0x305e, 0x20);
+    imx327_write_register (IspDev,0x305f, 0x01);
+    imx327_write_register (IspDev,0x3070, 0x02);
+    imx327_write_register (IspDev,0x3071, 0x11);
+    imx327_write_register (IspDev,0x309b, 0x10);
+    imx327_write_register (IspDev,0x309c, 0x22);
+    imx327_write_register (IspDev,0x30a2, 0x02);
+    imx327_write_register (IspDev,0x30a6, 0x20);
+    imx327_write_register (IspDev,0x30a8, 0x20);
+    imx327_write_register (IspDev,0x30aa, 0x20);
+    imx327_write_register (IspDev,0x30ac, 0x20);
+    imx327_write_register (IspDev,0x30b0, 0x43);
+    imx327_write_register (IspDev,0x3106, 0x11);
+    imx327_write_register (IspDev,0x3119, 0x9e);
+    imx327_write_register (IspDev,0x311c, 0x1e);
+    imx327_write_register (IspDev,0x311e, 0x08);
+    imx327_write_register (IspDev,0x3128, 0x05);
+    imx327_write_register (IspDev,0x3129, 0x1d);
+    imx327_write_register (IspDev,0x313d, 0x83);
+    imx327_write_register (IspDev,0x3150, 0x03);
+    imx327_write_register (IspDev,0x315e, 0x1a);
+    imx327_write_register (IspDev,0x3164, 0x1a);
+    imx327_write_register (IspDev,0x317c, 0x12);
+    imx327_write_register (IspDev,0x317e, 0x00);
+    imx327_write_register (IspDev,0x31ec, 0x37);
+                                         
+    imx327_write_register (IspDev,0x32b8, 0x50);
+    imx327_write_register (IspDev,0x32b9, 0x10);
+    imx327_write_register (IspDev,0x32ba, 0x00);
+    imx327_write_register (IspDev,0x32bb, 0x04);
+    imx327_write_register (IspDev,0x32c8, 0x50);
+    imx327_write_register (IspDev,0x32c9, 0x10);
+    imx327_write_register (IspDev,0x32ca, 0x00);
+    imx327_write_register (IspDev,0x32cb, 0x04);
+                                        
+    imx327_write_register (IspDev,0x332c, 0xd3);
+    imx327_write_register (IspDev,0x332d, 0x10);
+    imx327_write_register (IspDev,0x332e, 0x0d);
+    imx327_write_register (IspDev,0x3358, 0x06);
+    imx327_write_register (IspDev,0x3359, 0xe1);
+    imx327_write_register (IspDev,0x335a, 0x11);
+    imx327_write_register (IspDev,0x3360, 0x1e);
+    imx327_write_register (IspDev,0x3361, 0x61);
+    imx327_write_register (IspDev,0x3362, 0x10);
+    imx327_write_register (IspDev,0x33b0, 0x50);
+    imx327_write_register (IspDev,0x33b2, 0x1a);
+    imx327_write_register (IspDev,0x33b3, 0x04);
+                                         
+    imx327_write_register (IspDev,0x3405, 0x00);
+    imx327_write_register (IspDev,0x3407, 0x03);
+    imx327_write_register (IspDev,0x3414, 0x0a);
+    imx327_write_register (IspDev,0x3418, 0xb2);
+    imx327_write_register (IspDev,0x3419, 0x08);
+    imx327_write_register (IspDev,0x3441, 0x0a);
+    imx327_write_register (IspDev,0x3442, 0x0a);
+    imx327_write_register (IspDev,0x3443, 0x03);
+    imx327_write_register (IspDev,0x3444, 0x20);
+    imx327_write_register (IspDev,0x3445, 0x25);
+    imx327_write_register (IspDev,0x3446, 0x77);
+    imx327_write_register (IspDev,0x3447, 0x00);
+    imx327_write_register (IspDev,0x3448, 0x67);
+    imx327_write_register (IspDev,0x3449, 0x00);
+    imx327_write_register (IspDev,0x344a, 0x47);
+    imx327_write_register (IspDev,0x344b, 0x00);
+    imx327_write_register (IspDev,0x344c, 0x37);
+    imx327_write_register (IspDev,0x344d, 0x00);
+    imx327_write_register (IspDev,0x344e, 0x3f);
+    imx327_write_register (IspDev,0x344f, 0x00);
+    imx327_write_register (IspDev,0x3450, 0xff);
+    imx327_write_register (IspDev,0x3451, 0x00);
+    imx327_write_register (IspDev,0x3452, 0x3f);
+    imx327_write_register (IspDev,0x3453, 0x00);
+    imx327_write_register (IspDev,0x3454, 0x37);
+    imx327_write_register (IspDev,0x3455, 0x00);
+    imx327_write_register (IspDev,0x3472, 0x9c);
+    imx327_write_register (IspDev,0x3473, 0x07);
+    imx327_write_register (IspDev,0x3480, 0x49);
+
+    imx327_write_register (IspDev,0x3000, 0x00); /* standby */
+    delay_ms(20); 
+    imx327_write_register (IspDev,0x3002, 0x00); /* master mode start */
+ 
+    printf("===Imx327 imx327 1080P60fps 10bit 2to1 WDR(120fps->60fps) init success!=====\n");
+    return;
+}
+
+void imx327_wdr_1080p120_3to1_init(ISP_DEV IspDev)
+{
+    imx327_write_register (IspDev,0x3000, 0x01); /* standby */
+    imx327_write_register (IspDev,0x3002, 0x01); /* XTMSTA */
+
+    imx327_write_register (IspDev,0x3005, 0x00);
+    imx327_write_register (IspDev,0x3007, 0x00);
+    imx327_write_register (IspDev,0x3009, 0x00);
+    imx327_write_register (IspDev,0x300a, 0x3c);
+    imx327_write_register (IspDev,0x300c, 0x21);
+    imx327_write_register (IspDev,0x300f, 0x00);
+    imx327_write_register (IspDev,0x3010, 0x21);
+    imx327_write_register (IspDev,0x3012, 0x64);
+    imx327_write_register (IspDev,0x3016, 0x09);
+    imx327_write_register (IspDev,0x3018, 0x65);
+    imx327_write_register (IspDev,0x3019, 0x04);
+    imx327_write_register (IspDev,0x301c, 0x4c);
+    imx327_write_register (IspDev,0x301d, 0x04);
+
+#if 1
+    imx327_write_register (IspDev,0x3020, 0x04);  /* SHS1 */
+    imx327_write_register (IspDev,0x3021, 0x00);
+    //imx327_write_register (IspDev,0x3022, 0x00);
+    imx327_write_register (IspDev,0x3024, 0xf2);  /* SHS2 */ 
+    imx327_write_register (IspDev,0x3025, 0x01);
+    //imx327_write_register (IspDev,0x3025, 0x00);
+    imx327_write_register (IspDev,0x3028, 0x57);  /* SHS3 */
+    imx327_write_register (IspDev,0x3029, 0x02);
+    //imx327_write_register (IspDev,0x302A, 0x00);
+    imx327_write_register (IspDev,0x3030, 0xed);  /* RHS1 */
+    imx327_write_register (IspDev,0x3031, 0x01);
+    imx327_write_register (IspDev,0x3034, 0x30);  /* RHS2 */ 
+    imx327_write_register (IspDev,0x3035, 0x02);
+#else
+    imx327_write_register (IspDev,0x3020, 0x04);
+    imx327_write_register (IspDev,0x3024, 0x89);
+    imx327_write_register (IspDev,0x3028, 0x93);
+    imx327_write_register (IspDev,0x3029, 0x01);
+    imx327_write_register (IspDev,0x3030, 0x85);
+    imx327_write_register (IspDev,0x3034, 0x92);
+#endif
+
+    imx327_write_register (IspDev,0x3045, 0x05);
+    imx327_write_register (IspDev,0x3046, 0x00);
+    imx327_write_register (IspDev,0x304b, 0x0a);
+    imx327_write_register (IspDev,0x305c, 0x18);
+    imx327_write_register (IspDev,0x305d, 0x03);
+    imx327_write_register (IspDev,0x305e, 0x20);
+    imx327_write_register (IspDev,0x305f, 0x01);
+    imx327_write_register (IspDev,0x3070, 0x02);
+    imx327_write_register (IspDev,0x3071, 0x11);
+    imx327_write_register (IspDev,0x309b, 0x10);
+    imx327_write_register (IspDev,0x309c, 0x22);
+    imx327_write_register (IspDev,0x30a2, 0x02);
+    imx327_write_register (IspDev,0x30a6, 0x20);
+    imx327_write_register (IspDev,0x30a8, 0x20);
+    imx327_write_register (IspDev,0x30aa, 0x20);
+    imx327_write_register (IspDev,0x30ac, 0x20);
+    imx327_write_register (IspDev,0x30b0, 0x43);
+    imx327_write_register (IspDev,0x3106, 0x33);
+    imx327_write_register (IspDev,0x3119, 0x9e);
+    imx327_write_register (IspDev,0x311c, 0x1e);
+    imx327_write_register (IspDev,0x311e, 0x08);
+    imx327_write_register (IspDev,0x3128, 0x05);
+    imx327_write_register (IspDev,0x3129, 0x1d);
+    imx327_write_register (IspDev,0x313d, 0x83);
+    imx327_write_register (IspDev,0x3150, 0x03);
+    imx327_write_register (IspDev,0x315e, 0x1a);
+    imx327_write_register (IspDev,0x3164, 0x1a);
+    imx327_write_register (IspDev,0x317c, 0x12);
+    imx327_write_register (IspDev,0x317e, 0x00);
+    imx327_write_register (IspDev,0x31ec, 0x37);
+                                         
+    imx327_write_register (IspDev,0x32b8, 0x50);
+    imx327_write_register (IspDev,0x32b9, 0x10);
+    imx327_write_register (IspDev,0x32ba, 0x00);
+    imx327_write_register (IspDev,0x32bb, 0x04);
+    imx327_write_register (IspDev,0x32c8, 0x50);
+    imx327_write_register (IspDev,0x32c9, 0x10);
+    imx327_write_register (IspDev,0x32ca, 0x00);
+    imx327_write_register (IspDev,0x32cb, 0x04);
+                                        
+    imx327_write_register (IspDev,0x332c, 0xd3);
+    imx327_write_register (IspDev,0x332d, 0x10);
+    imx327_write_register (IspDev,0x332e, 0x0d);
+    imx327_write_register (IspDev,0x3358, 0x06);
+    imx327_write_register (IspDev,0x3359, 0xe1);
+    imx327_write_register (IspDev,0x335a, 0x11);
+    imx327_write_register (IspDev,0x3360, 0x1e);
+    imx327_write_register (IspDev,0x3361, 0x61);
+    imx327_write_register (IspDev,0x3362, 0x10);
+    imx327_write_register (IspDev,0x33b0, 0x50);
+    imx327_write_register (IspDev,0x33b2, 0x1a);
+    imx327_write_register (IspDev,0x33b3, 0x04);
+                                         
+    imx327_write_register (IspDev,0x3405, 0x00);
+    imx327_write_register (IspDev,0x3407, 0x03);
+    imx327_write_register (IspDev,0x3414, 0x0a);
+    imx327_write_register (IspDev,0x3418, 0x55);
+    imx327_write_register (IspDev,0x3419, 0x11);
+    imx327_write_register (IspDev,0x3441, 0x0a);
+    imx327_write_register (IspDev,0x3442, 0x0a);
+    imx327_write_register (IspDev,0x3443, 0x03);
+    imx327_write_register (IspDev,0x3444, 0x20);
+    imx327_write_register (IspDev,0x3445, 0x25);
+    imx327_write_register (IspDev,0x3446, 0x77);
+    imx327_write_register (IspDev,0x3447, 0x00);
+    imx327_write_register (IspDev,0x3448, 0x67);
+    imx327_write_register (IspDev,0x3449, 0x00);
+    imx327_write_register (IspDev,0x344a, 0x47);
+    imx327_write_register (IspDev,0x344b, 0x00);
+    imx327_write_register (IspDev,0x344c, 0x37);
+    imx327_write_register (IspDev,0x344d, 0x00);
+    imx327_write_register (IspDev,0x344e, 0x3f);
+    imx327_write_register (IspDev,0x344f, 0x00);
+    imx327_write_register (IspDev,0x3450, 0xff);
+    imx327_write_register (IspDev,0x3451, 0x00);
+    imx327_write_register (IspDev,0x3452, 0x3f);
+    imx327_write_register (IspDev,0x3453, 0x00);
+    imx327_write_register (IspDev,0x3454, 0x37);
+    imx327_write_register (IspDev,0x3455, 0x00);
+    imx327_write_register (IspDev,0x3472, 0x9c);
+    imx327_write_register (IspDev,0x3473, 0x07);
+    imx327_write_register (IspDev,0x3480, 0x49);
+
+    imx327_write_register (IspDev,0x3000, 0x00); /* standby */
+    delay_ms(20); 
+    imx327_write_register (IspDev,0x3002, 0x00); /* master mode start */
+ 
+    printf("===Imx327 imx327 1080P30fps 10bit 3to1 WDR(120fps->30fps) init success!=====\n");
+
+    return;
+}
+
+


### PR DESCRIPTION
## Summary

- **Fix `hi3516cv100` header set** — replace mpp/ (T1) headers and sources with their mpp2 (T1+) equivalents. OpenIPC firmware runs on the mpp2 MPI runtime; the repo had been shipping ABI-incompatible mpp/ artifacts (single-arg `HI_MPI_ISP_SensorRegCallBack(&funcs)` against a host that only exports the 2-arg form). Source: HiSilicon Hi3518 SDK V1.0.B.0 `mpp2/`. Sees 13 headers updated and all 16 existing CV100 sensor sources replaced.
- **Add JXH42 driver** for `hi3516cv100` (T1+) — Soi 720p sensor. Source from [OpenIPC/sensors/hisilicon/jxh42_i2c_hi3516cv100_rev1](https://github.com/OpenIPC/sensors/tree/master/hisilicon/jxh42_i2c_hi3516cv100_rev1).
- **Add IMX327 driver** for `hi3519v101` (T3) — Sony Starvis 1080p, third in-repo IMX327 (already had T4/CV500 and T5/EV200 versions). Source from [OpenIPC/sensors/hisilicon/imx327_i2c_mipi_hi3516av200_rev1](https://github.com/OpenIPC/sensors/tree/master/hisilicon/imx327_i2c_mipi_hi3516av200_rev1).
- **Docs/README** updated — `docs/sensor-driver-api.md` §3.1 rewritten to reflect that this repo's CV100 is T1+ (not T1), with new in-repo anchors. README sensor table grows IMX327 V3A entry + a new "Silicon Optronics (JX)" group.

## Why this is bigger than just adding two sensors

The original ask was *"copy sensor drivers from OpenIPC/sensors/hisilicon"*. Surveying the 9 sensors there, only **2** are net-new ports — JXH42 and IMX327. Of the remaining 7: 2 are byte-identical to what we already ship, and 5 have repo copies that diverged forward (additional ISP tuning, real silicon timing differences). See the disposition table in the plan file.

The JXH42 port turned out to be blocked on a real bug: this repo's `kernel/include/hi3516cv100/` had the older mpp/ T1 headers, but per @user OpenIPC firmware uses mpp2 at runtime. So the CV100 build was producing artifacts incompatible with the host firmware. Fixing that header set is the bulk of this PR — but it's a real correctness fix, not just JXH42 plumbing. After the upgrade, JXH42 compiles cleanly without any further ceremony.

## Verification

- All 16 pre-existing CV100 sensors compile cleanly with arm-linux-gnueabihf-gcc against the new headers (regression check). 0 errors, 0 warnings.
- New JXH42 builds; `nm -D libsns_jxh42.so | grep HI_MPI_*SensorRegCallBack` shows the three expected `U` (undefined, runtime-resolved) entries.
- All 9 V3A sensors (including new IMX327) compile cleanly with arm-linux-gnueabihf-gcc.
- `libraries/Makefile`'s `find … -name Makefile` filtered by `CHIPARCH` auto-discovers both new sensor dirs — no top-level enumeration to update.

## Test plan
- [ ] CI `Build SDK (hi3516cv100, hi3516cv100_lite)` job stays green
- [ ] CI `Build SDK (hi3519v101, hi3519v101_lite)` job stays green
- [ ] Eyeball the README "Supported sensors" table renders correctly
- [ ] Spot-check that `docs/sensor-driver-api.md` §3.1 anchors still resolve (`grep -n "sensor_register_callback" libraries/sensor/hi3516cv100/sony_imx236/imx236_cmos.c` and similar)

## Risk

The CV100 mpp/→mpp2 swap is a runtime ABI shift. Anyone outside OpenIPC consuming this repo's CV100 build with a mpp/-flavoured `libmpi.so` host will see breakage at sensor registration time. Per the OpenIPC project that's the intended fix (firmware uses mpp2); flagging here in case anyone else has a different setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)