### PR TITLE
kernel: build V4 module set for gk7205v200 too

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -50,7 +50,7 @@ include $(src)/sensor_spi/Kbuild
 include $(src)/mipi_rx/Kbuild
 #+user
 
-ifeq ($(CHIPARCH),hi3516ev200)
+ifneq ($(filter $(CHIPARCH),hi3516ev200 gk7205v200),)
     include $(src)/acodec/Kbuild
     include $(src)/adec/Kbuild
     include $(src)/aenc/Kbuild


### PR DESCRIPTION
## Summary

The V4 heavy module set (`acodec, adec, aenc, ai, aio, ao, base, chnl, h264e, h265e, ive, ive_neo, jpege, rc, rgn, sys, vedu, venc, vgs, vi, vpss`) was gated \`ifeq (\$(CHIPARCH),hi3516ev200)\` in `kernel/Kbuild`, so the pin-compatible `gk7205v200` SoC didn't get any of them. Real `gk7205v300` cameras boot loading 21 vendor `gk7205v200_*.ko` blobs from the goke-osdrv firmware package while `ev300` cameras run the full `open_*` set.

`lsmod` confirms the asymmetry on cameras booted from current master:

| | hi3516ev300 | gk7205v300 |
|---|---|---|
| Taint flag | `G` (GPL clean) | **`P`** (proprietary) |
| Heavy modules | 22× `open_*` | 20× `gk7205v200_*` (vendor) |

Per `CLAUDE.md` ("hi3516ev200 and gk7205v200 are pin-compatible. Same source compiles for both via different CHIPARCH values"), these chips share register layout. The vendor SDK source/binaries used for `ev200` have been running successfully on `gk7205v200` for a long time (Goke firmware uses the same SDK path).

## Change

```diff
-ifeq ($(CHIPARCH),hi3516ev200)
+ifneq ($(filter $(CHIPARCH),hi3516ev200 gk7205v200),)
     include $(src)/acodec/Kbuild
     ...
     include $(src)/vpss/Kbuild
 endif
```

## Companion firmware change

Required so the resulting `open_*.ko` files actually replace the vendor blobs at runtime:

- Add a `gk7205v200` install branch in `firmware/general/package/hisilicon-opensdk/hisilicon-opensdk.mk` that copies `open_*.ko` to `/lib/modules/.../goke/` with the `gk7205v200_*.ko` filenames `load_goke` already insmods (no boot-script change needed).
- Drop the matching vendor blob INSTALL lines from `goke-osdrv-gk7205v200.mk`.

(Tracked separately; will reference this PR when filed.)

## Test plan

- [ ] CI: `Build SDK (gk7205v200, gk7205v200_lite)` passes — should produce 31 open_*.ko (matching hi3516ev200_lite's count)
- [ ] CI: `QEMU boot (gk7205v200)` still green
- [ ] Hardware: gk7205v300 camera (`openipc-gk7205v300.dlab.doty.ru`) boots with new firmware, `lsmod` shows tainted `G` not `P`, `/image.jpg` returns valid JPEG

🤖 Generated with [Claude Code](https://claude.com/claude-code)