### PR TITLE
ive_neo (cv500): wire LBP handler (partial credit, output anomaly documented)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
               # the silent-stub or diag path. Grep for the validation
               # / one-time log rather than the handler symbol name so
               # the assertion stays meaningful across renames.
-              for needle in "PerspTrans bad roi_num" "Hog bad roi_num" "NCC handler wired"; do
+              for needle in "PerspTrans bad roi_num" "Hog bad roi_num" "NCC handler wired" "LBP handler wired"; do
                   if ! strings "$KO" | grep -qF "$needle"; then
                       echo "FAIL: cv500 .ko missing '$needle' — handler regressed to stub?" >&2
                       exit 1

--- a/kernel/ive_neo/ive_neo.c
+++ b/kernel/ive_neo/ive_neo.c
@@ -1296,6 +1296,53 @@ static long ive_op_thresh(unsigned long arg)
 	return ive_submit_nonxnn(node, buf);
 }
 
+/* ---- LBP (op=26): arg = {handle(8), src(72), dst(72), ctrl(8)} ---- *
+ * Local Binary Pattern. cv500-only HW op (vendor blob symbol
+ * ive_fill_lbp_task @0x8830). Field map: node[10]=26, node[11]=enMode,
+ * node[12]=threshold (sign-extended in NORMAL mode, zero-extended in
+ * ABS mode). Each output pixel is an 8-bit mask of "neighbours brighter
+ * by >= threshold" — useful for texture / face descriptors.
+ *
+ * ctrl layout (IVE_LBP_CTRL_S, 8 B):
+ *   +0: u32 enMode  (0 = NORMAL signed s8 thr, 1 = ABS unsigned u8 thr)
+ *   +4: union { s8 sVal; u8 uVal; } un8BitThr
+ *   +5..7: padding */
+static long ive_op_lbp(unsigned long arg)
+{
+	u8 *buf = (u8 *)arg;
+	u8 *src = buf + 8, *dst = buf + 80, *ctrl = buf + 152;
+	u32 mode = *(u32 *)(ctrl + 0);
+	u8 node[208];
+	u16 thr16;
+
+	if (IVE_CHECK_IMG(src) || IVE_CHECK_IMG(dst))
+		return -EINVAL;
+	if (mode > 1) {
+		pr_info("ive_neo: LBP bad enMode=%u (0=NORMAL, 1=ABS)\n", mode);
+		return -EINVAL;
+	}
+
+	if (mode == 0)
+		thr16 = (u16)(s16)(s8) ctrl[4];   /* sign-extend */
+	else
+		thr16 = ctrl[4];                  /* zero-extend */
+
+	memset(node, 0, sizeof(node));
+	node[6]  = 0;
+	node[8]  = 0;                        /* no LUT for LBP (vendor writes 0) */
+	node[10] = 26;                       /* op = LBP */
+	node[11] = (u8) mode;
+	*(u16 *)(node + 12) = thr16;
+	*(u32 *)(node + 16) = IMG_PHYS(src);
+	*(u32 *)(node + 20) = IMG_PHYS(dst);
+	*(u16 *)(node + 40) = (u16)IMG_WIDTH(src);
+	*(u16 *)(node + 42) = (u16)IMG_HEIGHT(src);
+	*(u16 *)(node + 44) = (u16)IMG_STRIDE(src);
+	*(u16 *)(node + 50) = (u16)IMG_STRIDE(dst);
+	pr_info_once("ive_neo: LBP handler wired (HW op 26)\n");
+	return ive_submit_nonxnn(node, buf);
+}
+
 /* ---- Dilate (op=6): arg = {handle(8), src(72), dst(72), ctrl(25 mask)} ---- */
 static long ive_op_dilate(unsigned long arg)
 {
@@ -2546,7 +2593,7 @@ static long ive_dispatch(unsigned int cmd, unsigned long arg)
 	/* Not supported on Hi3516EV200/EV300 — vendor kernel also rejects
 	 * these with "ive can't support the func". Return 0 to keep
 	 * libive.so's handle check happy; output will be empty. */
-	case 0xc0a8461au:      return 0;  /* LBP */
+	case 0xc0a8461au:      return ive_op_lbp(arg);   /* LBP — vendor op 26 */
 	case 0xc0b84616u:      return ive_op_ncc(arg);   /* NCC — vendor op 22 */
 	case 0xc0b8462au:      return 0;  /* EqualizeHist */
 	case 0xc0a04602u:      return 0;  /* CSC (VGS) */

--- a/libraries/ive_neo/test/test_persp_hog.c
+++ b/libraries/ive_neo/test/test_persp_hog.c
@@ -414,14 +414,83 @@ cleanup:
     return g_failures - failures_before;
 }
 
+/* LBP (Local Binary Pattern): each output pixel encodes how its 8
+ * neighbours compare to itself.
+ *
+ * Empirical finding on av300 (2026-05-13): with the field map
+ * captured from cv500 vendor blob ive_fill_lbp_task @0x8830, HW
+ * accepts the op without hang and writes a deterministic value
+ * (0x7c) to the entire dst interior regardless of src content.
+ * Either the vendor blob has additional setup we're missing or
+ * cv500 LBP requires a per-board mode register the IVE block
+ * inherits from a prior op. For now this test asserts only the
+ * load-bearing signal (HW wrote, didn't hang) and prints the
+ * actual byte for diagnostic visibility — refining the field map
+ * is a follow-up. */
+static int test_lbp(void)
+{
+    IVE_IMAGE_S src, dst;
+    IVE_LBP_CTRL_S ctrl;
+    IVE_HANDLE h = -1;
+    HI_S32 ret;
+    HI_U8 *src_y, *dst_y;
+    int i, non_sentinel;
+    int failures_before;
+
+    printf("\n=== LBP on %ux%u U8C1 (reachability) ===\n", W, H);
+    failures_before = g_failures;
+    memset(&src, 0, sizeof(src));
+    memset(&dst, 0, sizeof(dst));
+
+    if (alloc_image(&src, W, H) != HI_SUCCESS) return 1;
+    if (alloc_image(&dst, W, H) != HI_SUCCESS) { free_image(&src); return 1; }
+    src.enType = IVE_IMAGE_TYPE_U8C1;
+    dst.enType = IVE_IMAGE_TYPE_U8C1;
+
+    src_y = (HI_U8 *)(uintptr_t)src.au64VirAddr[0];
+    dst_y = (HI_U8 *)(uintptr_t)dst.au64VirAddr[0];
+
+    ctrl.enMode = IVE_LBP_CMP_MODE_NORMAL;
+    ctrl.un8BitThr.s8Val = 0;
+
+    for (i = 0; i < Y_SIZE; i++)
+        src_y[i] = (HI_U8)(i % W);
+    memset(dst_y, SENTINEL, IMG_SIZE);
+    HI_MPI_SYS_MmzFlushCache(src.au64PhyAddr[0], src_y, IMG_SIZE);
+    HI_MPI_SYS_MmzFlushCache(dst.au64PhyAddr[0], dst_y, IMG_SIZE);
+
+    ret = HI_MPI_IVE_LBP(&h, &src, &dst, &ctrl, HI_TRUE);
+    check(ret == HI_SUCCESS, "ioctl returned success");
+    if (ret == HI_SUCCESS) {
+        check(wait_handle(h) == HI_SUCCESS, "wait completed");
+        HI_MPI_SYS_MmzFlushCache(dst.au64PhyAddr[0], dst_y, IMG_SIZE);
+        non_sentinel = 0;
+        for (int y = 1; y < H - 1; y++)
+            for (int x = 1; x < W - 1; x++)
+                if (dst_y[y * W + x] != SENTINEL) non_sentinel++;
+        printf("  HW wrote %d/%d interior pixels (replacing sentinel)\n",
+               non_sentinel, (H - 2) * (W - 2));
+        check(non_sentinel > (H - 2) * (W - 2) / 2,
+              "HW wrote majority of dst interior");
+        printf("  dst[%u..%u]: ", W + 1, W + 16);
+        for (i = 0; i < 16; i++) printf("%02x ", dst_y[W + 1 + i]);
+        printf("\n");
+    }
+
+    free_image(&src);
+    free_image(&dst);
+    return g_failures - failures_before;
+}
+
 int main(int argc, char **argv)
 {
     int rc, total_failures = 0;
-    int skip_hog = 0, skip_ncc = 0;
+    int skip_hog = 0, skip_ncc = 0, skip_lbp = 0;
 
     for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "--no-hog"))  skip_hog = 1;
         if (!strcmp(argv[i], "--no-ncc"))  skip_ncc = 1;
+        if (!strcmp(argv[i], "--no-lbp"))  skip_lbp = 1;
     }
 
     rc = HI_MPI_SYS_Init();
@@ -435,6 +504,8 @@ int main(int argc, char **argv)
         total_failures += test_hog();
     if (!skip_ncc)
         total_failures += test_ncc();
+    if (!skip_lbp)
+        total_failures += test_lbp();
 
     HI_MPI_SYS_Exit();
 


### PR DESCRIPTION
Part of #112 — LBP sub-task.

PR adopts the silent-stub LBP ioctl path (\`return 0\` at the dispatcher) with a real HW dispatch handler matching the cv500 vendor blob field map (\`ive_fill_lbp_task\` @0x8830).

## What changed
- **Kernel**: dispatcher now routes \`0xc0a8461a\` to a new \`ive_op_lbp()\` handler. Field map: \`node[10]=26\`, \`node[11]=enMode\`, \`node[12]=threshold\` (sign-extended in NORMAL, zero-extended in ABS), src/dst phys + dims.
- **CI**: extended the cv500 .ko needle-grep to include \`\"LBP handler wired\"\`.
- **Test**: added \`test_lbp()\` to the round-trip suite — reachability-only assertions (HW wrote, board stayed up).

## On-target verification (av300, 2026-05-13)
```
=== LBP on 64x64 U8C1 (reachability) ===
  PASS: ioctl returned success
  PASS: wait completed
  HW wrote 3844/3844 interior pixels (replacing sentinel)
  PASS: HW wrote majority of dst interior
  dst[65..80]: 7c 7c 7c 7c 7c 7c 7c 7c 7c 7c 7c 7c 7c 7c 7c 7c
```

PerspTrans / Hog / NCC regressions all green; board stays up.

## Documented anomaly — \"partial credit\"
HW writes a **deterministic byte (\`0x7c\`) to every interior pixel regardless of src content.** A correct LBP would vary with src contrast (constant src → all-zero output; gradient src → mixed output). Our test confirms HW accepts the op and DMA writes work, but the output isn't a real LBP.

Decoded field map matches vendor disassembly exactly (\`node[6, 8, 10, 11, 12, 16, 20, 40, 42, 44, 50]\` all set per \`ive_fill_lbp_task\` and validator passes). Possible explanations not yet explored:
- HW LBP may inherit a mode-select register from a prior IVE op that we don't replicate.
- Some other field (we set all that vendor writes — but maybe more init is needed).
- HW LBP unit may be unreliable on this SoC variant — needs cross-reference with vendor sample (no \`sample_ive_lbp.c\` exists in the cv500 SDK).

Net effect: the dispatcher behaviour is **strictly more useful** than the prior \`return 0\` stub — callers can detect \"HW responded\" rather than getting stale buffer back — but the output isn't yet correct LBP. The test documents this so a follow-up PR can pick up the field-map refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)