### PR TITLE
kernel/ive_neo + libraries/ive_neo: cv500 LKOpticalFlowPyr HW dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,13 +246,13 @@ jobs:
               # the silent-stub or diag path. Grep for the validation
               # / one-time log rather than the handler symbol name so
               # the assertion stays meaningful across renames.
-              for needle in "PerspTrans bad roi_num" "Hog bad roi_num" "NCC handler wired" "LBP handler wired" "CSC handler wired" "FilterAndCSC handler wired" "Resize handler wired"; do
+              for needle in "PerspTrans bad roi_num" "Hog bad roi_num" "NCC handler wired" "LBP handler wired" "CSC handler wired" "FilterAndCSC handler wired" "Resize handler wired" "LK handler wired"; do
                   if ! strings "$KO" | grep -qF "$needle"; then
                       echo "FAIL: cv500 .ko missing '$needle' — handler regressed to stub?" >&2
                       exit 1
                   fi
               done
-              echo "ok: cv500 build has PerspTrans + Hog + NCC + LBP + CSC + FilterAndCSC + Resize HW handlers wired"
+              echo "ok: cv500 build has PerspTrans + Hog + NCC + LBP + CSC + FilterAndCSC + Resize + LK HW handlers wired"
 
               # The N-node chain submit helper is the shared HW kick
               # path for both new ops. Its timeout log is the only

--- a/kernel/ive_neo/ive_neo.c
+++ b/kernel/ive_neo/ive_neo.c
@@ -2875,6 +2875,201 @@ static long ive_op_resize_cv500(unsigned long arg)
 	pr_info_once("ive_neo: Resize handler wired (HW op 0x30, U8C1 + multi-plane)\n");
 	return ive_submit_nonxnn(node, buf);
 }
+
+/* ---- cv500 LKOpticalFlowPyr (HW op 0x1c, ioctl 0xc2c0461c) ----
+ *
+ * Lucas-Kanade pyramidal optical flow. Up to 4 pyramid levels
+ * (u8MaxLevel = 0..3). Vendor blob symbols: ive_lk_optical_flow_pyr
+ * @0x46cc (top), ive_fill_lk_optical_flow_pyr_task @0x8ec4,
+ * ive_check_lk_optical_flow_pyr_param @0x129c8.
+ *
+ * Arg buffer (704 bytes, vendor's IVE_CMD_LK_OPT_FLOW=0xc2c0461c):
+ *   +0:    HI_HANDLE                                  8
+ *   +8:    IVE_SRC_IMAGE_S prev[4]   (4 * 72)        288
+ *   +296:  IVE_SRC_IMAGE_S next[4]                   288
+ *   +584:  IVE_SRC_MEM_INFO_S prevPts (24)            24
+ *   +608:  IVE_MEM_INFO_S    nextPts                  24
+ *   +632:  IVE_DST_MEM_INFO_S status                  24
+ *   +656:  IVE_DST_MEM_INFO_S err                     24
+ *   +680:  IVE_LK_OPTICAL_FLOW_PYR_CTRL_S ctrl        16
+ *       +0:  u32 enOutMode (0=NONE, 1=STATUS, 2=BOTH)
+ *       +4:  u32 bUseInitFlow
+ *       +8:  u16 u16PtsNum
+ *      +10:  u8  u8MaxLevel (0..3)
+ *      +11:  u8  u0q8MinEigThr
+ *      +12:  u8  u8IterCnt
+ *      +13:  u8  u0q8Eps
+ *   +696:  HI_BOOL instant                             4
+ *   +700:  padding                                     4
+ *
+ * Validator constraints:
+ *   u16PtsNum <= 500, u8MaxLevel <= 3, u8IterCnt <= 19, enOutMode <= 2.
+ *
+ * Per-level pyramid node-field layout (decoded from
+ * ive_fill_lk_optical_flow_pyr_task @0x8ec4):
+ *
+ *   level 0: node[16]=prev.phys,  node[120]=next.phys,
+ *            node[44]=prev.stride, node[50]=next.stride
+ *   level 1: node[24]=prev.phys,  node[124]=next.phys,
+ *            node[46]=prev.stride, node[52]=next.stride
+ *   level 2: node[32]=prev.phys,  node[128]=next.phys,
+ *            node[48]=prev.stride, node[54]=next.stride
+ *   level 3: node[136]=prev.phys, node[132]=next.phys,
+ *            node[12]=prev.stride, node[14]=next.stride
+ *
+ * Output mem buffers:
+ *   node[140] = prevPts.phys (always)
+ *   node[20]  = nextPts.phys (always)
+ *   node[28]  = status.phys  (if enOutMode >= 1, else 0)
+ *   node[36]  = err.phys     (if enOutMode == 2, else 0)
+ *
+ * ctrl-mirrored node fields:
+ *   node[9]   = enOutMode
+ *   node[40]  = prev[0].width, node[42] = prev[0].height
+ *   node[56]  = u8MaxLevel
+ *   node[57]  = bUseInitFlow != 0
+ *   node[58]  = u0q8MinEigThr
+ *   node[59]  = u0q8Eps
+ *   node[94]  = u8IterCnt
+ *   node[96]  = u16PtsNum
+ */
+static long ive_op_lk_optical_flow_pyr_cv500(unsigned long arg)
+{
+	u8 *buf  = (u8 *)arg;
+	u8 *prev = buf + 8;
+	u8 *next = buf + 296;
+	u8 *prevPts = buf + 584;
+	u8 *nextPts = buf + 608;
+	u8 *status  = buf + 632;
+	u8 *err     = buf + 656;
+	u8 *ctrl    = buf + 680;
+	u32 out_mode  = *(u32 *)(ctrl + 0);
+	u32 use_init  = *(u32 *)(ctrl + 4);
+	u16 pts_num   = *(u16 *)(ctrl + 8);
+	u8  max_level = ctrl[10];
+	u8  min_eig   = ctrl[11];
+	u8  iter_cnt  = ctrl[12];
+	u8  eps       = ctrl[13];
+	u32 p0_w, p0_h, p0_s;
+	u8 node[208];
+	u32 i;
+
+	if (out_mode > 2) {
+		pr_info("ive_neo: LK bad enOutMode=%u (0..2)\n", out_mode);
+		return -EINVAL;
+	}
+	if (max_level > 3) {
+		pr_info("ive_neo: LK bad u8MaxLevel=%u (0..3)\n", max_level);
+		return -EINVAL;
+	}
+	if (iter_cnt > 19) {
+		pr_info("ive_neo: LK bad u8IterCnt=%u (1..19)\n", iter_cnt);
+		return -EINVAL;
+	}
+	if (!pts_num || pts_num > 500) {
+		pr_info("ive_neo: LK bad u16PtsNum=%u (1..500)\n", pts_num);
+		return -EINVAL;
+	}
+	if (!*(u32 *)prevPts || !*(u32 *)nextPts) {
+		pr_info("ive_neo: LK prevPts/nextPts phys is 0\n");
+		return -EINVAL;
+	}
+	if (out_mode >= 1 && !*(u32 *)status) {
+		pr_info("ive_neo: LK status.phys is 0 (required when enOutMode>=1)\n");
+		return -EINVAL;
+	}
+	if (out_mode == 2 && !*(u32 *)err) {
+		pr_info("ive_neo: LK err.phys is 0 (required when enOutMode==BOTH)\n");
+		return -EINVAL;
+	}
+
+	/* Level 0 is mandatory. Validate src and grab dims. */
+	if (IVE_CHECK_IMG(prev) || IVE_CHECK_IMG(next))
+		return -EINVAL;
+	p0_w = *(u32 *)(prev + 60);
+	p0_h = *(u32 *)(prev + 64);
+	p0_s = *(u32 *)(prev + 48);
+
+	memset(node, 0, sizeof(node));
+
+	/* Constants */
+	node[10] = 0x1c;                            /* op = LK */
+	node[9]  = (u8) out_mode;
+	*(u16 *)(node + 40) = (u16) p0_w;
+	*(u16 *)(node + 42) = (u16) p0_h;
+
+	/* ctrl mirror */
+	node[56] = max_level;
+	node[57] = use_init ? 1 : 0;
+	node[58] = min_eig;
+	node[59] = eps;
+	node[94] = iter_cnt;
+	*(u16 *)(node + 96) = pts_num;
+
+	/* Pyramid level fields. Higher levels get written only when
+	 * max_level reaches them — same conditional as vendor's fill_task. */
+	for (i = 0; i <= max_level; i++) {
+		u8 *pi = prev + i * 72;
+		u8 *ni = next + i * 72;
+		u32 pi_phys = *(u32 *)pi;
+		u32 ni_phys = *(u32 *)ni;
+		u32 pi_stride = *(u32 *)(pi + 48);
+		u32 ni_stride = *(u32 *)(ni + 48);
+
+		if (!pi_phys || !ni_phys || (pi_phys & 0xF) || (ni_phys & 0xF)) {
+			pr_info("ive_neo: LK level %u phys invalid (prev=0x%x next=0x%x)\n",
+				i, pi_phys, ni_phys);
+			return -EINVAL;
+		}
+		if (!pi_stride || !ni_stride) {
+			pr_info("ive_neo: LK level %u stride invalid (prev=%u next=%u)\n",
+				i, pi_stride, ni_stride);
+			return -EINVAL;
+		}
+
+		switch (i) {
+		case 0:
+			*(u32 *)(node + 16)  = pi_phys;
+			*(u32 *)(node + 120) = ni_phys;
+			*(u16 *)(node + 44)  = (u16) pi_stride;
+			*(u16 *)(node + 50)  = (u16) ni_stride;
+			break;
+		case 1:
+			*(u32 *)(node + 24)  = pi_phys;
+			*(u32 *)(node + 124) = ni_phys;
+			*(u16 *)(node + 46)  = (u16) pi_stride;
+			*(u16 *)(node + 52)  = (u16) ni_stride;
+			break;
+		case 2:
+			*(u32 *)(node + 32)  = pi_phys;
+			*(u32 *)(node + 128) = ni_phys;
+			*(u16 *)(node + 48)  = (u16) pi_stride;
+			*(u16 *)(node + 54)  = (u16) ni_stride;
+			break;
+		case 3:
+			/* Level 3 uses unusual offsets — vendor's fill_task
+			 * writes prev.phys to node[136] (not 40+8*i pattern)
+			 * and the strides to node[12]/[14]. */
+			*(u32 *)(node + 136) = pi_phys;
+			*(u32 *)(node + 132) = ni_phys;
+			*(u16 *)(node + 12)  = (u16) pi_stride;
+			*(u16 *)(node + 14)  = (u16) ni_stride;
+			break;
+		}
+	}
+	(void)p0_s;  /* p0_s used only via the level-0 IVE_CHECK_IMG above. */
+
+	/* Output buffers (phys of user-allocated MMZ blobs). */
+	*(u32 *)(node + 140) = *(u32 *)prevPts;
+	*(u32 *)(node + 20)  = *(u32 *)nextPts;
+	if (out_mode >= 1)
+		*(u32 *)(node + 28) = *(u32 *)status;
+	if (out_mode == 2)
+		*(u32 *)(node + 36) = *(u32 *)err;
+
+	pr_info_once("ive_neo: LK handler wired (HW op 0x1c, levels 0..3)\n");
+	return ive_submit_nonxnn(node, buf);
+}
 #endif
 
 #ifndef IVE_STANDALONE
@@ -3048,7 +3243,15 @@ static long ive_dispatch(unsigned int cmd, unsigned long arg)
 		return 0;
 #endif
 	case 0xc008462eu:      return 0;  /* Resize (vendor's small 8-B stub ioctl) — superseded by 0xc4c0462e below */
-	case 0xc2c0461cu:      return 0;  /* LKOpticalFlowPyr — has ive_lk_optical_flow_pyr + fill + check */
+	case 0xc2c0461cu:                /* LKOpticalFlowPyr */
+#if defined(hi3516cv500)
+		/* HW dispatch — single 208-B node, up to 4 pyramid levels.
+		 * Output mem buffers (prevPts/nextPts/status/err) are
+		 * user-allocated MMZ blobs; HW writes via their phys. */
+		return ive_op_lk_optical_flow_pyr_cv500(arg);
+#else
+		return 0;
+#endif
 
 	/* (b) GMM (single-Gaussian) is GMM2 with default params in
 	 * vendor. No separate fill_gmm_task — vendor only has fill_gmm2. */

--- a/libraries/ive_neo/src/ive_ops.c
+++ b/libraries/ive_neo/src/ive_ops.c
@@ -783,6 +783,21 @@ HI_S32 HI_MPI_IVE_UpdateBgModel(IVE_HANDLE *h, IVE_SRC_IMAGE_S *cur,
     return ret;
 }
 
+/* cv500 LK Optical Flow Pyramid — multi-level Lucas-Kanade tracker.
+ * Arg buffer layout decoded from vendor ive_fill_lk_optical_flow_pyr_task
+ * @0x8ec4 (reads at fixed offsets from arg base). 704-byte total —
+ * matches the IVE_CMD_LK_OPT_FLOW=0xc2c0461c size encoding. */
+#define LK_OFF_PREV     8
+#define LK_OFF_NEXT     296
+#define LK_OFF_PREV_PTS 584
+#define LK_OFF_NEXT_PTS 608
+#define LK_OFF_STATUS   632
+#define LK_OFF_ERR      656
+#define LK_OFF_CTRL     680
+#define LK_OFF_INST     696
+#define LK_ARG_SIZE     704
+#define LK_MAX_LEVELS   4
+
 HI_S32 HI_MPI_IVE_LKOpticalFlowPyr(IVE_HANDLE *h, IVE_SRC_IMAGE_S prev[],
                                    IVE_SRC_IMAGE_S next[],
                                    IVE_SRC_MEM_INFO_S *prevPts,
@@ -792,19 +807,40 @@ HI_S32 HI_MPI_IVE_LKOpticalFlowPyr(IVE_HANDLE *h, IVE_SRC_IMAGE_S prev[],
                                    IVE_LK_OPTICAL_FLOW_PYR_CTRL_S *c,
                                    HI_BOOL inst)
 {
-    /* Vendor lays out 288 bytes per pyramid array (4 levels * 72 bytes).
-     * Kernel stub returns 0 — we just need to keep the buffer sized
-     * correctly enough that the kernel reads its 0-handle slot. */
-    uint8_t buf[800];
+    uint8_t buf[LK_ARG_SIZE];
     HI_S32 ret;
+    int i, levels;
 
-    (void)prev; (void)next; (void)prevPts; (void)nextPts;
-    (void)status; (void)err;
-    IVE_CHECK_NULL("HI_MPI_IVE_LKOpticalFlowPyr", h, "pIveHandle");
+    IVE_CHECK_NULL("HI_MPI_IVE_LKOpticalFlowPyr", h,        "pIveHandle");
+    IVE_CHECK_NULL("HI_MPI_IVE_LKOpticalFlowPyr", prev,     "astPrev");
+    IVE_CHECK_NULL("HI_MPI_IVE_LKOpticalFlowPyr", next,     "astNext");
+    IVE_CHECK_NULL("HI_MPI_IVE_LKOpticalFlowPyr", prevPts,  "pstPrevPts");
+    IVE_CHECK_NULL("HI_MPI_IVE_LKOpticalFlowPyr", nextPts,  "pstNextPts");
+    IVE_CHECK_NULL("HI_MPI_IVE_LKOpticalFlowPyr", c,        "pstLkCtrl");
+
+    if (c->u8MaxLevel >= LK_MAX_LEVELS) {
+        IVE_LOG("HI_MPI_IVE_LKOpticalFlowPyr",
+                "u8MaxLevel(%u) must be 0..%u", c->u8MaxLevel, LK_MAX_LEVELS - 1);
+        return HI_ERR_IVE_ILLEGAL_PARAM;
+    }
+    levels = c->u8MaxLevel + 1;
+
     if (ive_open_fd() != HI_SUCCESS) return HI_FAILURE;
+
     memset(buf, 0, sizeof(buf));
-    if (c) memcpy(buf + 720, c, sizeof(*c));
-    put_u32(buf, 720 + sizeof(*c) + 4, (uint32_t)inst);
+    for (i = 0; i < levels; i++) {
+        memcpy(buf + LK_OFF_PREV + i * sizeof(IVE_IMAGE_S),
+               &prev[i], sizeof(IVE_IMAGE_S));
+        memcpy(buf + LK_OFF_NEXT + i * sizeof(IVE_IMAGE_S),
+               &next[i], sizeof(IVE_IMAGE_S));
+    }
+    memcpy(buf + LK_OFF_PREV_PTS, prevPts, sizeof(*prevPts));
+    memcpy(buf + LK_OFF_NEXT_PTS, nextPts, sizeof(*nextPts));
+    if (status) memcpy(buf + LK_OFF_STATUS, status, sizeof(*status));
+    if (err)    memcpy(buf + LK_OFF_ERR,    err,    sizeof(*err));
+    memcpy(buf + LK_OFF_CTRL, c, sizeof(*c));
+    put_u32(buf, LK_OFF_INST, (uint32_t)inst);
+
     ret = ioctl(g_ive_fd, IVE_CMD_LK_OPT_FLOW, buf);
     *h = (ret == 0) ? (IVE_HANDLE)get_u32(buf, 0) : -1;
     return ret;

--- a/libraries/ive_neo/test/test_persp_hog.c
+++ b/libraries/ive_neo/test/test_persp_hog.c
@@ -738,11 +738,123 @@ static int test_resize(void)
     return rc;
 }
 
+static int test_lk_optical_flow_pyr(void)
+{
+    IVE_IMAGE_S prev_lvl[2], next_lvl[2];
+    IVE_MEM_INFO_S prev_pts, next_pts, status, err;
+    IVE_LK_OPTICAL_FLOW_PYR_CTRL_S ctrl;
+    IVE_HANDLE h = -1;
+    HI_S32 ret;
+    HI_U8 *prev_y, *next_y;
+    HI_U8 *prev_pts_buf;
+    int failures_before;
+    int n_pts = 4;
+    int written, i;
+
+    printf("\n=== LK Optical Flow Pyramid %ux%u, 1-level, %d points (reachability) ===\n",
+           W, H, n_pts);
+    failures_before = g_failures;
+    memset(prev_lvl, 0, sizeof(prev_lvl));
+    memset(next_lvl, 0, sizeof(next_lvl));
+    memset(&prev_pts, 0, sizeof(prev_pts));
+    memset(&next_pts, 0, sizeof(next_pts));
+    memset(&status, 0, sizeof(status));
+    memset(&err, 0, sizeof(err));
+
+    if (alloc_image(&prev_lvl[0], W, H) != HI_SUCCESS) return 1;
+    if (alloc_image(&next_lvl[0], W, H) != HI_SUCCESS) {
+        free_image(&prev_lvl[0]); return 1;
+    }
+    /* prev / next pts arrays — each point = IVE_POINT_U16S16_S = 4B
+     * (X Q14.2 + Y Q14.2). 16-byte alignment required for HW. */
+    if (alloc_mem_info(&prev_pts, 64) != HI_SUCCESS) goto fail_imgs;
+    if (alloc_mem_info(&next_pts, 64) != HI_SUCCESS) goto fail_prevpts;
+    if (alloc_mem_info(&status, 64)   != HI_SUCCESS) goto fail_nextpts;
+    if (alloc_mem_info(&err, 64)      != HI_SUCCESS) goto fail_status;
+
+    prev_lvl[0].enType = IVE_IMAGE_TYPE_U8C1;
+    next_lvl[0].enType = IVE_IMAGE_TYPE_U8C1;
+    prev_y = (HI_U8 *)(uintptr_t)prev_lvl[0].au64VirAddr[0];
+    next_y = (HI_U8 *)(uintptr_t)next_lvl[0].au64VirAddr[0];
+
+    /* Static-scene gradient: prev == next, so any tracked point should
+     * report "unchanged" (best case) or "could not track" (worst). */
+    for (i = 0; i < Y_SIZE; i++) {
+        prev_y[i] = (HI_U8)(i & 0xff);
+        next_y[i] = (HI_U8)(i & 0xff);
+    }
+    HI_MPI_SYS_MmzFlushCache(prev_lvl[0].au64PhyAddr[0], prev_y, IMG_SIZE);
+    HI_MPI_SYS_MmzFlushCache(next_lvl[0].au64PhyAddr[0], next_y, IMG_SIZE);
+
+    /* Seed 4 points around the image. Format: X (Q14.2) + Y (Q14.2) in 4B. */
+    prev_pts_buf = (HI_U8 *)(uintptr_t)prev_pts.u64VirAddr;
+    memset(prev_pts_buf, 0, 64);
+    for (i = 0; i < n_pts; i++) {
+        HI_U16 x = (HI_U16)((16 + i * 8) << 2);     /* Q14.2 encoding */
+        HI_U16 y = (HI_U16)((16 + i * 8) << 2);
+        prev_pts_buf[i * 4 + 0] = (HI_U8)(x & 0xff);
+        prev_pts_buf[i * 4 + 1] = (HI_U8)(x >> 8);
+        prev_pts_buf[i * 4 + 2] = (HI_U8)(y & 0xff);
+        prev_pts_buf[i * 4 + 3] = (HI_U8)(y >> 8);
+    }
+    HI_MPI_SYS_MmzFlushCache(prev_pts.u64PhyAddr, prev_pts_buf, 64);
+
+    memset((void *)(uintptr_t)next_pts.u64VirAddr, SENTINEL, 64);
+    memset((void *)(uintptr_t)status.u64VirAddr,   SENTINEL, 64);
+    memset((void *)(uintptr_t)err.u64VirAddr,      SENTINEL, 64);
+    HI_MPI_SYS_MmzFlushCache(next_pts.u64PhyAddr,
+                             (void *)(uintptr_t)next_pts.u64VirAddr, 64);
+    HI_MPI_SYS_MmzFlushCache(status.u64PhyAddr,
+                             (void *)(uintptr_t)status.u64VirAddr,   64);
+    HI_MPI_SYS_MmzFlushCache(err.u64PhyAddr,
+                             (void *)(uintptr_t)err.u64VirAddr,      64);
+
+    memset(&ctrl, 0, sizeof(ctrl));
+    ctrl.enOutMode    = IVE_LK_OPTICAL_FLOW_PYR_OUT_MODE_BOTH;
+    ctrl.bUseInitFlow = HI_FALSE;
+    ctrl.u16PtsNum    = n_pts;
+    ctrl.u8MaxLevel   = 0;          /* single-level: prev/next[0] only */
+    ctrl.u0q8MinEigThr = 0;
+    ctrl.u8IterCnt    = 5;
+    ctrl.u0q8Eps      = 1;
+
+    ret = HI_MPI_IVE_LKOpticalFlowPyr(&h, prev_lvl, next_lvl,
+                                      &prev_pts, &next_pts, &status, &err,
+                                      &ctrl, HI_TRUE);
+    check(ret == HI_SUCCESS, "ioctl returned success");
+    if (ret == HI_SUCCESS) {
+        check(wait_handle(h) == HI_SUCCESS, "wait completed");
+        HI_MPI_SYS_MmzFlushCache(next_pts.u64PhyAddr,
+                                 (void *)(uintptr_t)next_pts.u64VirAddr, 64);
+        HI_MPI_SYS_MmzFlushCache(status.u64PhyAddr,
+                                 (void *)(uintptr_t)status.u64VirAddr, 64);
+        written = 0;
+        for (i = 0; i < n_pts * 4; i++)
+            if (((HI_U8 *)(uintptr_t)next_pts.u64VirAddr)[i] != SENTINEL)
+                written++;
+        printf("  HW wrote %d/%d nextPts bytes (replacing sentinel)\n",
+               written, n_pts * 4);
+        check(written > 0, "HW wrote nextPts buffer (LK reached HW)");
+    }
+
+    free_mem(&err);
+fail_status:
+    free_mem(&status);
+fail_nextpts:
+    free_mem(&next_pts);
+fail_prevpts:
+    free_mem(&prev_pts);
+fail_imgs:
+    free_image(&prev_lvl[0]);
+    free_image(&next_lvl[0]);
+    return g_failures - failures_before;
+}
+
 int main(int argc, char **argv)
 {
     int rc, total_failures = 0;
     int skip_hog = 0, skip_ncc = 0, skip_lbp = 0, skip_csc = 0, skip_flt_csc = 0;
-    int skip_resize = 0;
+    int skip_resize = 0, skip_lk = 0;
 
     for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "--no-hog"))      skip_hog = 1;
@@ -751,6 +863,7 @@ int main(int argc, char **argv)
         if (!strcmp(argv[i], "--no-csc"))      skip_csc = 1;
         if (!strcmp(argv[i], "--no-flt-csc"))  skip_flt_csc = 1;
         if (!strcmp(argv[i], "--no-resize"))   skip_resize = 1;
+        if (!strcmp(argv[i], "--no-lk"))       skip_lk = 1;
     }
 
     rc = HI_MPI_SYS_Init();
@@ -772,6 +885,8 @@ int main(int argc, char **argv)
         total_failures += test_flt_csc();
     if (!skip_resize)
         total_failures += test_resize();
+    if (!skip_lk)
+        total_failures += test_lk_optical_flow_pyr();
 
     HI_MPI_SYS_Exit();
 


### PR DESCRIPTION
## Summary

Wires the cv500 Lucas-Kanade pyramidal optical flow HW unit. Replaces a buggy libive stub (wrote ctrl at buf+720 with only 704-byte ioctl size, so the bytes never reached the kernel — silent because the kernel handler also stubbed and returned 0).

Closes #122 — last remaining #112 sub-task.

## Field map (statically decoded)

Top handler \`ive_lk_optical_flow_pyr\` @0x46cc reads arg inline (no copy_from_user indirection unlike Resize). Fill task \`ive_fill_lk_optical_flow_pyr_task\` @0x8ec4 writes a single 208-byte HW node.

Per-level pyramid offsets (one entry per level i ∈ [0..u8MaxLevel]):

| Level | prev.phys | next.phys | prev.stride | next.stride |
|-------|-----------|-----------|-------------|-------------|
| 0 | node[16] | node[120] | node[44] | node[50] |
| 1 | node[24] | node[124] | node[46] | node[52] |
| 2 | node[32] | node[128] | node[48] | node[54] |
| 3 | node[136] | node[132] | node[12] | node[14] |

Level 3 uses unusual offsets — not the +8 progression of levels 0..2; matches vendor's special case at \`fill_task @0x904c-0x9088\`.

Output buffers + ctrl mirror, validator bounds, etc. — see commit message + kaeru \`ive-neo-cv500-lk-optical-flow-pyr-field-map\`.

## ABI

- Existing ioctl \`0xc2c0461c\` (\_IOWR('F', 0x1c, 704)) reused; vendor's actual 704-byte arg layout now respected.
- \`u8MaxLevel\` 0..3 (1..4 pyramid levels).
- Caller must pre-build the pyramid via \`HI_MPI_IVE_Resize\` (downscale 2x per level).

## Test plan
- [x] cv500 cross-build clean
- [x] ev200 cross-build clean
- [ ] On-target av300: \`test_lk_optical_flow_pyr\` — 1-level, 4 points, static scene asserts HW wrote nextPts buffer
- [ ] CI: "LK handler wired" needle on cv500 .ko

🤖 Generated with [Claude Code](https://claude.com/claude-code)