### PR TITLE
libraries/ive_neo: KCF tracker family stubs (link surface for #109)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,6 +388,18 @@ jobs:
           for sym in HI_MPI_IVE_PerspTrans HI_MPI_IVE_Hog; do
               check libraries/ive_neo/libive_neo.so $sym
           done
+          # KCF tracker family — 10 stubs added per issue #109. Real
+          # impls land in follow-ups; this assertion is purely
+          # link-surface (symbols must exist) so callers compiled
+          # against cv500 SDK headers can load the library.
+          for sym in \
+              HI_MPI_IVE_KCF_GetMemSize HI_MPI_IVE_KCF_CreateObjList \
+              HI_MPI_IVE_KCF_DestroyObjList HI_MPI_IVE_KCF_CreateGaussPeak \
+              HI_MPI_IVE_KCF_CreateCosWin HI_MPI_IVE_KCF_GetTrainObj \
+              HI_MPI_IVE_KCF_Process HI_MPI_IVE_KCF_GetObjBbox \
+              HI_MPI_IVE_KCF_JudgeObjBboxTrackState HI_MPI_IVE_KCF_ObjUpdate; do
+              check libraries/ive_neo/libive_neo.so $sym
+          done
           for sym in hi_ivp_init hi_ivp_deinit hi_ivp_process_ex hi_ivp_load_resource_from_memory hi_ivp_set_ctrl_attr; do
               check libraries/ivp_neo/libivp_neo.so $sym
           done

--- a/libraries/ive_neo/include/hi_ive.h
+++ b/libraries/ive_neo/include/hi_ive.h
@@ -753,6 +753,79 @@ typedef struct hiIVE_HOG_CTRL_S {
     HI_U8          au8Rsv[2];
 } IVE_HOG_CTRL_S;
 
+/* --- KCF (Kernelized Correlation Filter tracker) — cv500-only ---
+ * Structs match the cv500 SDK header (Hi3516CV500_SDK_V2.0.2.1). The
+ * 10 HI_MPI_IVE_KCF_* userland funcs in libive_neo currently ship as
+ * stubs returning HI_ERR_IVE_NOT_SUPPORT — see issue #109. The kernel
+ * has no KCF dispatch yet either; KCF_Process needs HW node build,
+ * the other nine are CPU-side helpers (trig tables, list mgmt, bbox
+ * math). */
+
+typedef struct hiIVE_KCF_PRO_CTRL_S {
+    IVE_CSC_MODE_E enCscMode;
+    IVE_MEM_INFO_S stTmpBuf;
+    HI_U1Q15       u1q15InterFactor; /* Blend coefficient, [0, 32768] */
+    HI_U0Q16       u0q16Lamda;       /* Regularization coefficient, [0, 65535] */
+    HI_U4Q12       u4q12TrancAlfa;   /* Normalization thresh, [0, 4095] */
+    HI_U0Q8        u0q8Sigma;        /* Gaussian kernel bandwidth, [0, 255] */
+    HI_U8          u8RespThr;
+} IVE_KCF_PRO_CTRL_S;
+
+typedef struct hiIVE_KCF_OBJ_S {
+    IVE_ROI_INFO_S stRoiInfo;
+    IVE_MEM_INFO_S stCosWinX;
+    IVE_MEM_INFO_S stCosWinY;
+    IVE_MEM_INFO_S stGaussPeak;
+    IVE_MEM_INFO_S stHogFeature;
+    IVE_MEM_INFO_S stAlpha;
+    IVE_MEM_INFO_S stDst;
+    HI_U3Q5        u3q5Padding;      /* Padding multiplier on ROI dimensions [48, 160] */
+    HI_U8          au8Reserved[3];
+} IVE_KCF_OBJ_S;
+
+typedef struct hiIVE_LIST_HEAD_S {
+    struct hiIVE_LIST_HEAD_S *pstNext, *pstPrev;
+} IVE_LIST_HEAD_S;
+
+typedef struct hiIVE_KCF_OBJ_NODE_S {
+    IVE_LIST_HEAD_S stList;
+    IVE_KCF_OBJ_S   stKcfObj;
+} IVE_KCF_OBJ_NODE_S;
+
+typedef enum hiIVE_KCF_LIST_STATE_E {
+    IVE_KCF_LIST_STATE_CREATE  = 0x1,
+    IVE_KCF_LIST_STATE_DESTORY = 0x2,
+    IVE_KCF_LIST_STATE_BUTT
+} IVE_KCF_LIST_STATE_E;
+
+typedef struct hiIVE_KCF_OBJ_LIST_S {
+    IVE_KCF_OBJ_NODE_S   *pstObjNodeBuf;
+    IVE_LIST_HEAD_S       stFreeObjList;
+    IVE_LIST_HEAD_S       stTrainObjList;
+    IVE_LIST_HEAD_S       stTrackObjList;
+    HI_U32                u32FreeObjNum;
+    HI_U32                u32TrainObjNum;
+    HI_U32                u32TrackObjNum;
+    HI_U32                u32MaxObjNum;
+    IVE_KCF_LIST_STATE_E  enListState;
+    HI_U8                *pu8TmpBuf;
+    HI_U32                u32Width;
+    HI_U32                u32Height;
+} IVE_KCF_OBJ_LIST_S;
+
+typedef struct hiIVE_KCF_BBOX_S {
+    IVE_KCF_OBJ_NODE_S *pstNode;
+    HI_S32              s32Response;
+    IVE_ROI_INFO_S      stRoiInfo;
+    HI_BOOL             bTrackOk;
+    HI_BOOL             bRoiRefresh;
+} IVE_KCF_BBOX_S;
+
+typedef struct hiIVE_KCF_BBOX_CTRL_S {
+    HI_U32 u32MaxBboxNum;
+    HI_S32 s32RespThr;
+} IVE_KCF_BBOX_CTRL_S;
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/ive_neo/include/mpi_ive.h
+++ b/libraries/ive_neo/include/mpi_ive.h
@@ -351,6 +351,45 @@ HI_S32 HI_MPI_IVE_Hog(IVE_HANDLE *pIveHandle,
                       IVE_HOG_CTRL_S *pstHogCtrl,
                       HI_BOOL bInstant);
 
+/* KCF (Kernelized Correlation Filter) tracker — cv500-only family
+ * (10 entry points). Userland helpers do trig table precomputation,
+ * free-list management, and bbox/state-machine bookkeeping; only
+ * KCF_Process needs kernel HW dispatch.
+ *
+ * All 10 currently return HI_ERR_IVE_NOT_SUPPORT — see issue #109.
+ * Symbols are exported so callers compiled against the cv500 SDK
+ * headers can link, even though runtime calls will fail until the
+ * implementations land. */
+HI_S32 HI_MPI_IVE_KCF_GetMemSize(HI_U32 u32MaxObjNum, HI_U32 *pu32Size);
+HI_S32 HI_MPI_IVE_KCF_CreateObjList(IVE_MEM_INFO_S *pstMem, HI_U32 u32MaxObjNum,
+                                    IVE_KCF_OBJ_LIST_S *pstObjList);
+HI_S32 HI_MPI_IVE_KCF_DestroyObjList(IVE_KCF_OBJ_LIST_S *pstObjList);
+HI_S32 HI_MPI_IVE_KCF_CreateGaussPeak(HI_U3Q5 u3q5Padding,
+                                      IVE_DST_MEM_INFO_S *pstGaussPeak);
+HI_S32 HI_MPI_IVE_KCF_CreateCosWin(IVE_DST_MEM_INFO_S *pstCosWinX,
+                                   IVE_DST_MEM_INFO_S *pstCosWinY);
+HI_S32 HI_MPI_IVE_KCF_GetTrainObj(HI_U3Q5 u3q5Padding, IVE_ROI_INFO_S astRoiInfo[],
+                                  HI_U32 u32ObjNum,
+                                  IVE_MEM_INFO_S *pstCosWinX,
+                                  IVE_MEM_INFO_S *pstCosWinY,
+                                  IVE_MEM_INFO_S *pstGaussPeak,
+                                  IVE_KCF_OBJ_LIST_S *pstObjList);
+HI_S32 HI_MPI_IVE_KCF_Process(IVE_HANDLE *pIveHandle,
+                              IVE_SRC_IMAGE_S *pstSrc,
+                              IVE_KCF_OBJ_LIST_S *pstObjList,
+                              IVE_KCF_PRO_CTRL_S *pstKcfProCtrl,
+                              HI_BOOL bInstant);
+HI_S32 HI_MPI_IVE_KCF_GetObjBbox(IVE_KCF_OBJ_LIST_S *pstObjList,
+                                 IVE_KCF_BBOX_S astBbox[],
+                                 HI_U32 *pu32BboxObjNum,
+                                 IVE_KCF_BBOX_CTRL_S *pstKcfBboxCtrl);
+HI_S32 HI_MPI_IVE_KCF_JudgeObjBboxTrackState(IVE_ROI_INFO_S *pstRoiInfo,
+                                             IVE_KCF_BBOX_S *pstBbox,
+                                             HI_BOOL *pbTrackOk);
+HI_S32 HI_MPI_IVE_KCF_ObjUpdate(IVE_KCF_OBJ_LIST_S *pstObjList,
+                                IVE_KCF_BBOX_S astBbox[],
+                                HI_U32 u32BboxObjNum);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/ive_neo/src/ive_ops.c
+++ b/libraries/ive_neo/src/ive_ops.c
@@ -1064,3 +1064,101 @@ HI_S32 HI_MPI_IVE_CNN_GetResult(IVE_SRC_DATA_S *pstSrc, IVE_DST_MEM_INFO_S *pstD
     (void)pstSrc; (void)pstDst; (void)pstCnnModel; (void)pstCnnCtrl;
     return HI_ERR_IVE_NOT_SUPPORT;
 }
+
+/* ===================================================================
+ * KCF tracker family — cv500-only HW. All 10 stubs for issue #109.
+ *
+ * Symbols are exported so callers compiled against the cv500 SDK
+ * headers can link against libive_neo.so even though runtime calls
+ * fail with HI_ERR_IVE_NOT_SUPPORT. Real implementations land in
+ * follow-up PRs:
+ *   - 9 userspace helpers (trig tables, list mgmt, bbox math)
+ *   - KCF_Process needs kernel HW dispatch (vendor blob symbol
+ *     ive_fill_kcf_task @0x9718 in obj/hi3516cv500/hi_ive.o)
+ * =================================================================== */
+
+HI_S32 HI_MPI_IVE_KCF_GetMemSize(HI_U32 u32MaxObjNum, HI_U32 *pu32Size)
+{
+    (void)u32MaxObjNum;
+    if (pu32Size) *pu32Size = 0;
+    return HI_ERR_IVE_NOT_SUPPORT;
+}
+
+HI_S32 HI_MPI_IVE_KCF_CreateObjList(IVE_MEM_INFO_S *pstMem, HI_U32 u32MaxObjNum,
+                                    IVE_KCF_OBJ_LIST_S *pstObjList)
+{
+    (void)pstMem; (void)u32MaxObjNum;
+    if (pstObjList)
+        memset(pstObjList, 0, sizeof(*pstObjList));
+    return HI_ERR_IVE_NOT_SUPPORT;
+}
+
+HI_S32 HI_MPI_IVE_KCF_DestroyObjList(IVE_KCF_OBJ_LIST_S *pstObjList)
+{
+    (void)pstObjList;
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_MPI_IVE_KCF_CreateGaussPeak(HI_U3Q5 u3q5Padding,
+                                      IVE_DST_MEM_INFO_S *pstGaussPeak)
+{
+    (void)u3q5Padding; (void)pstGaussPeak;
+    return HI_ERR_IVE_NOT_SUPPORT;
+}
+
+HI_S32 HI_MPI_IVE_KCF_CreateCosWin(IVE_DST_MEM_INFO_S *pstCosWinX,
+                                   IVE_DST_MEM_INFO_S *pstCosWinY)
+{
+    (void)pstCosWinX; (void)pstCosWinY;
+    return HI_ERR_IVE_NOT_SUPPORT;
+}
+
+HI_S32 HI_MPI_IVE_KCF_GetTrainObj(HI_U3Q5 u3q5Padding, IVE_ROI_INFO_S astRoiInfo[],
+                                  HI_U32 u32ObjNum,
+                                  IVE_MEM_INFO_S *pstCosWinX,
+                                  IVE_MEM_INFO_S *pstCosWinY,
+                                  IVE_MEM_INFO_S *pstGaussPeak,
+                                  IVE_KCF_OBJ_LIST_S *pstObjList)
+{
+    (void)u3q5Padding; (void)astRoiInfo; (void)u32ObjNum;
+    (void)pstCosWinX; (void)pstCosWinY; (void)pstGaussPeak; (void)pstObjList;
+    return HI_ERR_IVE_NOT_SUPPORT;
+}
+
+HI_S32 HI_MPI_IVE_KCF_Process(IVE_HANDLE *pIveHandle,
+                              IVE_SRC_IMAGE_S *pstSrc,
+                              IVE_KCF_OBJ_LIST_S *pstObjList,
+                              IVE_KCF_PRO_CTRL_S *pstKcfProCtrl,
+                              HI_BOOL bInstant)
+{
+    (void)pstSrc; (void)pstObjList; (void)pstKcfProCtrl; (void)bInstant;
+    if (pIveHandle) *pIveHandle = -1;
+    return HI_ERR_IVE_NOT_SUPPORT;
+}
+
+HI_S32 HI_MPI_IVE_KCF_GetObjBbox(IVE_KCF_OBJ_LIST_S *pstObjList,
+                                 IVE_KCF_BBOX_S astBbox[],
+                                 HI_U32 *pu32BboxObjNum,
+                                 IVE_KCF_BBOX_CTRL_S *pstKcfBboxCtrl)
+{
+    (void)pstObjList; (void)astBbox; (void)pstKcfBboxCtrl;
+    if (pu32BboxObjNum) *pu32BboxObjNum = 0;
+    return HI_ERR_IVE_NOT_SUPPORT;
+}
+
+HI_S32 HI_MPI_IVE_KCF_JudgeObjBboxTrackState(IVE_ROI_INFO_S *pstRoiInfo,
+                                             IVE_KCF_BBOX_S *pstBbox,
+                                             HI_BOOL *pbTrackOk)
+{
+    (void)pstRoiInfo; (void)pstBbox;
+    if (pbTrackOk) *pbTrackOk = HI_FALSE;
+    return HI_ERR_IVE_NOT_SUPPORT;
+}
+
+HI_S32 HI_MPI_IVE_KCF_ObjUpdate(IVE_KCF_OBJ_LIST_S *pstObjList,
+                                IVE_KCF_BBOX_S astBbox[],
+                                HI_U32 u32BboxObjNum)
+{
+    (void)pstObjList; (void)astBbox; (void)u32BboxObjNum;
+    return HI_ERR_IVE_NOT_SUPPORT;
+}


### PR DESCRIPTION
Partial work on #109 — adds the 10 \`HI_MPI_IVE_KCF_*\` exports + struct typedefs as link-only stubs so callers compiled against cv500 SDK headers can resolve \`libive_neo.so\` even though runtime calls fail until the real impls land in follow-up PRs.

## What's exported
| Symbol | Will be |
|---|---|
| \`HI_MPI_IVE_KCF_GetMemSize\` | userspace size calc |
| \`HI_MPI_IVE_KCF_CreateObjList\` | userspace list init |
| \`HI_MPI_IVE_KCF_DestroyObjList\` | userspace cleanup |
| \`HI_MPI_IVE_KCF_CreateGaussPeak\` | userspace gauss-peak math |
| \`HI_MPI_IVE_KCF_CreateCosWin\` | userspace trig tables |
| \`HI_MPI_IVE_KCF_GetTrainObj\` | userspace bbox matching |
| **\`HI_MPI_IVE_KCF_Process\`** | **kernel HW dispatch** — vendor blob symbol \`ive_fill_kcf_task\` @0x9718 (RE pending) |
| \`HI_MPI_IVE_KCF_GetObjBbox\` | userspace bbox readback |
| \`HI_MPI_IVE_KCF_JudgeObjBboxTrackState\` | userspace state machine |
| \`HI_MPI_IVE_KCF_ObjUpdate\` | userspace list update |

All currently return \`HI_ERR_IVE_NOT_SUPPORT\`. 9 of the 10 are pure userspace once implemented; only \`KCF_Process\` needs kernel HW work (similar effort to PerspTrans/Hog from #107).

## Structs added to \`hi_ive.h\`
\`IVE_KCF_PRO_CTRL_S\` / \`IVE_KCF_OBJ_S\` / \`IVE_LIST_HEAD_S\` / \`IVE_KCF_OBJ_NODE_S\` / \`IVE_KCF_LIST_STATE_E\` / \`IVE_KCF_OBJ_LIST_S\` / \`IVE_KCF_BBOX_S\` / \`IVE_KCF_BBOX_CTRL_S\` — copied verbatim from \`Hi3516CV500_SDK_V2.0.2.1/smp/a7_linux/mpp/include/hi_ive.h\` so on-the-wire layouts match when real impls land.

## CI
Extended the \`libraries-cross-compile\` symbol-export check (the same one that already gates PerspTrans + Hog from #107) to assert all 10 KCF symbols exist on every \`libive_neo.so\` build. A silent symbol-rename or accidental \`#ifdef\`-out now fails CI.

## What this is NOT
Not a real KCF implementation — callers get \`HI_ERR_IVE_NOT_SUPPORT\` from any KCF call. The follow-up PRs (separate sub-tasks of #109) will:
1. CPU-side trig tables + list mgmt (9 funcs)
2. \`KCF_Process\` kernel HW dispatch + integration test in \`libraries/ive_neo/test/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)