### PR TITLE
kernel/ive_neo: cv500 EqualizeHist HW dispatch + GMM-stub comment update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,13 +246,13 @@ jobs:
               # the silent-stub or diag path. Grep for the validation
               # / one-time log rather than the handler symbol name so
               # the assertion stays meaningful across renames.
-              for needle in "PerspTrans bad roi_num" "Hog bad roi_num" "NCC handler wired" "LBP handler wired" "CSC handler wired" "FilterAndCSC handler wired" "Resize handler wired" "LK handler wired"; do
+              for needle in "PerspTrans bad roi_num" "Hog bad roi_num" "NCC handler wired" "LBP handler wired" "CSC handler wired" "FilterAndCSC handler wired" "Resize handler wired" "LK handler wired" "EqualizeHist handler wired"; do
                   if ! strings "$KO" | grep -qF "$needle"; then
                       echo "FAIL: cv500 .ko missing '$needle' — handler regressed to stub?" >&2
                       exit 1
                   fi
               done
-              echo "ok: cv500 build has PerspTrans + Hog + NCC + LBP + CSC + FilterAndCSC + Resize + LK HW handlers wired"
+              echo "ok: cv500 build has PerspTrans + Hog + NCC + LBP + CSC + FilterAndCSC + Resize + LK + EqualizeHist HW handlers wired"
 
               # The N-node chain submit helper is the shared HW kick
               # path for both new ops. Its timeout log is the only

--- a/kernel/ive_neo/ive_neo.c
+++ b/kernel/ive_neo/ive_neo.c
@@ -1725,6 +1725,58 @@ static long ive_op_hist(unsigned long arg)
 	return ive_submit_nonxnn(node, buf);
 }
 
+/* ---- EqualizeHist (op=13 reused, ioctl 0xc0b8462a) ----
+ *
+ * Vendor cv500 calls `ive_fill_hist_task` to set up the standard Hist
+ * node, then overrides node[7]=0x61 (EqualizeHist mode marker) and
+ * adds the dst-related fields for the equalized output image. Decoded
+ * from `ive_ioctl` dispatcher @0x68dc-0x6938.
+ *
+ * Arg layout (ioctl size 184 B):
+ *   +0:    HI_HANDLE
+ *   +8:    IVE_SRC_IMAGE_S src
+ *   +80:   IVE_DST_IMAGE_S dst  (equalized output)
+ *   +152:  IVE_MEM_INFO_S stMem (24 B — workspace for histogram bins)
+ *   +176:  HI_BOOL instant
+ *
+ * Field map: standard Hist (op=13) + dst.phys @ node[28], dst.stride
+ * @ node[52], mode-byte @ node[7]=0x61.
+ */
+static long ive_op_equalize_hist(unsigned long arg)
+{
+	u8 *buf = (u8 *)arg;
+	u8 *src = buf + 8;
+	u8 *dst = buf + 80;
+	u8 *stMem = buf + 152;
+	u32 stMem_phys = *(u32 *)stMem;
+	u8 node[208];
+
+	if (IVE_CHECK_IMG(src) || IVE_CHECK_IMG(dst))
+		return -EINVAL;
+	if (!stMem_phys || (stMem_phys & 0xF)) {
+		pr_info("ive_neo: EqualizeHist stMem.phys=0x%x invalid\n", stMem_phys);
+		return -EINVAL;
+	}
+
+	memset(node, 0, sizeof(node));
+	/* Standard Hist field map (same as ive_op_hist + LUT byte). */
+	node[8]  = cv500_src_fmt(IMG_TYPE(src));
+	node[10] = 13;                              /* op = Hist */
+	*(u32 *)(node + 16) = IMG_PHYS(src);
+	*(u32 *)(node + 20) = stMem_phys;
+	*(u16 *)(node + 40) = (u16)IMG_WIDTH(src);
+	*(u16 *)(node + 42) = (u16)IMG_HEIGHT(src);
+	*(u16 *)(node + 44) = (u16)IMG_STRIDE(src);
+
+	/* EqualizeHist overrides: mode-byte + dst image fields. */
+	node[7]  = 0x61;                            /* EqualizeHist mode marker */
+	*(u32 *)(node + 28) = IMG_PHYS(dst);
+	*(u16 *)(node + 52) = (u16)IMG_STRIDE(dst);
+
+	pr_info_once("ive_neo: EqualizeHist handler wired (HW op 13 + mode 0x61)\n");
+	return ive_submit_nonxnn(node, buf);
+}
+
 /* ---- Thresh_S16 (op=14): arg = {handle(8), src(72), dst(72), ctrl(12+)} ---- */
 static long ive_op_thresh_s16(unsigned long arg)
 {
@@ -3223,8 +3275,8 @@ static long ive_dispatch(unsigned int cmd, unsigned long arg)
 	 *     or rejects. Silent stub is correct here.
 	 */
 
-	/* (b) reuses ive_fill_hist_task with node[7]=0x61 + LUT remap. */
-	case 0xc0b8462au:      return 0;  /* EqualizeHist — issue #112 follow-up */
+	/* (b) reuses ive_fill_hist_task with node[7]=0x61 + dst-image overrides. */
+	case 0xc0b8462au:      return ive_op_equalize_hist(arg);  /* EqualizeHist */
 
 	case 0xc0a04602u:                /* CSC */
 #if defined(hi3516cv500)
@@ -3253,8 +3305,11 @@ static long ive_dispatch(unsigned int cmd, unsigned long arg)
 		return 0;
 #endif
 
-	/* (b) GMM (single-Gaussian) is GMM2 with default params in
-	 * vendor. No separate fill_gmm_task — vendor only has fill_gmm2. */
+	/* (c) GMM (single-Gaussian) — vendor cv500 ive_ioctl has no
+	 * dispatch case for ioctl 0x4618 (verified via objdump grep of
+	 * the ioctl-nr movw immediates). Userspace libive.so likely
+	 * routes single-Gaussian through GMM2 with mixture=1, or
+	 * computes on CPU. Silent stub is correct. */
 	case 0xc1184618u:      return 0;  /* GMM */
 
 	/* (c) cv500 vendor blob has no symbols at all for these — HW

--- a/libraries/ive_neo/test/test_persp_hog.c
+++ b/libraries/ive_neo/test/test_persp_hog.c
@@ -738,6 +738,64 @@ static int test_resize(void)
     return rc;
 }
 
+static int test_equalize_hist(void)
+{
+    IVE_IMAGE_S src, dst;
+    IVE_EQUALIZE_HIST_CTRL_S ctrl;
+    IVE_MEM_INFO_S stMem;
+    IVE_HANDLE h = -1;
+    HI_S32 ret;
+    HI_U8 *src_y, *dst_y;
+    int non_sentinel, failures_before, i;
+
+    printf("\n=== EqualizeHist %ux%u U8C1 (reachability) ===\n", W, H);
+    failures_before = g_failures;
+    memset(&src, 0, sizeof(src));
+    memset(&dst, 0, sizeof(dst));
+    memset(&stMem, 0, sizeof(stMem));
+
+    if (alloc_image(&src, W, H) != HI_SUCCESS) return 1;
+    if (alloc_image(&dst, W, H) != HI_SUCCESS) { free_image(&src); return 1; }
+    /* stMem workspace for histogram bins — vendor sample sizes it
+     * generously; 4KB is plenty for 256-bin u32 histogram. */
+    if (alloc_mem_info(&stMem, 4096) != HI_SUCCESS) {
+        free_image(&src); free_image(&dst); return 1;
+    }
+    src.enType = IVE_IMAGE_TYPE_U8C1;
+    dst.enType = IVE_IMAGE_TYPE_U8C1;
+    src_y = (HI_U8 *)(uintptr_t)src.au64VirAddr[0];
+    dst_y = (HI_U8 *)(uintptr_t)dst.au64VirAddr[0];
+
+    /* Compressed-range gradient (0..63) so equalization has work to do. */
+    for (i = 0; i < Y_SIZE; i++) src_y[i] = (HI_U8)(i & 0x3f);
+    memset(dst_y, SENTINEL, IMG_SIZE);
+    HI_MPI_SYS_MmzFlushCache(src.au64PhyAddr[0], src_y, IMG_SIZE);
+    HI_MPI_SYS_MmzFlushCache(dst.au64PhyAddr[0], dst_y, IMG_SIZE);
+
+    ctrl.stMem = stMem;
+
+    ret = HI_MPI_IVE_EqualizeHist(&h, &src, &dst, &ctrl, HI_TRUE);
+    check(ret == HI_SUCCESS, "ioctl returned success");
+    if (ret == HI_SUCCESS) {
+        check(wait_handle(h) == HI_SUCCESS, "wait completed");
+        HI_MPI_SYS_MmzFlushCache(dst.au64PhyAddr[0], dst_y, IMG_SIZE);
+        non_sentinel = 0;
+        for (i = 0; i < Y_SIZE; i++)
+            if (dst_y[i] != SENTINEL) non_sentinel++;
+        printf("  HW wrote %d/%d Y bytes\n", non_sentinel, Y_SIZE);
+        check(non_sentinel > Y_SIZE / 2,
+              "HW wrote majority of dst (EqualizeHist reached HW)");
+        printf("  dst[0..15]: ");
+        for (i = 0; i < 16; i++) printf("%02x ", dst_y[i]);
+        printf("\n");
+    }
+
+    free_image(&src);
+    free_image(&dst);
+    free_mem(&stMem);
+    return g_failures - failures_before;
+}
+
 static int test_lk_optical_flow_pyr(void)
 {
     IVE_IMAGE_S prev_lvl[2], next_lvl[2];
@@ -854,7 +912,7 @@ int main(int argc, char **argv)
 {
     int rc, total_failures = 0;
     int skip_hog = 0, skip_ncc = 0, skip_lbp = 0, skip_csc = 0, skip_flt_csc = 0;
-    int skip_resize = 0, skip_lk = 0;
+    int skip_resize = 0, skip_lk = 0, skip_eq_hist = 0;
 
     for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "--no-hog"))      skip_hog = 1;
@@ -864,6 +922,7 @@ int main(int argc, char **argv)
         if (!strcmp(argv[i], "--no-flt-csc"))  skip_flt_csc = 1;
         if (!strcmp(argv[i], "--no-resize"))   skip_resize = 1;
         if (!strcmp(argv[i], "--no-lk"))       skip_lk = 1;
+        if (!strcmp(argv[i], "--no-eq-hist"))  skip_eq_hist = 1;
     }
 
     rc = HI_MPI_SYS_Init();
@@ -887,6 +946,8 @@ int main(int argc, char **argv)
         total_failures += test_resize();
     if (!skip_lk)
         total_failures += test_lk_optical_flow_pyr();
+    if (!skip_eq_hist)
+        total_failures += test_equalize_hist();
 
     HI_MPI_SYS_Exit();
 


### PR DESCRIPTION
## Summary

Wires EqualizeHist (\`0xc0b8462a\`) on cv500 — was a silent stub. Vendor reuses \`ive_fill_hist_task\` for the standard Hist setup, then overrides \`node[7] = 0x61\` (EqualizeHist mode marker) and adds dst-image fields.

Bonus: GMM (single-Gaussian) stub comment updated with positive static evidence that cv500 vendor \`ive_ioctl\` has no case for ioctl nr \`0x4618\` — confirmed by grepping the dispatcher's \`movw r3, #0x46xx\` immediate table. Silent-stub is the correct cv500 behavior; promoted to (c) category.

## EqualizeHist field map (vs Hist)

Same as Hist (op=13, src.phys/dim/stride to standard offsets, stMem.phys to node[20]) plus:
- \`node[7] = 0x61\` (mode marker)
- \`node[28] = dst.phys\`
- \`node[52] = dst.stride\`

Decoded from vendor \`ive_ioctl\` dispatcher @0x68dc-0x6938.

## Closes #112 list progress

| Op | Status |
|---|---|
| LBP | wired (#117) |
| NCC | wired (#115) |
| EqualizeHist | wired (this PR) |
| LKOpticalFlowPyr | wired (#127) |
| GMM (single) | confirmed no HW (this PR comment update) |
| GradFg, MatchBgModel, UpdateBgModel | confirmed no HW (audit #123) |
| ANN_MLP_Predict, SVM_Predict | confirmed no HW (audit #123) |

## Test plan
- [x] cv500 cross-build clean
- [x] ev200 cross-build clean
- [ ] On-target av300: \`test_equalize_hist\` — compressed-range gradient gets equalized; HW writes majority of dst bytes
- [ ] CI: "EqualizeHist handler wired" needle on cv500 .ko

🤖 Generated with [Claude Code](https://claude.com/claude-code)