### PR TITLE
WITHDRAWN: sony_imx335 Isp_SnsMode=5 (M7 + FPS-priority) — clamp is dead code

### DIFF
--- a/libraries/sensor/hi3516ev200/sony_imx335/imx335_cmos.c
+++ b/libraries/sensor/hi3516ev200/sony_imx335/imx335_cmos.c
@@ -61,6 +61,15 @@ static GK_U32 g_u32Imx335DGain[ISP_MAX_PIPE_NUM] = { [0 ...(ISP_MAX_PIPE_NUM -
 static GK_U32 g_au32Imx335CropW[ISP_MAX_PIPE_NUM] = {[0 ...(ISP_MAX_PIPE_NUM - 1)] = 1920};
 static GK_U32 g_au32Imx335CropH[ISP_MAX_PIPE_NUM] = {[0 ...(ISP_MAX_PIPE_NUM - 1)] = 1080};
 
+/* When set, cmos_slow_framerate_set forces the per-frame VMAX update to the
+ * datasheet minimum (vmax_min = (crop_h+20)*2 + 96) instead of accepting the
+ * AE library's chosen u32FullLines. Selected by Isp_SnsMode=5 in the sensor
+ * INI; pins the sensor at its theoretical max rate at the cost of shrinking
+ * AE max-integration-time to a few ms. Out-of-scope for IP-cam scenes that
+ * need long exposures; intended for FPV / machine-vision where the camera
+ * lives in daylight and motion rate is the priority. */
+static GK_BOOL g_abImx335FpsPriority[ISP_MAX_PIPE_NUM] = { 0 };
+
 GK_VOID IMX335_get_crop(VI_PIPE ViPipe, GK_U32 *pu32W, GK_U32 *pu32H)
 {
 	if (ViPipe < 0 || ViPipe >= ISP_MAX_PIPE_NUM) {
@@ -611,6 +620,20 @@ static GK_VOID cmos_slow_framerate_set(VI_PIPE ViPipe, GK_U32 u32FullLines,
 	CMOS_CHECK_POINTER_VOID(pstAeSnsDft);
 	IMX335_SENSOR_GET_CTX(ViPipe, pstSnsState);
 	CMOS_CHECK_POINTER_VOID(pstSnsState);
+
+	/* FPS-priority mode (Isp_SnsMode=5): clamp the AE-supplied u32FullLines
+	 * down to the datasheet vmax_min so the sensor stays at its theoretical
+	 * max rate. Without this clamp, AE-feedback in M7 picks larger VMAX and
+	 * pulls real fps to ~half theoretical at small crops. See
+	 * docs/imx335-v4-high-fps.md §8.5. */
+	if (IMX335_CROP_FLEX_LINEAR_MODE == pstSnsState->u8ImgMode &&
+	    ViPipe >= 0 && ViPipe < ISP_MAX_PIPE_NUM &&
+	    g_abImx335FpsPriority[ViPipe]) {
+		GK_U32 cw, ch, vmax_min;
+		IMX335_get_crop(ViPipe, &cw, &ch);
+		vmax_min = (ch + 20) * 2 + 96;
+		if (u32FullLines > vmax_min) u32FullLines = vmax_min;
+	}
 
 	if (WDR_MODE_2To1_LINE == pstSnsState->enWDRMode) {
 		if (IMX335_4M_30FPS_10BIT_WDR_MODE == pstSnsState->u8ImgMode) {
@@ -1794,8 +1817,16 @@ cmos_set_image_mode(VI_PIPE ViPipe,
 	 * W×H in stWndRect / stSnsSize → ISP_CMOS_SENSOR_IMAGE_MODE_S.u16Width/
 	 * u16Height. Driver applies WINMODE=4 with parameterized HTRIMMING_START
 	 * / HNUM / AREA3_ST_ADR_1 / AREA3_WIDTH_1 so users can pick arbitrary
-	 * crop sizes within the datasheet's all-pixel window-crop constraints. */
-	if (pstSensorImageMode->u8SnsMode == 4 &&
+	 * crop sizes within the datasheet's all-pixel window-crop constraints.
+	 *
+	 * Isp_SnsMode=5 is the same flex-crop dispatch + the AE-VMAX clamp
+	 * (cmos_slow_framerate_set forces VMAX = vmax_min so AE-feedback can't
+	 * drag the sensor below its theoretical max rate). Trade-off: max
+	 * integration time shrinks to (vmax_min - 8) lines (e.g. ~2.9 ms at
+	 * 480×352 with HMAX=0x0100). Use for FPV / machine-vision where
+	 * motion-rate is the priority and the camera lives in daylight. Not
+	 * appropriate for indoor IP-cam scenes that need longer exposures. */
+	if ((pstSensorImageMode->u8SnsMode == 4 || pstSensorImageMode->u8SnsMode == 5) &&
 	    WDR_MODE_NONE == pstSnsState->enWDRMode) {
 		u8SensorImageMode = IMX335_CROP_FLEX_LINEAR_MODE;
 		g_astimx335State[ViPipe].u32BRL = 1984 * 2;
@@ -1803,6 +1834,8 @@ cmos_set_image_mode(VI_PIPE ViPipe,
 		if (ViPipe >= 0 && ViPipe < ISP_MAX_PIPE_NUM) {
 			g_au32Imx335CropW[ViPipe] = pstSensorImageMode->u16Width  ?: 1920;
 			g_au32Imx335CropH[ViPipe] = pstSensorImageMode->u16Height ?: 1080;
+			g_abImx335FpsPriority[ViPipe] =
+				(pstSensorImageMode->u8SnsMode == 5) ? GK_TRUE : GK_FALSE;
 		}
 		goto img_mode_set;
 	}


### PR DESCRIPTION
## Withdrawing this PR

The "+145% deliverable fps lift" claim that justified this PR turns
out to be a measurement artifact, not reproducible on retest. The
clamp in `cmos_slow_framerate_set` is **dead code in normal
operation**.

## What the retest showed (2026-05-13)

Tested on freshly-power-cycled gk7205v300 and on hi3516ev300 (with 13h
uptime, accumulated state). Identical INI/yaml between runs, only
`Isp_SnsMode` flipping between `4` (existing M7) and `5` (this PR's
new opt-in):

| Board | Crop @ req | SnsMode=4 wire | SnsMode=5 wire | MaxLine |
|-------|------------|----------------|----------------|---------|
| ev300 | 1280×720 @100 | 98.2 fps | 98.2 fps | 2058 |
| ev300 | 800×480 @240  | 185.1 fps | 185.1 fps | 1088 |
| ev300 | 480×352 @60   | 58.9 fps | 58.9 fps | 3436 |
| ev300 | 480×352 @100  | 98.2 fps | 98.2 fps | 2058 |
| ev300 | 480×352 @240  | 235.0 fps | 235.0 fps | 853 |
| gk300 | 480×352 @240 (3-min soak) | 234.7 fps | 234.7 fps | 853 |
| gk300 | 480×352 @240 (4 restart cycles) | 234.6-234.8 fps | 234.6-234.8 fps | 853 |

**Both modes deliver identical wire fps AND identical MaxLine in every
test.** Including: long soak, multiple restart cycles, fresh boot, multiple
crops. The clamp does not fire.

## Why it's dead code

`cmos_slow_framerate_set` is the AE callback for *extending* exposure
beyond `u32FullLinesStd` (for low-light scenes that need longer
shutter than the configured framerate allows). In normal operation at
static scenes, AE finds adequate exposure within the configured
`u32FLStd` and never invokes this function. So the new guard executes
zero times.

The function that actually sets `u32FLStd` in M7 is `cmos_fps_set`
(`imx335_cmos.c:426-447`), called once at sensor init. It already has
its own `vmax_min` floor.

## What's actually true

PR #100's HMAX=0x0100 patch is real and reproducible — 235 fps wire
at 480×352 vs the smaller numbers at HMAX=0x016E baseline. That PR
stays valid.

For users who want max sensor rate at any crop, simply request a high
`Isp_FrameRate` in the INI — `cmos_fps_set`'s formula
`u32Lines = 2296 × 90 / f32Fps` lands `u32FLStd` at or near `vmax_min`
naturally at high request fps. No patch needed; the existing driver
already does the right thing.

## Lessons

1. **Measure before claiming**: the "+145% lift" was based on a
   single-session comparison. Should have re-measured on a clean
   board state before raising the PR.
2. **Verify the code path actually executes**: I should have added a
   print or counter to confirm the clamp fires before claiming it
   does anything.
3. **Volatile testing sessions accumulate state**: between many
   sensor mode switches, AE-clamp experiments, and binary swaps in
   the original session, the earlier measurements were not capturing
   what I thought they were.

## Refuted by

- Test data above (this PR body)
- kaeru `v4-ae-vmax-clamp-claim-refuted-2026-05-13` — full retraction with detail

## Out of scope

Future work on max-fps for FPV could go in `cmos_fps_set` itself
(replace the `IMX335_VMAX_CROPPED_1080P * 90 / f32Fps` formula with
a direct `vmax_min` write for an FPS-priority mode). That would
actually fire. But that's a different PR.

Closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)