### PR TITLE
libraries: fail the build when any sensor fails to compile

### DIFF
--- a/libraries/Makefile
+++ b/libraries/Makefile
@@ -32,6 +32,13 @@ ifeq ($(CHIPARCH),hi3519v101)
 endif
 
 all:
+	@failed=""; \
 	for dir in $(SUBDIRS); do \
-		make -C $$dir CHIPARCH=$(CHIPARCH) all || true; \
-	done
+		$(MAKE) -C $$dir CHIPARCH=$(CHIPARCH) all || failed="$$failed $$dir"; \
+	done; \
+	if [ -n "$$failed" ]; then \
+		echo; \
+		echo "Build failed for:" >&2; \
+		for d in $$failed; do echo "  $$d" >&2; done; \
+		exit 1; \
+	fi

--- a/libraries/sensor/hi3516cv500/Makefile
+++ b/libraries/sensor/hi3516cv500/Makefile
@@ -1,9 +1,16 @@
 SENSOR_DIRS := $(sort $(dir $(wildcard */Makefile)))
 
 all:
+	@failed=""; \
 	for dir in $(SENSOR_DIRS); do \
-		make -C $$dir all || true; \
-	done
+		$(MAKE) -C $$dir all || failed="$$failed $$dir"; \
+	done; \
+	if [ -n "$$failed" ]; then \
+		echo; \
+		echo "Build failed for:" >&2; \
+		for d in $$failed; do echo "  $$d" >&2; done; \
+		exit 1; \
+	fi
 
 clean:
 	for dir in $(SENSOR_DIRS); do \


### PR DESCRIPTION
## Summary

Both \`libraries/Makefile\` and \`libraries/sensor/hi3516cv500/Makefile\` iterated subdirs with \`make ... || true\`, which silently swallowed per-sensor compile failures. Three musl-only header bugs surfaced through this gap during the per-platform sensor source migration ([#82](https://github.com/OpenIPC/openhisilicon/issues/82)):

| Bug | Sensor | Fix |
|---|---|---|
| missing `<linux/ioctl.h>` → `_IOC_SIZEBITS` undeclared | cv300/imx323 | #84 |
| missing `-I kernel/pwm/hi3516av100` | av100/imx117 | #83 |
| av100 `hi_spi.h` used `<sys/ioctl.h>` (broken under musl) | av100/imx123, imx185 | #90 |

In each case the `Build SDK (chiparch)` CI job stayed green because the libraries Makefile reported success even when individual sensors didn't link. The breakage was only caught when the firmware-side `INSTALL_TARGET_CMDS` step couldn't stat the missing `.so`. For **cv300 it even slipped past CI entirely** — the install foreach uses `;` separators, so its exit code is the *last* install's exit code, and `sony_imx323` (which failed) was followed by `sony_imx385` (which succeeded). Only sysupgrading a real camera surfaced the missing `libsns_imx323.so`.

## Change

Replace `|| true` with a fail-late accumulator: keep iterating so all errors surface in one CI run, then exit 1 with a summary list of failing dirs at the end.

```makefile
all:
	@failed=""; \
	for dir in $(SUBDIRS); do \
		$(MAKE) -C $$dir CHIPARCH=$(CHIPARCH) all || failed="$$failed $$dir"; \
	done; \
	if [ -n "$$failed" ]; then \
		echo; \
		echo "Build failed for:" >&2; \
		for d in $$failed; do echo "  $$d" >&2; done; \
		exit 1; \
	fi
```

## Test plan

- [x] All 7 platforms still build clean under \`arm-openipc-linux-gnueabi-gcc\` 13.3.0
- [x] Injecting \`#error\` into one sensor source produces the right behaviour:
  - surrounding sensors continue to build
  - loop reports `Build failed for: ./sensor/.../`
  - make exits 1
- [ ] CI: `Build SDK (...)` passes on all 11 platform/kernel matrix rows under musl

## Why both Makefiles

`libraries/Makefile` is the top-level entry. `libraries/sensor/hi3516cv500/Makefile` is reached when `CHIPARCH=hi3516cv500` because the outer SUBDIRS filter `./sensor/hi3516cv500/% ./isp/` matches both subsensor dirs *and* the cv500 dir itself (the `%` matches empty), so the loop runs make on the cv500 dir which delegates to its inner Makefile. Both paths had the same `|| true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)