### PR TITLE
kernel/hi3520dv200: add gpio_i2c include path for nvp6134c

### DIFF
--- a/kernel/hi3520dv200.kbuild
+++ b/kernel/hi3520dv200.kbuild
@@ -118,4 +118,8 @@ $(PREFIX)nvp6134_ex-objs := \
 	$(DV200_NVP_DIR)/motion.o \
 	$(DV200_NVP_DIR)/audio.o
 ccflags-y += -I$(src)/$(DV200_NVP_DIR) -DSUPPORT_HI3520D
+# nvp6134c/common.h includes "gpio_i2c.h" when HI_GPIO_I2C is set
+# (family default). The header lives in the gpio_i2c source dir, not
+# under nvp6134c/. Make it findable.
+ccflags-y += -I$(src)/gpio_i2c/hi3520dv200
 obj-m += $(PREFIX)nvp6134_ex.o


### PR DESCRIPTION
## Summary

Follow-up to the hi3520dv200 source mirror — fix the kbuild include path so \`nvp6134c\` finds \`gpio_i2c.h\`.

\`nvp6134c/common.h\` does \`#include \"gpio_i2c.h\"\` under \`HI_GPIO_I2C\` (set at family level). The header lives in \`kernel/gpio_i2c/hi3520dv200/\`, not in \`kernel/nvp6134c/\` itself, so the compile fails with:

\`\`\`
kernel/nvp6134c/common.h:19:10: fatal error: gpio_i2c.h: No such file or directory
\`\`\`

Other extdrv modules (tw286x, cx26828, tlv\*, etc.) all ship their own \`gpio_i2c.h\` copy under their own per-SoC dir, so they find it via the implicit \`-I\$(M-dir)\` kbuild adds for in-tree modules — only nvp6134c (top-level, shared across SoCs) needs the explicit family-level include path.

Caught by a local firmware build against this opensdk: every other source-built module compiled clean, nvp6134c\'s \`coax.o\` and \`nvp6134_drv.o\` failed.

## Test plan

- [ ] \`make BOARD=hi3520dv200_lite\` builds \`open_nvp6134_ex.ko\` clean.