### PR TITLE
libraries/sensor/hi3516ev200: IMX307 high-fps flex modes (2-lane + 4-lane)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,38 @@ Flexible-crop ceiling rises as crop shrinks; per-size points measured:
 Set `Isp_FrameRate` in the sensor INI to request a target rate; the driver
 clamps to the per-mode sensor ceiling.
 
+### IMX307 high-framerate modes (hi3516ev200 / gk7205v200)
+
+Wire fps from VENC `Send` counter (5 s window, h.265 @ 4 Mbps wire) on
+`openipc-gk7205v200` with the `sony_imx307_2L` driver (2-lane MIPI
+CSI-2). `Isp_SnsMode` dispatch follows the same IMX335 PR #99 pattern
+(`u8SnsMode=4` → window crop, programmable W×H). Register values
+verified against Sony IMX307LQD-C datasheet pp.49 / 54-58 / 60-65 /
+66-68. The 4-lane variant (`sony_imx307`) carries the same dispatch
+infrastructure with MIPI D-PHY timings from the datasheet's "4-Lane"
+columns — not yet validated on real hardware.
+
+| Mode | Sensor crop | Wire fps | Encoder ceiling | Selected by |
+|------|-------------|----------|------------------|-------------|
+| Stock 1080p | 1920×1080 | 30 fps | — | (default) |
+| 1080p60 boost | 1920×1080 | 44 fps | **44** (encoder-bound) | `Isp_FrameRate=60` |
+| 720p60 sub-readout | 1280×720 | 60 fps | 60 (sensor PHY tier) | `Isp_SnsMode=1` |
+| 720p flex | 1280×720 | up to **91 fps** | 91 (encoder-bound) | `Isp_SnsMode=4` + `Isp_W=1280 Isp_H=720` |
+| VGA flex | 640×480 | up to **130 fps** | 130 (encoder-bound) | `Isp_SnsMode=4` + `Isp_W=640 Isp_H=480` |
+| CIF flex | 368×304 | up to **200 fps** | 200-219 (encoder-bound) | `Isp_SnsMode=4` + `Isp_W=368 Isp_H=304` |
+
+Lower bound on flex-crop dimensions is 368×304 (datasheet WINMODE=4h
+constraint: WINWH ≥ 368 mult-of-4, WINWV ≥ 304). At 1080p the encoder
+caps wire fps regardless of sensor rate; sub-1080p resolutions lift
+the ceiling roughly with the reciprocal of pixel count, until either
+the encoder hits a per-frame budget or the sensor reaches its own
+VMAX-floor at the requested crop.
+
+gk7205v200 requires `clock=37.125MHz` in the INI's `[mode]` section
+(vendor blob defaults to 27 MHz INCK; without the override the
+delivered rate is ~73% of nominal). Same gotcha applies to IMX335
+high-fps presets on the gk side.
+
 ## Kernel modules
 
 All modules are prefixed `open_` to distinguish from vendor SDK modules. The set of modules varies by platform generation:

--- a/libraries/sensor/hi3516ev200/sony_imx307/imx307_cmos.c
+++ b/libraries/sensor/hi3516ev200/sony_imx307/imx307_cmos.c
@@ -106,10 +106,39 @@ extern int imx307_read_register(VI_PIPE ViPipe, int addr);
 
 #define IMX307_VMAX_1080P30_LINEAR (1125 + IMX307_INCREASE_LINES)
 #define IMX307_VMAX_1080P60TO30_WDR (1220 + IMX307_INCREASE_LINES) // 10bit
+#define IMX307_VMAX_720P60_LINEAR  (750)
 
 // sensor fps mode
 #define IMX307_SENSOR_1080P_30FPS_LINEAR_MODE (1)
 #define IMX307_SENSOR_1080P_30FPS_2t1_WDR_MODE (2)
+#define IMX307_SENSOR_1080P_60FPS_LINEAR_MODE (3)
+#define IMX307_SENSOR_720P_60FPS_LINEAR_MODE  (4)
+#define IMX307_SENSOR_FLEX_CROP_LINEAR_MODE   (5)
+
+/* Crop window dimensions for FLEX_CROP mode (Isp_SnsMode=4). Mirrors
+ * the IMX335 PR #99 g_au32Imx335CropW/H pattern; populated by
+ * cmos_set_image_mode from pstSensorImageMode->u16Width/u16Height,
+ * read by imx307_flex_crop_init when programming WINMODE=4h +
+ * WINPH/WINPV/WINWH/WINWV. */
+extern GK_U32 g_au32Imx307_CropW[ISP_MAX_PIPE_NUM];
+extern GK_U32 g_au32Imx307_CropH[ISP_MAX_PIPE_NUM];
+
+GK_U32 g_au32Imx307_CropW[ISP_MAX_PIPE_NUM] = {
+	[0 ...(ISP_MAX_PIPE_NUM - 1)] = 1920
+};
+GK_U32 g_au32Imx307_CropH[ISP_MAX_PIPE_NUM] = {
+	[0 ...(ISP_MAX_PIPE_NUM - 1)] = 1080
+};
+
+void imx307_get_crop(VI_PIPE ViPipe, GK_U32 *pu32W, GK_U32 *pu32H)
+{
+	if (ViPipe < 0 || ViPipe >= ISP_MAX_PIPE_NUM)
+		return;
+	if (pu32W)
+		*pu32W = g_au32Imx307_CropW[ViPipe];
+	if (pu32H)
+		*pu32H = g_au32Imx307_CropH[ViPipe];
+}
 
 #define IMX307_RES_IS_1080P(w, h) ((w) <= 1920 && (h) <= 1080)
 
@@ -278,6 +307,58 @@ static GK_VOID cmos_fps_set(VI_PIPE ViPipe, GK_FLOAT f32Fps,
 				  DIV_0_TO_1_FLOAT(f32Fps);
 			pstAeSnsDft->u32LinesPer500ms =
 				IMX307_VMAX_1080P30_LINEAR * 15;
+		} else {
+			ISP_TRACE(MODULE_DBG_ERR, "Not support Fps: %f\n",
+				  f32Fps);
+			return;
+		}
+		u32VMAX = (u32VMAX > IMX307_FULL_LINES_MAX) ?
+				  IMX307_FULL_LINES_MAX :
+				  u32VMAX;
+		break;
+
+	case IMX307_SENSOR_1080P_60FPS_LINEAR_MODE:
+		if ((f32Fps <= 60) && (f32Fps >= 0.12)) {
+			u32VMAX = IMX307_VMAX_1080P30_LINEAR * 60 /
+				  DIV_0_TO_1_FLOAT(f32Fps);
+			pstAeSnsDft->u32LinesPer500ms =
+				IMX307_VMAX_1080P30_LINEAR * 30;
+		} else {
+			ISP_TRACE(MODULE_DBG_ERR, "Not support Fps: %f\n",
+				  f32Fps);
+			return;
+		}
+		u32VMAX = (u32VMAX > IMX307_FULL_LINES_MAX) ?
+				  IMX307_FULL_LINES_MAX :
+				  u32VMAX;
+		break;
+
+	case IMX307_SENSOR_720P_60FPS_LINEAR_MODE:
+		if ((f32Fps <= 60) && (f32Fps >= 0.12)) {
+			u32VMAX = IMX307_VMAX_720P60_LINEAR * 60 /
+				  DIV_0_TO_1_FLOAT(f32Fps);
+			pstAeSnsDft->u32LinesPer500ms =
+				IMX307_VMAX_720P60_LINEAR * 30;
+		} else {
+			ISP_TRACE(MODULE_DBG_ERR, "Not support Fps: %f\n",
+				  f32Fps);
+			return;
+		}
+		u32VMAX = (u32VMAX > IMX307_FULL_LINES_MAX) ?
+				  IMX307_FULL_LINES_MAX :
+				  u32VMAX;
+		break;
+
+	case IMX307_SENSOR_FLEX_CROP_LINEAR_MODE:
+		/* WINMODE=4h, HMAX=0x0898 locked → fps scales with VMAX.
+		 * Datasheet p.49 1H period at FRSEL=1h = 14.8 us =>
+		 * VMAX = 1 / (fps × 14.8e-6). Same formula as 2-Lane
+		 * variant since HMAX is in pixel-clocks (lane-count
+		 * invariant); only MIPI PHY timings differ. */
+		if ((f32Fps <= 240) && (f32Fps >= 0.12)) {
+			u32VMAX = (GK_U32)(67568 / DIV_0_TO_1_FLOAT(f32Fps));
+			pstAeSnsDft->u32LinesPer500ms =
+				IMX307_VMAX_720P60_LINEAR * 30;
 		} else {
 			ISP_TRACE(MODULE_DBG_ERR, "Not support Fps: %f\n",
 				  f32Fps);
@@ -1229,6 +1310,31 @@ cmos_set_image_mode(VI_PIPE ViPipe,
 	u8SensorImageMode = pstSnsState->u8ImgMode;
 	pstSnsState->bSyncInit = GK_FALSE;
 
+	/* Explicit Isp_SnsMode dispatch (mirrors IMX335 PR #99 / IMX415 PR #97).
+	 * Isp_SnsMode=1: 720p sub-readout (WINMODE=1h).
+	 * Isp_SnsMode=4: flex window crop (WINMODE=4h), arbitrary W×H from
+	 *   pstSensorImageMode->u16Width/u16Height. */
+	if (pstSensorImageMode->u8SnsMode == 1 &&
+	    pstSnsState->enWDRMode == WDR_MODE_NONE) {
+		u8SensorImageMode = IMX307_SENSOR_720P_60FPS_LINEAR_MODE;
+		pstSnsState->u32FLStd = IMX307_VMAX_720P60_LINEAR;
+		g_astimx307State[ViPipe].u8Hcg = 0x2;
+		goto img_mode_set;
+	}
+	if (pstSensorImageMode->u8SnsMode == 4 &&
+	    pstSnsState->enWDRMode == WDR_MODE_NONE) {
+		u8SensorImageMode = IMX307_SENSOR_FLEX_CROP_LINEAR_MODE;
+		pstSnsState->u32FLStd = IMX307_VMAX_1080P30_LINEAR;
+		g_astimx307State[ViPipe].u8Hcg = 0x2;
+		if (ViPipe >= 0 && ViPipe < ISP_MAX_PIPE_NUM) {
+			g_au32Imx307_CropW[ViPipe] =
+				pstSensorImageMode->u16Width ?: 1920;
+			g_au32Imx307_CropH[ViPipe] =
+				pstSensorImageMode->u16Height ?: 1080;
+		}
+		goto img_mode_set;
+	}
+
 	if (pstSensorImageMode->f32Fps <= 30) {
 		if (pstSnsState->enWDRMode == WDR_MODE_NONE) {
 			if (IMX307_RES_IS_1080P(pstSensorImageMode->u16Width,
@@ -1261,8 +1367,19 @@ cmos_set_image_mode(VI_PIPE ViPipe,
 			IMX307_ERR_MODE_PRINT(pstSensorImageMode, pstSnsState);
 			return GK_FAILURE;
 		}
+	} else if (pstSensorImageMode->f32Fps <= 60 &&
+		   pstSnsState->enWDRMode == WDR_MODE_NONE &&
+		   IMX307_RES_IS_1080P(pstSensorImageMode->u16Width,
+				       pstSensorImageMode->u16Height)) {
+		u8SensorImageMode = IMX307_SENSOR_1080P_60FPS_LINEAR_MODE;
+		pstSnsState->u32FLStd = IMX307_VMAX_1080P30_LINEAR;
+		g_astimx307State[ViPipe].u8Hcg = 0x2;
 	} else {
+		IMX307_ERR_MODE_PRINT(pstSensorImageMode, pstSnsState);
+		return GK_FAILURE;
 	}
+
+img_mode_set:
 
 	if ((pstSnsState->bInit == GK_TRUE) &&
 	    (u8SensorImageMode == pstSnsState->u8ImgMode)) {

--- a/libraries/sensor/hi3516ev200/sony_imx307/imx307_sensor_ctl.c
+++ b/libraries/sensor/hi3516ev200/sony_imx307/imx307_sensor_ctl.c
@@ -147,9 +147,17 @@ void imx307_restart(VI_PIPE ViPipe)
 
 #define IMX307_SENSOR_1080P_30FPS_LINEAR_MODE (1)
 #define IMX307_SENSOR_1080P_30FPS_2t1_WDR_MODE (2)
+#define IMX307_SENSOR_1080P_60FPS_LINEAR_MODE (3)
+#define IMX307_SENSOR_720P_60FPS_LINEAR_MODE  (4)
+#define IMX307_SENSOR_FLEX_CROP_LINEAR_MODE   (5)
+
+extern void imx307_get_crop(VI_PIPE ViPipe, GK_U32 *pu32W, GK_U32 *pu32H);
 
 void imx307_wdr_1080p30_2to1_init(VI_PIPE ViPipe);
 void imx307_linear_1080p30_init(VI_PIPE ViPipe);
+void imx307_linear_1080p60_init(VI_PIPE ViPipe);
+void imx307_linear_720p60_init(VI_PIPE ViPipe);
+void imx307_flex_crop_init(VI_PIPE ViPipe);
 void imx307_default_reg_init(VI_PIPE ViPipe)
 {
 	GK_U32 i;
@@ -183,6 +191,12 @@ void imx307_init(VI_PIPE ViPipe)
 			imx307_wdr_1080p30_2to1_init(ViPipe);
 		} else {
 		}
+	} else if (IMX307_SENSOR_1080P_60FPS_LINEAR_MODE == u8ImgMode) {
+		imx307_linear_1080p60_init(ViPipe);
+	} else if (IMX307_SENSOR_720P_60FPS_LINEAR_MODE == u8ImgMode) {
+		imx307_linear_720p60_init(ViPipe);
+	} else if (IMX307_SENSOR_FLEX_CROP_LINEAR_MODE == u8ImgMode) {
+		imx307_flex_crop_init(ViPipe);
 	} else {
 		imx307_linear_1080p30_init(ViPipe);
 	}
@@ -258,6 +272,293 @@ void imx307_linear_1080p30_init(VI_PIPE ViPipe)
 	printf("==============================================================\n");
 	printf("===Sony imx307 sensor 1080P30fps(MIPI) init success!=====\n");
 	printf("==============================================================\n");
+	return;
+}
+
+/* 1080P60 linear, 4-lane MIPI CSI-2. FRSEL=1h → 445.5 Mbps/lane
+ * (datasheet p.48 / p.62 column "60/50 fps 4-Lane"). HMAX=0x0898,
+ * VMAX=0x0465. MIPI D-PHY HS timings match the 445.5 Mbps/lane tier
+ * (same byte-clock as 2-Lane 30 fps, hence the values that the
+ * existing 4-lane WDR init at FRSEL=1h already uses). Built from
+ * datasheet but NOT yet verified on real hardware — exercise with
+ * a 4-lane IMX307 board and validate before declaring production-ready.
+ */
+void imx307_linear_1080p60_init(VI_PIPE ViPipe)
+{
+	imx307_write_register(ViPipe, 0x3000, 0x01); // Standby
+	imx307_write_register(ViPipe, 0x3002, 0x01); // Master mode stop
+
+	imx307_write_register(ViPipe, 0x3005, 0x01);
+	imx307_write_register(ViPipe, 0x3007, 0x00); // WINMODE=0h
+	imx307_write_register(ViPipe, 0x3009, 0x01); // FRSEL=1h (60fps, 445.5 Mbps/lane)
+	imx307_write_register(ViPipe, 0x300c, 0x00);
+	imx307_write_register(ViPipe, 0x3010, 0x21);
+	imx307_write_register(ViPipe, 0x3011, 0x0a);
+	imx307_write_register(ViPipe, 0x3014, 0x00);
+	imx307_write_register(ViPipe, 0x3018, 0x65); // VMAX[7:0]
+	imx307_write_register(ViPipe, 0x3019, 0x04); // VMAX[15:8]
+	imx307_write_register(ViPipe, 0x301c, 0x98); // HMAX=0x0898
+	imx307_write_register(ViPipe, 0x301d, 0x08);
+	imx307_write_register(ViPipe, 0x3046, 0x01); // MIPI
+	imx307_write_register(ViPipe, 0x305c, 0x18); // INCKSEL1 37.125 MHz
+	imx307_write_register(ViPipe, 0x305d, 0x03);
+	imx307_write_register(ViPipe, 0x305e, 0x20);
+	imx307_write_register(ViPipe, 0x305f, 0x01);
+	imx307_write_register(ViPipe, 0x309e, 0x4a);
+	imx307_write_register(ViPipe, 0x309f, 0x4a);
+	imx307_write_register(ViPipe, 0x3106, 0x00);
+	imx307_write_register(ViPipe, 0x311c, 0x0e);
+	imx307_write_register(ViPipe, 0x3128, 0x04);
+	imx307_write_register(ViPipe, 0x3129, 0x1D); // ADBIT1 (10-bit)
+	imx307_write_register(ViPipe, 0x313b, 0x41);
+	imx307_write_register(ViPipe, 0x315e, 0x1a); // INCKSEL5
+	imx307_write_register(ViPipe, 0x3164, 0x1a);
+	imx307_write_register(ViPipe, 0x317c, 0x12); // ADBIT2 (10-bit)
+	imx307_write_register(ViPipe, 0x31ec, 0x37); // ADBIT3 (10-bit)
+
+	imx307_write_register(ViPipe, 0x3405, 0x10); // REPETITION (FRSEL=1h 4-lane)
+	imx307_write_register(ViPipe, 0x3407, 0x03); // PHYSICAL_LANE_NUM (4-lane)
+	imx307_write_register(ViPipe, 0x3414, 0x0A);
+	imx307_write_register(ViPipe, 0x3418, 0x49); // Y_OUT_SIZE 0x0449 = 1097
+	imx307_write_register(ViPipe, 0x3419, 0x04);
+	imx307_write_register(ViPipe, 0x3441, 0x0A);
+	imx307_write_register(ViPipe, 0x3442, 0x0A);
+	imx307_write_register(ViPipe, 0x3443, 0x03); // CSI_LANE_MODE (4-lane)
+	imx307_write_register(ViPipe, 0x3444, 0x20); // EXTCK_FREQ
+	imx307_write_register(ViPipe, 0x3445, 0x25);
+	/* MIPI D-PHY HS timings for 445.5 Mbps/lane (datasheet p.62 column
+	 * "60/50 fps 4-Lane"); matches the 4-lane WDR init at FRSEL=1h. */
+	imx307_write_register(ViPipe, 0x3446, 0x57); // TCLKPOST
+	imx307_write_register(ViPipe, 0x3447, 0x00);
+	imx307_write_register(ViPipe, 0x3448, 0x37); // THSZERO
+	imx307_write_register(ViPipe, 0x3449, 0x00);
+	imx307_write_register(ViPipe, 0x344A, 0x1F); // THSPREPARE
+	imx307_write_register(ViPipe, 0x344B, 0x00);
+	imx307_write_register(ViPipe, 0x344C, 0x1F); // TCLKTRAIL
+	imx307_write_register(ViPipe, 0x344D, 0x00);
+	imx307_write_register(ViPipe, 0x344E, 0x1F); // THSTRAIL
+	imx307_write_register(ViPipe, 0x344F, 0x00);
+	imx307_write_register(ViPipe, 0x3450, 0x77); // TCLKZERO
+	imx307_write_register(ViPipe, 0x3451, 0x00);
+	imx307_write_register(ViPipe, 0x3452, 0x1F); // TCLKPREPARE
+	imx307_write_register(ViPipe, 0x3453, 0x00);
+	imx307_write_register(ViPipe, 0x3454, 0x17); // TLPX
+	imx307_write_register(ViPipe, 0x3455, 0x00);
+	imx307_write_register(ViPipe, 0x3472, 0x9C); // X_OUT_SIZE 0x079C = 1948
+	imx307_write_register(ViPipe, 0x3473, 0x07);
+	imx307_write_register(ViPipe, 0x3480, 0x49); // INCKSEL7
+
+	imx307_default_reg_init(ViPipe);
+	imx307_write_register(ViPipe, 0x3000, 0x00); // standby
+	usleep(20000);
+	imx307_write_register(ViPipe, 0x3002, 0x00);
+	imx307_write_register(ViPipe, 0x304B, 0x0a);
+	usleep(20000);
+
+	printf("==============================================================\n");
+	printf("===Sony imx307 sensor 1080P60fps(MIPI 4-lane) init success!===\n");
+	printf("==============================================================\n");
+	return;
+}
+
+/* HD 720p sub-readout, 4-lane CSI-2, WINMODE=1h, FRSEL=1h. Per
+ * datasheet pp.66-68 "All-pixel HD720p" + p.68 column "720p60 4-Lane":
+ * 297 Mbps/lane. HMAX=0x0CE4 (same pixel-clock structure as 2-Lane),
+ * VMAX=0x02EE=750. MIPI D-PHY timings use the 297 Mbps/lane tier
+ * (matches the 2-Lane "720p30" column since both are 297 Mbps/lane).
+ */
+void imx307_linear_720p60_init(VI_PIPE ViPipe)
+{
+	imx307_write_register(ViPipe, 0x3000, 0x01);
+	imx307_write_register(ViPipe, 0x3002, 0x01);
+	imx307_write_register(ViPipe, 0x3005, 0x01);
+	imx307_write_register(ViPipe, 0x3007, 0x10); // WINMODE=1h (HD720p)
+	imx307_write_register(ViPipe, 0x3009, 0x01); // FRSEL=1h
+	imx307_write_register(ViPipe, 0x300c, 0x00);
+	imx307_write_register(ViPipe, 0x3010, 0x21);
+	imx307_write_register(ViPipe, 0x3011, 0x0a);
+	imx307_write_register(ViPipe, 0x3018, 0xEE); // VMAX 0x02EE = 750
+	imx307_write_register(ViPipe, 0x3019, 0x02);
+	imx307_write_register(ViPipe, 0x301c, 0xE4); // HMAX 0x0CE4 = 3300
+	imx307_write_register(ViPipe, 0x301d, 0x0C);
+	imx307_write_register(ViPipe, 0x3046, 0x01);
+	imx307_write_register(ViPipe, 0x305c, 0x18);
+	imx307_write_register(ViPipe, 0x305d, 0x03);
+	imx307_write_register(ViPipe, 0x305e, 0x20);
+	imx307_write_register(ViPipe, 0x305f, 0x01);
+	imx307_write_register(ViPipe, 0x309e, 0x4a);
+	imx307_write_register(ViPipe, 0x309f, 0x4a);
+	imx307_write_register(ViPipe, 0x311c, 0x0e);
+	imx307_write_register(ViPipe, 0x3128, 0x04);
+	imx307_write_register(ViPipe, 0x3129, 0x1D);
+	imx307_write_register(ViPipe, 0x313b, 0x41);
+	imx307_write_register(ViPipe, 0x315e, 0x1a);
+	imx307_write_register(ViPipe, 0x3164, 0x1a);
+	imx307_write_register(ViPipe, 0x317c, 0x12);
+	imx307_write_register(ViPipe, 0x31ec, 0x37);
+
+	imx307_write_register(ViPipe, 0x3405, 0x10);
+	imx307_write_register(ViPipe, 0x3407, 0x03); // 4-lane
+	imx307_write_register(ViPipe, 0x3414, 0x04); // OPB_SIZE_V (720p)
+	imx307_write_register(ViPipe, 0x3418, 0xD9); // Y_OUT_SIZE 0x02D9 = 729
+	imx307_write_register(ViPipe, 0x3419, 0x02);
+	imx307_write_register(ViPipe, 0x3441, 0x0A);
+	imx307_write_register(ViPipe, 0x3442, 0x0A);
+	imx307_write_register(ViPipe, 0x3443, 0x03);
+	imx307_write_register(ViPipe, 0x3444, 0x20);
+	imx307_write_register(ViPipe, 0x3445, 0x25);
+	/* MIPI D-PHY HS timings for 297 Mbps/lane (datasheet p.68
+	 * column "720p60 4-Lane" = 2-Lane "720p30" 297 Mbps tier). */
+	imx307_write_register(ViPipe, 0x3446, 0x4F);
+	imx307_write_register(ViPipe, 0x3447, 0x00);
+	imx307_write_register(ViPipe, 0x3448, 0x2F);
+	imx307_write_register(ViPipe, 0x3449, 0x00);
+	imx307_write_register(ViPipe, 0x344A, 0x17);
+	imx307_write_register(ViPipe, 0x344B, 0x00);
+	imx307_write_register(ViPipe, 0x344C, 0x17);
+	imx307_write_register(ViPipe, 0x344D, 0x00);
+	imx307_write_register(ViPipe, 0x344E, 0x17);
+	imx307_write_register(ViPipe, 0x344F, 0x00);
+	imx307_write_register(ViPipe, 0x3450, 0x57);
+	imx307_write_register(ViPipe, 0x3451, 0x00);
+	imx307_write_register(ViPipe, 0x3452, 0x17);
+	imx307_write_register(ViPipe, 0x3453, 0x00);
+	imx307_write_register(ViPipe, 0x3454, 0x17);
+	imx307_write_register(ViPipe, 0x3455, 0x00);
+	imx307_write_register(ViPipe, 0x3472, 0x1C); // X_OUT_SIZE 0x051C = 1308
+	imx307_write_register(ViPipe, 0x3473, 0x05);
+	imx307_write_register(ViPipe, 0x3480, 0x49);
+
+	imx307_default_reg_init(ViPipe);
+	imx307_write_register(ViPipe, 0x3000, 0x00);
+	usleep(20000);
+	imx307_write_register(ViPipe, 0x3002, 0x00);
+	imx307_write_register(ViPipe, 0x304B, 0x0a);
+	usleep(20000);
+
+	printf("==============================================================\n");
+	printf("===Sony imx307 sensor 720P60fps(MIPI 4-lane) init success!====\n");
+	printf("==============================================================\n");
+	return;
+}
+
+/* Flex window-crop, 4-lane CSI-2, WINMODE=4h, FRSEL=1h locked
+ * (HMAX=0x0898, 445.5 Mbps/lane on 4-lane = same as 1080p60). Crop
+ * W×H from g_au32Imx307_CropW/H (populated by cmos_set_image_mode
+ * when Isp_SnsMode=4). Datasheet p.63 worked examples: VGA 640×480
+ * and CIF 352×288 land in this tier with HMAX=0x0898 + VMAX scaled
+ * by cmos_fps_set. NOT yet verified on real hardware. */
+void imx307_flex_crop_init(VI_PIPE ViPipe)
+{
+	GK_U32 crop_w = 1920, crop_h = 1080;
+	imx307_get_crop(ViPipe, &crop_w, &crop_h);
+
+	crop_w = (crop_w / 4) * 4;
+	if (crop_w < 368)
+		crop_w = 368;
+	if (crop_w > 1920)
+		crop_w = 1920;
+	crop_h = (crop_h / 2) * 2;
+	if (crop_h < 304)
+		crop_h = 304;
+	if (crop_h > 1080)
+		crop_h = 1080;
+
+	GK_U32 winph    = ((1944 - crop_w) / 2) & ~0x3U;
+	GK_U32 winpv    = ((1096 - crop_h) / 2) & ~0x1U;
+	GK_U32 winwh    = crop_w;
+	GK_U32 winwv    = crop_h;
+	GK_U32 winwv_ob = 2;
+
+	GK_U32 y_out_size = winwv + winwv_ob;
+	GK_U32 x_out_size = winwh + 8;
+
+	GK_U32 vmax = 1126;
+	if (vmax < y_out_size + 10)
+		vmax = y_out_size + 10;
+
+	imx307_write_register(ViPipe, 0x3000, 0x01);
+	imx307_write_register(ViPipe, 0x3002, 0x01);
+	imx307_write_register(ViPipe, 0x3005, 0x01);
+	imx307_write_register(ViPipe, 0x3007, 0x40); // WINMODE=4h
+	imx307_write_register(ViPipe, 0x3009, 0x01); // FRSEL=1h
+	imx307_write_register(ViPipe, 0x300c, 0x00);
+	imx307_write_register(ViPipe, 0x3010, 0x21);
+	imx307_write_register(ViPipe, 0x3011, 0x0a);
+
+	imx307_write_register(ViPipe, 0x3018, vmax & 0xFF);
+	imx307_write_register(ViPipe, 0x3019, (vmax >> 8) & 0xFF);
+	imx307_write_register(ViPipe, 0x301A, (vmax >> 16) & 0x03);
+	imx307_write_register(ViPipe, 0x301c, 0x98); // HMAX=0x0898
+	imx307_write_register(ViPipe, 0x301d, 0x08);
+
+	imx307_write_register(ViPipe, 0x303A, winwv_ob & 0x0F);
+	imx307_write_register(ViPipe, 0x303C, winpv & 0xFF);
+	imx307_write_register(ViPipe, 0x303D, (winpv >> 8) & 0x07);
+	imx307_write_register(ViPipe, 0x303E, winwv & 0xFF);
+	imx307_write_register(ViPipe, 0x303F, (winwv >> 8) & 0x07);
+	imx307_write_register(ViPipe, 0x3040, winph & 0xFF);
+	imx307_write_register(ViPipe, 0x3041, (winph >> 8) & 0x07);
+	imx307_write_register(ViPipe, 0x3042, winwh & 0xFF);
+	imx307_write_register(ViPipe, 0x3043, (winwh >> 8) & 0x07);
+
+	imx307_write_register(ViPipe, 0x3046, 0x01);
+	imx307_write_register(ViPipe, 0x305c, 0x18);
+	imx307_write_register(ViPipe, 0x305d, 0x03);
+	imx307_write_register(ViPipe, 0x305e, 0x20);
+	imx307_write_register(ViPipe, 0x305f, 0x01);
+	imx307_write_register(ViPipe, 0x309e, 0x4a);
+	imx307_write_register(ViPipe, 0x309f, 0x4a);
+	imx307_write_register(ViPipe, 0x311c, 0x0e);
+	imx307_write_register(ViPipe, 0x3128, 0x04);
+	imx307_write_register(ViPipe, 0x3129, 0x1D);
+	imx307_write_register(ViPipe, 0x313b, 0x41);
+	imx307_write_register(ViPipe, 0x315e, 0x1a);
+	imx307_write_register(ViPipe, 0x3164, 0x1a);
+	imx307_write_register(ViPipe, 0x317c, 0x12);
+	imx307_write_register(ViPipe, 0x31ec, 0x37);
+
+	imx307_write_register(ViPipe, 0x3405, 0x10);
+	imx307_write_register(ViPipe, 0x3407, 0x03);
+	imx307_write_register(ViPipe, 0x3414, 0x0A);
+	imx307_write_register(ViPipe, 0x3418, y_out_size & 0xFF);
+	imx307_write_register(ViPipe, 0x3419, (y_out_size >> 8) & 0x1F);
+	imx307_write_register(ViPipe, 0x3441, 0x0A);
+	imx307_write_register(ViPipe, 0x3442, 0x0A);
+	imx307_write_register(ViPipe, 0x3443, 0x03);
+	imx307_write_register(ViPipe, 0x3444, 0x20);
+	imx307_write_register(ViPipe, 0x3445, 0x25);
+	/* MIPI D-PHY HS timings for 445.5 Mbps/lane (FRSEL=1h 4-lane). */
+	imx307_write_register(ViPipe, 0x3446, 0x57);
+	imx307_write_register(ViPipe, 0x3447, 0x00);
+	imx307_write_register(ViPipe, 0x3448, 0x37);
+	imx307_write_register(ViPipe, 0x3449, 0x00);
+	imx307_write_register(ViPipe, 0x344A, 0x1F);
+	imx307_write_register(ViPipe, 0x344B, 0x00);
+	imx307_write_register(ViPipe, 0x344C, 0x1F);
+	imx307_write_register(ViPipe, 0x344D, 0x00);
+	imx307_write_register(ViPipe, 0x344E, 0x1F);
+	imx307_write_register(ViPipe, 0x344F, 0x00);
+	imx307_write_register(ViPipe, 0x3450, 0x77);
+	imx307_write_register(ViPipe, 0x3451, 0x00);
+	imx307_write_register(ViPipe, 0x3452, 0x1F);
+	imx307_write_register(ViPipe, 0x3453, 0x00);
+	imx307_write_register(ViPipe, 0x3454, 0x17);
+	imx307_write_register(ViPipe, 0x3455, 0x00);
+	imx307_write_register(ViPipe, 0x3472, x_out_size & 0xFF);
+	imx307_write_register(ViPipe, 0x3473, (x_out_size >> 8) & 0x1F);
+	imx307_write_register(ViPipe, 0x3480, 0x49);
+
+	imx307_default_reg_init(ViPipe);
+	imx307_write_register(ViPipe, 0x3000, 0x00);
+	usleep(20000);
+	imx307_write_register(ViPipe, 0x3002, 0x00);
+	imx307_write_register(ViPipe, 0x304B, 0x0a);
+	usleep(20000);
+
+	printf("=== Sony imx307 FLEX_CROP (4-lane) init: %ux%u (WINPH=%u "
+	       "WINWH=%u WINPV=%u WINWV=%u VMAX=%u HMAX=0x0898) ===\n",
+	       crop_w, crop_h, winph, winwh, winpv, winwv, vmax);
 	return;
 }
 

--- a/libraries/sensor/hi3516ev200/sony_imx307_2L/imx307_2l_cmos.c
+++ b/libraries/sensor/hi3516ev200/sony_imx307_2L/imx307_2l_cmos.c
@@ -106,10 +106,39 @@ extern int imx307_2l_read_register(VI_PIPE ViPipe, int addr);
 
 #define IMX307_VMAX_1080P30_LINEAR (1125 + IMX307_INCREASE_LINES)
 #define IMX307_VMAX_1080P60TO30_WDR (1125 + IMX307_INCREASE_LINES) // 10bit
+#define IMX307_VMAX_720P60_LINEAR  (750)
 
 // sensor fps mode
 #define IMX307_SENSOR_1080P_30FPS_LINEAR_MODE (1)
 #define IMX307_SENSOR_1080P_30FPS_2t1_WDR_MODE (2)
+#define IMX307_SENSOR_1080P_60FPS_LINEAR_MODE (3)
+#define IMX307_SENSOR_720P_60FPS_LINEAR_MODE  (4)
+#define IMX307_SENSOR_FLEX_CROP_LINEAR_MODE   (5)
+
+/* Crop window dimensions for FLEX_CROP mode (Isp_SnsMode=4). Set by
+ * cmos_set_image_mode from pstSensorImageMode->u16Width/u16Height,
+ * read by imx307_2l_flex_crop_init when programming WINMODE=4h +
+ * WINPH/WINPV/WINWH/WINWV. Mirrors the IMX335 g_au32Imx335CropW/H
+ * pattern from PR #99. */
+extern GK_U32 g_au32Imx307_2l_CropW[ISP_MAX_PIPE_NUM];
+extern GK_U32 g_au32Imx307_2l_CropH[ISP_MAX_PIPE_NUM];
+
+GK_U32 g_au32Imx307_2l_CropW[ISP_MAX_PIPE_NUM] = {
+	[0 ...(ISP_MAX_PIPE_NUM - 1)] = 1920
+};
+GK_U32 g_au32Imx307_2l_CropH[ISP_MAX_PIPE_NUM] = {
+	[0 ...(ISP_MAX_PIPE_NUM - 1)] = 1080
+};
+
+void imx307_2l_get_crop(VI_PIPE ViPipe, GK_U32 *pu32W, GK_U32 *pu32H)
+{
+	if (ViPipe < 0 || ViPipe >= ISP_MAX_PIPE_NUM)
+		return;
+	if (pu32W)
+		*pu32W = g_au32Imx307_2l_CropW[ViPipe];
+	if (pu32H)
+		*pu32H = g_au32Imx307_2l_CropH[ViPipe];
+}
 
 #define IMX307_RES_IS_1080P(w, h) ((w) <= 1920 && (h) <= 1080)
 
@@ -283,6 +312,53 @@ static GK_VOID cmos_fps_set(VI_PIPE ViPipe, GK_FLOAT f32Fps,
 				  IMX307_FULL_LINES_MAX :
 				  u32VMAX;
 		pstAeSnsDft->u32LinesPer500ms = IMX307_VMAX_1080P30_LINEAR * 15;
+		break;
+
+	case IMX307_SENSOR_1080P_60FPS_LINEAR_MODE:
+		if ((f32Fps <= 60) && (f32Fps >= 0.12)) {
+			u32VMAX = IMX307_VMAX_1080P30_LINEAR * 60 /
+				  DIV_0_TO_1_FLOAT(f32Fps);
+		} else {
+			ISP_TRACE(MODULE_DBG_ERR, "Not support Fps: %f\n",
+				  f32Fps);
+			return;
+		}
+		u32VMAX = (u32VMAX > IMX307_FULL_LINES_MAX) ?
+				  IMX307_FULL_LINES_MAX :
+				  u32VMAX;
+		pstAeSnsDft->u32LinesPer500ms = IMX307_VMAX_1080P30_LINEAR * 30;
+		break;
+
+	case IMX307_SENSOR_720P_60FPS_LINEAR_MODE:
+		if ((f32Fps <= 60) && (f32Fps >= 0.12)) {
+			u32VMAX = IMX307_VMAX_720P60_LINEAR * 60 /
+				  DIV_0_TO_1_FLOAT(f32Fps);
+		} else {
+			ISP_TRACE(MODULE_DBG_ERR, "Not support Fps: %f\n",
+				  f32Fps);
+			return;
+		}
+		u32VMAX = (u32VMAX > IMX307_FULL_LINES_MAX) ?
+				  IMX307_FULL_LINES_MAX :
+				  u32VMAX;
+		pstAeSnsDft->u32LinesPer500ms = IMX307_VMAX_720P60_LINEAR * 30;
+		break;
+
+	case IMX307_SENSOR_FLEX_CROP_LINEAR_MODE:
+		/* WINMODE=4h, HMAX=0x0898 locked → VMAX dominates fps.
+		 * Datasheet p.49 1H period at FRSEL=1h = 14.8 us =>
+		 * VMAX = 1 / (fps * 14.8e-6). Permit 0.12..240 fps. */
+		if ((f32Fps <= 240) && (f32Fps >= 0.12)) {
+			u32VMAX = (GK_U32)(67568 / DIV_0_TO_1_FLOAT(f32Fps));
+		} else {
+			ISP_TRACE(MODULE_DBG_ERR, "Not support Fps: %f\n",
+				  f32Fps);
+			return;
+		}
+		u32VMAX = (u32VMAX > IMX307_FULL_LINES_MAX) ?
+				  IMX307_FULL_LINES_MAX :
+				  u32VMAX;
+		pstAeSnsDft->u32LinesPer500ms = IMX307_VMAX_720P60_LINEAR * 30;
 		break;
 
 	default:
@@ -1214,6 +1290,33 @@ cmos_set_image_mode(VI_PIPE ViPipe,
 	u8SensorImageMode = pstSnsState->u8ImgMode;
 	pstSnsState->bSyncInit = GK_FALSE;
 
+	/* Explicit Isp_SnsMode dispatch (mirrors IMX335 PR #99 / IMX415 PR #97).
+	 * Isp_SnsMode=1: 720p sub-readout (WINMODE=1h), up to 60 fps.
+	 * Isp_SnsMode=4: flex window crop (WINMODE=4h), arbitrary W×H from
+	 *   pstSensorImageMode->u16Width/u16Height, up to ~200 fps for small
+	 *   crops (datasheet p.63 worked examples: VGA 640x480 @ 129.8,
+	 *   CIF 352x288 @ 205.8 at FRSEL=1h). */
+	if (pstSensorImageMode->u8SnsMode == 1 &&
+	    pstSnsState->enWDRMode == WDR_MODE_NONE) {
+		u8SensorImageMode = IMX307_SENSOR_720P_60FPS_LINEAR_MODE;
+		pstSnsState->u32FLStd = IMX307_VMAX_720P60_LINEAR;
+		g_astimx307_2l_State[ViPipe].u8Hcg = 0x2;
+		goto img_mode_set;
+	}
+	if (pstSensorImageMode->u8SnsMode == 4 &&
+	    pstSnsState->enWDRMode == WDR_MODE_NONE) {
+		u8SensorImageMode = IMX307_SENSOR_FLEX_CROP_LINEAR_MODE;
+		pstSnsState->u32FLStd = IMX307_VMAX_1080P30_LINEAR;
+		g_astimx307_2l_State[ViPipe].u8Hcg = 0x2;
+		if (ViPipe >= 0 && ViPipe < ISP_MAX_PIPE_NUM) {
+			g_au32Imx307_2l_CropW[ViPipe] =
+				pstSensorImageMode->u16Width ?: 1920;
+			g_au32Imx307_2l_CropH[ViPipe] =
+				pstSensorImageMode->u16Height ?: 1080;
+		}
+		goto img_mode_set;
+	}
+
 	if (pstSensorImageMode->f32Fps <= 30) {
 		if (pstSnsState->enWDRMode == WDR_MODE_NONE) {
 			if (IMX307_RES_IS_1080P(pstSensorImageMode->u16Width,
@@ -1247,8 +1350,19 @@ cmos_set_image_mode(VI_PIPE ViPipe,
 						 pstSnsState);
 			return GK_FAILURE;
 		}
+	} else if (pstSensorImageMode->f32Fps <= 60 &&
+		   pstSnsState->enWDRMode == WDR_MODE_NONE &&
+		   IMX307_RES_IS_1080P(pstSensorImageMode->u16Width,
+				       pstSensorImageMode->u16Height)) {
+		u8SensorImageMode = IMX307_SENSOR_1080P_60FPS_LINEAR_MODE;
+		pstSnsState->u32FLStd = IMX307_VMAX_1080P30_LINEAR;
+		g_astimx307_2l_State[ViPipe].u8Hcg = 0x2;
 	} else {
+		IMX307_2L_ERR_MODE_PRINT(pstSensorImageMode, pstSnsState);
+		return GK_FAILURE;
 	}
+
+img_mode_set:
 
 	if ((pstSnsState->bInit == GK_TRUE) &&
 	    (u8SensorImageMode == pstSnsState->u8ImgMode)) {

--- a/libraries/sensor/hi3516ev200/sony_imx307_2L/imx307_2l_sensor_ctl.c
+++ b/libraries/sensor/hi3516ev200/sony_imx307_2L/imx307_2l_sensor_ctl.c
@@ -156,9 +156,17 @@ void imx307_2l_restart(VI_PIPE ViPipe)
 
 #define IMX307_SENSOR_1080P_30FPS_LINEAR_MODE (1)
 #define IMX307_SENSOR_1080P_30FPS_2t1_WDR_MODE (2)
+#define IMX307_SENSOR_1080P_60FPS_LINEAR_MODE (3)
+#define IMX307_SENSOR_720P_60FPS_LINEAR_MODE  (4)
+#define IMX307_SENSOR_FLEX_CROP_LINEAR_MODE   (5)
+
+extern void imx307_2l_get_crop(VI_PIPE ViPipe, GK_U32 *pu32W, GK_U32 *pu32H);
 
 void imx307_2l_wdr_1080p30_2to1_init(VI_PIPE ViPipe);
 void imx307_2l_linear_1080p30_init(VI_PIPE ViPipe);
+void imx307_2l_linear_1080p60_init(VI_PIPE ViPipe);
+void imx307_2l_linear_720p60_init(VI_PIPE ViPipe);
+void imx307_2l_flex_crop_init(VI_PIPE ViPipe);
 
 void imx307_2l_default_reg_init(VI_PIPE ViPipe)
 {
@@ -195,6 +203,12 @@ void imx307_2l_init(VI_PIPE ViPipe)
 			imx307_2l_wdr_1080p30_2to1_init(ViPipe);
 		} else {
 		}
+	} else if (IMX307_SENSOR_1080P_60FPS_LINEAR_MODE == u8ImgMode) {
+		imx307_2l_linear_1080p60_init(ViPipe);
+	} else if (IMX307_SENSOR_720P_60FPS_LINEAR_MODE == u8ImgMode) {
+		imx307_2l_linear_720p60_init(ViPipe);
+	} else if (IMX307_SENSOR_FLEX_CROP_LINEAR_MODE == u8ImgMode) {
+		imx307_2l_flex_crop_init(ViPipe);
 	} else {
 		imx307_2l_linear_1080p30_init(ViPipe);
 	}
@@ -282,6 +296,280 @@ void imx307_2l_linear_1080p30_init(VI_PIPE ViPipe)
 	printf("==============================================================\n");
 	printf("=====Sony imx307_2l sensor 1080P30fps(MIPI) init success!=====\n");
 	printf("==============================================================\n");
+	return;
+}
+
+/* 1080P60 — derived from 30fps init with FRSEL=1 (891 Mbps/lane),
+ * HMAX=0x0898, and the MIPI D-PHY HS timings from IMX307LQD-C
+ * datasheet page 56 column "60/50 fps 2-Lane". All other registers
+ * identical to 30fps linear init.
+ */
+void imx307_2l_linear_1080p60_init(VI_PIPE ViPipe)
+{
+	imx307_2l_write_register(ViPipe, 0x3000, 0x01); // Standby
+	imx307_2l_write_register(ViPipe, 0x3002, 0x00); // XMSTA
+	imx307_2l_write_register(ViPipe, 0x3005, 0x00); // ADBIT 10-bit
+	imx307_2l_write_register(ViPipe, 0x3007, 0x00); // VREVERSE/HREVERSE/WINMODE
+	imx307_2l_write_register(ViPipe, 0x3009, 0x01); // FRSEL=1 (60fps, 891 Mbps/lane)
+	imx307_2l_write_register(ViPipe, 0x300A, 0x3C); // BLKLEVEL
+	imx307_2l_write_register(ViPipe, 0x3011, 0x0A);
+	imx307_2l_write_register(ViPipe, 0x3018, 0x65); // VMAX[7:0]
+	imx307_2l_write_register(ViPipe, 0x3019, 0x04); // VMAX[15:8]
+	imx307_2l_write_register(ViPipe, 0x301C, 0x98); // HMAX=0x0898
+	imx307_2l_write_register(ViPipe, 0x301D, 0x08);
+	imx307_2l_write_register(ViPipe, 0x3046, 0x00); // ODBIT & OPORTSEL
+	imx307_2l_write_register(ViPipe, 0x304B, 0x0A); // XVSOUTSEL & XHSOUTSEL
+	imx307_2l_write_register(ViPipe, 0x305C, 0x18); // INCKSEL1 37.125MHz
+	imx307_2l_write_register(ViPipe, 0x305D, 0x03); // INCKSEL2
+	imx307_2l_write_register(ViPipe, 0x305E, 0x20);
+	imx307_2l_write_register(ViPipe, 0x305F, 0x01);
+	imx307_2l_write_register(ViPipe, 0x309E, 0x4A);
+	imx307_2l_write_register(ViPipe, 0x309F, 0x4A);
+
+	imx307_2l_write_register(ViPipe, 0x311C, 0x0E);
+	imx307_2l_write_register(ViPipe, 0x3128, 0x04);
+	imx307_2l_write_register(ViPipe, 0x3129, 0x1D); // ADBIT1
+	imx307_2l_write_register(ViPipe, 0x313B, 0x41);
+	imx307_2l_write_register(ViPipe, 0x315E, 0x1A); // INCKSEL5 37.125MHz
+	imx307_2l_write_register(ViPipe, 0x3164, 0x1A); // INCKSEL6
+	imx307_2l_write_register(ViPipe, 0x317C, 0x12); // ADBIT2
+	imx307_2l_write_register(ViPipe, 0x31EC, 0x37); // ADBIT3
+
+	imx307_2l_write_register(ViPipe, 0x3405, 0x00); // REPETITION (60fps)
+	imx307_2l_write_register(ViPipe, 0x3407, 0x01); // PHYSICAL_LANE_NUM
+	imx307_2l_write_register(ViPipe, 0x3414, 0x0A); // OPB_SIZE_V
+	imx307_2l_write_register(ViPipe, 0x3418, 0x49); // Y_OUT_SIZE
+	imx307_2l_write_register(ViPipe, 0x3419, 0x04);
+	imx307_2l_write_register(ViPipe, 0x3441, 0x0A); // CSI_DT_FMT
+	imx307_2l_write_register(ViPipe, 0x3442, 0x0A);
+	imx307_2l_write_register(ViPipe, 0x3443, 0x01); // CSI_LANE_MODE
+	imx307_2l_write_register(ViPipe, 0x3444, 0x20); // EXTCK_FREQ
+	imx307_2l_write_register(ViPipe, 0x3445, 0x25);
+	imx307_2l_write_register(ViPipe, 0x3446, 0x77); // TCLKPOST (60fps PHY)
+	imx307_2l_write_register(ViPipe, 0x3447, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3448, 0x67); // THSZERO
+	imx307_2l_write_register(ViPipe, 0x3449, 0x00);
+	imx307_2l_write_register(ViPipe, 0x344A, 0x47); // THSPREPARE
+	imx307_2l_write_register(ViPipe, 0x344B, 0x00);
+	imx307_2l_write_register(ViPipe, 0x344C, 0x37); // TCLKTRAIL
+	imx307_2l_write_register(ViPipe, 0x344D, 0x00);
+	imx307_2l_write_register(ViPipe, 0x344E, 0x3F); // THSTRAIL
+	imx307_2l_write_register(ViPipe, 0x344F, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3450, 0xFF); // TCLKZERO
+	imx307_2l_write_register(ViPipe, 0x3451, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3452, 0x3F); // TCLKPREPARE
+	imx307_2l_write_register(ViPipe, 0x3453, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3454, 0x37); // TLPX
+	imx307_2l_write_register(ViPipe, 0x3455, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3472, 0x9C); // X_OUT_SIZE
+	imx307_2l_write_register(ViPipe, 0x3473, 0x07);
+	imx307_2l_write_register(ViPipe, 0x3480, 0x49); // INCKSEL7
+
+	imx307_2l_default_reg_init(ViPipe);
+
+	imx307_2l_write_register(ViPipe, 0x3000, 0x00); // Standby Cancel
+
+	printf("==============================================================\n");
+	printf("=====Sony imx307_2l sensor 1080P60fps(MIPI) init success!=====\n");
+	printf("==============================================================\n");
+	return;
+}
+
+/* HD 720p sub-readout, WINMODE=1h, FRSEL=1h, 594 Mbps/lane (10-bit
+ * 2-lane CSI-2). Register values from IMX307LQD-C datasheet pp.66-68
+ * "All-pixel HD720p" section. VMAX=0x02EE=750, HMAX=0x0CE4=3300,
+ * Y_OUT_SIZE=0x02D9=729, X_OUT_SIZE=0x051C=1308. MIPI PHY values are
+ * the middle tier between 1080p30 (445.5 Mbps) and 1080p60 (891 Mbps). */
+void imx307_2l_linear_720p60_init(VI_PIPE ViPipe)
+{
+	imx307_2l_write_register(ViPipe, 0x3000, 0x01); // Standby
+	imx307_2l_write_register(ViPipe, 0x3002, 0x00); // XMSTA
+	imx307_2l_write_register(ViPipe, 0x3005, 0x00); // ADBIT 10-bit
+	imx307_2l_write_register(ViPipe, 0x3007, 0x10); // WINMODE=1h (HD720p)
+	imx307_2l_write_register(ViPipe, 0x3009, 0x01); // FRSEL=1h (60fps tier)
+	imx307_2l_write_register(ViPipe, 0x300A, 0x3C); // BLKLEVEL
+	imx307_2l_write_register(ViPipe, 0x3011, 0x0A);
+	imx307_2l_write_register(ViPipe, 0x3018, 0xEE); // VMAX[7:0]   (0x02EE=750)
+	imx307_2l_write_register(ViPipe, 0x3019, 0x02); // VMAX[15:8]
+	imx307_2l_write_register(ViPipe, 0x301C, 0xE4); // HMAX[7:0]   (0x0CE4=3300)
+	imx307_2l_write_register(ViPipe, 0x301D, 0x0C); // HMAX[15:8]
+	imx307_2l_write_register(ViPipe, 0x3046, 0x00);
+	imx307_2l_write_register(ViPipe, 0x304B, 0x0A);
+	imx307_2l_write_register(ViPipe, 0x305C, 0x18); // INCKSEL1 37.125MHz
+	imx307_2l_write_register(ViPipe, 0x305D, 0x03);
+	imx307_2l_write_register(ViPipe, 0x305E, 0x20);
+	imx307_2l_write_register(ViPipe, 0x305F, 0x01);
+	imx307_2l_write_register(ViPipe, 0x309E, 0x4A);
+	imx307_2l_write_register(ViPipe, 0x309F, 0x4A);
+
+	imx307_2l_write_register(ViPipe, 0x311C, 0x0E);
+	imx307_2l_write_register(ViPipe, 0x3128, 0x04);
+	imx307_2l_write_register(ViPipe, 0x3129, 0x1D);
+	imx307_2l_write_register(ViPipe, 0x313B, 0x41);
+	imx307_2l_write_register(ViPipe, 0x315E, 0x1A);
+	imx307_2l_write_register(ViPipe, 0x3164, 0x1A);
+	imx307_2l_write_register(ViPipe, 0x317C, 0x12);
+	imx307_2l_write_register(ViPipe, 0x31EC, 0x37);
+
+	imx307_2l_write_register(ViPipe, 0x3405, 0x00); // REPETITION (60fps tier)
+	imx307_2l_write_register(ViPipe, 0x3407, 0x01); // PHYSICAL_LANE_NUM
+	imx307_2l_write_register(ViPipe, 0x3414, 0x04); // OPB_SIZE_V (720p)
+	imx307_2l_write_register(ViPipe, 0x3418, 0xD9); // Y_OUT_SIZE[7:0] 0x02D9=729
+	imx307_2l_write_register(ViPipe, 0x3419, 0x02);
+	imx307_2l_write_register(ViPipe, 0x3441, 0x0A); // CSI_DT_FMT 10-bit
+	imx307_2l_write_register(ViPipe, 0x3442, 0x0A);
+	imx307_2l_write_register(ViPipe, 0x3443, 0x01); // CSI_LANE_MODE
+	imx307_2l_write_register(ViPipe, 0x3444, 0x20); // EXTCK_FREQ
+	imx307_2l_write_register(ViPipe, 0x3445, 0x25);
+	/* MIPI D-PHY HS timings for 594 Mbps/lane (720p60 column, p.68). */
+	imx307_2l_write_register(ViPipe, 0x3446, 0x67); // TCLKPOST
+	imx307_2l_write_register(ViPipe, 0x3447, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3448, 0x57); // THSZERO
+	imx307_2l_write_register(ViPipe, 0x3449, 0x00);
+	imx307_2l_write_register(ViPipe, 0x344A, 0x2F); // THSPREPARE
+	imx307_2l_write_register(ViPipe, 0x344B, 0x00);
+	imx307_2l_write_register(ViPipe, 0x344C, 0x27); // TCLKTRAIL
+	imx307_2l_write_register(ViPipe, 0x344D, 0x00);
+	imx307_2l_write_register(ViPipe, 0x344E, 0x2F); // THSTRAIL
+	imx307_2l_write_register(ViPipe, 0x344F, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3450, 0xBF); // TCLKZERO
+	imx307_2l_write_register(ViPipe, 0x3451, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3452, 0x2F); // TCLKPREPARE
+	imx307_2l_write_register(ViPipe, 0x3453, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3454, 0x27); // TLPX
+	imx307_2l_write_register(ViPipe, 0x3455, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3472, 0x1C); // X_OUT_SIZE[7:0] 0x051C=1308
+	imx307_2l_write_register(ViPipe, 0x3473, 0x05);
+	imx307_2l_write_register(ViPipe, 0x3480, 0x49); // INCKSEL7
+
+	imx307_2l_default_reg_init(ViPipe);
+	imx307_2l_write_register(ViPipe, 0x3000, 0x00); // Standby Cancel
+
+	printf("==============================================================\n");
+	printf("=====Sony imx307_2l sensor 720P60fps(MIPI) init success!======\n");
+	printf("==============================================================\n");
+	return;
+}
+
+/* Flex window-crop, WINMODE=4h, FRSEL=1h locked (HMAX=0x0898, 891 Mbps/lane).
+ * Crop W×H from g_au32Imx307_2l_CropW/H, set by cmos_set_image_mode from the
+ * sensor INI's Isp_W/Isp_H when Isp_SnsMode=4. Datasheet p.63 worked examples:
+ * VGA 640×480 sustains 129.8 fps, CIF 352×288 sustains 205.8 fps at this tier.
+ * fps is controlled by VMAX from cmos_fps_set; init sets a 60 fps baseline VMAX
+ * that AE may scale per requested f32Fps. */
+void imx307_2l_flex_crop_init(VI_PIPE ViPipe)
+{
+	GK_U32 crop_w = 1920, crop_h = 1080;
+	imx307_2l_get_crop(ViPipe, &crop_w, &crop_h);
+
+	/* Snap to datasheet multiples-of-4 (WINPH, WINWH) and clamp. */
+	crop_w = (crop_w / 4) * 4;
+	if (crop_w < 368)
+		crop_w = 368;
+	if (crop_w > 1920)
+		crop_w = 1920;
+	crop_h = (crop_h / 2) * 2;
+	if (crop_h < 304)
+		crop_h = 304;
+	if (crop_h > 1080)
+		crop_h = 1080;
+
+	/* Centre the crop in the 1944×1097 active area. WINPH mult of 4. */
+	GK_U32 winph    = ((1944 - crop_w) / 2) & ~0x3U;
+	GK_U32 winpv    = ((1096 - crop_h) / 2) & ~0x1U;
+	GK_U32 winwh    = crop_w;
+	GK_U32 winwv    = crop_h;
+	GK_U32 winwv_ob = 2;
+
+	/* CSI-2 output sizes: Y_OUT_SIZE = WINWV + WINWV_OB; X_OUT_SIZE = WINWH + 8. */
+	GK_U32 y_out_size = winwv + winwv_ob;
+	GK_U32 x_out_size = winwh + 8;
+
+	/* Baseline VMAX for ~60 fps at HMAX=0x0898 (datasheet p.49 1H=14.8µs).
+	 * cmos_fps_set scales further per AE. */
+	GK_U32 vmax = 1126;
+	if (vmax < y_out_size + 10)
+		vmax = y_out_size + 10;
+
+	imx307_2l_write_register(ViPipe, 0x3000, 0x01); // Standby
+	imx307_2l_write_register(ViPipe, 0x3002, 0x00); // XMSTA
+	imx307_2l_write_register(ViPipe, 0x3005, 0x00); // ADBIT 10-bit
+	imx307_2l_write_register(ViPipe, 0x3007, 0x40); // WINMODE=4h
+	imx307_2l_write_register(ViPipe, 0x3009, 0x01); // FRSEL=1h (60fps tier)
+	imx307_2l_write_register(ViPipe, 0x300A, 0x3C);
+	imx307_2l_write_register(ViPipe, 0x3011, 0x0A);
+
+	imx307_2l_write_register(ViPipe, 0x3018, vmax & 0xFF);
+	imx307_2l_write_register(ViPipe, 0x3019, (vmax >> 8) & 0xFF);
+	imx307_2l_write_register(ViPipe, 0x301A, (vmax >> 16) & 0x03);
+	imx307_2l_write_register(ViPipe, 0x301C, 0x98); // HMAX=0x0898
+	imx307_2l_write_register(ViPipe, 0x301D, 0x08);
+
+	imx307_2l_write_register(ViPipe, 0x303A, winwv_ob & 0x0F);
+	imx307_2l_write_register(ViPipe, 0x303C, winpv & 0xFF);
+	imx307_2l_write_register(ViPipe, 0x303D, (winpv >> 8) & 0x07);
+	imx307_2l_write_register(ViPipe, 0x303E, winwv & 0xFF);
+	imx307_2l_write_register(ViPipe, 0x303F, (winwv >> 8) & 0x07);
+	imx307_2l_write_register(ViPipe, 0x3040, winph & 0xFF);
+	imx307_2l_write_register(ViPipe, 0x3041, (winph >> 8) & 0x07);
+	imx307_2l_write_register(ViPipe, 0x3042, winwh & 0xFF);
+	imx307_2l_write_register(ViPipe, 0x3043, (winwh >> 8) & 0x07);
+
+	imx307_2l_write_register(ViPipe, 0x3046, 0x00);
+	imx307_2l_write_register(ViPipe, 0x304B, 0x0A);
+	imx307_2l_write_register(ViPipe, 0x305C, 0x18);
+	imx307_2l_write_register(ViPipe, 0x305D, 0x03);
+	imx307_2l_write_register(ViPipe, 0x305E, 0x20);
+	imx307_2l_write_register(ViPipe, 0x305F, 0x01);
+	imx307_2l_write_register(ViPipe, 0x309E, 0x4A);
+	imx307_2l_write_register(ViPipe, 0x309F, 0x4A);
+
+	imx307_2l_write_register(ViPipe, 0x311C, 0x0E);
+	imx307_2l_write_register(ViPipe, 0x3128, 0x04);
+	imx307_2l_write_register(ViPipe, 0x3129, 0x1D);
+	imx307_2l_write_register(ViPipe, 0x313B, 0x41);
+	imx307_2l_write_register(ViPipe, 0x315E, 0x1A);
+	imx307_2l_write_register(ViPipe, 0x3164, 0x1A);
+	imx307_2l_write_register(ViPipe, 0x317C, 0x12);
+	imx307_2l_write_register(ViPipe, 0x31EC, 0x37);
+
+	imx307_2l_write_register(ViPipe, 0x3405, 0x00); // REPETITION (60fps tier)
+	imx307_2l_write_register(ViPipe, 0x3407, 0x01);
+	imx307_2l_write_register(ViPipe, 0x3414, 0x0A); // OPB_SIZE_V (default)
+	imx307_2l_write_register(ViPipe, 0x3418, y_out_size & 0xFF);
+	imx307_2l_write_register(ViPipe, 0x3419, (y_out_size >> 8) & 0x1F);
+	imx307_2l_write_register(ViPipe, 0x3441, 0x0A);
+	imx307_2l_write_register(ViPipe, 0x3442, 0x0A);
+	imx307_2l_write_register(ViPipe, 0x3443, 0x01);
+	imx307_2l_write_register(ViPipe, 0x3444, 0x20);
+	imx307_2l_write_register(ViPipe, 0x3445, 0x25);
+	/* MIPI D-PHY HS timings for 891 Mbps/lane (60fps tier, p.62). */
+	imx307_2l_write_register(ViPipe, 0x3446, 0x77);
+	imx307_2l_write_register(ViPipe, 0x3447, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3448, 0x67);
+	imx307_2l_write_register(ViPipe, 0x3449, 0x00);
+	imx307_2l_write_register(ViPipe, 0x344A, 0x47);
+	imx307_2l_write_register(ViPipe, 0x344B, 0x00);
+	imx307_2l_write_register(ViPipe, 0x344C, 0x37);
+	imx307_2l_write_register(ViPipe, 0x344D, 0x00);
+	imx307_2l_write_register(ViPipe, 0x344E, 0x3F);
+	imx307_2l_write_register(ViPipe, 0x344F, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3450, 0xFF);
+	imx307_2l_write_register(ViPipe, 0x3451, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3452, 0x3F);
+	imx307_2l_write_register(ViPipe, 0x3453, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3454, 0x37);
+	imx307_2l_write_register(ViPipe, 0x3455, 0x00);
+	imx307_2l_write_register(ViPipe, 0x3472, x_out_size & 0xFF);
+	imx307_2l_write_register(ViPipe, 0x3473, (x_out_size >> 8) & 0x1F);
+	imx307_2l_write_register(ViPipe, 0x3480, 0x49);
+
+	imx307_2l_default_reg_init(ViPipe);
+	imx307_2l_write_register(ViPipe, 0x3000, 0x00); // Standby Cancel
+
+	printf("=== Sony imx307_2l FLEX_CROP init: %ux%u (WINPH=%u WINWH=%u "
+	       "WINPV=%u WINWV=%u VMAX=%u HMAX=0x0898) ===\n",
+	       crop_w, crop_h, winph, winwh, winpv, winwv, vmax);
 	return;
 }
 


### PR DESCRIPTION
## Summary

Mirrors the IMX335 PR OpenIPC/majestic#115 flex-mode infrastructure for both IMX307 variants — `sony_imx307_2L` (2-lane MIPI CSI-2) and `sony_imx307` (4-lane). Adds explicit `Isp_SnsMode` dispatch, three new sensor modes, and the corresponding `cmos_fps_set` cases. Existing 30 fps linear and 30 fps WDR paths unchanged in both drivers.

## New modes (sensor INI controls, both variants)

| Mode | INI knob | Dispatch | Register highlights |
|------|----------|----------|---------------------|
| 1080p60 linear | `Isp_FrameRate>30` (auto-promotion) | u8ImgMode = 3 | FRSEL=1h, HMAX=0x0898, MIPI D-PHY HS timings rescaled to the 60 fps lane tier |
| 720p60 sub-readout | `Isp_SnsMode=1` | u8ImgMode = 4 | WINMODE=1h, FRSEL=1h, HMAX=0x0CE4, VMAX=0x02EE, lower (297 Mbps) MIPI tier |
| Flex window-crop | `Isp_SnsMode=4` + `Isp_W`/`Isp_H` | u8ImgMode = 5 | WINMODE=4h, programmable WINPH/WINPV/WINWH/WINWV centred in 1944×1097, HMAX=0x0898 locked, VMAX scaled by `cmos_fps_set` from 14.8 µs 1H |

Datasheet-driven snap & clamp on flex-crop W×H: multiples of 4, minimum 368×304 (`WINWH ≥ 368`, `WINWV ≥ 304` per p.63 / p.65).

## Per-variant differences

| | sony_imx307_2L (2-lane) | sony_imx307 (4-lane) |
|---|---|---|
| PHYSICAL_LANE_NUM (0x3407) | 1 | 3 |
| CSI_LANE_MODE (0x3443) | 1 | 3 |
| 1080p60 / flex MIPI tier | 891 Mbps/lane (p.56 "2-Lane") | 445.5 Mbps/lane (p.56 "4-Lane"; matches existing 4-lane WDR init) |
| 720p60 MIPI tier | 594 Mbps/lane (p.68 "2-Lane") | 297 Mbps/lane (p.68 "4-Lane") |

## Verified on real hardware (gk7205v200 + IMX307 2-lane MIPI)

`openipc-gk7205v200` board, `sony_imx307_2L` driver, wire fps from `/proc/umap/venc` SEND counter delta (5 s window, h.265 @ 4 Mbps):

| Mode | Sensor crop | Wire fps | Notes |
|------|-------------|----------|-------|
| Stock 1080p30 | 1920×1080 | 30 fps | no regression |
| 1080p60 boost | 1920×1080 | 44 fps | encoder-bound at 1080p |
| 720p60 sub-readout | 1280×720 | 60 fps | sensor PHY tier limit |
| 720p flex | 1280×720 | 91 fps | encoder ceiling |
| VGA flex | 640×480 | 130 fps | encoder ceiling |
| CIF flex | 368×304 | 200 fps | encoder ceiling (~200-219) |

ISP IntRat confirms the sensor delivers exactly the requested rate at each measurement; the encoder is the ceiling above sub-1080p modes.

## 4-lane variant: NOT yet validated on hardware

No 4-lane IMX307 board available at the time of writing. The driver mirrors the 2-lane structure exactly with MIPI D-PHY timings sourced from the datasheet "4-Lane" columns. Expected to work without modification given:
- Both variants share the same `cmos.c` dispatch logic
- Per-lane data rates are within the chip's documented capability for each mode
- The 60 fps lane tier values (445.5 Mbps/lane on 4-lane) match the existing 4-lane WDR init exactly (which already runs at this rate today)

README adds an explicit note: *"The 4-lane variant carries the same dispatch infrastructure with MIPI D-PHY timings from the datasheet's '4-Lane' columns — not yet validated on real hardware."*

## Datasheet citations

Sony IMX307LQD-C datasheet (`IMX307LQD-C-p108.pdf`):
- p.35 — WINMODE field definition (0x3007 bits[6:4])
- p.48 — data-rate matrix (FRSEL vs MIPI Mbps/lane per lane count)
- p.49 — 1H period table at 37.125 MHz INCK
- pp.54-58 — 1080p all-pixel register tables (CSI-2 2-lane / 4-lane / LVDS)
- pp.60-65 — window-crop register tables + VGA / CIF worked examples
- pp.66-68 — 720p sub-readout register tables (LVDS + CSI-2 2-lane / 4-lane)

## Test plan

- [ ] CI build green (both sensor library cross-compiles for hi3516ev200)
- [x] Existing IMX307 1080p30 stock path unchanged (verified locally, both compiled drivers)
- [x] IMX307 2-lane new modes deliver advertised wire fps (table above)
- [ ] IMX307 4-lane new modes — pending 4-lane hardware availability
- [ ] hi3516ev200 (Hisilicon-side) board re-verification — same source, expected identical behaviour given equal silicon

## Companion work

- OpenIPC/majestic#77 already merged — removed the hardcoded V200 chip_id 45 fps clamp so `Isp_FrameRate > 45` from the INI now flows through to the driver.
- Follow-up firmware PR will ship `imx307_1920x1080_60fps.ini`, `imx307_1280x720_60fps.ini`, and flex-crop presets in `/etc/sensors/high-fps/` for both ev200 and gk7205v200 packages, with matching `[vi_chn]` `CapRect`/`DestSize` per crop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)