### PR TITLE
bootrom/hi3516av300: note independent verification from two more boards

### DIFF
--- a/bootrom/README
+++ b/bootrom/README
@@ -233,6 +233,16 @@ cv500). Concrete agreements:
     pending a cv500 dump)
   - CCITT-16 CRC table at bootrom 0x7e08 is shared
 
+**Single-mask silicon across av300 board variants.** The mask-ROM
+hash tracked in MANIFEST has been independently reproduced from two
+additional hi3516av300 cameras (one with SPI NOR flash, one with
+eMMC) by reading the mask-ROM MMIO window at 0x04000000..0x04010000
+on each board. Both produced 65,536-byte dumps with the same sha256
+as the tracked MANIFEST. Storage controller wiring and DDR chip choice
+differ board-to-board within the av300 family, but the bootrom does
+not — corroborating the single-mask-silicon premise the reverse
+depends on.
+
 
 Structural findings
 -------------------

--- a/bootrom/hi3516av300/MANIFEST
+++ b/bootrom/hi3516av300/MANIFEST
@@ -6,3 +6,4 @@ first16: 10 00 00 ea 14 f0 9f e5 14 f0 9f e5 14 f0 9f e5
 magic_at_3c: 0x12345678
 dump_tool: ipctool master+956052a built 2026-05-14
 dump_date: 2026-05-14
+verified_by: OpenIPC/defib (SPI NOR + eMMC variants, 2026-05-16)


### PR DESCRIPTION
## Summary

Reproduced the tracked MANIFEST sha256 (\`1944d7b4c6eca8003f55110abc3b9fc26df14be1027903107591eb4afab32c0a\`) on two additional hi3516av300 cameras — one with SPI NOR flash, one with eMMC. Both gave byte-identical 65,536-byte dumps from the mask-ROM MMIO at \`0x04000000..0x04010000\`, matching the tracked hash exactly.

## Changes

- \`bootrom/README\` — adds a "Single-mask silicon across av300 board variants" bullet to the cross-validation section, right after the cv500 cross-check.
- \`bootrom/hi3516av300/MANIFEST\` — adds a \`verified_by:\` line noting the corroborating boards.

Total: +11 / -0.

## What this resolves

The av300 reverse rests on an unstated single-mask-silicon premise (one mask-ROM image across every av300 part). The MANIFEST tracks a single reference dump from one board. This adds N=2 more boards as independent corroboration — useful confidence that the reverse work in this directory generalises to other av300 cameras, not just the lab reference unit.

## What this does NOT resolve

The README's existing open questions about V4-family sharing remain open:

- *"Chip-uniqueness check is OPEN ... whether sibling V4 chips (hi3516cv500, hi3516ev300, gk7205v300) share the same constants requires dumping their bootroms and comparing"*
- *"KLAD key-ladder inputs at bootrom 0x7e38..0x7e57 are identically located (whether the bytes themselves match — open question pending a cv500 dump)"*

We only have av300 hardware on the bench; the cv500 / ev300 / gk7205v300 byte-identity questions still need their own dumps.

## Methodology

Both boards were dumped via the agent's CMD_READ over UART after a bootrom-protocol agent upload — the agent's \`addr_readable\` whitelist covers the mask-ROM MMIO range, and the seq-validated read path catches any UART corruption mid-stream rather than silently returning short data. Two 64-KiB reads (~6 s each at 115200 baud) produced identical sha256s on both boards.

Origin of the work is OpenIPC/defib (PRs #103, #105, #106); not linking from this README since the dumps themselves aren't yet published as repo artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)