### PR TITLE
ci: NNIE regression coverage (Tier 1 + Tier 2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,21 +308,16 @@ jobs:
           fi
           echo "ok: descriptor MMZ pre-alloc wired"
 
-          # IRQ handler symbol must be exported (request_irq target).
-          if ! arm-linux-gnueabi-nm "$KO" 2>/dev/null | grep -q ' [tT] nnie_irq_handler'; then
-              echo "FAIL: $KO missing nnie_irq_handler symbol" >&2
-              exit 1
-          fi
-          echo "ok: nnie_irq_handler symbol present"
-
-          # The Forward dispatch path. If somebody deletes the
-          # serialization mutex or the dispatch path itself, the
-          # function disappears too.
-          if ! arm-linux-gnueabi-nm "$KO" 2>/dev/null | grep -q ' [tT] nnie_dispatch_forward'; then
-              echo "FAIL: $KO missing nnie_dispatch_forward — HW dispatch regressed?" >&2
-              exit 1
-          fi
-          echo "ok: nnie_dispatch_forward present"
+          # Function names appear in the .ko's symbol string table, so
+          # `strings | grep -x` is enough — avoids needing
+          # arm-linux-gnueabi-nm, which isn't installed in this job.
+          for sym in nnie_irq_handler nnie_dispatch_forward; do
+              if ! strings "$KO" | grep -qx "$sym"; then
+                  echo "FAIL: $KO missing $sym symbol" >&2
+                  exit 1
+              fi
+              echo "ok: $sym present"
+          done
 
   #
   # libraries-header-check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,6 +265,65 @@ jobs:
               echo "ok: cv500 build has ive_submit_chain helper"
           fi
 
+      # nnie_neo ships on cv500-family only (separate NNIE block at
+      # 0x11100000 — V4 has no NNIE). Same shape as the ive_neo check
+      # above: confirm the .ko built, that it carries the expected
+      # platform-driver match string, and that the load-bearing
+      # support functions (descriptor MMZ pre-alloc, IRQ handler) are
+      # present.
+      - name: Verify nnie_neo built for this platform
+        if: matrix.platform == 'hi3516cv500'
+        run: |
+          KO=$(find ../firmware/output -name open_nnie_neo.ko 2>/dev/null | head -1)
+          if [ -z "$KO" ] || [ ! -f "$KO" ]; then
+              echo "FAIL: open_nnie_neo.ko not built for ${{ matrix.platform }}" >&2
+              find ../firmware/output -name 'open_nnie*' 2>/dev/null >&2 || true
+              exit 1
+          fi
+          echo "ok: $KO ($(stat -c%s "$KO") bytes)"
+
+          # Platform-driver bind target must match the DT compatible.
+          if ! strings "$KO" | grep -qF "hisilicon,hisi-nnie"; then
+              echo "FAIL: $KO missing DT compatible 'hisilicon,hisi-nnie'" >&2
+              exit 1
+          fi
+          echo "ok: DT compatible wired"
+
+          # /dev/nnie miscdevice — caller-facing surface. Renaming this
+          # silently would break every userspace consumer.
+          if ! strings "$KO" | grep -qF "/dev/nnie ready"; then
+              echo "FAIL: $KO missing '/dev/nnie ready' init log" >&2
+              exit 1
+          fi
+          echo "ok: /dev/nnie miscdevice wired"
+
+          # Descriptor MMZ is pre-allocated at module init so its phys
+          # stays stable across Forwards. The hil_mmb_alloc name is
+          # baked in as the MMZ-zone label — losing it means the
+          # pre-alloc step was removed and we'd regress to per-Forward
+          # alloc (TASK_ADDR drift → HW cfg_err).
+          if ! strings "$KO" | grep -qx "nnie_desc"; then
+              echo "FAIL: $KO missing 'nnie_desc' MMZ label — descriptor pre-alloc regressed?" >&2
+              exit 1
+          fi
+          echo "ok: descriptor MMZ pre-alloc wired"
+
+          # IRQ handler symbol must be exported (request_irq target).
+          if ! arm-linux-gnueabi-nm "$KO" 2>/dev/null | grep -q ' [tT] nnie_irq_handler'; then
+              echo "FAIL: $KO missing nnie_irq_handler symbol" >&2
+              exit 1
+          fi
+          echo "ok: nnie_irq_handler symbol present"
+
+          # The Forward dispatch path. If somebody deletes the
+          # serialization mutex or the dispatch path itself, the
+          # function disappears too.
+          if ! arm-linux-gnueabi-nm "$KO" 2>/dev/null | grep -q ' [tT] nnie_dispatch_forward'; then
+              echo "FAIL: $KO missing nnie_dispatch_forward — HW dispatch regressed?" >&2
+              exit 1
+          fi
+          echo "ok: nnie_dispatch_forward present"
+
   #
   # libraries-header-check
   #
@@ -331,6 +390,51 @@ jobs:
               /tmp/probe.c
           echo "all headers compile cleanly; ABI sizes locked"
 
+      - name: Compile NNIE public-header probe
+        run: |
+          cat > /tmp/probe_nnie.c <<'EOF'
+          #include <stddef.h>
+          #include "hi_type.h"
+          #include "hi_common.h"
+          #include "hi_comm_svp.h"
+          #include "hi_nnie.h"
+          #include "mpi_nnie.h"
+          #include "nnie_wk_format.h"
+
+          /* Binary ABI for the NNIE userspace ↔ kernel interface. The
+           * 1624-byte Forward ioctl arg buffer packs SVP_BLOB_S +
+           * SVP_NNIE_FORWARD_CTRL_S at fixed offsets; SVP_NNIE_MODEL_S
+           * is copy_from_user'd directly by the kernel and indexed by
+           * offsetof(stBase) + sizeof(SEG_S) — drift in either of those
+           * silently corrupts the kernel's read. */
+          _Static_assert(sizeof(SVP_BLOB_S)                       == 48,   "SVP_BLOB_S size");
+          _Static_assert(sizeof(SVP_NNIE_NODE_S)                  == 52,   "SVP_NNIE_NODE_S size");
+          _Static_assert(sizeof(SVP_NNIE_ROIPOOL_INFO_S)          == 104,  "SVP_NNIE_ROIPOOL_INFO_S size");
+          _Static_assert(sizeof(SVP_NNIE_SEG_S)                   == 1692, "SVP_NNIE_SEG_S size");
+          _Static_assert(sizeof(SVP_NNIE_MODEL_S)                 == 13992,"SVP_NNIE_MODEL_S size");
+          _Static_assert(sizeof(SVP_NNIE_FORWARD_CTRL_S)          == 64,   "SVP_NNIE_FORWARD_CTRL_S size");
+          _Static_assert(sizeof(SVP_NNIE_FORWARD_WITHBBOX_CTRL_S) == 72,   "SVP_NNIE_FORWARD_WITHBBOX_CTRL_S size");
+
+          /* The kernel's nnie_op_forward reads pstModel via copy_from_user
+           * and indexes ([+0x3690] = stBase, +12 + seg*1692 + 12/16 for
+           * astSeg[seg].u32InstOffset / u32InstLen). Lock those offsets
+           * here so a header refactor can't drift them silently. */
+          _Static_assert(offsetof(SVP_NNIE_MODEL_S, stBase)       == 13968, "MODEL_S.stBase offset");
+
+          int main(void) { return 0; }
+          EOF
+
+          gcc -Wall -Wextra -Werror -fsyntax-only \
+              -I libraries/include \
+              -I libraries/nnie_neo/include \
+              /tmp/probe_nnie.c
+          echo "NNIE ABI sizes locked"
+
+      - name: Run NNIE LoadModel sanity test
+        run: |
+          make -C libraries/nnie_neo/test test_loadmodel
+          ./libraries/nnie_neo/test/test_loadmodel
+
   #
   # libraries-cross-compile
   #
@@ -360,13 +464,16 @@ jobs:
             CC=arm-linux-gnueabi-gcc AR=arm-linux-gnueabi-ar
           make -C libraries/ivp_neo \
             CC=arm-linux-gnueabi-gcc AR=arm-linux-gnueabi-ar
+          make -C libraries/nnie_neo \
+            CC=arm-linux-gnueabi-gcc AR=arm-linux-gnueabi-ar
 
       - name: Verify outputs exist
         run: |
           for f in \
               libraries/mpi_neo/libmpi_neo.so libraries/mpi_neo/libmpi_neo.a \
               libraries/ive_neo/libive_neo.so libraries/ive_neo/libive_neo.a \
-              libraries/ivp_neo/libivp_neo.so libraries/ivp_neo/libivp_neo.a; do
+              libraries/ivp_neo/libivp_neo.so libraries/ivp_neo/libivp_neo.a \
+              libraries/nnie_neo/libnnie_neo.so libraries/nnie_neo/libnnie_neo.a; do
               [ -f "$f" ] || { echo "MISSING: $f" >&2; exit 1; }
               echo "ok: $f ($(stat -c%s $f) bytes)"
           done
@@ -403,13 +510,24 @@ jobs:
           for sym in hi_ivp_init hi_ivp_deinit hi_ivp_process_ex hi_ivp_load_resource_from_memory hi_ivp_set_ctrl_attr; do
               check libraries/ivp_neo/libivp_neo.so $sym
           done
+          # NNIE — eight HI_MPI_SVP_NNIE_* entry points. LoadModel /
+          # UnloadModel / GetTskBufSize are pure-userspace; the other
+          # five ioctl through /dev/nnie.
+          for sym in \
+              HI_MPI_SVP_NNIE_LoadModel HI_MPI_SVP_NNIE_UnloadModel \
+              HI_MPI_SVP_NNIE_GetTskBufSize HI_MPI_SVP_NNIE_Forward \
+              HI_MPI_SVP_NNIE_ForwardWithBbox HI_MPI_SVP_NNIE_Query \
+              HI_MPI_SVP_NNIE_AddTskBuf HI_MPI_SVP_NNIE_RemoveTskBuf; do
+              check libraries/nnie_neo/libnnie_neo.so $sym
+          done
 
       - name: Assert no vendor libs in NEEDED
         run: |
           for f in \
               libraries/mpi_neo/libmpi_neo.so \
               libraries/ive_neo/libive_neo.so \
-              libraries/ivp_neo/libivp_neo.so; do
+              libraries/ivp_neo/libivp_neo.so \
+              libraries/nnie_neo/libnnie_neo.so; do
               echo "=== $(basename $f) NEEDED ==="
               arm-linux-gnueabi-readelf -d "$f" | grep NEEDED
               # Expect only libc and (for pthread) libpthread. Any NEEDED

--- a/libraries/nnie_neo/test/.gitignore
+++ b/libraries/nnie_neo/test/.gitignore
@@ -1,0 +1,1 @@
+libraries/nnie_neo/test/test_loadmodel

--- a/libraries/nnie_neo/test/Makefile
+++ b/libraries/nnie_neo/test/Makefile
@@ -1,0 +1,36 @@
+# Host-runnable LoadModel sanity test.
+#
+# Pure-userspace: parses a synthesised .wk file in memory and asserts
+# every decoded field. Doesn't open /dev/nnie. Builds with the system
+# gcc on whatever host the CI / developer is on.
+#
+# Like libraries/ive_neo/test, default `all` is a no-op so the
+# package-level recursive build doesn't try to cross-compile this
+# host test for the target.
+#
+# Usage:
+#   make -C libraries/nnie_neo/test test_loadmodel
+#   ./libraries/nnie_neo/test/test_loadmodel
+
+CC      ?= gcc
+ROOT    := $(abspath ../../..)
+
+CFLAGS  := -O2 -Wall -Wextra -Werror -std=gnu99 \
+           -I$(ROOT)/libraries/include \
+           -I$(ROOT)/libraries/nnie_neo/include
+
+SRCS := test_loadmodel.c $(ROOT)/libraries/nnie_neo/src/nnie_ops.c
+
+all:
+	@:
+
+test_loadmodel: $(SRCS)
+	$(CC) $(CFLAGS) -o $@ $(SRCS) -lpthread
+
+run: test_loadmodel
+	./test_loadmodel
+
+clean:
+	rm -f test_loadmodel
+
+.PHONY: all run clean

--- a/libraries/nnie_neo/test/test_loadmodel.c
+++ b/libraries/nnie_neo/test/test_loadmodel.c
@@ -1,0 +1,245 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0
+ *
+ * Host-runnable sanity test for HI_MPI_SVP_NNIE_LoadModel.
+ *
+ * Synthesises a minimal .wk file in memory that mirrors the structure
+ * of a real mnist model (1 segment, 1 input, 1 output, 28×28×1 input,
+ * named "data"), feeds it to LoadModel, and asserts every decoded
+ * field matches what the real parser produced for the vendor mnist
+ * .wk in development. Catches regressions in:
+ *
+ *   - .wk header decode (run_mode, net_seg_num, inst_off_extra)
+ *   - CRC32 verifier (vendor uses init=0, final XOR, non-standard zlib
+ *     CRC32 setup)
+ *   - Segment record decode (net_type, src/dst counts, inst offset/len)
+ *   - Per-node compact form (H/W/C, enType, NodeId, name)
+ *   - astSrcNode[0].enType in particular — was the load-bearing field
+ *     that took NNIE Phase 14 to fix
+ *
+ * Pure host test: doesn't touch /dev/nnie, doesn't need cross-compile,
+ * runs in <50ms on a CI worker.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <assert.h>
+
+#include "hi_type.h"
+#include "hi_common.h"
+#include "hi_comm_svp.h"
+#include "hi_nnie.h"
+#include "mpi_nnie.h"
+#include "nnie_wk_format.h"
+
+/* IEEE 802.3 CRC-32, reflected, poly 0xEDB88320 — vendor variant uses
+ * init=0 (NOT ~0) and final XOR ~. Has to match nnie_wk_verify_crc()
+ * in libnnie_neo bit-for-bit. */
+static uint32_t crc32_step(uint32_t crc, uint8_t b)
+{
+	int i;
+
+	crc ^= b;
+	for (i = 0; i < 8; i++)
+		crc = (crc >> 1) ^ (0xEDB88320u & -(int)(crc & 1));
+	return crc;
+}
+
+static uint32_t crc32_range(const uint8_t *buf, size_t off, size_t end)
+{
+	uint32_t crc = 0;
+	size_t i;
+
+	for (i = off; i < end; i++)
+		crc = crc32_step(crc, buf[i]);
+	return ~crc;
+}
+
+/* Layout of the synthesised file:
+ *   [0..191]     header (192 B)
+ *   [192..207]   segment record (16 B)
+ *   [208..255]   src node compact (16 B) + name (32 B)
+ *   [256..303]   dst node compact (16 B) + name (32 B)
+ *   [304..0x150) header-tail filler (zeros)
+ *   [0x150..]    instruction stream region (header_extra to end of inst)
+ *   then weights / quant tables follow (not CRC'd)
+ *
+ * The seg record's u32InstOffset must point at a 16-byte-aligned offset
+ * inside [inst_off_extra, file_size). LoadModel checks
+ * `inst_off + inst_len <= file_size`. */
+#define WK_HEADER_EXTRA  0x150u    /* file[52]: where instruction stream starts */
+#define WK_INST_LEN      0x100u    /* short synthetic instruction stream */
+#define WK_FILE_SIZE     (WK_HEADER_EXTRA + WK_INST_LEN + 16u)  /* + tail pad */
+
+static void put_le32(uint8_t *p, uint32_t v)
+{
+	p[0] = v; p[1] = v >> 8; p[2] = v >> 16; p[3] = v >> 24;
+}
+
+static void put_le16(uint8_t *p, uint16_t v)
+{
+	p[0] = v; p[1] = v >> 8;
+}
+
+static void synth_wk(uint8_t *buf, size_t buf_size)
+{
+	uint8_t *seg, *src_node, *dst_node;
+	uint32_t crc;
+
+	assert(buf_size >= WK_FILE_SIZE);
+	memset(buf, 0, buf_size);
+
+	/* Header (192 B). */
+	buf[16] = NNIE_WK_VER_MAJ;       /* file[16..19] = {1,1,1,2} */
+	buf[17] = NNIE_WK_VER_MIN;
+	buf[18] = NNIE_WK_VER_3;
+	buf[19] = NNIE_WK_VER_4;
+	buf[48] = 0;                     /* run_mode */
+	buf[49] = 1;                     /* net_seg_num = 1 */
+	put_le32(buf + 52, WK_HEADER_EXTRA);  /* inst_offset_extra */
+	put_le32(buf + 56, WK_INST_LEN);      /* inst total length */
+
+	/* Segment record (16 B at file[192]). */
+	seg = buf + 192;
+	seg[0] = 0;                     /* net_type: 0 = CNN */
+	seg[1] = 1;                     /* src_num */
+	seg[2] = 1;                     /* dst_num */
+	seg[3] = 0;                     /* roi_pool_num */
+	put_le16(seg + 4, 0);           /* max_step */
+	/* The seg's u32InstOffset must be inside the CRC range
+	 * [inst_offset_extra, inst_offset_extra + inst_len). Pick the
+	 * start of the instruction stream itself. */
+	put_le32(seg + 8,  WK_HEADER_EXTRA);  /* u32InstOffset */
+	put_le32(seg + 12, WK_INST_LEN);      /* u32InstLen */
+
+	/* Src node (48 B): mnist-style 28×28×1 with enType=1, name "data". */
+	src_node = buf + 208;
+	put_le32(src_node + 0,  28);    /* height */
+	put_le32(src_node + 4,  28);    /* width */
+	put_le32(src_node + 8,   1);    /* chn */
+	src_node[14] = 1;               /* enType (SVP_BLOB_TYPE_YVU420SP) */
+	src_node[15] = 0;               /* NodeId */
+	memcpy(src_node + 16, "data", 4);
+
+	/* Dst node (48 B): mnist-style 10-class output, name "prob". */
+	dst_node = buf + 256;
+	put_le32(dst_node + 0,   1);    /* height */
+	put_le32(dst_node + 4,   1);    /* (chn in file order) */
+	put_le32(dst_node + 8,  10);    /* (width in file order — vendor's
+	                                   libnnie remaps so Width holds the
+	                                   layer's feature count) */
+	memcpy(dst_node + 16, "prob", 4);
+
+	/* Fill the instruction stream region with a deterministic pattern
+	 * so the CRC isn't trivially zero. */
+	for (size_t i = WK_HEADER_EXTRA;
+	     i < WK_HEADER_EXTRA + WK_INST_LEN; i++)
+		buf[i] = (uint8_t)(i * 0x9e + 0x37);
+
+	/* Compute CRC over bytes [4..inst_offset_extra + inst_len) and
+	 * write it at file[0..3]. */
+	crc = crc32_range(buf, 4, WK_HEADER_EXTRA + WK_INST_LEN);
+	put_le32(buf + 0, crc);
+}
+
+#define CHECK(cond, fmt, ...) do {                                          \
+	if (!(cond)) {                                                      \
+		fprintf(stderr, "FAIL %s:%d: %s — " fmt "\n",               \
+		        __FILE__, __LINE__, #cond, ##__VA_ARGS__);          \
+		exit(1);                                                    \
+	}                                                                   \
+} while (0)
+
+int main(void)
+{
+	uint8_t buf[WK_FILE_SIZE];
+	SVP_SRC_MEM_INFO_S mem = { 0 };
+	SVP_NNIE_MODEL_S model;
+	HI_S32 ret;
+
+	synth_wk(buf, sizeof(buf));
+
+	mem.u64VirAddr = (uintptr_t)buf;
+	mem.u64PhyAddr = 0xAA880000ULL;     /* arbitrary stable phys */
+	mem.u32Size    = sizeof(buf);
+
+	ret = HI_MPI_SVP_NNIE_LoadModel(&mem, &model);
+	CHECK(ret == HI_SUCCESS, "LoadModel returned 0x%x", (unsigned)ret);
+
+	/* Top-level model. */
+	CHECK(model.u32NetSegNum == 1, "got %u", model.u32NetSegNum);
+	CHECK(model.enRunMode == 0,    "got %u", (unsigned)model.enRunMode);
+	CHECK(model.stBase.u64PhyAddr == 0xAA880000ULL + WK_HEADER_EXTRA,
+	      "stBase.PhyAddr should be rebased by inst_offset_extra; got 0x%llx",
+	      (unsigned long long)model.stBase.u64PhyAddr);
+
+	/* Segment 0. */
+	CHECK(model.astSeg[0].enNetType  == 0,   "got %u", model.astSeg[0].enNetType);
+	CHECK(model.astSeg[0].u16SrcNum  == 1,   "got %u", model.astSeg[0].u16SrcNum);
+	CHECK(model.astSeg[0].u16DstNum  == 1,   "got %u", model.astSeg[0].u16DstNum);
+	CHECK(model.astSeg[0].u32InstOffset == WK_HEADER_EXTRA,
+	      "got 0x%x", model.astSeg[0].u32InstOffset);
+	CHECK(model.astSeg[0].u32InstLen == WK_INST_LEN,
+	      "got 0x%x", model.astSeg[0].u32InstLen);
+
+	/* Src node — the field that took NNIE Phase 14 to get right. */
+	CHECK(model.astSeg[0].astSrcNode[0].enType == 1,
+	      "src enType must be YVU420SP (1); got %u",
+	      (unsigned)model.astSeg[0].astSrcNode[0].enType);
+	CHECK(model.astSeg[0].astSrcNode[0].unShape.stWhc.u32Width  == 28,
+	      "got %u", model.astSeg[0].astSrcNode[0].unShape.stWhc.u32Width);
+	CHECK(model.astSeg[0].astSrcNode[0].unShape.stWhc.u32Height == 28,
+	      "got %u", model.astSeg[0].astSrcNode[0].unShape.stWhc.u32Height);
+	CHECK(model.astSeg[0].astSrcNode[0].unShape.stWhc.u32Chn    == 1,
+	      "got %u", model.astSeg[0].astSrcNode[0].unShape.stWhc.u32Chn);
+	CHECK(model.astSeg[0].astSrcNode[0].u32NodeId == 0,
+	      "got %u", model.astSeg[0].astSrcNode[0].u32NodeId);
+	CHECK(strcmp(model.astSeg[0].astSrcNode[0].szName, "data") == 0,
+	      "got '%s'", model.astSeg[0].astSrcNode[0].szName);
+
+	/* Dst node — vendor remaps fields so Width holds the layer's
+	 * feature count (10 for mnist) and enType is hardcoded to S32. */
+	CHECK(model.astSeg[0].astDstNode[0].enType == SVP_BLOB_TYPE_S32,
+	      "dst enType must be S32 (4); got %u",
+	      (unsigned)model.astSeg[0].astDstNode[0].enType);
+	CHECK(model.astSeg[0].astDstNode[0].unShape.stWhc.u32Width  == 10,
+	      "dst W (feature count) should be 10; got %u",
+	      model.astSeg[0].astDstNode[0].unShape.stWhc.u32Width);
+	CHECK(model.astSeg[0].astDstNode[0].u32NodeId == 8,
+	      "dst NodeId pattern (j+1)*8 → 8; got %u",
+	      model.astSeg[0].astDstNode[0].u32NodeId);
+	CHECK(strcmp(model.astSeg[0].astDstNode[0].szName, "prob") == 0,
+	      "got '%s'", model.astSeg[0].astDstNode[0].szName);
+
+	/* Tear-down: must zero the struct + return HI_SUCCESS. */
+	ret = HI_MPI_SVP_NNIE_UnloadModel(&model);
+	CHECK(ret == HI_SUCCESS, "UnloadModel returned 0x%x", (unsigned)ret);
+	CHECK(model.u32NetSegNum == 0, "model not zeroed by UnloadModel");
+
+	/* Negative tests: bad CRC, bad version, undersized buffer. */
+	{
+		SVP_NNIE_MODEL_S m;
+
+		/* corrupt CRC */
+		buf[0] ^= 0xff;
+		CHECK(HI_MPI_SVP_NNIE_LoadModel(&mem, &m) != HI_SUCCESS,
+		      "LoadModel must reject bad CRC");
+		buf[0] ^= 0xff;
+
+		/* corrupt version */
+		buf[16] = 99;
+		CHECK(HI_MPI_SVP_NNIE_LoadModel(&mem, &m) != HI_SUCCESS,
+		      "LoadModel must reject bad version");
+		buf[16] = NNIE_WK_VER_MAJ;
+
+		/* undersized buffer */
+		mem.u32Size = 10;
+		CHECK(HI_MPI_SVP_NNIE_LoadModel(&mem, &m) != HI_SUCCESS,
+		      "LoadModel must reject too-small buffer");
+		mem.u32Size = sizeof(buf);
+	}
+
+	printf("ok: NNIE LoadModel sanity (synth .wk + negative cases)\n");
+	return 0;
+}


### PR DESCRIPTION
## Summary

Mirrors the existing IVE CI test pattern (`libraries-header-check`, `libraries-cross-compile`, per-platform `.ko` symbol grep) for the new NNIE driver. Catches the bulk of realistic regression surface without needing QEMU machine-model work upstream.

Three new guards:

1. **Header ABI lock** (extends `libraries-header-check`)
   `_Static_assert` the size of every SVP_NNIE struct the kernel indexes by hand: `SVP_NNIE_MODEL_S` (13992 B), `SVP_NNIE_SEG_S` (1692 B), `SVP_NNIE_NODE_S` (52 B), `SVP_NNIE_ROIPOOL_INFO_S` (104 B), `SVP_NNIE_FORWARD_CTRL_S` (64 B), `SVP_NNIE_FORWARD_WITHBBOX_CTRL_S` (72 B), `SVP_BLOB_S` (48 B). Plus `offsetof(SVP_NNIE_MODEL_S, stBase) == 13968` because `nnie_op_forward` reads it via raw pointer arithmetic from `copy_from_user`.

2. **Host-runnable LoadModel test** (`libraries/nnie_neo/test/test_loadmodel.c`)
   Synthesises a minimal .wk file in memory mirroring mnist's structure (1 segment, 1 input named `data` at 28×28×1, 1 output named `prob`, valid CRC32), calls `HI_MPI_SVP_NNIE_LoadModel`, asserts every decoded field. Pure-userspace, ~50 ms on a CI worker. Verified locally that deliberately corrupting LoadModel (`enType = p[14] + 1`) fails the test cleanly.

   Negative cases included: bad CRC, bad version, undersized buffer.

3. **Link surface + per-platform `.ko` sanity**
   - `libraries-cross-compile` job: builds `libnnie_neo.so`/`.a`, asserts all 8 `HI_MPI_SVP_NNIE_*` symbols exported, asserts no vendor lib in NEEDED.
   - `Build SDK (hi3516cv500, …)` matrix entry: asserts `open_nnie_neo.ko` was built, that the DT compatible `hisilicon,hisi-nnie` is baked in, that the descriptor MMZ pre-alloc label (`nnie_desc`) is present, and that `nnie_irq_handler` + `nnie_dispatch_forward` symbols exist.

## What this catches

| Regression class | Caught by |
|---|---|
| Vendor MPI struct size drift in libraries/nnie_neo/include/* | Tier 1 `_Static_assert` |
| `.wk` decoder breakage (CRC, version, node-table layout) | Tier 2 LoadModel test |
| `astSrcNode[0].enType` regression (the Phase 14 fix) | Tier 2 src-node assertions |
| Missing `HI_MPI_SVP_NNIE_*` exports / refactor renames | Cross-compile symbol check |
| Vendor blob in NEEDED | Cross-compile NEEDED grep |
| `open_nnie_neo.ko` missing from cv500 build (Kbuild include lost) | Per-platform .ko grep |
| Per-Forward descriptor MMZ alloc regression (would lose stable phys → cfg_err) | `nnie_desc` label grep |
| DT compatible drift | platform-driver match string grep |

## What this does NOT catch (Tier 3 / Tier 4 follow-ups)

- Real HW dispatch correctness (Tier 3 = upstream qemu-hisilicon NNIE machine model, separate PR; Tier 4 = on-target self-hosted runner)
- Cross-process / parallel Forward serialization correctness (would need real `/dev/nnie`)
- Real .wk parsing on vendor models other than mnist (the synth .wk shape is a subset)

## Test plan

- [x] Local: host probe + LoadModel test pass (`./libraries/nnie_neo/test/test_loadmodel` → `ok`)
- [x] Local: deliberate LoadModel bug → test fails at the right line
- [x] Local: cross-compile of `libraries/nnie_neo` produces `.so` + `.a`
- [ ] CI: all jobs green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)