### PR TITLE
ci: drop cv300 qemu-boot allow-failure (issue chain complete)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -872,25 +872,10 @@ jobs:
             mem: 256M
             allow-failure: true
             append: "console=ttyAMA0,115200 mem=32M root=/dev/ram0 rootfstype=squashfs"
-          # cv300: the cma_osal.ko-missing bug is fixed in firmware
-          # (OpenIPC/firmware#2105), but qemu-hisilicon's hi3516cv300
-          # machine model appends `mmz_allocator=hisi mmz=…,96M` to
-          # bootargs unconditionally, while the cv300_lite kernel ships
-          # with `# CONFIG_CMA is not set`. load_hisilicon sees `mmz=` in
-          # /proc/cmdline → takes the cma allocator branch → hi_osal.ko
-          # tries to register a CMA allocator against a kernel without
-          # CMA support → registration fails silently and the script
-          # hangs. Real cv300 hardware doesn't pass mmz= in bootargs and
-          # always takes the hisi branch (verified on
-          # openipc-hi3516cv300.dlab.torturelabs.com:
-          # `mem=32M console=ttyAMA0,115200 panic=20 ...`, no mmz=).
-          # Keep allow-failure pending either a qemu-hisilicon bootargs
-          # fix (drop mmz= for cv300 to match real boards) or a cv300
-          # CMA kernel config (orthogonal scope).
           - machine: hi3516cv300
             firmware: hi3516cv300
             mem: 128M
-            allow-failure: true
+            min_modules: 20
             append: "console=ttyAMA0,115200 mem=32M root=/dev/ram0 rootfstype=squashfs"
           - machine: hi3519v101
             firmware: hi3519v101


### PR DESCRIPTION
## Summary

Two upstream fixes unblock the cv300 qemu-boot row:

1. **OpenIPC/firmware#2105** — \`load_hisilicon\` now uses \`hi_osal.ko\` in both branches (was: \`cma_osal.ko\`, which the firmware never builds).
2. **widgetii/qemu-hisilicon#101** (commit \`42dea48a\`) — \`hi3516cv300\` machine model no longer appends \`mmz=…\` to bootargs, matching real V3 board u-boot env. The script now takes the hisi allocator branch as it always did on real hardware.

## Test plan

Local QEMU boot with both fixes in place:

\`\`\`
$ ./run-qemu-cv300.sh fixed \
    .../uImage.hi3516cv300 \
    .../rootfs.squashfs.hi3516cv300

===CI:HISI_MOD_COUNT===31===
===CI:LSMOD_BEGIN===
open_acodec   open_adec     open_aenc     open_ai       open_aio      open_ao
open_base     open_chnl     open_h264e    open_h265e    open_hwrng    open_isp
open_ive      open_jpege    open_mipi_rx  open_osal     open_pwm      open_rc
open_rgn      open_sensor_i2c open_sensor_spi open_sys   open_sys_config open_vedu
open_venc     open_vgs      open_vi       open_vpss     open_wdt
hi3516cv300_vou hi_piris (vendor blobs from osdrv)
===CI:LSMOD_END===

Welcome to OpenIPC
openipc-hi3516cv300 login:
\`\`\`

- 31 HISI modules (vs 34 on \`openipc-hi3516cv300.dlab.torturelabs.com\` real hardware — diff is benign QEMU env)
- No Oops/panic/BUG/Trace
- login prompt reached

Drop \`allow-failure: true\`, gate on \`min_modules: 20\` (well below observed 31, with margin for benign drift).

Closes the CI-hardcoding cleanup item originally tracked in OpenIPC/firmware#2061.