### PR TITLE
libraries/ive_neo: KCF Stage 3 — CreateCosWin (Hann window generator)

### DIFF
--- a/libraries/ive_neo/Makefile
+++ b/libraries/ive_neo/Makefile
@@ -15,7 +15,7 @@ OBJS := $(SRCS:%.c=%.o)
 all: $(LIB_NAME).so $(LIB_NAME).a
 
 $(LIB_NAME).so: $(OBJS)
-	$(CC) -shared -o $@ $(OBJS) -lpthread
+	$(CC) -shared -o $@ $(OBJS) -lpthread -lm
 
 $(LIB_NAME).a: $(OBJS)
 	$(AR) -rcs $(LIB_NAME).a $(OBJS)

--- a/libraries/ive_neo/src/ive_ops.c
+++ b/libraries/ive_neo/src/ive_ops.c
@@ -1203,8 +1203,9 @@ HI_S32 HI_MPI_IVE_KCF_CreateGaussPeak(HI_U3Q5 u3q5Padding,
 }
 
 /* Hann-window generator, decoded from cv500 vendor libive.so internal
- * helper @0x2e08. Writes a u16 cosine-window (Hann shape) into `dst`
- * for size N, padding the result to a fixed buffer width:
+ * helper @0x2e08 and verified against on-target output. Writes a u16
+ * cosine-window (Hann shape) into `dst` for size N, padding the result
+ * to a fixed buffer width:
  *
  *   if (N < 17): buf_width = 16 samples (32 B), step = 8
  *   else      : buf_width = 32 samples (64 B), step = 16
@@ -1213,10 +1214,19 @@ HI_S32 HI_MPI_IVE_KCF_CreateGaussPeak(HI_U3Q5 u3q5Padding,
  * give the source position; for k outside that range the value is the
  * edge sample (flat padding). The cosine itself is:
  *
- *   v = (1.0 - cos(2π * idx / N)) * 0.5 * 65536, cast to u16
+ *   v = (1.0 - cos(2π * idx / (N - 1))) * 0.5 * 16384, cast to u16
  *
- * Constants 2π and 65536.0 come from the .rodata pool at vendor offsets
- * 0x2ec0 and 0x2ec8. Float ops use double precision to match vendor.
+ * Constants verified at .rodata vendor offsets:
+ *   0x2ec0: 2π (double 0x401921FB54442D18)
+ *   0x2ec8: 16384.0 (double 0x40D0000000000000)
+ *
+ * Denominator is (N - 1), not N — vendor's `vcvt.f64.u32 d8, s16` is
+ * fed by `sub r3, r0, #1` at function entry. Easy to miss in static
+ * decode; the on-target probe (kcf_probe2) showed u16[5]=0x0c0c=3084
+ * for N=8 which matches `(1 - cos(2π*1/7)) * 0.5 * 16384 = 3084.5`
+ * exactly, ruling out the prior N-denominator + 65536-scale guess.
+ *
+ * Float ops use double precision to match vendor's VFP d-register path.
  */
 static void ive_kcf_gen_hann_window(HI_U32 u32N, HI_U16 *pu16Dst)
 {
@@ -1235,8 +1245,8 @@ static void ive_kcf_gen_hann_window(HI_U32 u32N, HI_U16 *pu16Dst)
         else                      clamped = i;
         clamped += half;          /* shift to [0, N-1] */
 
-        f = (double)clamped * (2.0 * 3.141592653589793238) / (double)u32N;
-        v = (1.0 - cos(f)) * 0.5 * 65536.0;
+        f = (double)clamped * (2.0 * 3.141592653589793238) / (double)(u32N - 1);
+        v = (1.0 - cos(f)) * 0.5 * 16384.0;
         q = (HI_U32) v;           /* vcvt.u32.f64 truncation */
         *pu16Dst++ = (HI_U16) q;
     }

--- a/libraries/ive_neo/src/ive_ops.c
+++ b/libraries/ive_neo/src/ive_ops.c
@@ -26,6 +26,7 @@
 #include <sys/ioctl.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <math.h>
 
 /* ioctl cmd numbers (authoritative — extracted from libive.so decomp) */
 #define IVE_CMD_DMA            0xC0684600u
@@ -1201,11 +1202,81 @@ HI_S32 HI_MPI_IVE_KCF_CreateGaussPeak(HI_U3Q5 u3q5Padding,
     return HI_ERR_IVE_NOT_SUPPORT;
 }
 
+/* Hann-window generator, decoded from cv500 vendor libive.so internal
+ * helper @0x2e08. Writes a u16 cosine-window (Hann shape) into `dst`
+ * for size N, padding the result to a fixed buffer width:
+ *
+ *   if (N < 17): buf_width = 16 samples (32 B), step = 8
+ *   else      : buf_width = 32 samples (64 B), step = 16
+ *
+ * The window samples at buf index k = clamp(k - step, -N/2, N/2-1) + N/2
+ * give the source position; for k outside that range the value is the
+ * edge sample (flat padding). The cosine itself is:
+ *
+ *   v = (1.0 - cos(2π * idx / N)) * 0.5 * 65536, cast to u16
+ *
+ * Constants 2π and 65536.0 come from the .rodata pool at vendor offsets
+ * 0x2ec0 and 0x2ec8. Float ops use double precision to match vendor.
+ */
+static void ive_kcf_gen_hann_window(HI_U32 u32N, HI_U16 *pu16Dst)
+{
+    HI_U32 cap  = (u32N < 17) ? 16 : 32;
+    HI_S32 step = (u32N < 17) ?  8 : 16;
+    HI_S32 half = (HI_S32)(u32N >> 1);
+    HI_S32 i;
+
+    for (i = -step; i < (HI_S32)cap - step; i++) {
+        HI_S32 clamped;
+        double f, v;
+        HI_U32 q;
+
+        if (i >= half)            clamped = half - 1;
+        else if (i <= -half)      clamped = -half;
+        else                      clamped = i;
+        clamped += half;          /* shift to [0, N-1] */
+
+        f = (double)clamped * (2.0 * 3.141592653589793238) / (double)u32N;
+        v = (1.0 - cos(f)) * 0.5 * 65536.0;
+        q = (HI_U32) v;           /* vcvt.u32.f64 truncation */
+        *pu16Dst++ = (HI_U16) q;
+    }
+}
+
+/* Mirrors cv500 vendor libive.so HI_MPI_IVE_KCF_CreateCosWin @0xda38.
+ *
+ * Generates 13 Hann windows for ROI sizes N ∈ {8, 10, 12, …, 32}, two
+ * copies (X and Y) per size. Each size's output occupies a 64-byte
+ * slot at offset (N-8) * 32 inside pstCosWinX.virt / pstCosWinY.virt;
+ * for N < 17 only the first 32 B (16 u16) are written and the upper
+ * half stays zero. Total per buffer: 13 * 64 = 832 bytes; user must
+ * pre-allocate at least that much MMZ for both X and Y. */
 HI_S32 HI_MPI_IVE_KCF_CreateCosWin(IVE_DST_MEM_INFO_S *pstCosWinX,
                                    IVE_DST_MEM_INFO_S *pstCosWinY)
 {
-    (void)pstCosWinX; (void)pstCosWinY;
-    return HI_ERR_IVE_NOT_SUPPORT;
+    HI_U16 *x_virt, *y_virt;
+    HI_U32  n;
+
+    IVE_CHECK_NULL("HI_MPI_IVE_KCF_CreateCosWin", pstCosWinX, "pstCosWinX");
+    IVE_CHECK_NULL("HI_MPI_IVE_KCF_CreateCosWin", pstCosWinY, "pstCosWinY");
+    if (pstCosWinX->u32Size < 832 || pstCosWinY->u32Size < 832) {
+        IVE_LOG("HI_MPI_IVE_KCF_CreateCosWin",
+                "buffer too small (X=%u Y=%u, need >= 832)",
+                pstCosWinX->u32Size, pstCosWinY->u32Size);
+        return HI_ERR_IVE_ILLEGAL_PARAM;
+    }
+    x_virt = (HI_U16 *)(uintptr_t)pstCosWinX->u64VirAddr;
+    y_virt = (HI_U16 *)(uintptr_t)pstCosWinY->u64VirAddr;
+    IVE_CHECK_NULL("HI_MPI_IVE_KCF_CreateCosWin", x_virt, "pstCosWinX.virt");
+    IVE_CHECK_NULL("HI_MPI_IVE_KCF_CreateCosWin", y_virt, "pstCosWinY.virt");
+
+    for (n = 8; n <= 32; n += 2) {
+        HI_U32 offset_bytes = (n - 8) * 32;
+        ive_kcf_gen_hann_window(n,
+            (HI_U16 *)((HI_U8 *)x_virt + offset_bytes));
+        ive_kcf_gen_hann_window(n,
+            (HI_U16 *)((HI_U8 *)y_virt + offset_bytes));
+    }
+    return HI_SUCCESS;
 }
 
 HI_S32 HI_MPI_IVE_KCF_GetTrainObj(HI_U3Q5 u3q5Padding, IVE_ROI_INFO_S astRoiInfo[],


### PR DESCRIPTION
## Summary

Stage 3 of #109. Fourth KCF function with a real implementation, **byte-equivalent with vendor** as verified on av300 board.

### \`CreateCosWin\`

Generates 13 Hann (cosine) windows for ROI sizes N ∈ {8, 10, 12, …, 32}, X and Y axes, into a single contiguous 832-byte buffer per axis. Decoded from vendor \`libive.so\` \`HI_MPI_IVE_KCF_CreateCosWin\` @0xda38 + internal Hann generator @0x2e08.

Sample value:

\`\`\`
v = (1.0 - cos(2π * idx / (N - 1))) * 0.5 * 16384  →  cast to u16
\`\`\`

### On-target verification

Pushed an initial commit with the formula derived from static disassembly only — turned out to have **two errors**:

1. d9 constant = **16384** (FP64 0x40D0000000000000 = 1.0 * 2^14), not 65536 as I'd misread.
2. Denominator is **N - 1**, not N (vendor's \`sub r3, r0, #1\` at function entry feeds \`vcvt.f64.u32 d8, s16\`).

Caught by \`kcf_coswin_diff\` — a userland tool that dlopens both /usr/lib/libive.so (vendor) and /tmp/libive_neo.so (ours), runs both \`CreateCosWin\` into separate MMZ buffers, memcmps the 832-byte output region. Initial run showed mostly-different output. After fix:

\`\`\`
X axis diff (first 832 bytes):  0/832 bytes differ
Y axis diff (first 832 bytes):  0/832 bytes differ
\`\`\`

Full byte-equivalence with vendor. The on-target verification breadcrumb is in the source-code comment so the next reader sees what runtime data ruled out the static-only guess.

### Build

Added \`-lm\` to libive_neo.so link line for \`cos()\`.

### Status: 4/10 KCF functions wired (byte-equivalent with vendor where verifiable)

| Function | State |
|---|---|
| \`GetMemSize\` | wired (PR #129) |
| \`DestroyObjList\` | wired (PR #129) |
| \`JudgeObjBboxTrackState\` | wired (PR #129); also on-target diffed today, 3/3 test cases MATCH |
| **\`CreateCosWin\`** | **wired (this PR), byte-equivalent vs vendor verified on-target** |
| \`CreateObjList\` | stub — ownership decoded today: doesn't touch pstMem, heap-mallocs pstObjNodeBuf (184·N bytes) + pu8TmpBuf (22656 bytes) |
| \`CreateGaussPeak\` | stub — structure decoded today: 13×13 mem-info table in first 4064 B + variable per-cell Gaussian data, min buf 455680 B for padding=96 |
| \`GetTrainObj\`, \`GetObjBbox\`, \`ObjUpdate\` | stub |
| \`Process\` | stub — kernel HW dispatch |

Runtime findings captured to kaeru as \`ive-neo-cv500-kcf-runtime-findings\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)