### PR TITLE
kernel: don't build ive_neo for V4 (ev200/ev300/gk7205v200)

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -103,7 +103,12 @@ endif
     include $(src)/h264e/Kbuild
     include $(src)/h265e/Kbuild
     include $(src)/ive/Kbuild
-    include $(src)/ive_neo/Kbuild
+    # ive_neo is cv500-targeted experimental work (see hi3516cv500.kbuild).
+    # It compiles for V4 too but nothing on V4 insmods it — load_hisilicon
+    # / load_goke don't reference open_ive_neo.ko on ev200/ev300/gk7205v200.
+    # Shipping it on V4 just consumes ~28 KB of the lite NOR rootfs (and
+    # grows with every cv500 dispatch addition). Skip on V4 until there's
+    # an actual V4 consumer.
     include $(src)/jpege/Kbuild
 ifndef DISABLE_PM
     # it doesn't compile yet


### PR DESCRIPTION
## Summary

\`ive_neo\` is cv500-targeted experimental work. The Kbuild dispatch pulled it into the V4 ev200 / gk7205v200 build too, where nothing actually uses it:

- \`load_hisilicon\` / \`load_goke\` don't reference \`open_ive_neo.ko\`
- majestic / userspace MPI on V4 doesn't call into it
- no init script \`insmod\`'s it on any V4 board

Verified by extracting today's nightly \`hi3518ev300-nor-lite\` rootfs:

\`\`\`
$ grep ive_neo /etc/init.d/* /usr/bin/load_*
(no matches)
$ ls /lib/modules/4.9.37/extra/open_ive_neo.ko
-rw-r--r--    1 root root 28364  open_ive_neo.ko    # dead weight
\`\`\`

But it still costs ~28 KB on every V4 lite rootfs, and that number grows every time the cv500 HW-dispatch tables get extended in \`ive_neo.c\` — the file doubled in size since the previous firmware-side opensdk pin (66 KB → 130 KB source, +20-30 KB stripped .ko). On \`hi3518ev300_lite\` the 5 MB rootfs partition is at 5116/5120 KB on master, so the next bump pushed it 48 KB over.

Skip the include on V4. cv500 still builds it via \`kernel/hi3516cv500.kbuild\` line 99 — unchanged. If a V4 consumer ever appears, add a load-script reference and flip the gate.

## Test plan

- [x] cv500 \`open_ive_neo.ko\` still builds (separate Kbuild include path)
- [ ] V4 (ev200 / ev300 / gk7205v200) builds drop \`open_ive_neo.ko\` — verified via firmware-side CI once the opensdk hash bump that pulls this lands in OpenIPC/firmware
- [ ] \`hi3518ev300_lite\` rootfs is back under 5120 KB