### PR TITLE
libraries/nnie_neo: marshal ForwardWithBbox to /dev/nnie

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -570,6 +570,19 @@ jobs:
               fi
           done
 
+      - name: Cross-compile NNIE bbox marshalling test
+        # Target-only smoke test (needs /dev/nnie) — we just verify it
+        # links against libnnie_neo so a missing/renamed symbol in the
+        # bbox wrapper trips CI rather than waiting for on-target.
+        run: |
+          make -C libraries/nnie_neo/test test_forward_with_bbox \
+              CC=arm-linux-gnueabi-gcc
+          file libraries/nnie_neo/test/test_forward_with_bbox | grep -q ARM
+          arm-linux-gnueabi-nm libraries/nnie_neo/test/test_forward_with_bbox \
+              | grep -qE ' T HI_MPI_SVP_NNIE_ForwardWithBbox$' \
+              || { echo "FAIL: bbox symbol missing from test binary" >&2; exit 1; }
+          echo "ok: bbox test links cleanly"
+
   #
   # qemu-ive-ops
   #

--- a/libraries/nnie_neo/src/nnie_ops.c
+++ b/libraries/nnie_neo/src/nnie_ops.c
@@ -37,7 +37,21 @@
 #define NNIE_IOC_REMOVE_TSKBUF        0xc0184d04u
 
 #define NNIE_FWD_ARG_SIZE       1624u
+#define NNIE_FWD_BBOX_ARG_SIZE  1728u
 #define NNIE_BLOB_SIZE            48u
+
+/* ForwardWithBbox user buffer offsets (kernel-side mirror in
+ * kernel/nnie_neo/nnie_neo.c). The bbox CTRL_S inserts u32ProposalNum
+ * at +8, shifting NetSegId and the SVP_MEM_INFO_S members by 8 B
+ * compared to plain Forward CTRL_S — see
+ * `hiSVP_NNIE_FORWARD_WITHBBOX_CTRL_S` in hi_nnie.h. */
+#define NNIE_BBOX_OFF_HANDLE         0
+#define NNIE_BBOX_OFF_ASTSRC         8
+#define NNIE_BBOX_OFF_ASTBBOX      776
+#define NNIE_BBOX_OFF_PSTMODEL     872
+#define NNIE_BBOX_OFF_ASTDST       880
+#define NNIE_BBOX_OFF_CTRL        1648
+#define NNIE_BBOX_OFF_INSTANT     1720
 
 static int             g_nnie_fd      = -1;
 static pthread_mutex_t g_nnie_fd_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -305,9 +319,42 @@ HI_S32 HI_MPI_SVP_NNIE_ForwardWithBbox(SVP_NNIE_HANDLE *phSvpNnieHandle,
                                        const SVP_NNIE_FORWARD_WITHBBOX_CTRL_S *pstForwardCtrl,
                                        HI_BOOL bInstant)
 {
-	(void)phSvpNnieHandle; (void)astSrc; (void)astBbox; (void)pstModel;
-	(void)astDst; (void)pstForwardCtrl; (void)bInstant;
-	return HI_ERR_SVP_NNIE_NOT_SURPPORT;
+	uint8_t buf[NNIE_FWD_BBOX_ARG_SIZE];
+	uint64_t model_uva;
+	int fd, src_n, dst_n, bbox_n;
+
+	if (!phSvpNnieHandle || !astSrc || !pstModel ||
+	    !astDst || !pstForwardCtrl)
+		return HI_ERR_SVP_NNIE_NULL_PTR;
+
+	src_n  = (int)pstForwardCtrl->u32SrcNum;
+	dst_n  = (int)pstForwardCtrl->u32DstNum;
+	bbox_n = (int)pstForwardCtrl->u32ProposalNum;
+	if (src_n < 1 || src_n > 16 || dst_n < 1 || dst_n > 16 ||
+	    bbox_n < 0 || bbox_n > 2)
+		return HI_ERR_SVP_NNIE_ILLEGAL_PARAM;
+	if (bbox_n > 0 && !astBbox)
+		return HI_ERR_SVP_NNIE_NULL_PTR;
+
+	fd = nnie_open_dev();
+	if (fd < 0)
+		return nnie_err_to_hi(fd);
+
+	memset(buf, 0, sizeof(buf));
+	memcpy(buf + NNIE_BBOX_OFF_ASTSRC,   astSrc,  NNIE_BLOB_SIZE * src_n);
+	if (bbox_n)
+		memcpy(buf + NNIE_BBOX_OFF_ASTBBOX, astBbox, NNIE_BLOB_SIZE * bbox_n);
+	model_uva = (uint64_t)(uintptr_t)pstModel;
+	memcpy(buf + NNIE_BBOX_OFF_PSTMODEL, &model_uva, 8);
+	memcpy(buf + NNIE_BBOX_OFF_ASTDST,   astDst,  NNIE_BLOB_SIZE * dst_n);
+	memcpy(buf + NNIE_BBOX_OFF_CTRL, pstForwardCtrl, sizeof(*pstForwardCtrl));
+	*(uint32_t *)(buf + NNIE_BBOX_OFF_INSTANT) = bInstant ? 1 : 0;
+
+	if (ioctl(fd, NNIE_IOC_FORWARD_WITH_BBOX, buf) < 0)
+		return nnie_err_to_hi(-errno);
+
+	*phSvpNnieHandle = *(uint32_t *)(buf + NNIE_BBOX_OFF_HANDLE);
+	return HI_SUCCESS;
 }
 
 HI_S32 HI_MPI_SVP_NNIE_Query(SVP_NNIE_ID_E enNnieId,

--- a/libraries/nnie_neo/test/.gitignore
+++ b/libraries/nnie_neo/test/.gitignore
@@ -1,1 +1,2 @@
-libraries/nnie_neo/test/test_loadmodel
+test_loadmodel
+test_forward_with_bbox

--- a/libraries/nnie_neo/test/Makefile
+++ b/libraries/nnie_neo/test/Makefile
@@ -34,3 +34,8 @@ clean:
 	rm -f test_loadmodel
 
 .PHONY: all run clean
+
+# Target-runnable bbox marshalling test (requires /dev/nnie).
+# Builds with the cross toolchain; only runs on cv500/av300 boards.
+test_forward_with_bbox: test_forward_with_bbox.c $(ROOT)/libraries/nnie_neo/src/nnie_ops.c
+	$(CC) $(CFLAGS) -o $@ test_forward_with_bbox.c $(ROOT)/libraries/nnie_neo/src/nnie_ops.c -lpthread

--- a/libraries/nnie_neo/test/test_forward_with_bbox.c
+++ b/libraries/nnie_neo/test/test_forward_with_bbox.c
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0
+ *
+ * Integration test for HI_MPI_SVP_NNIE_ForwardWithBbox userspace
+ * marshalling. Runs on the target (cv500/av300) against the live
+ * /dev/nnie. Kernel currently returns -EOPNOTSUPP for the bbox path
+ * (see kernel/nnie_neo/nnie_neo.c::nnie_op_forward_with_bbox); this
+ * test asserts that we reach the kernel and translate the errno
+ * correctly — i.e. the wrapper's 1728 B arg-buffer marshalling does
+ * not get rejected at the userspace layer before the ioctl.
+ *
+ * Build (target):
+ *   make -C libraries/nnie_neo/test test_forward_with_bbox \
+ *     CC=arm-openipc-linux-gnueabi-gcc
+ *
+ * Run (on board):
+ *   insmod open_nnie_neo.ko && ./test_forward_with_bbox
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <assert.h>
+
+#include "hi_type.h"
+#include "hi_common.h"
+#include "hi_comm_svp.h"
+#include "hi_nnie.h"
+#include "mpi_nnie.h"
+
+int main(void)
+{
+	SVP_SRC_BLOB_S astSrc[1];
+	SVP_DST_BLOB_S astDst[1];
+	SVP_NNIE_MODEL_S model;
+	SVP_NNIE_FORWARD_WITHBBOX_CTRL_S ctrl;
+	SVP_NNIE_HANDLE handle = 0;
+	HI_S32 ret;
+
+	memset(astSrc, 0, sizeof(astSrc));
+	memset(astDst, 0, sizeof(astDst));
+	memset(&model, 0, sizeof(model));
+	memset(&ctrl, 0, sizeof(ctrl));
+
+	/* Minimal valid CTRL_S: 1 src, 1 dst, no proposals, segment 0.
+	 * No HW dispatch happens because the kernel rejects bbox before
+	 * touching any phys/virt — we just need the validation to pass
+	 * inside our wrapper. */
+	ctrl.u32SrcNum      = 1;
+	ctrl.u32DstNum      = 1;
+	ctrl.u32ProposalNum = 0;
+	ctrl.u32NetSegId    = 0;
+	ctrl.enNnieId       = 0;
+
+	ret = HI_MPI_SVP_NNIE_ForwardWithBbox(&handle, astSrc, NULL, &model,
+	                                      astDst, &ctrl, HI_TRUE);
+
+	/* Expected: -EOPNOTSUPP from kernel → HI_ERR_SVP_NNIE_NOT_SURPPORT. */
+	if (ret != HI_ERR_SVP_NNIE_NOT_SURPPORT) {
+		fprintf(stderr,
+		        "FAIL: ForwardWithBbox returned 0x%x, expected NOT_SURPPORT 0x%x\n",
+		        ret, HI_ERR_SVP_NNIE_NOT_SURPPORT);
+		return 1;
+	}
+
+	printf("PASS: bbox wrapper marshalled cleanly, kernel returned NOT_SURPPORT\n");
+	return 0;
+}


### PR DESCRIPTION
Stacked on top of #152 (kernel-side bbox stub).

## Summary
- Replace the userspace-only stub for `HI_MPI_SVP_NNIE_ForwardWithBbox` with the real 1728 B arg-buffer marshalling, so the lib now talks to the kernel ioctl exactly like vendor libnnie.so.
- Public API behaviour is unchanged today (kernel returns -EOPNOTSUPP → translated to `HI_ERR_SVP_NNIE_NOT_SURPPORT`), but the wrapper is now correctly hooked up for when the kernel-side bbox path lands.

## Why this matters now
Before: an app calling `HI_MPI_SVP_NNIE_ForwardWithBbox` against libnnie_neo never reached the kernel — the lib returned NOT_SURPPORT in userspace. That meant kernel instrumentation, ftrace, or future bbox impl work couldn't be exercised through our lib. Behaviour also silently diverged from vendor libnnie at the syscall boundary.

After: the wrapper marshals all six args per the SDK-declared `SVP_NNIE_FORWARD_WITHBBOX_CTRL_S` layout and ioctl's. Kernel-side rejection produces the same `HI_ERR_SVP_NNIE_NOT_SURPPORT` it did before, via the existing `nnie_err_to_hi` translator.

## Test plan
- [x] Cross-build: `make CC=arm-openipc-linux-gnueabi-gcc` cleanly produces libnnie_neo.so/.a.
- [x] CI: new build step in `libraries-cross-compile` compiles `test_forward_with_bbox` and asserts the bbox symbol is exported.
- [x] On-target (av300): with `open_nnie_neo.ko` loaded, `./test_forward_with_bbox` reports PASS; dmesg shows the kernel-side `pr_info_once`:
  ```
  PASS: bbox wrapper marshalled cleanly, kernel returned NOT_SURPPORT
  dmesg: nnie_neo: ForwardWithBbox not implemented yet; use Forward for classifier nets
  ```
- [x] Regression: mnist (`sample_nnie_main 4`) and SSD (`sample_nnie_main 5`) still byte-identical to vendor on av300.

## Out of scope
- Kernel-side bbox handler (#26) — the tskbuf §3 proposal-phys table layout still needs RE; a speculative impl was tested in this branch and hung the HW, requires a board reboot.
- libnnie_neo `HI_MPI_SVP_NNIE_GetTskBufSize` proper implementation — still a stub; would need a per-segment instruction-stream walker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)