### PR TITLE
ci: drop hi3516av300 row from QEMU NNIE forward regression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -715,11 +715,8 @@ jobs:
         platform:
           - machine: hi3516cv500
             firmware: hi3516cv500
-          - machine: hi3516av300
-            firmware: hi3516cv500   # av300 uses the cv500 firmware build
     env:
       # Bump when widgetii/qemu-hisilicon changes the hisi-nnie model.
-      # Initial NNIE support landed alongside hi3516av300 SoC config.
       QEMU_HISILICON_SHA: master
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

av300 is a packaging variant of cv500 with the same NNIE block. Both matrix rows built the same firmware and ran the same kernel + initrd; only the \`-M\` flag to qemu-system-arm differed. Driver code path under test was identical.

Cuts the job's CI runtime in half. Easy to re-add if qemu-hisilicon's av300 machine ever diverges in NNIE peripheral emulation.

## Test plan

- [x] Surviving \`hi3516cv500\` row continues to exercise the NNIE forward regression end-to-end (unchanged in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)