### PR TITLE
libraries/nnie_neo: fix .wk multi-segment parser (64 B node stride)

### DIFF
--- a/libraries/nnie_neo/include/nnie_wk_format.h
+++ b/libraries/nnie_neo/include/nnie_wk_format.h
@@ -76,14 +76,25 @@ _Static_assert(sizeof(nnie_wk_seg_record_t) == 16,
 	       "nnie_wk_seg_record_t must be exactly 16 bytes");
 
 /* Per-node record (48 bytes), one per src then one per dst, immediately
- * after the segment record(s):
- *   [+0..+11]  u32 height, u32 width, u32 chn
- *   [+12..+13] padding
- *   [+14]      u8  enType (SVP_BLOB_TYPE_E)
- *   [+15]      u8  node id
- *   [+16..+47] szName[32]
+ * after the segment record. Each node body is followed by a 16-byte
+ * inter-node separator on disk:
+ *   [+0..+47]  body
+ *     [+0..+11]  u32 height, u32 width, u32 chn
+ *     [+12..+13] padding
+ *     [+14]      u8  enType (SVP_BLOB_TYPE_E)
+ *     [+15]      u8  node id
+ *     [+16..+47] szName[32]
+ *   [+48..+63] separator (mostly zeros; first byte sometimes carries a
+ *                         node-link count, but vendor's runtime parser
+ *                         doesn't read it)
+ *
+ * For a segment with N total nodes, the on-disk footprint after the
+ * seg record is N * NNIE_WK_NODE_STRIDE bytes. The next segment record
+ * begins at the byte after the last node's separator.
  */
 #define NNIE_WK_NODE_SIZE       48u
+#define NNIE_WK_NODE_SEP_SIZE   16u
+#define NNIE_WK_NODE_STRIDE     (NNIE_WK_NODE_SIZE + NNIE_WK_NODE_SEP_SIZE)
 
 int nnie_wk_verify_crc(const void *file_buf, uint32_t file_size);
 

--- a/libraries/nnie_neo/src/nnie_ops.c
+++ b/libraries/nnie_neo/src/nnie_ops.c
@@ -186,29 +186,39 @@ HI_S32 HI_MPI_SVP_NNIE_LoadModel(const SVP_SRC_MEM_INFO_S *pstModelBuf,
 	 * detection models (yolov*, ssd) may need vendor's exact value. */
 	pstModel->u32TmpBufSize = 8 * 1024 * 1024;
 
-	p = file + NNIE_WK_HEADER_SIZE + (size_t)seg_num * sizeof(nnie_wk_seg_record_t);
+	/* Segments are interleaved with their node tables on disk —
+	 * NOT all-segs-then-all-nodes. Walk sequentially: read the 16 B
+	 * seg record at p, then each node body is 48 B followed by a
+	 * 16 B inter-node separator (= NNIE_WK_NODE_STRIDE). The next
+	 * seg record begins where the previous seg's last separator
+	 * ended. Verified against vendor pvanet (2-seg, FasterRCNN) and
+	 * mnist (1-seg) .wk files on av300. */
+	p = file + NNIE_WK_HEADER_SIZE;
 
 	for (i = 0; i < seg_num; i++) {
-		const uint8_t *r = file + NNIE_WK_HEADER_SIZE
-		                   + i * sizeof(nnie_wk_seg_record_t);
 		uint32_t j;
 
-		pstModel->astSeg[i].enNetType     = (SVP_NNIE_NET_TYPE_E)r[0];
-		pstModel->astSeg[i].u16SrcNum     = r[1];
-		pstModel->astSeg[i].u16DstNum     = r[2];
-		pstModel->astSeg[i].u16RoiPoolNum = r[3];
-		pstModel->astSeg[i].u16MaxStep    = *(const uint16_t *)(r + 4);
-		pstModel->astSeg[i].u32InstOffset = *(const uint32_t *)(r + 8);
-		pstModel->astSeg[i].u32InstLen    = *(const uint32_t *)(r + 12);
+		if ((size_t)(p + sizeof(nnie_wk_seg_record_t) - file) > file_size)
+			return HI_ERR_SVP_NNIE_ILLEGAL_PARAM;
+
+		pstModel->astSeg[i].enNetType     = (SVP_NNIE_NET_TYPE_E)p[0];
+		pstModel->astSeg[i].u16SrcNum     = p[1];
+		pstModel->astSeg[i].u16DstNum     = p[2];
+		pstModel->astSeg[i].u16RoiPoolNum = p[3];
+		pstModel->astSeg[i].u16MaxStep    = *(const uint16_t *)(p + 4);
+		pstModel->astSeg[i].u32InstOffset = *(const uint32_t *)(p + 8);
+		pstModel->astSeg[i].u32InstLen    = *(const uint32_t *)(p + 12);
 
 		if (pstModel->astSeg[i].u32InstOffset +
 		    pstModel->astSeg[i].u32InstLen > file_size)
 			return HI_ERR_SVP_NNIE_ILLEGAL_PARAM;
 
+		p += sizeof(nnie_wk_seg_record_t);
+
 		for (j = 0; j < pstModel->astSeg[i].u16SrcNum; j++) {
 			SVP_NNIE_NODE_S *n = &pstModel->astSeg[i].astSrcNode[j];
 
-			if ((size_t)(p + NNIE_WK_NODE_SIZE - file) > file_size)
+			if ((size_t)(p + NNIE_WK_NODE_STRIDE - file) > file_size)
 				return HI_ERR_SVP_NNIE_ILLEGAL_PARAM;
 			n->unShape.stWhc.u32Height = *(const uint32_t *)(p + 0);
 			n->unShape.stWhc.u32Width  = *(const uint32_t *)(p + 4);
@@ -217,12 +227,12 @@ HI_S32 HI_MPI_SVP_NNIE_LoadModel(const SVP_SRC_MEM_INFO_S *pstModelBuf,
 			n->u32NodeId               = p[15];
 			memcpy(n->szName, p + 16, SVP_NNIE_NODE_NAME_LEN - 1);
 			n->szName[SVP_NNIE_NODE_NAME_LEN - 1] = 0;
-			p += NNIE_WK_NODE_SIZE;
+			p += NNIE_WK_NODE_STRIDE;
 		}
 		for (j = 0; j < pstModel->astSeg[i].u16DstNum; j++) {
 			SVP_NNIE_NODE_S *n = &pstModel->astSeg[i].astDstNode[j];
 
-			if ((size_t)(p + NNIE_WK_NODE_SIZE - file) > file_size)
+			if ((size_t)(p + NNIE_WK_NODE_STRIDE - file) > file_size)
 				return HI_ERR_SVP_NNIE_ILLEGAL_PARAM;
 			/* Output activations: vendor's libnnie swaps fields so
 			 * the layer's feature count lands in Width. */
@@ -233,7 +243,7 @@ HI_S32 HI_MPI_SVP_NNIE_LoadModel(const SVP_SRC_MEM_INFO_S *pstModelBuf,
 			n->u32NodeId               = (j + 1) * 8;
 			memcpy(n->szName, p + 16, SVP_NNIE_NODE_NAME_LEN - 1);
 			n->szName[SVP_NNIE_NODE_NAME_LEN - 1] = 0;
-			p += NNIE_WK_NODE_SIZE;
+			p += NNIE_WK_NODE_STRIDE;
 		}
 	}
 

--- a/libraries/nnie_neo/test/test_loadmodel.c
+++ b/libraries/nnie_neo/test/test_loadmodel.c
@@ -56,12 +56,15 @@ static uint32_t crc32_range(const uint8_t *buf, size_t off, size_t end)
 	return ~crc;
 }
 
-/* Layout of the synthesised file:
+/* Layout of the synthesised file — matches real vendor .wk layout
+ * (each node body is followed by a 16 B inter-node separator):
  *   [0..191]     header (192 B)
  *   [192..207]   segment record (16 B)
- *   [208..255]   src node compact (16 B) + name (32 B)
- *   [256..303]   dst node compact (16 B) + name (32 B)
- *   [304..0x150) header-tail filler (zeros)
+ *   [208..255]   src node body (48 B): WHC + enType/id + name
+ *   [256..271]   16 B separator
+ *   [272..319]   dst node body (48 B)
+ *   [320..335]   16 B separator
+ *   [336..0x150) header-tail filler (zeros)
  *   [0x150..]    instruction stream region (header_extra to end of inst)
  *   then weights / quant tables follow (not CRC'd)
  *
@@ -113,7 +116,7 @@ static void synth_wk(uint8_t *buf, size_t buf_size)
 	put_le32(seg + 8,  WK_HEADER_EXTRA);  /* u32InstOffset */
 	put_le32(seg + 12, WK_INST_LEN);      /* u32InstLen */
 
-	/* Src node (48 B): mnist-style 28×28×1 with enType=1, name "data". */
+	/* Src node body (48 B at +208): mnist-style 28×28×1, name "data". */
 	src_node = buf + 208;
 	put_le32(src_node + 0,  28);    /* height */
 	put_le32(src_node + 4,  28);    /* width */
@@ -122,14 +125,19 @@ static void synth_wk(uint8_t *buf, size_t buf_size)
 	src_node[15] = 0;               /* NodeId */
 	memcpy(src_node + 16, "data", 4);
 
-	/* Dst node (48 B): mnist-style 10-class output, name "prob". */
-	dst_node = buf + 256;
+	/* Inter-node separator (16 B at +256), all zeros. */
+
+	/* Dst node body (48 B at +272): mnist-style 10-class output,
+	 * name "prob". Field order matches vendor's on-disk layout —
+	 * libnnie remaps so Width holds the feature count. */
+	dst_node = buf + 272;
 	put_le32(dst_node + 0,   1);    /* height */
-	put_le32(dst_node + 4,   1);    /* (chn in file order) */
-	put_le32(dst_node + 8,  10);    /* (width in file order — vendor's
-	                                   libnnie remaps so Width holds the
-	                                   layer's feature count) */
+	put_le32(dst_node + 4,   1);    /* chn (in file order) */
+	put_le32(dst_node + 8,  10);    /* width = feature count */
 	memcpy(dst_node + 16, "prob", 4);
+
+	/* Trailing inter-node separator at +320 (16 B zeros), then
+	 * +336..+0x150 is header-tail filler. */
 
 	/* Fill the instruction stream region with a deterministic pattern
 	 * so the CRC isn't trivially zero. */
@@ -241,5 +249,115 @@ int main(void)
 	}
 
 	printf("ok: NNIE LoadModel sanity (synth .wk + negative cases)\n");
+
+	/* === Multi-segment test (pvanet-shaped) ===
+	 *
+	 * Two segments interleaved with their node tables. Validates that
+	 * the parser correctly walks past seg[0]'s nodes + separators to
+	 * find seg[1]'s record, instead of reading 16 B into seg[0]'s src
+	 * node body. This was a real bug: a 48 B node-stride (no separator)
+	 * had seg[1] of any 2-seg model decode garbage (netType=224 etc).
+	 */
+	{
+		/* Layout (instructions placed after the seg+node region):
+		 *   [0..191]    header
+		 *   [192..207]  seg[0] record (netType=0 CNN, src=1 dst=1)
+		 *   [208..271]  seg[0].src_node "input0" body+sep (64 B)
+		 *   [272..335]  seg[0].dst_node "out0"   body+sep (64 B)
+		 *   [336..351]  seg[1] record (netType=1 ROI, src=1 dst=1)
+		 *   [352..415]  seg[1].src_node "input1" body+sep
+		 *   [416..479]  seg[1].dst_node "out1"   body+sep
+		 *   [480..]      filler then instruction stream
+		 */
+		#define MM_INST_EXTRA  512u    /* >= end of seg+node region (480) */
+		#define MM_INST_LEN    256u
+		#define MM_BUF_SIZE    (MM_INST_EXTRA + MM_INST_LEN + 16u)
+		uint8_t mbuf[MM_BUF_SIZE];
+		SVP_SRC_MEM_INFO_S mmem = { 0 };
+		SVP_NNIE_MODEL_S mm;
+		uint32_t crc;
+		uint8_t *seg0, *seg1;
+
+		memset(mbuf, 0, sizeof(mbuf));
+		mbuf[16] = NNIE_WK_VER_MAJ;
+		mbuf[17] = NNIE_WK_VER_MIN;
+		mbuf[18] = NNIE_WK_VER_3;
+		mbuf[19] = NNIE_WK_VER_4;
+		mbuf[49] = 2;                                 /* net_seg_num = 2 */
+		put_le32(mbuf + 52, MM_INST_EXTRA);
+		put_le32(mbuf + 56, MM_INST_LEN);
+
+		seg0 = mbuf + 192;
+		seg0[0] = 0;  seg0[1] = 1; seg0[2] = 1; seg0[3] = 0;
+		put_le32(seg0 + 8,  MM_INST_EXTRA);
+		put_le32(seg0 + 12, MM_INST_LEN / 2);
+
+		/* seg[0].src + sep at +208, dst + sep at +272. */
+		put_le32(mbuf + 208 + 0, 100);
+		put_le32(mbuf + 208 + 4, 100);
+		put_le32(mbuf + 208 + 8,   3);
+		mbuf[208 + 14] = 1;       /* enType U8 */
+		mbuf[208 + 15] = 0;
+		memcpy(mbuf + 208 + 16, "input0", 6);
+		put_le32(mbuf + 272 + 0,  50);
+		put_le32(mbuf + 272 + 4,   1);
+		put_le32(mbuf + 272 + 8,  10);
+		memcpy(mbuf + 272 + 16, "out0", 4);
+
+		/* seg[1] record at +336. ROI seg (FasterRCNN-class). */
+		seg1 = mbuf + 336;
+		seg1[0] = 1;  seg1[1] = 1; seg1[2] = 1; seg1[3] = 1;
+		put_le32(seg1 + 8,  MM_INST_EXTRA + MM_INST_LEN / 2);
+		put_le32(seg1 + 12, MM_INST_LEN / 2);
+
+		put_le32(mbuf + 352 + 0,  14);
+		put_le32(mbuf + 352 + 4,  14);
+		put_le32(mbuf + 352 + 8, 512);
+		mbuf[352 + 14] = 0;       /* enType S32 — RPN feature map input */
+		mbuf[352 + 15] = 1;
+		memcpy(mbuf + 352 + 16, "input1", 6);
+		put_le32(mbuf + 416 + 0,   7);
+		put_le32(mbuf + 416 + 4,   1);
+		put_le32(mbuf + 416 + 8,  84);
+		memcpy(mbuf + 416 + 16, "out1", 4);
+
+		for (size_t k = MM_INST_EXTRA;
+		     k < MM_INST_EXTRA + MM_INST_LEN; k++)
+			mbuf[k] = (uint8_t)(k * 0x9e + 0x37);
+		crc = crc32_range(mbuf, 4, MM_INST_EXTRA + MM_INST_LEN);
+		put_le32(mbuf + 0, crc);
+
+		mmem.u64VirAddr = (uintptr_t)mbuf;
+		mmem.u64PhyAddr = 0xBB880000ULL;
+		mmem.u32Size    = sizeof(mbuf);
+
+		ret = HI_MPI_SVP_NNIE_LoadModel(&mmem, &mm);
+		CHECK(ret == HI_SUCCESS, "multi-seg LoadModel ret=0x%x", ret);
+		CHECK(mm.u32NetSegNum == 2, "got %u", mm.u32NetSegNum);
+
+		/* seg[0]: CNN */
+		CHECK(mm.astSeg[0].enNetType == 0, "seg[0] netType=%u", mm.astSeg[0].enNetType);
+		CHECK(mm.astSeg[0].u16SrcNum == 1, "seg[0] src=%u", mm.astSeg[0].u16SrcNum);
+		CHECK(mm.astSeg[0].u16DstNum == 1, "seg[0] dst=%u", mm.astSeg[0].u16DstNum);
+		CHECK(strcmp(mm.astSeg[0].astSrcNode[0].szName, "input0") == 0,
+		      "seg[0].src.name='%s'", mm.astSeg[0].astSrcNode[0].szName);
+
+		/* seg[1]: ROI — this is what the old 48-stride parser would
+		 * mis-decode as netType=??? srcNum=0 dstNum=0. */
+		CHECK(mm.astSeg[1].enNetType == 1, "seg[1] netType=%u (expected 1=ROI)",
+		      mm.astSeg[1].enNetType);
+		CHECK(mm.astSeg[1].u16SrcNum == 1, "seg[1] src=%u", mm.astSeg[1].u16SrcNum);
+		CHECK(mm.astSeg[1].u16DstNum == 1, "seg[1] dst=%u", mm.astSeg[1].u16DstNum);
+		CHECK(mm.astSeg[1].u16RoiPoolNum == 1, "seg[1] roi=%u",
+		      mm.astSeg[1].u16RoiPoolNum);
+		CHECK(strcmp(mm.astSeg[1].astSrcNode[0].szName, "input1") == 0,
+		      "seg[1].src.name='%s'", mm.astSeg[1].astSrcNode[0].szName);
+		CHECK(strcmp(mm.astSeg[1].astDstNode[0].szName, "out1") == 0,
+		      "seg[1].dst.name='%s'", mm.astSeg[1].astDstNode[0].szName);
+
+		HI_MPI_SVP_NNIE_UnloadModel(&mm);
+		printf("ok: multi-seg LoadModel (ROI seg[1] decoded correctly)\n");
+	}
+
 	return 0;
 }


### PR DESCRIPTION
## Summary
- The .wk on-disk per-node footprint is **48 B body + 16 B inter-node separator = 64 B stride**, not 48 B as our parser had it.
- For single-segment models (mnist/SSD/YOLO/segnet) the bug was silent because the kernel Forward path reads `astSrc`/`astDst` from the user's blobs, never from `pstModel->astSeg[i].astDstNode[]`. mnist + SSD remain byte-identical to vendor on av300 after this fix.
- For two-segment models (pvanet, R-FCN, alexnet-frcnn, fasterrcnn_double_roipooling — every two-stage detector), `seg[1]` landed in the middle of `seg[0]`'s src-node body and decoded garbage. After the fix it matches vendor exactly:

  ```
  before: seg[1]: netType=224 srcNum=0 dstNum=0 inst@0x3       len=0x10000
  after:  seg[1]: netType=1   srcNum=1 dstNum=2 inst@0x14b7200 len=0x96f8
  ```

## What end-users get
Anyone calling `HI_MPI_SVP_NNIE_LoadModel` on a two-stage detector model now gets correctly-decoded `astSeg[1]` metadata: real netType, real src/dst counts, real node names, real instruction offsets. Before, those fields contained random bytes from the middle of `seg[0]`'s "data" node payload. Apps that pre-allocated based on these fields would have over- or under-allocated unpredictably.

Forward-dispatching single-shot models is unchanged (no kernel-path regression; verified on av300 against vendor `sample_nnie_main` for mnist + SSD — both byte-identical to vendor baseline).

## How
Walks segments sequentially: read 16 B seg record at `p`, then iterate `src_num + dst_num` nodes advancing by `NNIE_WK_NODE_STRIDE = 64` bytes per node. Next segment record begins where the previous segment's last separator ended.

## Test plan
- [x] Host unit test (`test_loadmodel`): synth `.wk` updated to match real vendor layout; new multi-segment fixture asserts `seg[1]` decode (`netType=1`, src/dst counts, node names).
- [x] Host unit test (`test_get_tskbuf_size`): unaffected — uses `astSrc` info which we already parsed correctly.
- [x] On-target (av300, `test_get_tskbuf_size_on_target` against real pvanet `.wk`):
  ```
  seg[0]: netType=0 srcNum=1 dstNum=4 inst@0x13e2000 len=0xd51e0
  seg[1]: netType=1 srcNum=1 dstNum=2 inst@0x14b7200 len=0x96f8
  GetTskBufSize: seg[0]=96 B, seg[1]=10624 B
  ```
- [x] On-target regression: mnist still classifies `0:4096`; SSD still emits class 7 + class 12 detections at the same coords / confidences as vendor.

## Out of scope
- The kernel-side `ForwardWithBbox` handler (#26) still returns `-EOPNOTSUPP`; this PR just makes the model metadata available to userspace correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)