### PR TITLE
sensor/av100: use <linux/ioctl.h> for _IOC_SIZEBITS in hi_spi.h

### DIFF
--- a/kernel/include/hi3516av100/hi_spi.h
+++ b/kernel/include/hi3516av100/hi_spi.h
@@ -1,7 +1,7 @@
 #ifndef __HI_SPI_H__
 #define __HI_SPI_H__
 
-#include <sys/ioctl.h>
+#include <linux/ioctl.h>
 
 typedef unsigned long long  __u64;
 typedef unsigned int        __u32;


### PR DESCRIPTION
## Summary

Take 2 of the musl fix from #83. The previous attempt added \`<sys/ioctl.h>\`, which works under glibc (transitively pulls in \`<asm-generic/ioctl.h>\` with \`_IOC_SIZEBITS\`) but **not under musl on arm** — musl's \`<sys/ioctl.h>\` -> \`<bits/ioctl.h>\` chain doesn't re-export the kernel UAPI \`_IOC_SIZEBITS\` macro.

Match the pattern that \`hi3516cv200/hi_spi.h\` and \`hi3516cv300/hi_spi.h\` already use:

\`\`\`diff
-#include <sys/ioctl.h>
+#include <linux/ioctl.h>
\`\`\`

\`<linux/ioctl.h>\` is the kernel UAPI header that defines \`_IOC_SIZEBITS\` directly (both libcs forward to it). No-op under glibc, fixes the musl build of \`imx117\`, \`imx123\`, \`imx185\` — every av100 sensor whose \`*_sensor_ctl.c\` issues \`SPI_IOC_MESSAGE\`.

## How surfaced

OpenIPC/firmware#2056's CI install step:

\`\`\`
hi_spi.h:92:60: error: '_IOC_SIZEBITS' undeclared (first use in this function)
…
/usr/bin/install: cannot stat '.../sony_imx117/libsns_imx117.so': No such file or directory
/usr/bin/install: cannot stat '.../sony_imx123/libsns_imx123.so': No such file or directory
/usr/bin/install: cannot stat '.../sony_imx185/libsns_imx185.so': No such file or directory
\`\`\`

The previous \`<sys/ioctl.h>\` change landed CI-green on #83 because the libraries Makefile's \`|| true\` hides per-sensor build failures — only the firmware-side install foreach surfaces them.

## Test plan

- [x] Build sony_imx117/imx123/imx185 locally with arm-openipc-linux-gnueabi-gcc 13.3.0 (still clean)
- [ ] CI: \`Build SDK (hi3516av100, hi3516av100_lite)\` job under musl produces all 3 .so files
- [ ] After merge + firmware pin bump: re-run firmware#2056 build-one for hi3516av100_lite, verify install succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)