### PR TITLE
ive_neo: wire ive_op_ncc() into dispatcher, fix HW op code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,19 +240,19 @@ jobs:
               echo "ok: cv500 build has no XNN dispatch code"
 
               # PR #107: PerspTrans and Hog have real HW handlers on
-              # cv500. Each handler emits a distinctive log line on bad
-              # input; if those strings vanish, someone reverted the
-              # handler to the silent-stub or diag path. Grep for the
-              # validation message rather than the handler symbol name
-              # so the assertion stays meaningful even if the function
-              # gets renamed.
-              for needle in "PerspTrans bad roi_num" "Hog bad roi_num"; do
+              # cv500. PR for #110: NCC handler is now wired (was a
+              # silent stub before). Each handler emits a distinctive
+              # log line; if those strings vanish, someone reverted to
+              # the silent-stub or diag path. Grep for the validation
+              # / one-time log rather than the handler symbol name so
+              # the assertion stays meaningful across renames.
+              for needle in "PerspTrans bad roi_num" "Hog bad roi_num" "NCC handler wired"; do
                   if ! strings "$KO" | grep -qF "$needle"; then
                       echo "FAIL: cv500 .ko missing '$needle' — handler regressed to stub?" >&2
                       exit 1
                   fi
               done
-              echo "ok: cv500 build has PerspTrans + Hog HW handlers wired"
+              echo "ok: cv500 build has PerspTrans + Hog + NCC HW handlers wired"
 
               # The N-node chain submit helper is the shared HW kick
               # path for both new ops. Its timeout log is the only

--- a/kernel/ive_neo/ive_neo.c
+++ b/kernel/ive_neo/ive_neo.c
@@ -2024,6 +2024,10 @@ static long ive_op_gmm2(unsigned long arg)
 }
 
 /* ---- NCC (op=?): arg = {handle(8), src1(72), src2(72), dst_mem(24+)} ---- */
+/* HI_MPI_IVE_NCC (ioctl 0xc0b84616) — Normalized Cross-Correlation.
+ * Field map decoded from cv500 vendor blob obj/hi3516cv500/hi_ive.o
+ * symbol ive_fill_ncc_task @0x86a0 (the previous handler guessed
+ * node[10]=18 from nr proximity; vendor actually uses 22). */
 static long ive_op_ncc(unsigned long arg)
 {
 	u8 *buf = (u8 *)arg;
@@ -2036,14 +2040,17 @@ static long ive_op_ncc(unsigned long arg)
 		return -EINVAL;
 
 	memset(node, 0, sizeof(node));
-	node[10] = 18; /* NCC op code (guessed from nr=0x15, nearby Hist=13) */
+	node[6]  = 0;
+	node[8]  = (u8) IMG_TYPE(src1);  /* approximation; vendor uses 12-entry LUT (issue #113) */
+	node[10] = 22;                   /* op = NCC */
 	*(u32 *)(node + 16) = IMG_PHYS(src1);
+	*(u32 *)(node + 20) = *(u32 *)dst_mem;  /* output mem phys */
 	*(u32 *)(node + 24) = IMG_PHYS(src2);
-	*(u32 *)(node + 20) = *(u32 *)dst_mem; /* output mem phys */
 	*(u16 *)(node + 40) = (u16)IMG_WIDTH(src1);
 	*(u16 *)(node + 42) = (u16)IMG_HEIGHT(src1);
 	*(u16 *)(node + 44) = (u16)IMG_STRIDE(src1);
 	*(u16 *)(node + 46) = (u16)IMG_STRIDE(src2);
+	pr_info_once("ive_neo: NCC handler wired (HW op 22)\n");
 	return ive_submit_nonxnn(node, buf);
 }
 
@@ -2504,7 +2511,7 @@ static long ive_dispatch(unsigned int cmd, unsigned long arg)
 	 * these with "ive can't support the func". Return 0 to keep
 	 * libive.so's handle check happy; output will be empty. */
 	case 0xc0a8461au:      return 0;  /* LBP */
-	case 0xc0b84616u:      return 0;  /* NCC */
+	case 0xc0b84616u:      return ive_op_ncc(arg);   /* NCC — vendor op 22 */
 	case 0xc0b8462au:      return 0;  /* EqualizeHist */
 	case 0xc0a04602u:      return 0;  /* CSC (VGS) */
 	case 0xc0c04603u:      return 0;  /* FilterAndCSC (VGS) */

--- a/libraries/ive_neo/test/test_persp_hog.c
+++ b/libraries/ive_neo/test/test_persp_hog.c
@@ -338,14 +338,91 @@ cleanup:
     return g_failures - failures_before;
 }
 
+/* NCC = Normalized Cross-Correlation. HW writes a 32-byte
+ * IVE_NCC_DST_MEM_S: u64 numerator + u64 quadSum1 + u64 quadSum2 +
+ * 8 reserved bytes. When src1 == src2, numerator equals both
+ * quadSums (since NCC = numerator/sqrt(qs1*qs2) = 1.0 for identical
+ * inputs). Use that as a strong correctness signal. */
+static int test_ncc(void)
+{
+    IVE_IMAGE_S src1, src2;
+    IVE_DST_MEM_INFO_S dst;
+    IVE_HANDLE h = -1;
+    HI_S32 ret;
+    HI_U8 *y1, *y2;
+    HI_U64 *dst_u64;
+    const HI_U32 NCC_DST_SIZE = 32;
+    int i;
+    int failures_before;
+
+    printf("\n=== NCC identity (src1==src2) on %ux%u U8C1 ===\n", W, H);
+    failures_before = g_failures;
+    memset(&src1, 0, sizeof(src1));
+    memset(&src2, 0, sizeof(src2));
+    memset(&dst,  0, sizeof(dst));
+
+    if (alloc_image(&src1, W, H) != HI_SUCCESS) return 1;
+    if (alloc_image(&src2, W, H) != HI_SUCCESS) { free_image(&src1); return 1; }
+    if (alloc_mem_info(&dst, NCC_DST_SIZE) != HI_SUCCESS) {
+        free_image(&src1); free_image(&src2); return 1;
+    }
+    src1.enType = IVE_IMAGE_TYPE_U8C1;
+    src2.enType = IVE_IMAGE_TYPE_U8C1;
+
+    y1 = (HI_U8 *)(uintptr_t)src1.au64VirAddr[0];
+    y2 = (HI_U8 *)(uintptr_t)src2.au64VirAddr[0];
+    for (i = 0; i < Y_SIZE; i++) {
+        y1[i] = (HI_U8)((i * 17 + 3) & 0xff);
+        y2[i] = y1[i];                          /* identical to src1 */
+    }
+    HI_MPI_SYS_MmzFlushCache(src1.au64PhyAddr[0],
+                             (void *)(uintptr_t)src1.au64VirAddr[0], IMG_SIZE);
+    HI_MPI_SYS_MmzFlushCache(src2.au64PhyAddr[0],
+                             (void *)(uintptr_t)src2.au64VirAddr[0], IMG_SIZE);
+
+    dst_u64 = (HI_U64 *)(uintptr_t)dst.u64VirAddr;
+    memset(dst_u64, SENTINEL, NCC_DST_SIZE);
+    HI_MPI_SYS_MmzFlushCache(dst.u64PhyAddr,
+                             (void *)(uintptr_t)dst.u64VirAddr, NCC_DST_SIZE);
+
+    ret = HI_MPI_IVE_NCC(&h, &src1, &src2, &dst, HI_TRUE);
+    check(ret == HI_SUCCESS, "ioctl returned success");
+    if (ret != HI_SUCCESS) goto cleanup;
+
+    ret = wait_handle(h);
+    check(ret == HI_SUCCESS, "Query/wait completed");
+
+    HI_MPI_SYS_MmzFlushCache(dst.u64PhyAddr,
+                             (void *)(uintptr_t)dst.u64VirAddr, NCC_DST_SIZE);
+
+    printf("  numerator=0x%016llx quadSum1=0x%016llx quadSum2=0x%016llx\n",
+           (unsigned long long)dst_u64[0],
+           (unsigned long long)dst_u64[1],
+           (unsigned long long)dst_u64[2]);
+
+    check(dst_u64[0] != 0, "numerator non-zero (HW wrote)");
+    check(dst_u64[1] != 0, "quadSum1 non-zero");
+    check(dst_u64[2] != 0, "quadSum2 non-zero");
+    /* The strong correctness signal: identical inputs => all 3 equal. */
+    check(dst_u64[0] == dst_u64[1] && dst_u64[1] == dst_u64[2],
+          "numerator == quadSum1 == quadSum2 (identity correlation)");
+
+cleanup:
+    free_image(&src1);
+    free_image(&src2);
+    free_mem(&dst);
+    return g_failures - failures_before;
+}
+
 int main(int argc, char **argv)
 {
     int rc, total_failures = 0;
-    int skip_hog = 0;
+    int skip_hog = 0, skip_ncc = 0;
 
-    for (int i = 1; i < argc; i++)
-        if (!strcmp(argv[i], "--no-hog"))
-            skip_hog = 1;
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--no-hog"))  skip_hog = 1;
+        if (!strcmp(argv[i], "--no-ncc"))  skip_ncc = 1;
+    }
 
     rc = HI_MPI_SYS_Init();
     if (rc != HI_SUCCESS) {
@@ -356,6 +433,8 @@ int main(int argc, char **argv)
     total_failures += test_persp_trans();
     if (!skip_hog)
         total_failures += test_hog();
+    if (!skip_ncc)
+        total_failures += test_ncc();
 
     HI_MPI_SYS_Exit();
 


### PR DESCRIPTION
Closes #110.

The `ive_op_ncc()` handler at `kernel/ive_neo/ive_neo.c:2027` was defined but never reached — the dispatcher routed ioctl `0xc0b84616` to the silent-stub `return 0` path. This PR adopts the orphaned handler and corrects its HW op code from the original \"guess\".

## What changed
- **Kernel**: \`node[10] = 18\` (guessed from nr proximity) → \`node[10] = 22\` (decoded from cv500 vendor blob symbol `ive_fill_ncc_task` @0x86a0). Field map otherwise matches vendor.
- **Dispatcher**: `case 0xc0b84616u: return 0;` → `return ive_op_ncc(arg);`
- **Diagnostic log**: handler now emits `\"NCC handler wired (HW op 22)\"` on first invocation so CI can string-grep the wired path.
- **CI**: extended the per-platform `Verify ive_neo built for this platform` step to assert the NCC needle string alongside PerspTrans / Hog (cv500 row).
- **Test harness**: added `test_ncc()` to `libraries/ive_neo/test/test_persp_hog.c` — identity-correlation test (src1 == src2 → NCC = 1.0).

## On-target verification (av300, CHIPARCH=hi3516cv500, 2026-05-13)

```
=== NCC identity (src1==src2) on 64x64 U8C1 ===
  PASS: ioctl returned success
  PASS: Query/wait completed
  numerator=0x054d5800 quadSum1=0x054d5800 quadSum2=0x054d5800
  PASS: numerator non-zero (HW wrote)
  PASS: quadSum1 non-zero
  PASS: quadSum2 non-zero
  PASS: numerator == quadSum1 == quadSum2 (identity correlation)

=== Summary: 0 failure(s) ===
```

All three accumulators (numerator, quadSum1, quadSum2) of `IVE_NCC_DST_MEM_S` are exactly equal at `0x054d5800` (89,000,832). Algebraically: NCC = numerator/√(qs1·qs2) = 1.0 exactly when inputs are identical. **The strongest correctness signal possible for NCC.**

PerspTrans + Hog regression in the same test run unchanged. Board stays up.

## ev300 regression
ev300 (CHIPARCH=hi3516ev200): NCC handler is generic (no chip gate), but ev200 libive doesn't call NCC in normal flow. SVP_INIT smoke test still returns HW ID 0x11e1a300 as before; no behaviour change observed.

## Open items
`node[8]` still uses the raw `src.enType` passthrough — same 12-entry LUT approximation as PerspTrans / Hog; will fold in when issue #113 lands. Affects only non-default `enType` paths and doesn't break this PR's identity test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)