### PR TITLE
sensor/cv300: include <linux/ioctl.h> in hi_spi.h for musl _IOC_SIZEBITS

### DIFF
--- a/kernel/include/hi3516cv300/hi_spi.h
+++ b/kernel/include/hi3516cv300/hi_spi.h
@@ -9,6 +9,7 @@ typedef unsigned char       __u8;
 #ifdef __HuaweiLite__
 #include <spi.h>
 #else
+#include <linux/ioctl.h>
 #include <linux/spi/spidev.h>
 #endif
 


### PR DESCRIPTION
## Summary

\`sony_imx323/imx323_sensor_ctl.c\` uses \`SPI_IOC_MESSAGE\` which expands through \`<linux/spi/spidev.h>\`'s \`SPI_MSGSIZE\` macro to reference \`_IOC_SIZEBITS\`. Under glibc, \`<sys/ioctl.h>\` transparently pulls in \`<asm-generic/ioctl.h>\` where \`_IOC_SIZEBITS\` is defined; under musl it doesn't, breaking imx323 with:

\`\`\`
imx323_sensor_ctl.c:99:23: error: '_IOC_SIZEBITS' undeclared
\`\`\`

Mirror the pattern that \`hi3516cv200/hi_spi.h\` already uses (`#include <linux/ioctl.h>` at the top), so the macro is always available regardless of libc. No-op under glibc.

## How surfaced

OpenIPC/firmware#2055 wired cv300 source-built sensors via \`HISILICON_OPENSDK_SENSORS_hi3516cv300\`. After sysupgrade on a real cv300 camera, \`/usr/lib/sensors/libsns_imx323.so\` was missing — the build had silently failed because \`libraries/Makefile\`'s \`|| true\` swallows per-sensor errors. All other 8 source-built cv300 sensors landed correctly.

## Test plan

- [x] sony_imx323/libsns_imx323.so builds clean under arm-openipc-linux-gnueabi-gcc 13.3.0 locally
- [ ] CI: \`Build SDK (hi3516cv300)\` job under musl passes
- [ ] After merge + firmware pin bump: re-run firmware build-one for hi3516cv300_lite, sysupgrade, verify libsns_imx323.so present

🤖 Generated with [Claude Code](https://claude.com/claude-code)