### PR TITLE
hisi-hwrng: hybrid hwrng_register/pump driver, universal V2..V4

### DIFF
--- a/kernel/hi3516cv200.kbuild
+++ b/kernel/hi3516cv200.kbuild
@@ -183,3 +183,6 @@ $(PREFIX)isp-objs := \
 ifndef DISABLE_ISP
     obj-m += $(PREFIX)isp.o
 endif
+
+# --- HWRNG module (source driver) ---
+include $(src)/hisi-hwrng/Kbuild

--- a/kernel/hi3516cv300.kbuild
+++ b/kernel/hi3516cv300.kbuild
@@ -162,3 +162,6 @@ obj-m += $(PREFIX)sensor_spi.o
 $(PREFIX)rtc-objs := rtc/hi3516cv300/hi_rtc.o
 ccflags-y += -I$(src)/rtc/hi3516cv300
 obj-m += $(PREFIX)rtc.o
+
+# --- HWRNG module (source driver) ---
+include $(src)/hisi-hwrng/Kbuild

--- a/kernel/hi3516cv500.kbuild
+++ b/kernel/hi3516cv500.kbuild
@@ -262,3 +262,6 @@ $(PREFIX)isp-objs := \
 ifndef DISABLE_ISP
     obj-m += $(PREFIX)isp.o
 endif
+
+# --- HWRNG module (source driver) ---
+include $(src)/hisi-hwrng/Kbuild

--- a/kernel/hi3519v101.kbuild
+++ b/kernel/hi3519v101.kbuild
@@ -186,3 +186,6 @@ obj-m += $(PREFIX)pwm.o
 $(PREFIX)piris-objs := piris/hi3519v101/piris.o
 ccflags-y += -I$(src)/piris/hi3519v101
 obj-m += $(PREFIX)piris.o
+
+# --- HWRNG module (source driver) ---
+include $(src)/hisi-hwrng/Kbuild

--- a/kernel/hisi-hwrng/Kbuild
+++ b/kernel/hisi-hwrng/Kbuild
@@ -1,7 +1,8 @@
-MOD_NAME := hisi-hwrng
+# --- HWRNG module (source driver) ---
+# Kernel 4.9 + GCC 13 trips -Wmissing-attributes on module_init/exit alias
+# decls (aliases inherit fewer attrs than the target). Suppress: this is
+# a known compat issue, fixed in newer kernels' include/linux/module.h.
+CFLAGS_hisi-hwrng.o := -Wno-missing-attributes
 
-DIR=$(MOD_NAME)
-
-$(MOD_NAME)-objs := $(DIR)/$(MOD_NAME).o
-
-obj-m += $(MOD_NAME).o
+$(PREFIX)hwrng-objs := hisi-hwrng/hisi-hwrng.o
+obj-m += $(PREFIX)hwrng.o

--- a/kernel/hisi-hwrng/hisi-hwrng.c
+++ b/kernel/hisi-hwrng/hisi-hwrng.c
@@ -1,103 +1,221 @@
-#include <asm/io.h>
-#include <linux/version.h>
-#include <linux/delay.h>
-#include <linux/hw_random.h>
-#include <linux/kthread.h>
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * HiSilicon on-die TRNG driver.
+ *
+ * Targets Linux 3.19 .. 7.0 across all OpenIPC HiSilicon SoCs that ship a
+ * documented TRNG block. Operates in one of two modes, picked at compile time:
+ *
+ *   1. Modern (CONFIG_HW_RANDOM=y/m, kernel >= 4.0):
+ *        register a struct hwrng; the kernel hwrng-core thread (krngd) reads
+ *        from .read() and feeds the entropy pool itself via .quality.
+ *        Also exposes /dev/hwrng. This is the 7.0 idiomatic path.
+ *
+ *   2. Pump (CONFIG_HW_RANDOM disabled, or kernel < 4.0):
+ *        run a small kthread that batches reads and pushes entropy via
+ *        add_hwgenerator_randomness() (added in 3.17, so 3.19+ has it).
+ *        On modern kernels with hwrng-core also available, mode 1 is taken
+ *        instead so the upstream path wins.
+ *
+ * On kernels where hwrng-core *is* enabled but is pre-4.0 (no krngd, no
+ * .quality field), both paths are taken: hwrng_register() to expose
+ * /dev/hwrng, plus the pump kthread to fill the entropy pool.
+ */
+#include <linux/io.h>
 #include <linux/module.h>
 #include <linux/slab.h>
+#include <linux/version.h>
+
+#if IS_ENABLED(CONFIG_HW_RANDOM)
+#  define HISI_HWRNG_USE_CORE 1
+#else
+#  define HISI_HWRNG_USE_CORE 0
+#endif
+
+#if !HISI_HWRNG_USE_CORE || LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
+#  define HISI_HWRNG_USE_PUMP 1
+#  include <linux/delay.h>
+#  include <linux/kthread.h>
+#  include <linux/random.h>
+#else
+#  define HISI_HWRNG_USE_PUMP 0
+#endif
+
+/*
+ * hw_random.h carries struct hwrng + add_hwgenerator_randomness() across the
+ * full 3.19..7.0 range (random.h didn't pick up the latter until 5.x).
+ * Header is safe to include even when CONFIG_HW_RANDOM is disabled.
+ */
+#include <linux/hw_random.h>
 
 #include "../compat/kernel_compat.h"
 
-struct rng_state *st;
-
-struct rng_state {
-	struct task_struct *rng_task;
-	void *regs;
-};
-
-#define RNG_BUF_SIZE 320
-#define RNG_ENTROPY(x) (((x)*8 * 320) >> 10) /* quality: 320/1024 */
-
-static int rng_data_read(struct rng_state *st, u32 *buf, u32 buf_size)
-{
-	int i;
-
-	for (i = 0; i < buf_size; i += 4) {
-		buf[i] = readl(st->regs);
-	}
-
-	return i;
-}
-
-static int rng_kthread(void *data)
-{
-	struct rng_state *st = data;
-	u32 *rng_buf;
-	int bytes_read;
-
-	rng_buf = kmalloc_array(RNG_BUF_SIZE, sizeof(u32), GFP_KERNEL);
-	if (!rng_buf)
-		goto out;
-
-	while (!kthread_should_stop()) {
-		bytes_read = rng_data_read(st, rng_buf, RNG_BUF_SIZE);
-
-		/* sleep until entropy bits under write_wakeup_threshold */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
-		add_hwgenerator_randomness((void *)rng_buf, bytes_read,
-					   RNG_ENTROPY(bytes_read), true);
+#if defined(hi3516ev200) || defined(gk7205v200)
+#  define HWRNG_BASE   0x10080000
+#  define HWRNG_DATA   0x204
+#elif defined(hi3516cv500)
+#  define HWRNG_BASE   0x10090000
+#  define HWRNG_DATA   0x204
+#elif defined(hi3516cv300)
+#  define HWRNG_BASE   0x120C0000
+#  define HWRNG_DATA   0x204
+#elif defined(hi3519v101)
+#  define HWRNG_BASE   0x120C0000
+#  define HWRNG_DATA   0x204
+#elif defined(hi3516cv200)
+#  define HWRNG_BASE   0x20280000
+#  define HWRNG_DATA   0x004    /* V2 RNG_GEN layout */
 #else
-		add_hwgenerator_randomness((void *)rng_buf, bytes_read,
-					   RNG_ENTROPY(bytes_read));
+#  error "hisi-hwrng: no TRNG base address known for this CHIPARCH"
 #endif
 
-		msleep_interruptible(1000);
+#define HWRNG_REG_SIZE   0x1000
+#define HWRNG_QUALITY    250    /* per-mille; ~25% entropy estimate */
+
+struct hisi_hwrng {
+	void __iomem       *base;
+	void __iomem       *data;
+#if HISI_HWRNG_USE_CORE
+	struct hwrng        rng;
+#endif
+#if HISI_HWRNG_USE_PUMP
+	struct task_struct *pump;
+#endif
+};
+
+static struct hisi_hwrng *g_hwrng;
+
+static int hisi_hwrng_fill(struct hisi_hwrng *h, void *buf, size_t max)
+{
+	u32 *out = buf;
+	size_t n = 0;
+
+	while (n + sizeof(u32) <= max) {
+		out[n / sizeof(u32)] = readl(h->data);
+		n += sizeof(u32);
 	}
-out:
-	kfree(rng_buf);
-
-	st->rng_task = NULL;
-
-	return 0;
+	return n;
 }
 
-static void rng_start(struct rng_state *st)
+#if HISI_HWRNG_USE_CORE
+static int hisi_hwrng_read(struct hwrng *rng, void *buf, size_t max, bool wait)
 {
-	if (st->rng_task)
+	struct hisi_hwrng *h = container_of(rng, struct hisi_hwrng, rng);
+
+	return hisi_hwrng_fill(h, buf, max);
+}
+#endif
+
+#if HISI_HWRNG_USE_PUMP
+#define HWRNG_BATCH_BYTES   1024
+#define HWRNG_INTERVAL_MS   1000
+
+static void hisi_hwrng_feed(const void *buf, size_t bytes)
+{
+	unsigned int entropy_bits = (bytes * 8 * HWRNG_QUALITY) / 1000;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+	add_hwgenerator_randomness(buf, bytes, entropy_bits, true);
+#else
+	add_hwgenerator_randomness(buf, bytes, entropy_bits);
+#endif
+}
+
+static int hisi_hwrng_pump(void *arg)
+{
+	struct hisi_hwrng *h = arg;
+	u32 *buf;
+
+	buf = kmalloc(HWRNG_BATCH_BYTES, GFP_KERNEL);
+	if (!buf)
+		return -ENOMEM;
+
+	while (!kthread_should_stop()) {
+		int n = hisi_hwrng_fill(h, buf, HWRNG_BATCH_BYTES);
+		hisi_hwrng_feed(buf, n);
+		msleep_interruptible(HWRNG_INTERVAL_MS);
+	}
+	kfree(buf);
+	return 0;
+}
+#endif /* HISI_HWRNG_USE_PUMP */
+
+static int __init hisi_hwrng_init(void)
+{
+	struct hisi_hwrng *h;
+	int ret;
+
+	h = kzalloc(sizeof(*h), GFP_KERNEL);
+	if (!h)
+		return -ENOMEM;
+
+	h->base = ioremap_nocache(HWRNG_BASE, HWRNG_REG_SIZE);
+	if (!h->base) {
+		ret = -ENOMEM;
+		goto fail_free;
+	}
+	h->data = h->base + HWRNG_DATA;
+
+#if HISI_HWRNG_USE_CORE
+	h->rng.name = "hisi-hwrng";
+	h->rng.read = hisi_hwrng_read;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0)
+	h->rng.quality = HWRNG_QUALITY;
+#endif
+	ret = hwrng_register(&h->rng);
+	if (ret)
+		goto fail_unmap;
+#endif
+
+#if HISI_HWRNG_USE_PUMP
+	h->pump = kthread_run(hisi_hwrng_pump, h, "hisi-hwrng");
+	if (IS_ERR(h->pump)) {
+		ret = PTR_ERR(h->pump);
+#if HISI_HWRNG_USE_CORE
+		hwrng_unregister(&h->rng);
+#endif
+		goto fail_unmap;
+	}
+#endif
+
+	g_hwrng = h;
+	pr_info("hisi-hwrng: TRNG at 0x%08lx+0x%x registered (%s)\n",
+		(unsigned long)HWRNG_BASE, HWRNG_DATA,
+#if HISI_HWRNG_USE_CORE && HISI_HWRNG_USE_PUMP
+		"hwrng-core + pump"
+#elif HISI_HWRNG_USE_CORE
+		"hwrng-core"
+#else
+		"pump"
+#endif
+		);
+	return 0;
+
+fail_unmap:
+	iounmap(h->base);
+fail_free:
+	kfree(h);
+	return ret;
+}
+
+static void __exit hisi_hwrng_exit(void)
+{
+	if (!g_hwrng)
 		return;
-
-	st->rng_task = kthread_run(rng_kthread, st, "hisi-hwrng");
-	if (IS_ERR(st->rng_task))
-		st->rng_task = NULL;
+#if HISI_HWRNG_USE_PUMP
+	if (g_hwrng->pump)
+		kthread_stop(g_hwrng->pump);
+#endif
+#if HISI_HWRNG_USE_CORE
+	hwrng_unregister(&g_hwrng->rng);
+#endif
+	iounmap(g_hwrng->base);
+	kfree(g_hwrng);
+	g_hwrng = NULL;
 }
 
-static void rng_stop(struct rng_state *st)
-{
-	if (st->rng_task) {
-		kthread_stop(st->rng_task);
-	}
-}
-
-static int mod_init(void)
-{
-	st = kmalloc(sizeof(struct rng_state), GFP_KERNEL);
-	memset(st, 0, sizeof(struct rng_state));
-	st->regs = ioremap_nocache(0x10080204, 4);
-
-	rng_start(st);
-
-	return 0;
-}
-
-static void mod_exit(void)
-{
-	rng_stop(st);
-	iounmap(st->regs);
-	kfree(st);
-}
-
-module_init(mod_init);
-module_exit(mod_exit);
+module_init(hisi_hwrng_init);
+module_exit(hisi_hwrng_exit);
 
 MODULE_LICENSE("GPL");
-MODULE_AUTHOR("Dmitry Ilyin <d.ilyin@openipc.org>");
+MODULE_AUTHOR("OpenIPC");
+MODULE_DESCRIPTION("HiSilicon on-die TRNG driver");


### PR DESCRIPTION
## Summary

- Rewrites `kernel/hisi-hwrng/hisi-hwrng.c` as a universal driver across V2/V3/V3A/V3.5/V4 (was V4-only with hardcoded `0x10080204`). Per-CHIPARCH base+offset selected at compile time via `-D<chiparch>`, table aligned with QEMU widgetii/qemu-hisilicon#54.
- Picks path at compile time:
  - `CONFIG_HW_RANDOM=y/m, kernel ≥ 4.0` → `hwrng_register()` + `.quality`; `krngd` auto-feeds, `/dev/hwrng` exposed. The 7.0 idiomatic path.
  - `CONFIG_HW_RANDOM=y/m, kernel < 4.0` → hybrid: `hwrng_register()` for `/dev/hwrng` plus a small kthread feeding `add_hwgenerator_randomness()` (pre-4.0 has no `krngd`).
  - `CONFIG_HW_RANDOM` disabled → pump-only.
- Targets Linux **3.19 .. 7.0**. `ioremap_nocache` shim handled by `compat/kernel_compat.h`. `add_hwgenerator_randomness` 4-arg form gated at 6.2.
- Renames artifact to `open_hwrng.ko` (project `\$(PREFIX)` convention). Wires into the 4 monolithic `.kbuild` files; V4 fall-through path already includes it. cv100/av100 left out (no documented TRNG).
- Fixes pre-existing bugs: index-overrun in read loop, unchecked `kmalloc`/`ioremap`, leaked `iounmap` on kthread fail, struct fwd-decl-before-definition, missing `__init`/`__exit`, no SPDX header.

## Test plan

End-to-end QEMU runs against the released OpenIPC firmware tarballs for each platform, using widgetii/qemu-hisilicon (HWRNG emulation from PR #54):

| Platform | Family | Kernel | HW_RANDOM | Driver mode | TRNG addr | entropy_avail | /dev/hwrng |
|---|---|---|---|---|---|---|---|
| hi3516cv200 | V2  | 4.9.37  | y | `hwrng-core`        | 0x20280000+0x4   | 922→923  | yes |
| hi3516cv300 | V3  | 3.18.20 | y | `hwrng-core + pump` | 0x120c0000+0x204 | 1536     | yes |
| hi3519v101  | V3A | 3.18.20 | n | `pump`              | 0x120c0000+0x204 | 1536     | n/a |
| hi3516cv500 | V3.5| 4.9.37  | n | `pump`              | 0x10090000+0x204 | 0→1280   | n/a |
| hi3516ev200 | V4  | 4.9.37  | n | `pump`              | 0x10080000+0x204 | 1024     | n/a |

On every platform `/dev/random` returns immediately (no `getrandom()` stall), kernel CRNG init completes, all 5 reach login prompt.

- [x] Build matrix (5 enabled CHIPARCHes × Linux 4.9.37 and 7.0 × {`HW_RANDOM=y`, `=n`})
- [x] QEMU end-to-end on every supported platform
- [x] cv100/av100 still build (HWRNG `Kbuild` not included → no `#error`)

## Pairs with

- `OpenIPC/firmware` load_hisilicon early-load patch — links coming once that PR is filed.
- Emulation: widgetii/qemu-hisilicon#54 (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)