### PR TITLE
nnie_neo: support YVU420SP / YVU422SP src blobs (VI→NNIE direct)

### DIFF
--- a/kernel/nnie_neo/nnie_neo.c
+++ b/kernel/nnie_neo/nnie_neo.c
@@ -388,16 +388,24 @@ static int nnie_build_task_tail(struct nnie_tskbuf *tb, const u8 *fwd_arg,
 		u32 chn     = *(u32 *)(blob + NNIE_BLOB_OFF_CHN);
 		u64 plane_size = (u64)stride * height;
 
-		/* en_type encoding matches SVP_BLOB_TYPE_E:
-		 *   0 = S32 (4 B per pixel; HW expects one phys per frame)
-		 *   1 = U8  image (chn=1 → 1 entry per frame; chn=3 → vendor
-		 *                  emits a 4-u64 quartet per frame for the
-		 *                  three planar channels + one zero slot)
-		 *   4 = VEC_S32 vector (one entry per frame)
+		/* en_type encoding matches SVP_BLOB_TYPE_E. Layout cross-
+		 * checked against vendor svp_nnie_fill_image_src_addr +
+		 * fill_forward_task (decompiled from open_nnie.ko):
 		 *
-		 * Vendor svp_nnie_fill_image_src_addr (hi_nnie.o:0x78ac)
-		 * encodes this; see kaeru node
-		 * `nnie-neo-cv500-detector-tskbuf-pattern-2026-05-17`. */
+		 *   0 = S32        — 1 u64 / frame at phys + j * stride*h*chn
+		 *   1 = U8 image   — chn=1: 1 u64 / frame at phys + j*stride*h
+		 *                    chn=3: 4 u64 quartet / frame (3 planar
+		 *                           channel phys + zero pad slot)
+		 *   2 = YVU420SP   — 2 u64 / frame: Y plane phys, UV plane phys
+		 *                    Frame size = 1.5 * stride*h (chroma
+		 *                    sub-sampled 2x2). UV offset = stride*h.
+		 *   3 = YVU422SP   — 2 u64 / frame: Y plane phys, UV plane phys
+		 *                    Frame size = 2 * stride*h (UV at full H).
+		 *   4 = VEC_S32    — 1 u64 / frame at phys + j*stride*h
+		 *
+		 * YVU420SP/YVU422SP unlock the VI→VPSS→NNIE pipeline path —
+		 * camera frames in their native YUV layout can be inferred
+		 * directly without an RGB conversion VPSS step. */
 		switch (en_type) {
 		case 0: /* S32 frame */
 			for (j = 0; j < num; j++)
@@ -416,6 +424,25 @@ static int nnie_build_task_tail(struct nnie_tskbuf *tb, const u8 *fwd_arg,
 				}
 			} else {
 				return -EOPNOTSUPP;
+			}
+			break;
+		case 2: { /* YVU420SP: Y full, UV half-height interleaved
+			   * Frame = 1.5 × stride×h (i.e. chn=3 / 2 of plane).
+			   * UV offset from frame start = stride×h (plane_size)
+			   * algebraically: 2·(chn·plane/2)/chn = plane. */
+			u64 frame_chr2 = (u64)chn * plane_size;  /* 2×frame */
+			u64 uv_off = plane_size;
+			for (j = 0; j < num; j++) {
+				u64 frame_base = (j * frame_chr2) >> 1;
+				TIP_PUT_U64(phys + frame_base);
+				TIP_PUT_U64(phys + frame_base + uv_off);
+			}
+			break;
+		}
+		case 3: /* YVU422SP: Y and UV both full-height interleaved */
+			for (j = 0; j < num; j++) {
+				TIP_PUT_U64(phys + (2 * j + 0) * plane_size);
+				TIP_PUT_U64(phys + (2 * j + 1) * plane_size);
 			}
 			break;
 		case 4: /* VEC_S32 */

--- a/libraries/nnie_neo/src/nnie_ops.c
+++ b/libraries/nnie_neo/src/nnie_ops.c
@@ -335,6 +335,10 @@ HI_S32 HI_MPI_SVP_NNIE_GetTskBufSize(HI_U32 u32MaxInputNum, HI_U32 u32MaxBboxNum
 			case SVP_BLOB_TYPE_VEC_S32:
 				per_frame_u64 = 1;
 				break;
+			case SVP_BLOB_TYPE_YVU420SP:
+			case SVP_BLOB_TYPE_YVU422SP:
+				per_frame_u64 = 2;  /* Y plane phys + UV plane phys */
+				break;
 			default:
 				return HI_ERR_SVP_NNIE_NOT_SURPPORT;
 			}

--- a/libraries/nnie_neo/test/test_get_tskbuf_size.c
+++ b/libraries/nnie_neo/test/test_get_tskbuf_size.c
@@ -141,6 +141,59 @@ static int test_roi_overprovision(void)
 	return 0;
 }
 
+static int test_yvu420sp_shape(void)
+{
+	/* YVU420SP: 2 u64 / frame (Y + UV) → stride table + dst phys +
+	 * 2*8 src phys = 16 + 16 + 16 = 48 B for (1 src,1 dst,num=1).
+	 * Vendor svp_nnie_fill_image_src_addr enType=2 path. */
+	SVP_NNIE_MODEL_S m = {0};
+	HI_U32 sizes[SVP_NNIE_MAX_NET_SEG_NUM] = {0};
+	HI_S32 ret;
+
+	m.u32NetSegNum = 1;
+	m.astSeg[0].enNetType = SVP_NNIE_NET_TYPE_CNN;
+	m.astSeg[0].u16SrcNum = 1;
+	m.astSeg[0].u16DstNum = 1;
+	fill_node(&m.astSeg[0].astSrcNode[0], SVP_BLOB_TYPE_YVU420SP, 3);
+
+	ret = HI_MPI_SVP_NNIE_GetTskBufSize(1, 0, &m, sizes, 1);
+	if (ret != HI_SUCCESS) {
+		fprintf(stderr, "FAIL: YVU420SP ret=0x%x\n", ret);
+		return 1;
+	}
+	if (sizes[0] != 48) {
+		fprintf(stderr, "FAIL: YVU420SP size=%u, expected 48\n", sizes[0]);
+		return 1;
+	}
+	printf("ok: YVU420SP shape → 48 B (VI/VPSS native — no RGB conversion)\n");
+	return 0;
+}
+
+static int test_yvu422sp_shape(void)
+{
+	SVP_NNIE_MODEL_S m = {0};
+	HI_U32 sizes[SVP_NNIE_MAX_NET_SEG_NUM] = {0};
+	HI_S32 ret;
+
+	m.u32NetSegNum = 1;
+	m.astSeg[0].enNetType = SVP_NNIE_NET_TYPE_CNN;
+	m.astSeg[0].u16SrcNum = 1;
+	m.astSeg[0].u16DstNum = 1;
+	fill_node(&m.astSeg[0].astSrcNode[0], SVP_BLOB_TYPE_YVU422SP, 3);
+
+	ret = HI_MPI_SVP_NNIE_GetTskBufSize(1, 0, &m, sizes, 1);
+	if (ret != HI_SUCCESS) {
+		fprintf(stderr, "FAIL: YVU422SP ret=0x%x\n", ret);
+		return 1;
+	}
+	if (sizes[0] != 48) {
+		fprintf(stderr, "FAIL: YVU422SP size=%u, expected 48\n", sizes[0]);
+		return 1;
+	}
+	printf("ok: YVU422SP shape → 48 B\n");
+	return 0;
+}
+
 static int test_lstm_unsupported(void)
 {
 	SVP_NNIE_MODEL_S m = {0};
@@ -182,6 +235,8 @@ int main(void)
 	fail += test_mnist_shape();
 	fail += test_ssd_shape();
 	fail += test_yolov2_shape();
+	fail += test_yvu420sp_shape();
+	fail += test_yvu422sp_shape();
 	fail += test_roi_overprovision();
 	fail += test_lstm_unsupported();
 	fail += test_null_pointer();


### PR DESCRIPTION
## Summary
- Adds `en_type=2` (YVU420SP) and `en_type=3` (YVU422SP) tail-builder branches to `nnie_build_task_tail` + matching `GetTskBufSize` sizing.
- Cross-validated against vendor `svp_nnie_fill_image_src_addr` (decompiled from `open_nnie.ko`) — same Y-plane + UV-plane phys layout, same stride math.

## What end-users get
Camera output from `VI` (MIPI-RX) / `VPSS` is natively **YUV420SP semi-planar**. Before this PR our driver rejected those blobs at the `nnie_build_task_tail` switch with `-EOPNOTSUPP`, so users had to:
1. VPSS-convert YUV→RGB,
2. write to an intermediate MMZ buffer,
3. pass that to NNIE.

After: point `astSrc[0]` at the YUV420SP buffer directly. No intermediate VPSS pass. Real latency + bandwidth savings on the VI→NNIE inference pipeline that's typical for IPC AI workloads (people/vehicle detection on raw camera feed).

## Layout (matches vendor)
For one (1 src, 1 dst, num=1) CNN segment with a YVU420SP/422SP input:
```
§1 stride table       = align16((1+1)·4)            = 16 B
§2 dst phys table     = align16(1·8)                = 16 B
§3 src phys table     = 2 u64 (Y + UV plane phys)   = 16 B
                       ── total                       48 B
```
matches vendor `HI_MPI_SVP_NNIE_GetTskBufSize` on the same shape.

Per-frame addresses:
- **YVU420SP**: `Y = base + j·(1.5·stride·H)`, `UV = Y + stride·H`
- **YVU422SP**: `Y = base + 2j·stride·H`, `UV = Y + stride·H`

## Test plan
- [x] Host unit test `test_get_tskbuf_size`: YVU420SP → 48 B, YVU422SP → 48 B (new fixtures).
- [x] On-target av300 regression: mnist (en=U8 chn=1) and SSD (en=U8 chn=3) still byte-identical to vendor (`class 0:4096`, `class 7+12 @ 0.997 conf`). No shared codepath touched — YVU branches are pure additions.
- [ ] Full byte-equivalence of YVU inference vs vendor would require a model trained on YVU input + a VPSS source on the board. None of the vendor SDK samples ship with that shape; the algebraic match against vendor's decompiled tail-builder is the strongest assurance we can do without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)