### PR TITLE
kernel/ive_neo: audit silent-stub dispatcher cases against cv500 vendor blob

### DIFF
--- a/kernel/ive_neo/ive_neo.c
+++ b/kernel/ive_neo/ive_neo.c
@@ -2590,20 +2590,49 @@ static long ive_dispatch(unsigned int cmd, unsigned long arg)
 	case 0xc0c0462bu:      return ive_op_st_candi_corner(arg); /* STCandiCorner */
 	case 0xc0f04619u:      return ive_op_canny_hys(arg);  /* CannyHysEdge */
 	case 0xc1a8462du:      return ive_op_gmm2(arg);       /* GMM2 (best effort) */
-	/* Not supported on Hi3516EV200/EV300 — vendor kernel also rejects
-	 * these with "ive can't support the func". Return 0 to keep
-	 * libive.so's handle check happy; output will be empty. */
 	case 0xc0a8461au:      return ive_op_lbp(arg);   /* LBP — vendor op 26 */
 	case 0xc0b84616u:      return ive_op_ncc(arg);   /* NCC — vendor op 22 */
-	case 0xc0b8462au:      return 0;  /* EqualizeHist */
-	case 0xc0a04602u:      return 0;  /* CSC (VGS) */
-	case 0xc0c04603u:      return 0;  /* FilterAndCSC (VGS) */
-	case 0xc008462eu:      return 0;  /* Resize (VGS) */
-	case 0xc1184618u:      return 0;  /* GMM (single gaussian, unsupported) */
+
+	/* ---- Silent-stub ops ----
+	 *
+	 * Audited 2026-05-13 against obj/hi3516cv500/hi_ive.o symbol table
+	 * + ive_ioctl dispatcher. Each op is in one of three categories:
+	 *
+	 * (a) cv500 HW supports it, we just haven't wired it. Vendor blob
+	 *     has both ive_check_<op>_param AND ive_fill_<op>_task. Worth
+	 *     porting — follow-up issues opened. Stub returns 0 to keep
+	 *     libive's handle-check happy until impl lands.
+	 *
+	 * (b) cv500 reuses another op's HW path with a flag override
+	 *     (e.g., EqualizeHist calls ive_fill_hist_task with
+	 *     node[7]=0x61 + an extra LUT remap at node[200]).
+	 *
+	 * (c) cv500 has no symbols for it — vendor genuinely doesn't
+	 *     dispatch HW. Userspace either falls back to CPU compute
+	 *     or rejects. Silent stub is correct here.
+	 */
+
+	/* (b) reuses ive_fill_hist_task with node[7]=0x61 + LUT remap. */
+	case 0xc0b8462au:      return 0;  /* EqualizeHist — issue #112 follow-up */
+
+	/* (a) cv500 has full HW path (ive_fill_csc_task @0x???? etc.) —
+	 * the "VGS" comment was wrong for cv500. Worth porting. */
+	case 0xc0a04602u:      return 0;  /* CSC — issue #112 follow-up */
+	case 0xc0c04603u:      return 0;  /* FilterAndCSC — issue #112 follow-up */
+	case 0xc008462eu:      return 0;  /* Resize — multi-N, issue #112 follow-up */
+	case 0xc2c0461cu:      return 0;  /* LKOpticalFlowPyr — has ive_lk_optical_flow_pyr + fill + check */
+
+	/* (b) GMM (single-Gaussian) is GMM2 with default params in
+	 * vendor. No separate fill_gmm_task — vendor only has fill_gmm2. */
+	case 0xc1184618u:      return 0;  /* GMM */
+
+	/* (c) cv500 vendor blob has no symbols at all for these — HW
+	 * unit either doesn't exist or vendor never wired userspace
+	 * to it. Silent stub is correct; libive presumably falls back
+	 * to CPU implementation or returns its own error. */
 	case 0xc138461du:      return 0;  /* GradFg */
 	case 0xc178461eu:      return 0;  /* MatchBgModel */
 	case 0xc1d8461fu:      return 0;  /* UpdateBgModel */
-	case 0xc2c0461cu:      return 0;  /* LKOpticalFlowPyr */
 	case 0xc0b04621u:      return 0;  /* ANN_MLP_Predict */
 	case 0xc0c04622u:      return 0;  /* SVM_Predict */
 #ifndef IVE_STANDALONE


### PR DESCRIPTION
Refresh the silent-stub comments in \`ive_neo.c\`'s dispatcher with evidence-backed findings from cross-referencing the cv500 vendor blob \`obj/hi3516cv500/hi_ive.o\` symbol table against each \`return 0;\` case. **No behaviour change** — comment-only refactor that closes the audit gap from #112.

## Three-tier classification

### (a) cv500 HW supports it, just unwired in openhisilicon
Vendor blob has full \`ive_check_<op>_param\` + \`ive_fill_<op>_task\`. The prior \"VGS-only\" comment for CSC/FilterAndCSC/Resize was wrong for cv500 — they have dedicated IVE HW paths.

Follow-up issues opened:
- #119 — CSC (\`ive_fill_csc_task\` + \`ive_csc\`)
- #120 — FilterAndCSC (\`ive_fill_filter_and_csc_task\` + \`ive_flt_csc\`)
- #121 — Resize (\`ive_fill_resize_task\` + \`ive_resize_proc\` — multi-N)
- #122 — LKOpticalFlowPyr (\`ive_fill_lk_optical_flow_pyr_task\` + \`ive_lk_optical_flow_pyr\`)

### (b) cv500 reuses another op's HW path with a flag override
EqualizeHist calls \`ive_fill_hist_task\` with \`node[7]=0x61\` + an extra LUT remap at \`node[200]\` (decoded from \`ive_ioctl\` dispatcher branch \`0x68d0..0x69d0\`). Distinct from (a) because the handler has no own \`fill_task\` symbol.

- EqualizeHist — #112 umbrella follow-up.
- GMM (single-Gaussian) — GMM2 with default params; vendor only ships \`fill_gmm2_task\`.

### (c) cv500 vendor blob has no symbols whatsoever
HW unit either doesn't exist or vendor never wired userspace to it. Silent-stub \`return 0\` is correct here — libive presumably falls back to CPU or returns its own error.

- GradFg, MatchBgModel, UpdateBgModel
- ANN_MLP_Predict, SVM_Predict

## Method
\`nm obj/hi3516cv500/hi_ive.o | grep -iE \"ive_(check_<op>|fill_<op>|<op>_proc)\"\` for each of the 13 silent-stub ops, cross-checked against the SDK header signatures and (where available) the vendor sample code at \`Hi3516CV500_SDK_V2.0.2.1/smp/a7_linux/mpp/sample/svp/ive/sample/\`.

## What's NOT in this PR
No new handlers, no userspace changes, no test changes. Pure documentation + four new follow-up issues to track each \"(a)\" op.