### PR TITLE
osal/cv500: fall back to default kernel CMA when no mmz= zone

### DIFF
--- a/kernel/osal/hi3516cv500/mmz/cma_allocator.c
+++ b/kernel/osal/hi3516cv500/mmz/cma_allocator.c
@@ -513,10 +513,31 @@ static int __allocator_init(char *s)
                 break;
             }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
-        /* Mainline kernels: use default CMA area, no vendor zone lookup */
         cma_zone = NULL;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
+        /* Vendor 4.9-style kernels expose hisi_get_cma_zone(name) which
+         * looks up a CMA region registered via the cmdline mmz= early_param
+         * in arch/arm/mach-hibvt's hi_cma.c. When U-Boot bootargs include
+         * mmz=, this is the preferred lookup (it preserves the per-zone
+         * name/gfp/alloc_type intent from the cmdline). */
         {
+            extern struct cma_zone *hisi_get_cma_zone(const char *name);
+            cma_zone = hisi_get_cma_zone(argv[0]);
+        }
+#endif
+        if (cma_zone == NULL) {
+            /* Fallback: use the kernel's default CMA pool (set by
+             * CONFIG_CMA_SIZE_MBYTES or the 'cma=' cmdline). This makes
+             * V3.5 cv500 boards work out-of-the-box with the legacy 4.9
+             * lite firmware — existing OpenIPC installs that never had
+             * mmz= in U-Boot bootargs still get a usable MMZ pool from
+             * the kernel default CMA, instead of failing with
+             * "can't get cma zone info:anonymous" + the subsequent
+             * -ENODEV from media_mem_init that PR #73 propagates.
+             *
+             * Available on every kernel that has CONFIG_CMA=y. The
+             * 5.16+ mainline path always lands here (no vendor
+             * hisi_get_cma_zone shim). */
             struct cma *default_cma = dev_get_cma_area(NULL);
             if (default_cma) {
                 static struct cma_zone default_zone;
@@ -526,14 +547,10 @@ static int __allocator_init(char *s)
                 cma_zone = &default_zone;
             }
         }
-#else
-        {
-            extern struct cma_zone *hisi_get_cma_zone(const char *name);
-            cma_zone = hisi_get_cma_zone(argv[0]);
-        }
-#endif
         if (cma_zone == NULL) {
-            printk(KERN_ERR "can't get cma zone info:%s\n", argv[0]);
+            printk(KERN_ERR "MMZ: no cma zone for '%s' and no default CMA pool either; "
+                   "set CONFIG_CMA_SIZE_MBYTES or pass mmz=/cma= in bootargs\n",
+                   argv[0]);
             continue;
         }
 


### PR DESCRIPTION
## Summary

Existing 4.9 lite installs on cv500 boards have never put \`mmz=anonymous,...\`
into U-Boot bootargs — they shipped with the vendor binary \`hi_osal.ko\`
which had its own raw allocator. After we replaced that with
\`open_osal.ko\` built from this tree, \`load_hisilicon\`'s no-MMZ branch
called \`cma_allocator_init\` → \`hisi_get_cma_zone(\"anonymous\")\` → NULL
→ skipped → PR [#73](https://github.com/OpenIPC/openhisilicon/pull/73)'s
\`-ENODEV\` propagation → \`insmod hi_osal.ko\` failed loud.

Existing cameras that \"worked for years\" stopped loading any vendor
module after a sysupgrade.

## Fix

When the named lookup fails (or on 5.16+ where there is no
\`hisi_get_cma_zone\` at all), fall back to \`dev_get_cma_area(NULL)\`,
which returns the kernel's default CMA pool — sized by
\`CONFIG_CMA_SIZE_MBYTES\` (16M on the \`av300/cv500/dv300\` generic
configs) or the \`cma=\` cmdline.

Installs that DO put \`mmz=\` in bootargs keep their per-zone intent —
the named lookup is still tried first.

## Test plan (verified on hi3516av300_imx415)

With default U-Boot bootargs — **no mmz=, no cma=** — and kernel
\`CONFIG_HIGHMEM=n\` + \`CONFIG_CMA_SIZE_MBYTES=16\`:

- [x] All 37 OSDRV modules load (open_osal → ... → open_acodec)
- [x] IMX415 sensor probed at 4K2K_10BIT_30FPS
- [x] H.264 + MJPEG channels created (\`HiSilicon SDK started\`)
- [x] RTSP server on :554
- [x] HTTP \`/image.jpg\` returns 130 KB baseline 3840×2160 JPEG
- [x] No \`can't get cma zone info\` error
- [x] No \`-ENODEV\` from \`media_mem_init\`

Companion firmware-side change incoming: disable \`CONFIG_HIGHMEM\` in
the cv500-family generic configs (av300/cv500/dv300). With HIGHMEM on,
the ARM kernel splits DDR at 0xb0000000 and any CMA region (vendor or
kernel) that crosses that boundary fails to reserve. Disabling HIGHMEM
matches what hi3516ev300 has shipped for years.

🤖 Generated with [Claude Code](https://claude.com/claude-code)