### PR TITLE
libraries/ive_neo: KCF Stage 5 — CreateGaussPeak mem-info table

### DIFF
--- a/libraries/ive_neo/src/ive_ops.c
+++ b/libraries/ive_neo/src/ive_ops.c
@@ -1167,20 +1167,108 @@ HI_S32 HI_MPI_IVE_KCF_GetMemSize(HI_U32 u32MaxObjNum, HI_U32 *pu32Size)
     return HI_SUCCESS;
 }
 
+/* Per-obj node bytes in the heap-malloc'd pstObjNodeBuf. Sizeof
+ * IVE_KCF_OBJ_NODE_S = 8 (stList) + 176 (stKcfObj, with internal
+ * u64-alignment padding) = 184 bytes. Vendor confirms via the
+ * `mov r6, #184` at libive.so 0x154ec. */
+#define KCF_NODE_BYTES 184u
+
+/* Vendor's pu8TmpBuf is always 22656 (0x5880) bytes regardless of
+ * u32MaxObjNum (libive.so 0x1555c). Holds the KCF_Process tmpBuf
+ * that the kernel copy_from_user's during ive_kcf_proc. */
+#define KCF_TMP_BUF_BYTES 22656u
+
+/* Mirrors cv500 vendor libive.so HI_MPI_IVE_KCF_CreateObjList @0xd588 +
+ * ive_create_obj_list @0x154e8. Initializes the obj list data structure:
+ *
+ *   - 3 list heads (free, train, track) become empty circular sentinels
+ *   - pstObjNodeBuf := malloc(184 * N), all N nodes pushed to free list
+ *   - pu8TmpBuf := malloc(22656), zeroed
+ *   - counters: u32FreeObjNum=N, train=track=0, u32MaxObjNum=N
+ *   - enListState := CREATE
+ *
+ * Critical runtime observation (verified via kcf_probe on av300 board):
+ * pstMem is NOT touched here. Vendor mallocs both pstObjNodeBuf and
+ * pu8TmpBuf from the C heap. pstMem usage is deferred to GetTrainObj
+ * (which slices it for stHogFeature/stAlpha/stDst per obj).
+ *
+ * Idempotent on the CREATE state — if pstObjList->enListState == CREATE
+ * already (e.g. caller did Create twice in a row), returns success
+ * without re-allocating (mirrors vendor at 0xd5b4-0xd5b8).
+ */
 HI_S32 HI_MPI_IVE_KCF_CreateObjList(IVE_MEM_INFO_S *pstMem, HI_U32 u32MaxObjNum,
                                     IVE_KCF_OBJ_LIST_S *pstObjList)
 {
-    (void)pstMem; (void)u32MaxObjNum;
-    if (pstObjList)
-        memset(pstObjList, 0, sizeof(*pstObjList));
-    return HI_ERR_IVE_NOT_SUPPORT;
+    HI_U32 i;
+    IVE_KCF_OBJ_NODE_S *nodes;
+    HI_U8 *tmp;
+
+    IVE_CHECK_NULL("HI_MPI_IVE_KCF_CreateObjList", pstMem,     "pstMem");
+    IVE_CHECK_NULL("HI_MPI_IVE_KCF_CreateObjList", pstObjList, "pstObjList");
+    if (!u32MaxObjNum || u32MaxObjNum > KCF_MAX_OBJ_NUM) {
+        IVE_LOG("HI_MPI_IVE_KCF_CreateObjList",
+                "u32MaxObjNum(%u) must be 1..%u",
+                u32MaxObjNum, KCF_MAX_OBJ_NUM);
+        return HI_ERR_IVE_ILLEGAL_PARAM;
+    }
+    if (pstMem->u32Size < u32MaxObjNum * KCF_PER_OBJ_BYTES) {
+        IVE_LOG("HI_MPI_IVE_KCF_CreateObjList",
+                "pstMem.u32Size(%u) < required(%u)",
+                pstMem->u32Size, u32MaxObjNum * KCF_PER_OBJ_BYTES);
+        return HI_ERR_IVE_ILLEGAL_PARAM;
+    }
+    if (pstObjList->enListState == IVE_KCF_LIST_STATE_CREATE)
+        return HI_SUCCESS;          /* already created — no-op */
+
+    nodes = (IVE_KCF_OBJ_NODE_S *) calloc(u32MaxObjNum, KCF_NODE_BYTES);
+    if (!nodes)
+        return HI_ERR_IVE_NOMEM;
+    tmp = (HI_U8 *) calloc(1, KCF_TMP_BUF_BYTES);
+    if (!tmp) {
+        free(nodes);
+        return HI_ERR_IVE_NOMEM;
+    }
+
+    /* Init train/track lists as empty (point to self). */
+    pstObjList->stTrainObjList.pstNext = &pstObjList->stTrainObjList;
+    pstObjList->stTrainObjList.pstPrev = &pstObjList->stTrainObjList;
+    pstObjList->stTrackObjList.pstNext = &pstObjList->stTrackObjList;
+    pstObjList->stTrackObjList.pstPrev = &pstObjList->stTrackObjList;
+
+    /* Push all N nodes onto free list as a circular doubly-linked list.
+     * Head sentinel is at &pstObjList->stFreeObjList. Each node's stList
+     * is at offset 0 of the 184-byte node — so we can treat the node
+     * pointer as IVE_LIST_HEAD_S* directly. */
+    {
+        IVE_LIST_HEAD_S *head = &pstObjList->stFreeObjList;
+        IVE_LIST_HEAD_S *prev = head;
+        for (i = 0; i < u32MaxObjNum; i++) {
+            IVE_LIST_HEAD_S *cur =
+                (IVE_LIST_HEAD_S *)((HI_U8 *)nodes + i * KCF_NODE_BYTES);
+            prev->pstNext = cur;
+            cur->pstPrev = prev;
+            prev = cur;
+        }
+        prev->pstNext = head;
+        head->pstPrev = prev;
+    }
+
+    pstObjList->pstObjNodeBuf  = nodes;
+    pstObjList->pu8TmpBuf      = tmp;
+    pstObjList->u32FreeObjNum  = u32MaxObjNum;
+    pstObjList->u32TrainObjNum = 0;
+    pstObjList->u32TrackObjNum = 0;
+    pstObjList->u32MaxObjNum   = u32MaxObjNum;
+    pstObjList->u32Width       = 0;
+    pstObjList->u32Height      = 0;
+    pstObjList->enListState    = IVE_KCF_LIST_STATE_CREATE;
+    return HI_SUCCESS;
 }
 
-/* Mirrors cv500 vendor libive.so HI_MPI_IVE_KCF_DestroyObjList @0xd668:
- * idempotent state-machine teardown — accepts a list in CREATE state,
- * leaves it in DESTORY (sic). No actual memory free because pstMem is
- * user-owned and pstObjNodeBuf / pu8TmpBuf are populated by CreateObjList
- * (not implemented yet — Stage 2 follow-up). */
+/* Mirrors cv500 vendor libive.so HI_MPI_IVE_KCF_DestroyObjList @0xd668
+ * + ive_destroy_obj_list @0x15850: re-inits all 3 list heads as empty
+ * sentinels, zeroes counters and (W,H), free()s pstObjNodeBuf and
+ * pu8TmpBuf, sets enListState=DESTORY. Idempotent on already-DESTORY. */
 HI_S32 HI_MPI_IVE_KCF_DestroyObjList(IVE_KCF_OBJ_LIST_S *pstObjList)
 {
     IVE_CHECK_NULL("HI_MPI_IVE_KCF_DestroyObjList", pstObjList, "pstObjList");
@@ -1191,6 +1279,29 @@ HI_S32 HI_MPI_IVE_KCF_DestroyObjList(IVE_KCF_OBJ_LIST_S *pstObjList)
                 "invalid enListState=%d", pstObjList->enListState);
         return HI_ERR_IVE_NOT_PERM;
     }
+
+    pstObjList->stFreeObjList.pstNext  = &pstObjList->stFreeObjList;
+    pstObjList->stFreeObjList.pstPrev  = &pstObjList->stFreeObjList;
+    pstObjList->stTrainObjList.pstNext = &pstObjList->stTrainObjList;
+    pstObjList->stTrainObjList.pstPrev = &pstObjList->stTrainObjList;
+    pstObjList->stTrackObjList.pstNext = &pstObjList->stTrackObjList;
+    pstObjList->stTrackObjList.pstPrev = &pstObjList->stTrackObjList;
+
+    pstObjList->u32FreeObjNum  = 0;
+    pstObjList->u32TrainObjNum = 0;
+    pstObjList->u32TrackObjNum = 0;
+    pstObjList->u32Width       = 0;
+    pstObjList->u32Height      = 0;
+
+    if (pstObjList->pu8TmpBuf) {
+        free(pstObjList->pu8TmpBuf);
+        pstObjList->pu8TmpBuf = NULL;
+    }
+    if (pstObjList->pstObjNodeBuf) {
+        free(pstObjList->pstObjNodeBuf);
+        pstObjList->pstObjNodeBuf = NULL;
+    }
+
     pstObjList->enListState = IVE_KCF_LIST_STATE_DESTORY;
     return HI_SUCCESS;
 }

--- a/libraries/ive_neo/src/ive_ops.c
+++ b/libraries/ive_neo/src/ive_ops.c
@@ -1306,11 +1306,92 @@ HI_S32 HI_MPI_IVE_KCF_DestroyObjList(IVE_KCF_OBJ_LIST_S *pstObjList)
     return HI_SUCCESS;
 }
 
+/* CreateGaussPeak constants — decoded from vendor `HI_MPI_IVE_KCF_CreateGaussPeak`
+ * @0xd738 + internal cell helper @0x2ca4.
+ *
+ * Output buffer layout (455680 B minimum for padding=96):
+ *   [0 .. 4055]:    169 × IVE_MEM_INFO_S table (13×13 grid)
+ *   [4056 .. 4063]: padding (zeroed by vendor)
+ *   [4064 .. 455647]: 169 cells of Gaussian peak coefficients,
+ *                     sizes varying by (col, row) quadrant.
+ *
+ * Each cell descriptor (24 B):
+ *   u64 phys  ←  pstGaussPeak.phys + 4064 + quadrant_offset(col,row)
+ *   u64 virt  ←  pstGaussPeak.virt + same offset
+ *   u32 size  ←  1024 / 2048 / 4096 per quadrant
+ *
+ * Quadrants (col, row ∈ [0..12], corresponding to HOG grid sizes N=8..32):
+ *
+ *   A  (col<5, row<5):     5×5,  size 1024,  offset = (5·row + col) · 1024
+ *   B1 (col≥5, row<5):     8×5,  size 2048,  offset = 25600 + (col + 8·row − 5) · 2048
+ *   B2 (col<5, row≥5):     5×8,  size 2048,  offset = 107520 + (5·row + col − 25) · 2048
+ *   B3 (col≥5, row≥5):     8×8,  size 4096,  offset = 189440 + (col + 8·row − 45) · 4096
+ *
+ *   25600 + 81920 + 81920 + 262144 + 4064 = 455648 ≤ 455680  (32 B tail pad)
+ *
+ * Cell-data contents (the actual Gaussian peak coefficients per cell)
+ * come from vendor's second-phase loop @0xd7e0 — VFP sqrt+exp math with
+ * constants {d8=4096.0, d10=−0.5, s24=1/32, s23=0.1}. Not yet ported.
+ * Cells stay zero-initialized; downstream KCF_Process will read zero
+ * peaks until the math phase lands in a follow-up stage. The mem-info
+ * table alone is sufficient for GetTrainObj's stGaussPeak slot lookup
+ * (which is the immediate consumer).
+ */
+#define KCF_GP_MIN_SIZE   455680u
+#define KCF_GP_HDR_BYTES  4064u
+
 HI_S32 HI_MPI_IVE_KCF_CreateGaussPeak(HI_U3Q5 u3q5Padding,
                                       IVE_DST_MEM_INFO_S *pstGaussPeak)
 {
-    (void)u3q5Padding; (void)pstGaussPeak;
-    return HI_ERR_IVE_NOT_SUPPORT;
+    HI_U8 *virt;
+    HI_U64 phys;
+    HI_U32 row, col;
+
+    (void)u3q5Padding;  /* placement of the mem-info table doesn't depend on
+                         * padding; only the cell DATA values do (TODO). */
+
+    IVE_CHECK_NULL("HI_MPI_IVE_KCF_CreateGaussPeak", pstGaussPeak, "pstGaussPeak");
+    if (pstGaussPeak->u32Size < KCF_GP_MIN_SIZE) {
+        IVE_LOG("HI_MPI_IVE_KCF_CreateGaussPeak",
+                "buffer too small (%u, need >= %u)",
+                pstGaussPeak->u32Size, KCF_GP_MIN_SIZE);
+        return HI_ERR_IVE_ILLEGAL_PARAM;
+    }
+    virt = (HI_U8 *)(uintptr_t) pstGaussPeak->u64VirAddr;
+    phys = pstGaussPeak->u64PhyAddr;
+    IVE_CHECK_NULL("HI_MPI_IVE_KCF_CreateGaussPeak", virt, "pstGaussPeak->u64VirAddr");
+
+    /* Zero the whole buffer so cells [4064..] are deterministic. */
+    memset(virt, 0, pstGaussPeak->u32Size);
+
+    /* 13×13 mem-info table — row-major iteration order matches vendor. */
+    for (row = 0; row < 13; row++) {
+        for (col = 0; col < 13; col++) {
+            HI_U8 *cell_desc = virt + (row * 13 + col) * 24;
+            HI_U32 size, offset;
+
+            if (col < 5 && row < 5) {
+                size   = 1024;
+                offset = (5 * row + col) * 1024;
+            } else if (col >= 5 && row < 5) {
+                size   = 2048;
+                offset = 25600 + (col + 8 * row - 5) * 2048;
+            } else if (col < 5 && row >= 5) {
+                size   = 2048;
+                offset = 107520 + (5 * row + col - 25) * 2048;
+            } else {
+                size   = 4096;
+                offset = 189440 + (col + 8 * row - 45) * 4096;
+            }
+            offset += KCF_GP_HDR_BYTES;  /* skip the table itself */
+
+            *(HI_U64 *)(cell_desc + 0) = phys + offset;
+            *(HI_U64 *)(cell_desc + 8) = (HI_U64)(uintptr_t)(virt + offset);
+            *(HI_U32 *)(cell_desc + 16) = size;
+            /* cell_desc + 20..23: 4 bytes pad — leave zero, vendor too. */
+        }
+    }
+    return HI_SUCCESS;
 }
 
 /* Hann-window generator, decoded from cv500 vendor libive.so internal


### PR DESCRIPTION
## Summary

Stage 5 of #109. 6/10 KCF functions now have real implementations. Generates the 169-cell IVE_MEM_INFO_S table at offset 0..4063 of pstGaussPeak.

### Layout (decoded from vendor cell helper @0x2ca4)

The 13×13 grid (HOG cell dims N=8..32) splits into 4 quadrants:

| Region | (col, row) | size | offset formula |
|---|---|---|---|
| A | col<5, row<5 | 1024 | (5·row + col) · 1024 |
| B1 | col≥5, row<5 | 2048 | 25600 + (col + 8·row − 5) · 2048 |
| B2 | col<5, row≥5 | 2048 | 107520 + (5·row + col − 25) · 2048 |
| B3 | col≥5, row≥5 | 4096 | 189440 + (col + 8·row − 45) · 4096 |

Total: 25600 + 81920 + 81920 + 262144 + 4064 = **455648** bytes, matching vendor's `>= 455680` validator (32 B tail pad).

### Stage-5b deferred

The actual Gaussian peak coefficients per cell (vendor's second-phase loop @0xd7e0, VFP sqrt+exp math) are **not yet ported**. Cells stay zero-initialized. KCF_Process will read zero peaks until that lands — but the mem-info table alone is sufficient for `GetTrainObj`'s stGaussPeak slot lookup, which is the immediate consumer.

### On-target verification

\`kcf_gauss_diff\` (dlopen both libs, run CreateGaussPeak, compare each cell's {phys_offset, virt_offset, size} relative to its buffer base): **0/169 cell mismatches**.

\`\`\`
vendor ret = 0x0
ours   ret = 0x0
mem-info table diff: 0 cell mismatches (out of 169)
\`\`\`

### Status

| Function | State |
|---|---|
| GetMemSize, DestroyObjList, JudgeObjBboxTrackState | wired |
| CreateCosWin | wired byte-equiv |
| CreateObjList | wired structural-equiv |
| **CreateGaussPeak** | **wired this PR (table); Gaussian math TBD Stage 5b** |
| GetTrainObj | stub — **now unblocked**, uses this table |
| GetObjBbox, ObjUpdate | stub — depend on Process |
| Process | stub — kernel HW, kprobe-required |

🤖 Generated with [Claude Code](https://claude.com/claude-code)