### PR TITLE
libraries/mpp_sample/hi3520dv200: mirror vendor MPP samples

### DIFF
--- a/libraries/mpp_sample/hi3520dv200/Makefile
+++ b/libraries/mpp_sample/hi3520dv200/Makefile
@@ -1,0 +1,31 @@
+# 
+rel:
+	@cd hifb;   make
+	@cd vio;    make
+	@cd venc;   make
+	@cd vdec;   make
+	@cd region;    make
+	@cd vda;    make
+	@cd audio;  make
+	@cd tde;    make
+
+clean:
+	@cd hifb;   make clean
+	@cd vio;    make clean
+	@cd venc;   make clean
+	@cd vdec;   make clean
+	@cd region; make clean
+	@cd vda;    make clean
+	@cd audio;  make clean
+	@cd tde; make clean
+
+cleanall:
+	@cd hifb;   make clean;   make cleanstream
+	@cd vio;    make clean;   make cleanstream
+	@cd venc;   make clean;   make cleanstream
+	@cd vdec;   make clean;   make cleanstream
+	@cd region;    make clean;   make cleanstream
+	@cd vda;    make clean;   make cleanstream
+	@cd audio;  make clean;   make cleanstream
+	@cd tde; make clean
+

--- a/libraries/mpp_sample/hi3520dv200/Makefile.param
+++ b/libraries/mpp_sample/hi3520dv200/Makefile.param
@@ -1,0 +1,27 @@
+# Hisilicon Hi3520D sample Makefile.param
+
+ifeq ($(PARAM_FILE), )
+     PARAM_FILE:=../../Makefile.param
+     include $(PARAM_FILE)
+endif
+
+#demo or socket, just useful for hi3520D
+HI3520D_BOARD=DEMO
+#HI3520D_BOARD=SOCKET
+
+
+COMMON_DIR:=$(PWD)/../common
+
+INC_FLAGS := -I$(REL_INC) 
+INC_FLAGS += -I$(COMMON_DIR) 
+INC_FLAGS += -I$(SDK_PATH)/mpp/$(EXTDRV)/tw2865 
+INC_FLAGS += -I$(SDK_PATH)/mpp/$(EXTDRV)/tw2960 
+INC_FLAGS += -I$(SDK_PATH)/mpp/$(EXTDRV)/tlv320aic31 
+INC_FLAGS += -I$(SDK_PATH)/mpp/$(EXTDRV)/cx26828
+INC_FLAGS += -I$(SDK_PATH)/mpp/$(EXTDRV)/nvp6114
+
+CFLAGS := -Wall -g $(INC_FLAGS) -D$(HIARCH) -DHICHIP=$(HICHIP) -D$(HIDBG) -D$(HI_FPGA) -D$(HI3520D_BOARD) -lpthread -lm
+
+CFLAGS += -Wl,-gc-sections
+COMM_SRC := $(wildcard $(COMMON_DIR)/*.c)
+COMM_OBJ := $(COMM_SRC:%.c=%.o)

--- a/libraries/mpp_sample/hi3520dv200/audio/Makefile
+++ b/libraries/mpp_sample/hi3520dv200/audio/Makefile
@@ -1,0 +1,33 @@
+# Hisilicon Hi3516 sample Makefile
+
+include ../Makefile.param
+#ifeq ($(SAMPLE_PARAM_FILE), )
+#     SAMPLE_PARAM_FILE:=../Makefile.param
+#     include $(SAMPLE_PARAM_FILE)
+#endif
+
+# target source
+SRC  := $(wildcard *.c) 
+OBJ  := $(SRC:%.c=%.o)
+
+TARGET := $(OBJ:%.o=%)
+.PHONY : clean all
+
+all: $(TARGET)
+
+MPI_LIBS := $(REL_LIB)/libmpi.a
+MPI_LIBS += $(REL_LIB)/libhdmi.a
+
+$(TARGET):%:%.o $(COMM_OBJ)
+	$(CC) $(CFLAGS) -lpthread -lm -o $@ $^ $(MPI_LIBS) $(AUDIO_LIBA) $(JPEGD_LIBA)
+
+clean:
+	@rm -f $(TARGET)
+	@rm -f $(OBJ)
+	@rm -f $(COMM_OBJ)
+
+cleanstream:
+	@rm -f *.h264
+	@rm -f *.jpg
+	@rm -f *.mjp
+	@rm -f *.mp4

--- a/libraries/mpp_sample/hi3520dv200/audio/sample_audio.c
+++ b/libraries/mpp_sample/hi3520dv200/audio/sample_audio.c
@@ -1,0 +1,658 @@
+/******************************************************************************
+  A simple program of Hisilicon HI3516 audio input/output/encoder/decoder implementation.
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-2 Created
+******************************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <errno.h>
+#include <signal.h>
+
+#include "sample_comm.h"
+//#include "acodec.h"
+#include "tw2865.h"
+#include "tlv320aic31.h"
+#include "cx26828.h"
+
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#define SAMPLE_AUDIO_PTNUMPERFRM   320
+
+#define SAMPLE_AUDIO_AI_DEV 0
+
+#define SAMPLE_AUDIO_AO_DEV 0
+
+
+static PAYLOAD_TYPE_E gs_enPayloadType = PT_ADPCMA;
+
+static HI_BOOL gs_bMicIn = HI_FALSE;
+
+static HI_BOOL gs_bAiAnr = HI_FALSE;
+static HI_BOOL gs_bAioReSample = HI_FALSE;
+static HI_BOOL gs_bUserGetMode = HI_FALSE;
+static AUDIO_RESAMPLE_ATTR_S *gs_pstAiReSmpAttr = NULL;
+static AUDIO_RESAMPLE_ATTR_S *gs_pstAoReSmpAttr = NULL;
+
+#define SAMPLE_DBG(s32Ret)\
+do{\
+    printf("s32Ret=%#x,fuc:%s,line:%d\n", s32Ret, __FUNCTION__, __LINE__);\
+}while(0)
+
+/******************************************************************************
+* function : PT Number to String
+******************************************************************************/
+static char* SAMPLE_AUDIO_Pt2Str(PAYLOAD_TYPE_E enType)
+{
+    if (PT_G711A == enType)  return "g711a";
+    else if (PT_G711U == enType)  return "g711u";
+    else if (PT_ADPCMA == enType)  return "adpcm";
+    else if (PT_G726 == enType)  return "g726";
+    else if (PT_LPCM == enType)  return "pcm";
+    else return "data";
+}
+
+/******************************************************************************
+* function : Open Aenc File
+******************************************************************************/
+static FILE * SAMPLE_AUDIO_OpenAencFile(AENC_CHN AeChn, PAYLOAD_TYPE_E enType)
+{
+    FILE *pfd;
+    HI_CHAR aszFileName[128];
+    
+    /* create file for save stream*/
+    sprintf(aszFileName, "audio_chn%d.%s", AeChn, SAMPLE_AUDIO_Pt2Str(enType));
+    pfd = fopen(aszFileName, "w+");
+    if (NULL == pfd)
+    {
+        printf("%s: open file %s failed\n", __FUNCTION__, aszFileName);
+        return NULL;
+    }
+    printf("open stream file:\"%s\" for aenc ok\n", aszFileName);
+    return pfd;
+}
+
+/******************************************************************************
+* function : Open Adec File
+******************************************************************************/
+static FILE *SAMPLE_AUDIO_OpenAdecFile(ADEC_CHN AdChn, PAYLOAD_TYPE_E enType)
+{
+    FILE *pfd;
+    HI_CHAR aszFileName[128];
+    
+    /* create file for save stream*/        
+    sprintf(aszFileName, "audio_chn%d.%s", AdChn, SAMPLE_AUDIO_Pt2Str(enType));
+    pfd = fopen(aszFileName, "rb");
+    if (NULL == pfd)
+    {
+        printf("%s: open file %s failed\n", __FUNCTION__, aszFileName);
+        return NULL;
+    }
+    printf("open stream file:\"%s\" for adec ok\n", aszFileName);
+    return pfd;
+}
+
+
+/******************************************************************************
+* function : file -> ADec -> Ao
+******************************************************************************/
+HI_S32 SAMPLE_AUDIO_AdecAo(AIO_ATTR_S *pstAioAttr)
+{
+    HI_S32      s32Ret;
+    AUDIO_DEV   AoDev = SAMPLE_AUDIO_AO_DEV;
+    AO_CHN      AoChn = 0;
+    ADEC_CHN    AdChn = 0;
+    FILE        *pfd = NULL;
+
+    if (NULL == pstAioAttr)
+    {
+        printf("[Func]:%s [Line]:%d [Info]:%s\n", __FUNCTION__, __LINE__, "NULL pointer");
+        return HI_FAILURE;
+    }
+
+    s32Ret = SAMPLE_COMM_AUDIO_CfgAcodec(pstAioAttr, gs_bMicIn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+    
+    s32Ret = SAMPLE_COMM_AUDIO_StartAdec(AdChn, gs_enPayloadType);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+
+    s32Ret = SAMPLE_COMM_AUDIO_StartAo(AoDev, AoChn, pstAioAttr, gs_pstAoReSmpAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+
+    s32Ret = SAMPLE_COMM_AUDIO_AoBindAdec(AoDev, AoChn, AdChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+
+    pfd = SAMPLE_AUDIO_OpenAdecFile(AdChn, gs_enPayloadType);
+    if (!pfd)
+    {
+        SAMPLE_DBG(HI_FAILURE);
+        return HI_FAILURE;
+    }
+    s32Ret = SAMPLE_COMM_AUDIO_CreatTrdFileAdec(AdChn, pfd);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+    
+    printf("bind adec:%d to ao(%d,%d) ok \n", AdChn, AoDev, AoChn);
+
+    printf("\nplease press twice ENTER to exit this sample\n");
+    getchar();
+    getchar();
+
+    SAMPLE_COMM_AUDIO_DestoryTrdFileAdec(AdChn);
+    SAMPLE_COMM_AUDIO_StopAo(AoDev, AoChn, gs_bAioReSample);
+    SAMPLE_COMM_AUDIO_StopAdec(AdChn);
+    SAMPLE_COMM_AUDIO_AoUnbindAdec(AoDev, AoChn, AdChn);
+    
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Ai -> Aenc -> file
+*                                -> Adec -> Ao
+******************************************************************************/
+HI_S32 SAMPLE_AUDIO_AiAenc(AIO_ATTR_S *pstAioAttr)
+{
+    HI_S32 i, s32Ret;
+    AUDIO_DEV   AiDev = SAMPLE_AUDIO_AI_DEV;
+    AI_CHN      AiChn;
+    AUDIO_DEV   AoDev = SAMPLE_AUDIO_AO_DEV;
+    AO_CHN      AoChn = 0;
+    ADEC_CHN    AdChn = 0;
+    HI_S32      s32AiChnCnt;
+    HI_S32      s32AencChnCnt;
+    AENC_CHN    AeChn;
+    HI_BOOL     bSendAdec = HI_TRUE;
+    FILE        *pfd = NULL;
+
+    /* config ai aenc dev attr */
+    if (NULL == pstAioAttr)
+    {
+        printf("[Func]:%s [Line]:%d [Info]:%s\n", __FUNCTION__, __LINE__, "NULL pointer");
+        return HI_FAILURE;
+    }
+
+    /********************************************
+      step 1: config audio codec
+    ********************************************/
+    s32Ret = SAMPLE_COMM_AUDIO_CfgAcodec(pstAioAttr, gs_bMicIn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+
+    /********************************************
+      step 2: start Ai
+    ********************************************/
+    s32AiChnCnt = pstAioAttr->u32ChnCnt; 
+    s32AencChnCnt = 1;//s32AiChnCnt;
+    s32Ret = SAMPLE_COMM_AUDIO_StartAi(AiDev, s32AiChnCnt, pstAioAttr, gs_bAiAnr, gs_pstAiReSmpAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+
+    /********************************************
+      step 3: start Aenc
+    ********************************************/
+    s32Ret = SAMPLE_COMM_AUDIO_StartAenc(s32AencChnCnt, gs_enPayloadType);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+
+    /********************************************
+      step 4: Aenc bind Ai Chn
+    ********************************************/
+    for (i=0; i<s32AencChnCnt; i++)
+    {
+        AeChn = i;
+        AiChn = i;
+
+        if (HI_TRUE == gs_bUserGetMode)
+        {
+            s32Ret = SAMPLE_COMM_AUDIO_CreatTrdAiAenc(AiDev, AiChn, AeChn);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_DBG(s32Ret);
+                return HI_FAILURE;
+            }
+        }
+        else
+        {        
+            s32Ret = SAMPLE_COMM_AUDIO_AencBindAi(AiDev, AiChn, AeChn);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_DBG(s32Ret);
+                return s32Ret;
+            }
+        }
+        printf("Ai(%d,%d) bind to AencChn:%d ok!\n",AiDev , AiChn, AeChn);
+    }
+
+    /********************************************
+      step 5: start Adec & Ao. ( if you want )
+    ********************************************/
+    if (HI_TRUE == bSendAdec)
+    {
+        s32Ret = SAMPLE_COMM_AUDIO_StartAdec(AdChn, gs_enPayloadType);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_DBG(s32Ret);
+            return HI_FAILURE;
+        }
+
+        s32Ret = SAMPLE_COMM_AUDIO_StartAo(AoDev, AoChn, pstAioAttr, gs_pstAoReSmpAttr);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_DBG(s32Ret);
+            return HI_FAILURE;
+        }
+
+        pfd = SAMPLE_AUDIO_OpenAencFile(AdChn, gs_enPayloadType);
+        if (!pfd)
+        {
+            SAMPLE_DBG(HI_FAILURE);
+            return HI_FAILURE;
+        }        
+        s32Ret = SAMPLE_COMM_AUDIO_CreatTrdAencAdec(AeChn, AdChn, pfd);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_DBG(s32Ret);
+            return HI_FAILURE;
+        }
+
+        s32Ret = SAMPLE_COMM_AUDIO_AoBindAdec(AoDev, AoChn, AdChn);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_DBG(s32Ret);
+            return HI_FAILURE;
+        }
+
+        printf("bind adec:%d to ao(%d,%d) ok \n", AdChn, AoDev, AoChn);
+    }
+
+    printf("\nplease press twice ENTER to exit this sample\n");
+    getchar();
+    getchar();
+
+    /********************************************
+      step 6: exit the process
+    ********************************************/
+    if (HI_TRUE == bSendAdec)
+    {
+        SAMPLE_COMM_AUDIO_DestoryTrdAencAdec(AdChn);
+        SAMPLE_COMM_AUDIO_StopAo(AoDev, AoChn, gs_bAioReSample);
+        SAMPLE_COMM_AUDIO_StopAdec(AdChn);
+        SAMPLE_COMM_AUDIO_AoUnbindAdec(AoDev, AoChn, AdChn);
+    }
+    
+    for (i=0; i<s32AencChnCnt; i++)
+    {
+        AeChn = i;
+        AiChn = i;
+
+        if (HI_TRUE == gs_bUserGetMode)
+        {
+            SAMPLE_COMM_AUDIO_DestoryTrdAi(AiDev, AiChn);
+        }
+        else
+        {        
+            SAMPLE_COMM_AUDIO_AencUnbindAi(AiDev, AiChn, AeChn);
+        }
+    }
+    
+    SAMPLE_COMM_AUDIO_StopAenc(s32AencChnCnt);
+    SAMPLE_COMM_AUDIO_StopAi(AiDev, s32AiChnCnt, gs_bAiAnr, gs_bAioReSample);
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Ai -> Ao
+******************************************************************************/
+HI_S32 SAMPLE_AUDIO_AiAo(AIO_ATTR_S *pstAioAttr)
+{
+    HI_S32 s32Ret, s32AiChnCnt;
+    AUDIO_DEV   AiDev = SAMPLE_AUDIO_AI_DEV;
+    AI_CHN      AiChn = 0;
+    AUDIO_DEV   AoDev = SAMPLE_AUDIO_AO_DEV;
+    AO_CHN      AoChn = 0;
+
+    /* config aio dev attr */
+    if (NULL == pstAioAttr)
+    {
+        printf("[Func]:%s [Line]:%d [Info]:%s\n", __FUNCTION__, __LINE__, "NULL pointer");
+        return HI_FAILURE;
+    }
+    
+    /* config audio codec */
+    s32Ret = SAMPLE_COMM_AUDIO_CfgAcodec(pstAioAttr, gs_bMicIn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+    
+    /* enable AI channle */    
+    s32AiChnCnt = pstAioAttr->u32ChnCnt;
+    s32Ret = SAMPLE_COMM_AUDIO_StartAi(AiDev, s32AiChnCnt, pstAioAttr, gs_bAiAnr, gs_pstAiReSmpAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+
+    /* enable AO channle */
+    pstAioAttr->u32ChnCnt = 2;
+    s32Ret = SAMPLE_COMM_AUDIO_StartAo(AoDev, AoChn, pstAioAttr, gs_pstAoReSmpAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+
+    /* bind AI to AO channle */
+    if (HI_TRUE == gs_bUserGetMode)
+    {
+        s32Ret = SAMPLE_COMM_AUDIO_CreatTrdAiAo(AiDev, AiChn, AoDev, AoChn);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_DBG(s32Ret);
+            return HI_FAILURE;
+        }
+    }
+    else
+    {   
+        s32Ret = SAMPLE_COMM_AUDIO_AoBindAi(AiDev, AiChn, AoDev, AoChn);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_DBG(s32Ret);
+            return HI_FAILURE;
+        }
+    }
+    printf("ai(%d,%d) bind to ao(%d,%d) ok\n", AiDev, AiChn, AoDev, AoChn);
+
+    printf("\nplease press twice ENTER to exit this sample\n");
+    getchar();
+    getchar();
+
+    if (HI_TRUE == gs_bUserGetMode)
+    {
+        SAMPLE_COMM_AUDIO_DestoryTrdAi(AiDev, AiChn);
+    }
+    else
+    {
+        SAMPLE_COMM_AUDIO_AoUnbindAi(AiDev, AiChn, AoDev, AoChn);
+    }
+    SAMPLE_COMM_AUDIO_StopAi(AiDev, s32AiChnCnt, gs_bAiAnr, gs_bAioReSample);
+    SAMPLE_COMM_AUDIO_StopAo(AoDev, AoChn, gs_bAioReSample);
+    return HI_SUCCESS;
+}
+
+
+/******************************************************************************
+* function : Ai -> Ao(Hdmi)
+******************************************************************************/
+HI_S32 SAMPLE_AUDIO_AiHdmiAo(AIO_ATTR_S *pstAiAttr, AIO_ATTR_S *pstHdmiAoAttr)
+{
+    HI_S32 s32Ret, s32AiChnCnt;
+    AUDIO_DEV   AiDev = SAMPLE_AUDIO_AI_DEV;
+    AI_CHN      AiChn = 0;
+    AUDIO_DEV   AoDev = SAMPLE_AUDIO_HDMI_AO_DEV;
+    AO_CHN      AoChn = 0;
+
+    /* config aio dev attr */
+    if (NULL == pstAiAttr)
+    {
+        printf("[Func]:%s [Line]:%d [Info]:%s\n", __FUNCTION__, __LINE__, "NULL pointer");
+        return HI_FAILURE;
+    }
+    
+    /* config audio codec */
+    s32Ret = SAMPLE_COMM_AUDIO_CfgAcodec(pstAiAttr, gs_bMicIn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+    
+    /* enable AI channle */    
+    s32AiChnCnt = pstAiAttr->u32ChnCnt;
+    s32Ret = SAMPLE_COMM_AUDIO_StartAi(AiDev, s32AiChnCnt, pstAiAttr, gs_bAiAnr, gs_pstAiReSmpAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+
+    /* enable AO channle */
+    s32Ret = SAMPLE_COMM_AUDIO_StartAo(AoDev, AoChn, pstHdmiAoAttr, gs_pstAoReSmpAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+
+    /* AI to AO channel */
+    s32Ret = SAMPLE_COMM_AUDIO_CreatTrdAiAo(AiDev, AiChn, AoDev, AoChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_DBG(s32Ret);
+        return HI_FAILURE;
+    }
+
+    printf("\nplease press twice ENTER to exit this sample\n");
+    getchar();
+    getchar();
+
+    SAMPLE_COMM_AUDIO_DestoryTrdAi(AiDev, AiChn);
+    SAMPLE_COMM_AUDIO_StopAi(AiDev, s32AiChnCnt, gs_bAiAnr, gs_bAioReSample);
+    SAMPLE_COMM_AUDIO_StopAo(AoDev, AoChn, gs_bAioReSample);
+    return HI_SUCCESS;
+}
+
+HI_VOID SAMPLE_AUDIO_Usage(void)
+{
+    printf("\n/************************************/\n");
+    printf("press sample command as follows!\n");
+    printf("1:  start AI to AO loop\n");
+    printf("2:  send audio frame to AENC channel from AI, save them\n");
+    printf("3:  read audio stream from file,decode and send AO\n");
+    printf("4:  start AI to AO(Hdmi) loop\n");
+    printf("q:  quit whole audio sample\n\n");
+    printf("sample command:");
+}
+
+/******************************************************************************
+* function : to process abnormal case
+******************************************************************************/
+void SAMPLE_AUDIO_HandleSig(HI_S32 signo)
+{
+    if (SIGINT == signo || SIGTSTP == signo)
+    {
+        SAMPLE_COMM_SYS_Exit();
+        printf("\033[0;31mprogram exit abnormally!\033[0;39m\n");
+    }
+
+    exit(0);
+}
+
+/******************************************************************************
+* function : main
+******************************************************************************/
+HI_S32 main(int argc, char *argv[])
+{
+    char ch;
+    HI_S32 s32Ret= HI_SUCCESS;
+    VB_CONF_S stVbConf;
+    AIO_ATTR_S stAioAttr;
+    AUDIO_RESAMPLE_ATTR_S stAiReSampleAttr;
+    AUDIO_RESAMPLE_ATTR_S stAoReSampleAttr;
+    AIO_ATTR_S stHdmiAoAttr;
+        
+    /* arg 1 is audio payload type */
+    if (argc >= 2)
+    {
+        gs_enPayloadType = atoi(argv[1]);
+
+        if (gs_enPayloadType != PT_G711A && gs_enPayloadType != PT_G711U &&\
+            gs_enPayloadType != PT_ADPCMA && gs_enPayloadType != PT_G726 &&\
+            gs_enPayloadType != PT_LPCM)
+        {
+            printf("payload type invalid!\n");
+            printf("\nargv[1]:%d is payload type ID, suport such type:\n", gs_enPayloadType);
+            printf("%d:g711a, %d:g711u, %d:adpcm, %d:g726, %d:lpcm\n",
+            PT_G711A, PT_G711U, PT_ADPCMA, PT_G726, PT_LPCM);
+            return HI_FAILURE;
+        }
+    }
+
+    /* init stAio. all of cases will use it */
+    stAioAttr.enSamplerate = AUDIO_SAMPLE_RATE_8000;
+    stAioAttr.enBitwidth = AUDIO_BIT_WIDTH_16;
+    stAioAttr.enWorkmode = AIO_MODE_I2S_SLAVE;
+    stAioAttr.enSoundmode = AUDIO_SOUND_MODE_MONO;
+    stAioAttr.u32EXFlag = 1;
+    stAioAttr.u32FrmNum = 30;
+    stAioAttr.u32PtNumPerFrm = SAMPLE_AUDIO_PTNUMPERFRM;
+    stAioAttr.u32ChnCnt = 2;
+    stAioAttr.u32ClkSel = 0;
+
+    /* config ao resample attr if needed */
+    if (HI_TRUE == gs_bAioReSample)
+    {
+        stAioAttr.enSamplerate = AUDIO_SAMPLE_RATE_32000;
+        stAioAttr.u32PtNumPerFrm = SAMPLE_AUDIO_PTNUMPERFRM * 4;
+
+        /* ai 32k -> 8k */
+        stAiReSampleAttr.u32InPointNum = SAMPLE_AUDIO_PTNUMPERFRM * 4;
+        stAiReSampleAttr.enInSampleRate = AUDIO_SAMPLE_RATE_32000;
+        stAiReSampleAttr.enReSampleType = AUDIO_RESAMPLE_4X1;
+        gs_pstAiReSmpAttr = &stAiReSampleAttr;
+
+        /* ao 8k -> 32k */
+        stAoReSampleAttr.u32InPointNum = SAMPLE_AUDIO_PTNUMPERFRM;
+        stAoReSampleAttr.enInSampleRate = AUDIO_SAMPLE_RATE_8000;
+        stAoReSampleAttr.enReSampleType = AUDIO_RESAMPLE_1X4;
+        gs_pstAoReSmpAttr = &stAoReSampleAttr;
+    }
+    else
+    {
+        gs_pstAiReSmpAttr = NULL;
+        gs_pstAoReSmpAttr = NULL;
+    }
+
+    /* resample and anr should be user get mode */
+    gs_bUserGetMode = (HI_TRUE == gs_bAioReSample || HI_TRUE == gs_bAiAnr) ? HI_TRUE : HI_FALSE;    
+
+    signal(SIGINT, SAMPLE_AUDIO_HandleSig);
+    signal(SIGTERM, SAMPLE_AUDIO_HandleSig);
+    
+    memset(&stVbConf, 0, sizeof(VB_CONF_S));
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        printf("%s: system init failed with %d!\n", __FUNCTION__, s32Ret);
+        return HI_FAILURE;
+    }
+
+    SAMPLE_AUDIO_Usage();
+    
+    while ((ch = getchar()) != 'q')
+    {
+        switch (ch)
+        {
+            case '1':
+            {
+                s32Ret = SAMPLE_AUDIO_AiAo(&stAioAttr);/* AI to AO*/
+                break;
+            }
+            case '2':
+            {
+                s32Ret = SAMPLE_AUDIO_AiAenc(&stAioAttr);/* send audio frame to AENC channel form AI, save them*/
+                break;
+            }
+            case '3':
+            {
+                s32Ret = SAMPLE_AUDIO_AdecAo(&stAioAttr);/* read audio stream from file,decode and send AO*/
+                break;
+            }
+            
+            case '4':
+            {
+                gs_pstAiReSmpAttr = NULL;
+                
+                /* ao 8k -> 48k */
+                stAoReSampleAttr.u32InPointNum = SAMPLE_AUDIO_PTNUMPERFRM;
+                stAoReSampleAttr.enInSampleRate = AUDIO_SAMPLE_RATE_8000;
+                stAoReSampleAttr.enReSampleType = AUDIO_RESAMPLE_1X6;
+                gs_pstAoReSmpAttr = &stAoReSampleAttr;
+                
+                memcpy(&stHdmiAoAttr, &stAioAttr, sizeof(AIO_ATTR_S));
+                stHdmiAoAttr.enBitwidth = AUDIO_BIT_WIDTH_16;
+                stHdmiAoAttr.enSamplerate = AUDIO_SAMPLE_RATE_48000;
+                stHdmiAoAttr.u32PtNumPerFrm = stAioAttr.u32PtNumPerFrm * 6;
+                stHdmiAoAttr.enWorkmode = AIO_MODE_I2S_MASTER;
+                stHdmiAoAttr.u32ChnCnt = 2;
+                s32Ret = SAMPLE_AUDIO_AiHdmiAo(&stAioAttr, &stHdmiAoAttr);/* AI to AO(Hdmi)*/
+                gs_pstAoReSmpAttr = NULL;
+                break;
+            }
+            
+            default:
+            {
+                SAMPLE_AUDIO_Usage();
+                break;
+            }
+        }
+        if (s32Ret != HI_SUCCESS)
+        {
+            break;
+        }
+    }
+
+    SAMPLE_COMM_SYS_Exit();
+
+    return HI_SUCCESS;
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif 
+#endif /* End of #ifdef __cplusplus */

--- a/libraries/mpp_sample/hi3520dv200/common/loadbmp.c
+++ b/libraries/mpp_sample/hi3520dv200/common/loadbmp.c
@@ -1,0 +1,427 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include "loadbmp.h"
+
+OSD_COMP_INFO s_OSDCompInfo[OSD_COLOR_FMT_BUTT] = {{0, 4, 4, 4},   /*RGB444*/
+                                                    {4, 4, 4, 4},   /*ARGB4444*/
+                                                    {0, 5, 5, 5},   /*RGB555*/
+                                                    {0, 5, 6, 5},   /*RGB565*/
+                                                    {1, 5, 5, 5},   /*ARGB1555*/
+                                                    {0, 0, 0, 0},   /*RESERVED*/
+                                                    {0, 8, 8, 8},   /*RGB888*/
+                                                    {8, 8, 8, 8}    /*ARGB8888*/
+                                                    };
+inline HI_U16 OSD_MAKECOLOR_U16(HI_U8 r, HI_U8 g, HI_U8 b, OSD_COMP_INFO compinfo)
+{
+    HI_U8 r1, g1, b1;
+    HI_U16 pixel = 0;
+    HI_U32 tmp = 15;
+
+    r1 = g1 = b1 = 0;
+    r1 = r >> (8 - compinfo.rlen);
+    g1 = g >> (8 - compinfo.glen);
+    b1 = b >> (8 - compinfo.blen);
+    while(compinfo.alen)
+    {
+        pixel |= (1 << tmp);
+        tmp --;
+        compinfo.alen--;
+    }
+    
+    pixel |= (r1 | (g1 << compinfo.blen) | (b1 << (compinfo.blen + compinfo.glen)));
+    return pixel;
+}
+
+HI_S32 GetBmpInfo(const char *filename,     OSD_BITMAPFILEHEADER  *pBmpFileHeader
+,OSD_BITMAPINFO *pBmpInfo)
+{
+    FILE *pFile;
+
+    HI_U16    bfType;
+
+    if(NULL == filename)
+    {
+        printf("OSD_LoadBMP: filename=NULL\n");
+        return -1;
+    }
+
+    if( (pFile = fopen((char *)filename, "rb")) == NULL)
+    {
+        printf("Open file faild:%s!\n", filename);
+        return -1;
+    }
+
+    (void)fread(&bfType, 1, sizeof(bfType), pFile);
+    if(bfType != 0x4d42)
+    {
+        printf("not bitmap file\n");
+        fclose(pFile);
+        return -1;
+    }
+    
+    (void)fread(pBmpFileHeader, 1, sizeof(OSD_BITMAPFILEHEADER), pFile);
+    (void)fread(pBmpInfo, 1, sizeof(OSD_BITMAPINFO), pFile);
+    fclose(pFile);
+    
+    return 0;  
+}
+
+int LoadBMP(const char *filename, OSD_LOGO_T *pVideoLogo)
+{
+    FILE *pFile;
+    HI_U16  i,j;
+
+    HI_U32  w,h;
+    HI_U16 Bpp;
+    HI_U16 dstBpp;
+
+    OSD_BITMAPFILEHEADER  bmpFileHeader;
+    OSD_BITMAPINFO            bmpInfo;
+
+    HI_U8 *pOrigBMPBuf;
+    HI_U8 *pRGBBuf;
+    HI_U32 stride;
+    
+    if(NULL == filename)
+    {
+        printf("OSD_LoadBMP: filename=NULL\n");
+        return -1;
+    }
+    
+    if(GetBmpInfo(filename,&bmpFileHeader,&bmpInfo)<0)
+    {
+        return -1;
+    }
+
+    Bpp = bmpInfo.bmiHeader.biBitCount/8;
+    if(Bpp < 2)
+    {
+        /* only support 1555.8888  888 bitmap */
+        printf("bitmap format not supported!\n");
+        return -1;
+    }
+    
+    if(bmpInfo.bmiHeader.biCompression != 0)
+    {
+        printf("not support compressed bitmap file!\n");
+        return -1;
+    }
+
+    if(bmpInfo.bmiHeader.biHeight < 0)
+    {
+        printf("bmpInfo.bmiHeader.biHeight < 0\n");
+        return -1;
+    }
+
+    if( (pFile = fopen((char *)filename, "rb")) == NULL)
+    {
+        printf("Open file faild:%s!\n", filename);
+        return -1;
+    }
+
+    pVideoLogo->width = (HI_U16)bmpInfo.bmiHeader.biWidth;
+    pVideoLogo->height = (HI_U16)((bmpInfo.bmiHeader.biHeight>0)?bmpInfo.bmiHeader.biHeight:(-bmpInfo.bmiHeader.biHeight));
+    w = pVideoLogo->width;
+    h = pVideoLogo->height;
+
+    stride = w*Bpp;
+#if 1    
+    if(stride%4)
+    {
+        stride = stride&&0xfffc + 4;
+    }
+#endif    
+    /* RGB8888 or RGB1555 */
+    pOrigBMPBuf = (HI_U8 *)malloc(h*stride);
+    if(NULL == pOrigBMPBuf)
+    {
+        printf("not enough memory to malloc!\n");
+        fclose(pFile);
+        return -1;
+    }
+    
+    pRGBBuf = pVideoLogo->pRGBBuffer;
+
+    fseek(pFile, bmpFileHeader.bfOffBits, 0);
+    if(fread(pOrigBMPBuf, 1, h*stride, pFile) != (h*stride) )
+    {
+        printf("fread error!line:%d\n",__LINE__);
+		perror("fread:");
+    }
+
+    if(Bpp > 2)
+    {
+        dstBpp = 4;
+    }
+    else
+    {
+        dstBpp = 2;
+    }
+
+    if(0 == pVideoLogo->stride)
+    {
+     	pVideoLogo->stride = pVideoLogo->width * dstBpp;
+     }
+    
+    for(i=0; i<h; i++)
+    {
+        for(j=0; j<w; j++)
+        {
+            memcpy(pRGBBuf + i*pVideoLogo->stride + j*dstBpp, pOrigBMPBuf + ((h-1)-i)*stride+j*Bpp, Bpp);
+           
+            if(dstBpp == 4)
+            {
+                //*(pRGBBuf + i*pVideoLogo->stride + j*dstbpp + 3) = random()&0xff; /*alpha*/
+                *(pRGBBuf + i*pVideoLogo->stride + j*dstBpp + 3) = 0x80; /*alpha*/
+            }
+        }
+        
+    }
+
+    free(pOrigBMPBuf);
+    pOrigBMPBuf = NULL;
+
+    fclose(pFile);
+    return 0;
+}
+
+int LoadBMPEx(const char *filename, OSD_LOGO_T *pVideoLogo, OSD_COLOR_FMT_E enFmt)
+{
+    FILE *pFile;
+    HI_U16  i,j;
+
+    HI_U32  w,h;
+    HI_U16 Bpp;
+
+    OSD_BITMAPFILEHEADER  bmpFileHeader;
+    OSD_BITMAPINFO            bmpInfo;
+
+    HI_U8 *pOrigBMPBuf;
+    HI_U8 *pRGBBuf;
+    HI_U32 stride;
+    HI_U8 r, g, b;
+    HI_U8 *pStart;
+    HI_U16 *pDst;
+
+    if(NULL == filename)
+    {
+        printf("OSD_LoadBMP: filename=NULL\n");
+        return -1;
+    }
+    
+    if(GetBmpInfo(filename,&bmpFileHeader,&bmpInfo)<0)
+    {
+        return -1;
+    }
+
+    Bpp = bmpInfo.bmiHeader.biBitCount/8;
+    if(Bpp < 2)
+    {
+        /* only support 1555.8888  888 bitmap */
+        printf("bitmap format not supported!\n");
+        return -1;
+    }
+    
+    if(bmpInfo.bmiHeader.biCompression != 0)
+    {
+        printf("not support compressed bitmap file!\n");
+        return -1;
+    }
+
+    if(bmpInfo.bmiHeader.biHeight < 0)
+    {
+        printf("bmpInfo.bmiHeader.biHeight < 0\n");
+        return -1;
+    }
+
+    if( (pFile = fopen((char *)filename, "rb")) == NULL)
+    {
+        printf("Open file faild:%s!\n", filename);
+        return -1;
+    }
+    
+    pVideoLogo->width = (HI_U16)bmpInfo.bmiHeader.biWidth;
+    pVideoLogo->height = (HI_U16)((bmpInfo.bmiHeader.biHeight>0)?bmpInfo.bmiHeader.biHeight:(-bmpInfo.bmiHeader.biHeight));
+    w = pVideoLogo->width;
+    h = pVideoLogo->height;
+
+    stride = w*Bpp;
+#if 1    
+	if(stride%4)
+	{
+        stride = (stride&0xfffc) + 4;
+ 	}
+#endif
+
+    /* RGB8888 or RGB1555 */
+    pOrigBMPBuf = (HI_U8 *)malloc(h*stride);
+    if(NULL == pOrigBMPBuf)
+    {
+        printf("not enough memory to malloc!\n");
+        fclose(pFile);
+        return -1;
+    }
+    
+    pRGBBuf = pVideoLogo->pRGBBuffer;
+
+    fseek(pFile, bmpFileHeader.bfOffBits, 0);
+    if(fread(pOrigBMPBuf, 1, h*stride, pFile) != (h*stride) )
+    {
+        printf("fread (%d*%d)error!line:%d\n",h,stride,__LINE__);
+		perror("fread:");
+    }
+
+    if(enFmt >= OSD_COLOR_FMT_RGB888)
+    {
+        pVideoLogo->stride = pVideoLogo->width * 4;
+    }
+    else
+    {
+		pVideoLogo->stride = pVideoLogo->width * 2;    			
+     }
+
+    for(i=0; i<h; i++)
+    {
+        for(j=0; j<w; j++)
+        {
+            if(Bpp == 3)/*.....*/
+            {
+                switch(enFmt)
+                {
+                    case OSD_COLOR_FMT_RGB444:
+                    case OSD_COLOR_FMT_RGB555:
+                    case OSD_COLOR_FMT_RGB565:
+                    case OSD_COLOR_FMT_RGB1555:
+                        /* start color convert */
+                        pStart = pOrigBMPBuf + ((h-1)-i)*stride+j*Bpp;
+                        pDst = (HI_U16*)(pRGBBuf + i*pVideoLogo->stride + j*2);
+                        r = *(pStart);
+                        g = *(pStart + 1);
+                        b = *(pStart + 2);
+                        *pDst = OSD_MAKECOLOR_U16(r, g, b, s_OSDCompInfo[enFmt]);
+                        break;
+                        
+                    case OSD_COLOR_FMT_RGB888:
+                    case OSD_COLOR_FMT_RGB8888:
+                        memcpy(pRGBBuf + i*pVideoLogo->stride + j*4, pOrigBMPBuf + ((h-1)-i)*stride+j*Bpp, Bpp);
+                        *(pRGBBuf + i*pVideoLogo->stride + j*4 + 3) = 0xff; /*alpha*/
+                        break;
+                        
+                    default:
+                        printf("file(%s), line(%d), no such format!\n", __FILE__, __LINE__);
+                        break;
+                }
+            }
+            else if((Bpp == 2)||(Bpp == 4))/*..............*/
+            {
+                memcpy(pRGBBuf + i*pVideoLogo->stride + j*Bpp, pOrigBMPBuf + ((h-1)-i)*stride+j*Bpp, Bpp);
+            }
+           
+        }
+        
+    }
+
+    free(pOrigBMPBuf);
+    pOrigBMPBuf = NULL;
+
+    fclose(pFile);
+    return 0;
+}
+
+
+char * GetExtName(char * filename)
+{
+    char *pret = NULL;
+    HI_U32 fnLen;
+
+    if(NULL == filename)
+    {
+        printf("filename can't be null!");
+        return NULL;
+    }
+
+    fnLen = strlen(filename);
+    while(fnLen)
+    {
+        pret = filename + fnLen;
+        if(*pret == '.')
+            return (pret+1);
+
+        fnLen--;
+    }
+
+    return pret;
+}
+
+
+int LoadImage(const char *filename, OSD_LOGO_T *pVideoLogo)
+{
+    char * ext = GetExtName((char *)filename);
+
+    if(strcmp(ext, "bmp") == 0)
+    {
+        if(0 != LoadBMP(filename, pVideoLogo))
+        {
+            printf("OSD_LoadBMP error!\n");
+            return -1;
+        }
+    }
+    else
+    {
+        printf("not supported image file!\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+int LoadImageEx(const char *filename, OSD_LOGO_T *pVideoLogo, OSD_COLOR_FMT_E enFmt)
+{
+    char * ext = GetExtName((char *)filename);
+
+    if(strcmp(ext, "bmp") == 0)
+    {
+        if(0 != LoadBMPEx(filename, pVideoLogo, enFmt))
+        {
+            printf("OSD_LoadBMP error!\n");
+            return -1;
+        }
+    }
+    else
+    {
+        printf("not supported image file!\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+HI_S32 LoadBitMap2Surface(const HI_CHAR *pszFileName, const OSD_SURFACE_S *pstSurface, HI_U8 *pu8Virt)
+{
+    OSD_LOGO_T stLogo;
+    stLogo.stride = pstSurface->u16Stride;
+    stLogo.pRGBBuffer = pu8Virt;
+
+    return LoadImage(pszFileName, &stLogo);
+}
+
+HI_S32 CreateSurfaceByBitMap(const HI_CHAR *pszFileName, OSD_SURFACE_S *pstSurface, HI_U8 *pu8Virt)
+{
+    OSD_LOGO_T stLogo;
+    stLogo.pRGBBuffer = pu8Virt;
+    if(LoadImageEx(pszFileName, &stLogo, pstSurface->enColorFmt) < 0)
+    {
+        printf("load bmp error!\n");
+        return -1;
+    }
+
+    pstSurface->u16Height = stLogo.height;
+    pstSurface->u16Width = stLogo.width;
+    pstSurface->u16Stride = stLogo.stride;
+    
+    return 0;
+}
+
+

--- a/libraries/mpp_sample/hi3520dv200/common/loadbmp.h
+++ b/libraries/mpp_sample/hi3520dv200/common/loadbmp.h
@@ -1,0 +1,106 @@
+#ifndef     __LOAD_BMP_H__
+#define     __LOAD_BMP_H__
+
+#include "hi_type.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+
+/* the color format OSD supported */
+typedef enum hiOSD_COLOR_FMT_E
+{
+    OSD_COLOR_FMT_RGB444    = 0,
+    OSD_COLOR_FMT_RGB4444   = 1,
+    OSD_COLOR_FMT_RGB555    = 2,
+    OSD_COLOR_FMT_RGB565    = 3,
+    OSD_COLOR_FMT_RGB1555   = 4,
+    OSD_COLOR_FMT_RGB888    = 6,
+    OSD_COLOR_FMT_RGB8888   = 7,
+    OSD_COLOR_FMT_BUTT
+}OSD_COLOR_FMT_E;
+
+typedef struct hiOSD_RGB_S
+{
+    HI_U8   u8B;
+    HI_U8   u8G;
+    HI_U8   u8R;
+    HI_U8   u8Reserved;
+}OSD_RGB_S;
+
+typedef struct hiOSD_SURFACE_S
+{
+    OSD_COLOR_FMT_E enColorFmt;         /* color format */
+    HI_U8  *pu8PhyAddr;               /* physical address */
+    HI_U16  u16Height;                /* operation height */
+    HI_U16  u16Width;                 /* operation width */
+    HI_U16  u16Stride;                /* surface stride */
+    HI_U16  u16Reserved;
+}OSD_SURFACE_S;
+
+typedef struct tag_OSD_Logo
+{
+    HI_U32    width;        /* out */
+    HI_U32    height;       /* out */
+    HI_U32    stride;       /* in */
+    HI_U8 *   pRGBBuffer;   /* in/out */
+}OSD_LOGO_T;
+
+typedef struct tag_OSD_BITMAPINFOHEADER{
+        HI_U16      biSize;
+        HI_U32       biWidth;
+        HI_S32       biHeight;
+        HI_U16       biPlanes;
+        HI_U16       biBitCount;
+        HI_U32      biCompression;
+        HI_U32      biSizeImage;
+        HI_U32       biXPelsPerMeter;
+        HI_U32       biYPelsPerMeter;
+        HI_U32      biClrUsed;
+        HI_U32      biClrImportant;
+} OSD_BITMAPINFOHEADER;
+
+typedef struct tag_OSD_BITMAPFILEHEADER {
+        HI_U32   bfSize;
+        HI_U16    bfReserved1;
+        HI_U16    bfReserved2;
+        HI_U32   bfOffBits;
+} OSD_BITMAPFILEHEADER; 
+
+typedef struct tag_OSD_RGBQUAD {
+        HI_U8    rgbBlue;
+        HI_U8    rgbGreen;
+        HI_U8    rgbRed;
+        HI_U8    rgbReserved;
+} OSD_RGBQUAD;
+
+typedef struct tag_OSD_BITMAPINFO {
+    OSD_BITMAPINFOHEADER    bmiHeader;
+    OSD_RGBQUAD                 bmiColors[1];
+} OSD_BITMAPINFO;
+
+typedef struct hiOSD_COMPONENT_INFO_S{
+
+    int alen;
+    int rlen;
+    int glen;
+    int blen;
+}OSD_COMP_INFO;
+
+HI_S32 LoadImage(const HI_CHAR *filename, OSD_LOGO_T *pVideoLogo);
+HI_S32 LoadBitMap2Surface(const HI_CHAR *pszFileName, const OSD_SURFACE_S *pstSurface, HI_U8 *pu8Virt);
+HI_S32 CreateSurfaceByBitMap(const HI_CHAR *pszFileName, OSD_SURFACE_S *pstSurface, HI_U8 *pu8Virt);
+HI_S32 GetBmpInfo(const HI_CHAR *filename, OSD_BITMAPFILEHEADER  *pBmpFileHeader,OSD_BITMAPINFO *pBmpInfo);
+
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#endif /* End of #ifndef __LOAD_BMP_H__*/
+

--- a/libraries/mpp_sample/hi3520dv200/common/sample_comm.h
+++ b/libraries/mpp_sample/hi3520dv200/common/sample_comm.h
@@ -1,0 +1,352 @@
+/******************************************************************************
+  Hisilicon HI3531 sample programs head file.
+
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-2 Created
+******************************************************************************/
+
+#ifndef __SAMPLE_COMM_H__
+#define __SAMPLE_COMM_H__
+
+#include "tw2865.h"
+#include "tw2960.h"
+
+#include "hi_common.h"
+#include "hi_comm_sys.h"
+#include "hi_comm_vb.h"
+#include "hi_comm_vi.h"
+#include "hi_comm_vo.h"
+#include "hi_comm_venc.h"
+#include "hi_comm_vpss.h"
+#include "hi_comm_vdec.h"
+#include "hi_comm_vda.h"
+#include "hi_comm_region.h"
+#include "hi_comm_adec.h"
+#include "hi_comm_aenc.h"
+#include "hi_comm_ai.h"
+#include "hi_comm_ao.h"
+#include "hi_comm_aio.h"
+#include "hi_comm_hdmi.h"
+#include "hi_defines.h"
+
+#include "mpi_sys.h"
+#include "mpi_vb.h"
+#include "mpi_vi.h"
+#include "mpi_vo.h"
+#include "mpi_venc.h"
+#include "mpi_vpss.h"
+#include "mpi_vdec.h"
+#include "mpi_vda.h"
+#include "mpi_region.h"
+#include "mpi_adec.h"
+#include "mpi_aenc.h"
+#include "mpi_ai.h"
+#include "mpi_ao.h"
+#include "mpi_hdmi.h"
+
+#include "tlv320aic31.h"
+#include "cx26828.h"
+#include "nvp6114.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+/*******************************************************
+    macro define 
+*******************************************************/
+#define ALIGN_BACK(x, a)              ((a) * (((x) / (a))))
+//#define SAMPLE_GLOBAL_NORM	    VIDEO_ENCODING_MODE_PAL
+#define SAMPLE_SYS_ALIGN_WIDTH      64
+#define SAMPLE_PIXEL_FORMAT         PIXEL_FORMAT_YUV_SEMIPLANAR_420
+#define SAMPLE_COMM_VI_GetSubChn(x) x+16
+
+#define TW2865_FILE "/dev/tw2865dev"
+#define TW2960_FILE "/dev/tw2960dev"
+#define TLV320_FILE "/dev/tlv320aic31"
+#define CX26828_FILE "/dev/cx268xx"
+#define NVP6114_FILE "/dev/nvp6114"
+
+#define D1_WIDTH 704
+
+/*** define vi chn(2/6/10/14)'s sub_chn size                                          */
+/***           vi chn(0/4/8/12)'s sub_chn size define D1 in sample program */
+#define SAMPLE_VI_SUBCHN_2_W 720
+#define SAMPLE_VI_SUBCHN_2_H  640
+
+#if HICHIP == HI3520D_V100 || HICHIP == HI3521_V100 || HICHIP == HI3520A_V100 
+#define SAMPLE_VO_DEV_DHD0 0
+#define SAMPLE_VO_DEV_DSD0 1
+#define SAMPLE_VO_DEV_DSD1 2
+#elif HICHIP == HI3531_V100 || HICHIP == HI3532_V100 
+#define SAMPLE_VO_DEV_DHD0 0
+#define SAMPLE_VO_DEV_DHD1 1
+#define SAMPLE_VO_DEV_DSD0 2
+#define SAMPLE_VO_DEV_DSD1 3
+#define SAMPLE_VO_DEV_DSD2 4
+#define SAMPLE_VO_DEV_DSD3 5
+#define SAMPLE_VO_DEV_DSD4 6
+#define SAMPLE_VO_DEV_DSD5 7
+#else
+/*
+#error HICHIP define may be error
+*/
+#endif
+
+/*** for init global parameter ***/
+#define SAMPLE_ENABLE 		    1
+#define SAMPLE_DISABLE 		    0
+#define SAMPLE_NOUSE 		    -1
+
+#if HICHIP == HI3531_V100
+#define SAMPLE_AUDIO_HDMI_AO_DEV 5
+#elif (HICHIP == HI3521_V100 || HICHIP == HI3520A_V100) 
+#define SAMPLE_AUDIO_HDMI_AO_DEV 3
+#elif (HICHIP == HI3520D_V100) 
+#define SAMPLE_AUDIO_HDMI_AO_DEV 1
+#endif
+
+
+
+
+#define SAMPLE_PRT(fmt...)   \
+    do {\
+        printf("[%s]-%d: ", __FUNCTION__, __LINE__);\
+        printf(fmt);\
+       }while(0)
+
+/*******************************************************
+    enum define 
+*******************************************************/
+typedef enum sample_vi_mode_e
+{   /* For Hi3531 or Hi3532 */
+    SAMPLE_VI_MODE_1_D1 = 0,
+    SAMPLE_VI_MODE_16_D1,
+    SAMPLE_VI_MODE_16_960H,
+    SAMPLE_VI_MODE_4_720P,
+    SAMPLE_VI_MODE_4_1080P,
+    /* For Hi3521 */
+	SAMPLE_VI_MODE_8_D1,
+	SAMPLE_VI_MODE_1_720P,
+	SAMPLE_VI_MODE_16_Cif,
+	SAMPLE_VI_MODE_16_2Cif,
+	SAMPLE_VI_MODE_16_D1Cif,
+	SAMPLE_VI_MODE_1_D1Cif,
+	/*For Hi3520A*/
+    
+    SAMPLE_VI_MODE_4_D1,
+    SAMPLE_VI_MODE_8_2Cif,
+    /*For Hi3520D*/
+    SAMPLE_VI_MODE_1_1080P,
+    SAMPLE_VI_MODE_8_D1Cif,
+}SAMPLE_VI_MODE_E;
+
+
+typedef enum 
+{
+    VI_DEV_BT656_D1_1MUX = 0,
+    VI_DEV_BT656_D1_4MUX,
+    VI_DEV_BT656_960H_1MUX,
+    VI_DEV_BT656_960H_4MUX,
+    VI_DEV_720P_HD_1MUX,
+    VI_DEV_1080P_HD_1MUX,
+    VI_DEV_BUTT
+}SAMPLE_VI_DEV_TYPE_E;
+
+typedef enum sample_vi_chn_set_e
+{
+    VI_CHN_SET_NORMAL = 0, /* mirror, filp close */
+    VI_CHN_SET_MIRROR,      /* open MIRROR */
+    VI_CHN_SET_FILP		/* open filp */
+}SAMPLE_VI_CHN_SET_E;
+
+typedef enum sample_vo_mode_e
+{
+    VO_MODE_1MUX  = 0,
+    VO_MODE_4MUX = 1,
+    VO_MODE_9MUX = 2,
+    VO_MODE_16MUX = 3,
+    VO_MODE_BUTT
+}SAMPLE_VO_MODE_E;
+
+typedef struct hisample_MEMBUF_S
+{
+    VB_BLK  hBlock;
+    VB_POOL hPool;
+    HI_U32  u32PoolId;
+    
+    HI_U32  u32PhyAddr;
+    HI_U8   *pVirAddr;
+    HI_S32  s32Mdev;
+} SAMPLE_MEMBUF_S;
+
+typedef enum sample_rc_e
+{
+    SAMPLE_RC_CBR = 0,
+    SAMPLE_RC_VBR,
+    SAMPLE_RC_FIXQP
+}SAMPLE_RC_E;
+
+typedef enum sample_rgn_change_type_e
+{
+    RGN_CHANGE_TYPE_FGALPHA = 0,
+    RGN_CHANGE_TYPE_BGALPHA,
+    RGN_CHANGE_TYPE_LAYER
+}SAMPLE_RGN_CHANGE_TYPE_EN;
+
+
+/*******************************************************
+    structure define 
+*******************************************************/
+typedef struct sample_vi_param_s
+{
+    HI_S32 s32ViDevCnt;		// VI Dev Total Count
+    HI_S32 s32ViDevInterval;	// Vi Dev Interval
+    HI_S32 s32ViChnCnt;		// Vi Chn Total Count
+    HI_S32 s32ViChnInterval;	// VI Chn Interval
+}SAMPLE_VI_PARAM_S;
+
+typedef struct sample_vo_param_s
+{
+    VO_DEV VoDev;
+    HI_CHAR acMmzName[20];
+    HI_U32 u32WndNum;
+    SAMPLE_VO_MODE_E enVoMode;
+    VO_PUB_ATTR_S stVoPubAttr;
+    HI_BOOL bVpssBind;
+}SAMPLE_VO_PARAM_S;
+
+typedef struct sample_video_loss_s
+{
+    HI_BOOL bStart;
+    pthread_t Pid;
+    SAMPLE_VI_MODE_E enViMode;
+} SAMPLE_VIDEO_LOSS_S;
+
+
+typedef struct sample_venc_getstream_s
+{
+     HI_BOOL bThreadStart;
+     HI_S32  s32Cnt;
+}SAMPLE_VENC_GETSTREAM_PARA_S;
+
+/*******************************************************
+    function announce  
+*******************************************************/
+HI_S32 SAMPLE_COMM_SYS_GetPicSize(VIDEO_NORM_E enNorm, PIC_SIZE_E enPicSize, SIZE_S *pstSize);
+HI_U32 SAMPLE_COMM_SYS_CalcPicVbBlkSize(VIDEO_NORM_E enNorm, PIC_SIZE_E enPicSize, PIXEL_FORMAT_E enPixFmt, HI_U32 u32AlignWidth);
+HI_S32 SAMPLE_COMM_SYS_MemConfig(HI_VOID);
+HI_VOID SAMPLE_COMM_SYS_Exit(void);
+HI_S32 SAMPLE_COMM_SYS_Init(VB_CONF_S *pstVbConf);
+HI_S32 SAMPLE_COMM_SYS_Payload2FilePostfix(PAYLOAD_TYPE_E enPayload, HI_CHAR* szFilePostfix);
+
+HI_S32 SAMPLE_COMM_VI_Mode2Param(SAMPLE_VI_MODE_E enViMode, SAMPLE_VI_PARAM_S *pstViParam);
+HI_S32 SAMPLE_COMM_VI_Mode2Size(SAMPLE_VI_MODE_E enViMode, VIDEO_NORM_E enNorm, RECT_S *pstCapRect, SIZE_S *pstDestSize);
+VI_DEV SAMPLE_COMM_VI_GetDev(SAMPLE_VI_MODE_E enViMode, VI_CHN ViChn);
+HI_S32 SAMPLE_COMM_VI_StartDev(VI_DEV ViDev, SAMPLE_VI_MODE_E enViMode);
+HI_S32 SAMPLE_COMM_VI_StartChn(VI_CHN ViChn, RECT_S *pstCapRect, SIZE_S *pstTarSize, 
+    SAMPLE_VI_MODE_E enViMode, SAMPLE_VI_CHN_SET_E enViChnSet);
+HI_S32 SAMPLE_COMM_VI_Start(SAMPLE_VI_MODE_E enViMode, VIDEO_NORM_E enNorm);
+HI_S32 SAMPLE_COMM_VI_Stop(SAMPLE_VI_MODE_E enViMode);
+HI_S32 SAMPLE_COMM_VI_BindVpss(SAMPLE_VI_MODE_E enViMode);
+HI_S32 SAMPLE_COMM_VI_UnBindVpss(SAMPLE_VI_MODE_E enViMode);
+HI_S32 SAMPLE_COMM_VI_MemConfig(SAMPLE_VI_MODE_E enViMode);
+HI_S32 SAMPLE_COMM_VI_GetSubChnSize(VI_CHN ViChn_Sub, VIDEO_NORM_E enNorm, SIZE_S *pstSize);
+HI_S32 SAMPLE_COMM_VI_GetVFrameFromYUV(FILE *pYUVFile, HI_U32 u32Width, HI_U32 u32Height,HI_U32 u32Stride, VIDEO_FRAME_INFO_S *pstVFrameInfo);
+HI_S32 SAMPLE_COMM_VI_ChangeCapSize(VI_CHN ViChn, HI_U32 u32CapWidth, HI_U32 u32CapHeight,HI_U32 u32Width, HI_U32 u32Height);
+HI_S32 SAMPLE_COMM_VI_MixCap_Start(SAMPLE_VI_MODE_E enViMode, VIDEO_NORM_E enNorm);
+HI_S32 SAMPLE_COMM_VI_ChangeMixCap(VI_CHN ViChn,HI_BOOL bMixCap,HI_U32 FrameRate);
+	
+HI_S32 SAMPLE_COMM_VPSS_MemConfig();
+HI_S32 SAMPLE_COMM_VPSS_Start(HI_S32 s32GrpCnt, SIZE_S *pstSize, HI_S32 s32ChnCnt,VPSS_GRP_ATTR_S *pstVpssGrpAttr);
+HI_S32 SAMPLE_COMM_VPSS_Stop(HI_S32 s32GrpCnt, HI_S32 s32ChnCnt) ;
+HI_S32 SAMPLE_COMM_DisableVpssPreScale(VPSS_GRP VpssGrp,SIZE_S stSize);
+HI_S32 SAMPLE_COMM_EnableVpssPreScale(VPSS_GRP VpssGrp,SIZE_S stSize);
+
+
+HI_S32 SAMPLE_COMM_VO_MemConfig(VO_DEV VoDev, HI_CHAR *pcMmzName);
+HI_S32 SAMPLE_COMM_VO_StartDevLayer(VO_DEV VoDev, VO_PUB_ATTR_S *pstPubAttr, HI_U32 u32SrcFrmRate);
+HI_S32 SAMPLE_COMM_VO_StopDevLayer(VO_DEV VoDev);
+HI_S32 SAMPLE_COMM_VO_StartChn(VO_DEV VoDev,VO_PUB_ATTR_S *pstPubAttr,SAMPLE_VO_MODE_E enMode);
+HI_S32 SAMPLE_COMM_VO_StopChn(VO_DEV VoDev,SAMPLE_VO_MODE_E enMode);
+HI_S32 SAMPLE_COMM_VO_BindVpss(VO_DEV VoDev,VO_CHN VoChn,VPSS_GRP VpssGrp,VPSS_CHN VpssChn);
+HI_S32 SAMPLE_COMM_VO_UnBindVpss(VO_DEV VoDev,VO_CHN VoChn,VPSS_GRP VpssGrp,VPSS_CHN VpssChn);
+HI_S32 SAMPLE_COMM_VO_BindVi(VO_DEV VoDev, VO_CHN VoChn, VI_CHN ViChn);
+HI_S32 SAMPLE_COMM_VO_UnBindVi(VO_DEV VoDev, VO_CHN VoChn);
+HI_S32 SAMPLE_COMM_VO_BindVi(VO_DEV VoDev, VO_CHN VoChn, VI_CHN ViChn);
+HI_S32 SAMPLE_COMM_VO_UnBindVi(VO_DEV VoDev, VO_CHN VoChn);
+HI_S32 SAMPLE_COMM_VO_BindVoWbc(VO_DEV VoWbcDev, VO_DEV VoDev, VO_CHN VoChn);
+HI_S32 SAMPLE_COMM_VO_UnBindVoWbc(VO_DEV VoDev, VO_CHN VoChn);
+HI_S32 SAMPLE_COMM_VO_GetWH(VO_INTF_SYNC_E enIntfSync,HI_U32 *pu32W,HI_U32 *pu32H,HI_U32 *pu32Frm);
+HI_S32 SAMPLE_COMM_VO_HdmiStart(VO_INTF_SYNC_E enIntfSync);
+HI_S32 SAMPLE_COMM_VO_HdmiStop(HI_VOID);
+
+HI_S32 SAMPLE_COMM_VENC_MemConfig(HI_VOID);
+HI_S32 SAMPLE_COMM_VENC_Start(VENC_GRP VencGrp,VENC_CHN VencChn, PAYLOAD_TYPE_E enType, VIDEO_NORM_E enNorm, PIC_SIZE_E enSize, SAMPLE_RC_E enRcMode);
+HI_S32 SAMPLE_COMM_VENC_Stop(VENC_GRP VencGrp,VENC_CHN VencChn);
+HI_S32 SAMPLE_COMM_VENC_SnapStart(VENC_GRP VencGrp,VENC_CHN VencChn, SIZE_S *pstSize);
+HI_S32 SAMPLE_COMM_VENC_SnapProcess(VENC_GRP VencGrp, VENC_CHN VencChn, VPSS_GRP VpssGrp, VPSS_CHN VpssChn);
+HI_S32 SAMPLE_COMM_VENC_SnapProcessEx(VENC_GRP VencGrp, VENC_CHN VencChn, VPSS_GRP VpssGrp, VPSS_CHN VpssChn);
+HI_S32 SAMPLE_COMM_VENC_SnapStop(VENC_GRP VencGrp,VENC_CHN VencChn);
+HI_S32 SAMPLE_COMM_VENC_StartGetStream(HI_S32 s32Cnt);
+HI_S32 SAMPLE_COMM_VENC_StopGetStream();
+HI_S32 SAMPLE_COMM_VENC_BindVpss(VENC_GRP GrpChn,VPSS_GRP VpssGrp,VPSS_CHN VpssChn);
+HI_S32 SAMPLE_COMM_VENC_UnBindVpss(VENC_GRP GrpChn,VPSS_GRP VpssGrp,VPSS_CHN VpssChn);
+
+HI_S32 SAMLE_COMM_VDEC_BindVpss(VDEC_CHN VdChn, VPSS_GRP VpssGrp);
+HI_S32 SAMLE_COMM_VDEC_UnBindVpss(VDEC_CHN VdChn, VPSS_GRP VpssGrp);
+HI_S32 SAMLE_COMM_VDEC_BindVo(VDEC_CHN VdChn, VO_DEV VoDev, VO_CHN VoChn);
+HI_S32 SAMLE_COMM_VDEC_UnBindVo(VDEC_CHN VdChn, VO_DEV VoDev, VO_CHN VoChn);
+HI_S32 SAMPLE_COMM_VDEC_MemConfig(HI_VOID);
+
+HI_S32 SAMPLE_COMM_VDA_MdStart(VDA_CHN VdaChn, VI_CHN ViChn, SIZE_S *pstSize);
+//HI_S32 SAMPLE_COMM_VDA_MdStart(VDA_CHN VdaChn, VPSS_GRP VpssGrp, VPSS_CHN VpssChn, SIZE_S *pstSize);
+HI_S32 SAMPLE_COMM_VDA_OdStart(VDA_CHN VdaChn, VI_CHN ViChn, SIZE_S *pstSize);
+HI_VOID SAMPLE_COMM_VDA_MdStop(VDA_CHN VdaChn, VI_CHN ViChn);
+HI_VOID SAMPLE_COMM_VDA_OdStop(VDA_CHN VdaChn, VI_CHN ViChn);
+
+HI_S32 SAMPLE_COMM_AUDIO_CreatTrdAiAo(AUDIO_DEV AiDev, AI_CHN AiChn, AUDIO_DEV AoDev, AO_CHN AoChn);
+HI_S32 SAMPLE_COMM_AUDIO_CreatTrdAiAenc(AUDIO_DEV AiDev, AI_CHN AiChn, AENC_CHN AeChn);
+HI_S32 SAMPLE_COMM_AUDIO_CreatTrdAencAdec(AENC_CHN AeChn, ADEC_CHN AdChn, FILE *pAecFd);
+HI_S32 SAMPLE_COMM_AUDIO_CreatTrdFileAdec(ADEC_CHN AdChn, FILE *pAdcFd);
+HI_S32 SAMPLE_COMM_AUDIO_DestoryTrdAi(AUDIO_DEV AiDev, AI_CHN AiChn);
+HI_S32 SAMPLE_COMM_AUDIO_DestoryTrdAencAdec(AENC_CHN AeChn);
+HI_S32 SAMPLE_COMM_AUDIO_DestoryTrdFileAdec(ADEC_CHN AdChn);
+HI_S32 SAMPLE_COMM_AUDIO_AoBindAdec(AUDIO_DEV AoDev, AO_CHN AoChn, ADEC_CHN AdChn);
+HI_S32 SAMPLE_COMM_AUDIO_AoUnbindAdec(AUDIO_DEV AoDev, AO_CHN AoChn, ADEC_CHN AdChn);
+HI_S32 SAMPLE_COMM_AUDIO_AoBindAi(AUDIO_DEV AiDev, AI_CHN AiChn, AUDIO_DEV AoDev, AO_CHN AoChn);
+HI_S32 SAMPLE_COMM_AUDIO_AoUnbindAi(AUDIO_DEV AiDev, AI_CHN AiChn, AUDIO_DEV AoDev, AO_CHN AoChn);
+HI_S32 SAMPLE_COMM_AUDIO_AencBindAi(AUDIO_DEV AiDev, AI_CHN AiChn, AENC_CHN AeChn);
+HI_S32 SAMPLE_COMM_AUDIO_AencUnbindAi(AUDIO_DEV AiDev, AI_CHN AiChn, AENC_CHN AeChn);
+HI_S32 SAMPLE_COMM_AUDIO_CfgAcodec(AIO_ATTR_S *pstAioAttr, HI_BOOL bMacIn);
+HI_S32 SAMPLE_COMM_AUDIO_DisableAcodec();
+HI_S32 SAMPLE_COMM_AUDIO_StartAi(AUDIO_DEV AiDevId, HI_S32 s32AiChnCnt,
+        AIO_ATTR_S *pstAioAttr, HI_BOOL bAnrEn, AUDIO_RESAMPLE_ATTR_S *pstAiReSmpAttr);
+HI_S32 SAMPLE_COMM_AUDIO_StopAi(AUDIO_DEV AiDevId, HI_S32 s32AiChnCnt,
+        HI_BOOL bAnrEn, HI_BOOL bResampleEn);
+HI_S32 SAMPLE_COMM_AUDIO_StartAo(AUDIO_DEV AoDevId, AO_CHN AoChn,
+        AIO_ATTR_S *pstAioAttr, AUDIO_RESAMPLE_ATTR_S *pstAiReSmpAttr);
+HI_S32 SAMPLE_COMM_AUDIO_StopAo(AUDIO_DEV AoDevId, AO_CHN AoChn, HI_BOOL bResampleEn);
+HI_S32 SAMPLE_COMM_AUDIO_StartAenc(HI_S32 s32AencChnCnt, PAYLOAD_TYPE_E enType);
+HI_S32 SAMPLE_COMM_AUDIO_StopAenc(HI_S32 s32AencChnCnt);
+HI_S32 SAMPLE_COMM_AUDIO_StartAdec(ADEC_CHN AdChn, PAYLOAD_TYPE_E enType);
+HI_S32 SAMPLE_COMM_AUDIO_StopAdec(ADEC_CHN AdChn);
+HI_VOID SAMPLE_COMM_VENC_ReadOneFrame( FILE * fp, HI_U8 * pY, HI_U8 * pU, HI_U8 * pV,
+                                              HI_U32 width, HI_U32 height, HI_U32 stride, HI_U32 stride2);
+
+HI_S32 SAMPLE_COMM_VENC_PlanToSemi(HI_U8 *pY, HI_S32 yStride, 
+                       HI_U8 *pU, HI_S32 uStride,
+					   HI_U8 *pV, HI_S32 vStride, 
+					   HI_S32 picWidth, HI_S32 picHeight);
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+
+#endif /* End of #ifndef __SAMPLE_COMMON_H__ */

--- a/libraries/mpp_sample/hi3520dv200/common/sample_comm_audio.c
+++ b/libraries/mpp_sample/hi3520dv200/common/sample_comm_audio.c
@@ -1,0 +1,1647 @@
+/******************************************************************************
+  A simple program of Hisilicon HI3516 audio input/output/encoder/decoder implementation.
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-2 Created
+******************************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <errno.h>
+#include <signal.h>
+
+#include "sample_comm.h"
+
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#define ACODEC_FILE     "/dev/acodec"
+
+#define AUDIO_ADPCM_TYPE ADPCM_TYPE_DVI4/* ADPCM_TYPE_IMA, ADPCM_TYPE_DVI4*/
+#define G726_BPS MEDIA_G726_40K         /* MEDIA_G726_16K, MEDIA_G726_24K ... */
+
+typedef struct tagSAMPLE_AENC_S
+{
+    HI_BOOL bStart;
+    pthread_t stAencPid;
+    HI_S32  AeChn;
+    HI_S32  AdChn;
+    FILE    *pfd;
+    HI_BOOL bSendAdChn;
+} SAMPLE_AENC_S;
+
+typedef struct tagSAMPLE_AI_S
+{
+    HI_BOOL bStart;
+    HI_S32  AiDev;
+    HI_S32  AiChn;
+    HI_S32  AencChn;
+    HI_S32  AoDev;
+    HI_S32  AoChn;
+    HI_BOOL bSendAenc;
+    HI_BOOL bSendAo;
+    pthread_t stAiPid;
+} SAMPLE_AI_S;
+
+typedef struct tagSAMPLE_ADEC_S
+{
+    HI_BOOL bStart;
+    HI_S32 AdChn;
+    FILE *pfd;
+    pthread_t stAdPid;
+} SAMPLE_ADEC_S;
+
+static SAMPLE_AI_S gs_stSampleAi[AI_DEV_MAX_NUM*AIO_MAX_CHN_NUM];
+static SAMPLE_AENC_S gs_stSampleAenc[AENC_MAX_CHN_NUM];
+static SAMPLE_ADEC_S gs_stSampleAdec[ADEC_MAX_CHN_NUM];
+
+//#define NVP_6114
+
+
+HI_S32 SAMPLE_TW2865_SetFormat(AIO_MODE_E enWorkMode)
+{
+    int fd;
+    tw2865_audio_format audio_farmat;
+
+    fd = open(TW2865_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        printf("open %s fail\n", TW2865_FILE);
+        return -1;
+    }
+
+    if (AIO_MODE_PCM_SLAVE_STD == enWorkMode
+        || AIO_MODE_PCM_SLAVE_NSTD == enWorkMode
+        || AIO_MODE_PCM_MASTER_STD == enWorkMode
+        || AIO_MODE_PCM_MASTER_NSTD == enWorkMode)
+    {
+        audio_farmat.format = 1;
+    }
+    else
+    {
+        audio_farmat.format = 0;
+    }
+
+    if (ioctl(fd, TW2865_SET_AUDIO_FORMAT, &audio_farmat))
+    {
+        printf("ioctl TW2865_SET_AUDIO_FORMAT err !!! \n");
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+    return 0;
+}
+
+HI_S32 SAMPLE_TW2865_CfgAudio(AUDIO_SAMPLE_RATE_E enSample)
+{
+    int fd;
+    tw2865_audio_samplerate samplerate;
+
+    fd = open(TW2865_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        printf("open %s fail\n", TW2865_FILE);
+        return -1;
+    }
+
+    if (AUDIO_SAMPLE_RATE_8000 == enSample)
+    {
+        samplerate = TW2865_SAMPLE_RATE_8000;
+    }
+    else if (AUDIO_SAMPLE_RATE_16000 == enSample)
+    {
+        samplerate = TW2865_SAMPLE_RATE_16000;
+    }
+    else if (AUDIO_SAMPLE_RATE_32000 == enSample)
+    {
+        samplerate = TW2865_SAMPLE_RATE_32000;
+    }
+    else if (AUDIO_SAMPLE_RATE_44100 == enSample)
+    {
+        samplerate = TW2865_SAMPLE_RATE_44100;
+    }
+    else if (AUDIO_SAMPLE_RATE_48000 == enSample)
+    {
+        samplerate = TW2865_SAMPLE_RATE_48000;
+    }
+    else
+    {
+        printf("func(%s) line(%d): tw2865 not support enSample:%d\n",
+                __FUNCTION__, __LINE__, enSample);
+        return -1;
+    }
+
+    if (ioctl(fd, TW2865_SET_SAMPLE_RATE, &samplerate))
+    {
+        printf("ioctl TW2865_SET_SAMPLE_RATE err !!! \n");
+        close(fd);
+        return -1;
+    }
+
+    printf("func(%s) line(%d): tw2865 start enSample(%d) ok\n",
+            __FUNCTION__, __LINE__, enSample);
+
+    close(fd);
+    return 0;
+}
+
+HI_S32 SAMPLE_TW2865_SetBitwidth(AUDIO_BIT_WIDTH_E enBitwidth)
+{
+    int fd;
+    tw2865_audio_bitwidth enTw2865Bitwidth;
+
+    switch (enBitwidth)
+    {
+        case AUDIO_BIT_WIDTH_8:
+            enTw2865Bitwidth = TW2865_AUDIO_BITWIDTH_8;
+            break;
+
+        case AUDIO_BIT_WIDTH_16:
+            enTw2865Bitwidth = TW2865_AUDIO_BITWIDTH_16;
+            break;
+
+        default:
+            printf("func(%s) line(%d): tw2865 not support bitwidth %d!\n",
+                    __FUNCTION__, __LINE__, enBitwidth);
+            return HI_FAILURE;
+    }
+
+    fd = open(TW2865_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        printf("open %s fail\n", TW2865_FILE);
+        return HI_FAILURE;
+    }
+
+    if (ioctl(fd, TW2865_SET_AUDIO_BITWIDTH, &enTw2865Bitwidth))
+    {
+        printf("func(%s) line(%d): ioctl TW2865_SET_AUDIO_BITWIDTH err!\n",
+                    __FUNCTION__, __LINE__);
+        close(fd);
+        return HI_FAILURE;
+    }
+    close(fd);
+    return HI_SUCCESS;
+}
+
+
+HI_S32 SAMPLE_CX26828_SetFormat(AIO_MODE_E enWorkMode)
+{
+    int fd;
+    cx26828_audio_format audio_format;
+
+    fd = open(CX26828_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        printf("open %s fail\n", CX26828_FILE);
+        return HI_FAILURE;
+    }
+
+    if (AIO_MODE_I2S_SLAVE == enWorkMode || AIO_MODE_I2S_MASTER == enWorkMode)
+    {
+        audio_format.format = 0;
+    }
+    else if (AIO_MODE_PCM_SLAVE_STD == enWorkMode || AIO_MODE_PCM_MASTER_STD == enWorkMode)
+    {
+        audio_format.format = 1;
+    }
+    else if (AIO_MODE_PCM_SLAVE_NSTD == enWorkMode || AIO_MODE_PCM_MASTER_NSTD == enWorkMode)
+    {
+        audio_format.format = 2;
+    }
+    else
+    {
+        printf("func(%s) line(%d): cx26828 not support workmode:%d\n",
+                __FUNCTION__, __LINE__, enWorkMode);
+        return HI_FAILURE;
+    }
+
+    /* set cx26828 master mode */
+    if (AIO_MODE_I2S_SLAVE == enWorkMode
+        || AIO_MODE_PCM_SLAVE_STD == enWorkMode
+        || AIO_MODE_PCM_SLAVE_NSTD == enWorkMode)
+    {
+        audio_format.master = 1;
+    }
+    else if (AIO_MODE_I2S_MASTER == enWorkMode
+        || AIO_MODE_PCM_MASTER_STD == enWorkMode
+        || AIO_MODE_PCM_MASTER_NSTD == enWorkMode)
+    {
+        audio_format.master = 0;
+    }
+    else
+    {
+        printf("func(%s) line(%d): cx26828 not support workmode:%d\n",
+                __FUNCTION__, __LINE__, enWorkMode);
+        return HI_FAILURE;
+    }
+
+    audio_format.chip = 0;
+    if (ioctl(fd, CX26828_SET_AUDIO_FORMAT, &audio_format))
+    {
+        printf("ioctl CX26828_SET_AUDIO_FORMAT err !!! \n");
+        close(fd);
+        return HI_FAILURE;
+    }
+
+    printf("func(%s) line(%d): set CX26828 audio format(%d) ok!\n", __FUNCTION__, __LINE__, enWorkMode);
+    close(fd);
+
+    return HI_SUCCESS;
+}
+
+
+HI_S32 SAMPLE_CX26828_SetSmprate(AUDIO_SAMPLE_RATE_E enSample)
+{
+    int fd;
+    cx26828_audio_sample_rate stCx26828SmpRate;
+
+    fd = open(CX26828_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        printf("open %s fail\n", CX26828_FILE);
+        return HI_FAILURE;
+    }
+
+    if (AUDIO_SAMPLE_RATE_8000 == enSample)
+    {
+        stCx26828SmpRate.sample_rate = CX26828_SAMPLE_RATE_8000;
+    }
+    else if (AUDIO_SAMPLE_RATE_16000 == enSample)
+    {
+        stCx26828SmpRate.sample_rate = CX26828_SAMPLE_RATE_16000;
+    }
+    else if (AUDIO_SAMPLE_RATE_32000 == enSample)
+    {
+        stCx26828SmpRate.sample_rate = CX26828_SAMPLE_RATE_32000;
+    }
+    else if (AUDIO_SAMPLE_RATE_44100 == enSample)
+    {
+        stCx26828SmpRate.sample_rate = CX26828_SAMPLE_RATE_44100;
+    }
+    else if (AUDIO_SAMPLE_RATE_48000 == enSample)
+    {
+        stCx26828SmpRate.sample_rate = CX26828_SAMPLE_RATE_48000;
+    }
+    else
+    {
+        printf("func(%s) line(%d): cx26828 not support enSample:%d\n",
+                __FUNCTION__, __LINE__, enSample);
+        return HI_FAILURE;
+    }
+
+    stCx26828SmpRate.chip = 0;
+    if (ioctl(fd, CX26828_SET_SAMPLE_RATE, &stCx26828SmpRate))
+    {
+        printf("ioctl CX26828_SET_SAMPLE_RATE err !!! \n");
+        close(fd);
+        return HI_FAILURE;
+    }
+
+    printf("\nfunc(%s) line(%d): set cx26828 sample rate(%d) ok\n", __FUNCTION__, __LINE__, enSample);
+    close(fd);
+
+    return HI_SUCCESS;
+}
+
+
+HI_S32 SAMPLE_CX26828_SetBitwidth(AUDIO_BIT_WIDTH_E enBitwidth)
+{
+    int fd;
+    cx26828_audio_bit_width stCx26828Bitwidth;
+
+    switch (enBitwidth)
+    {
+        case AUDIO_BIT_WIDTH_8:
+            stCx26828Bitwidth.bit_width = CX26828_AUDIO_BITWIDTH_8;
+            break;
+
+        case AUDIO_BIT_WIDTH_16:
+            stCx26828Bitwidth.bit_width = CX26828_AUDIO_BITWIDTH_16;
+            break;
+
+        default:
+            printf("func(%s) line(%d): cx26828 not support bitwidth %d!\n",
+                    __FUNCTION__, __LINE__, enBitwidth);
+            return HI_FAILURE;
+    }
+
+    fd = open(CX26828_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        printf("open %s fail\n", CX26828_FILE);
+        return HI_FAILURE;
+    }
+
+    stCx26828Bitwidth.chip = 0;
+    if (ioctl(fd, CX26828_SET_BIT_WIDTH, &stCx26828Bitwidth))
+    {
+        printf("func(%s) line(%d): ioctl CX26828_SET_AUDIO_BITWIDTH err!\n",
+                    __FUNCTION__, __LINE__);
+        close(fd);
+        return HI_FAILURE;
+    }
+
+    printf("func(%s) line(%d): set cx26828 bit width(%d) ok\n", __FUNCTION__, __LINE__, enBitwidth);
+    close(fd);
+
+    return HI_SUCCESS;
+}
+
+
+HI_S32 SAMPLE_CX26828_SetChnNum(HI_U32 u32ChnNum)
+{
+    int fd;
+    cx26828_audio_chn_num stcx26828ChnNum;
+
+    fd = open(CX26828_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        printf("open %s fail\n", CX26828_FILE);
+        return HI_FAILURE;
+    }
+
+    stcx26828ChnNum.chip    = 0;
+    stcx26828ChnNum.chn_num = u32ChnNum;
+    if (ioctl(fd, CX26828_SET_CHN_NUM, &stcx26828ChnNum))
+    {
+        printf("func(%s) line(%d): ioctl CX26828_SET_CHN_NUM err!\n",
+                    __FUNCTION__, __LINE__);
+        close(fd);
+        return HI_FAILURE;
+    }
+
+    printf("func(%s) line(%d): set cx26828 chn num(%d) ok\n", __FUNCTION__, __LINE__, u32ChnNum);
+    close(fd);
+
+    return HI_SUCCESS;
+}
+
+
+HI_S32 SAMPLE_Tlv320_CfgAudio(AIO_MODE_E enWorkmode,AUDIO_SAMPLE_RATE_E enSample)
+{
+     HI_S32 s32Samplerate;
+     HI_S32 vol = 0x100;
+     Audio_Ctrl audio_ctrl;
+     int s_fdTlv = -1;
+     HI_BOOL bPCMmode = HI_FALSE;
+     HI_BOOL bMaster = HI_TRUE;      /* 这里的主模式是对于Tlv320aic31来说的 */
+     HI_BOOL bPCMStd = HI_FALSE;
+
+     /* aic31外接着一个12.288M的晶振，对于44.1k系列的采样率与48k系列的采样率，
+         需要给aic31配置不同的P、R、J、D值，所以这里设置一标志来记录 */
+     HI_BOOL b44100HzSeries = HI_FALSE;
+
+     if (AUDIO_SAMPLE_RATE_8000 == enSample)
+     {
+         s32Samplerate = AC31_SET_8K_SAMPLERATE;
+     }
+     else if (AUDIO_SAMPLE_RATE_12000 == enSample)
+     {
+         s32Samplerate = AC31_SET_12K_SAMPLERATE;
+     }
+     else if (AUDIO_SAMPLE_RATE_11025 == enSample)
+     {
+         b44100HzSeries = HI_TRUE;
+         s32Samplerate = AC31_SET_11_025K_SAMPLERATE;
+     }
+     else if (AUDIO_SAMPLE_RATE_16000 == enSample)
+     {
+         s32Samplerate = AC31_SET_16K_SAMPLERATE;
+     }
+     else if (AUDIO_SAMPLE_RATE_22050 == enSample)
+     {
+         b44100HzSeries = HI_TRUE;
+         s32Samplerate = AC31_SET_22_05K_SAMPLERATE;
+     }
+     else if (AUDIO_SAMPLE_RATE_24000 == enSample)
+     {
+         s32Samplerate = AC31_SET_24K_SAMPLERATE;
+     }
+     else if (AUDIO_SAMPLE_RATE_32000 == enSample)
+     {
+         s32Samplerate = AC31_SET_32K_SAMPLERATE;
+     }
+     else if (AUDIO_SAMPLE_RATE_44100 == enSample)
+     {
+         b44100HzSeries = HI_TRUE;
+         s32Samplerate = AC31_SET_44_1K_SAMPLERATE;
+     }
+     else if (AUDIO_SAMPLE_RATE_48000 == enSample)
+     {
+         s32Samplerate = AC31_SET_48K_SAMPLERATE;
+     }
+     else
+     {
+         printf("SAMPLE_Tlv320_CfgAudio(), not support enSample:%d\n",enSample);
+         return -1;
+     }
+
+     if(AIO_MODE_I2S_MASTER == enWorkmode)
+     {
+         bPCMmode = HI_FALSE;
+         bMaster = HI_FALSE;
+     }
+     else if(AIO_MODE_I2S_SLAVE == enWorkmode)
+     {
+         bPCMmode = HI_FALSE;
+         bMaster = HI_TRUE;
+     }
+     else if((AIO_MODE_PCM_MASTER_NSTD == enWorkmode)||(AIO_MODE_PCM_MASTER_STD == enWorkmode))
+     {
+         bPCMmode = HI_TRUE;
+         bMaster = HI_FALSE;
+     }
+     else if((AIO_MODE_PCM_SLAVE_NSTD == enWorkmode)||(AIO_MODE_PCM_SLAVE_STD == enWorkmode))
+     {
+         bPCMmode = HI_TRUE;
+         bMaster = HI_TRUE;
+     }
+     else
+     {
+         printf("SAMPLE_Tlv320_CfgAudio(), not support workmode:%d\n\n",enWorkmode);
+     }
+
+     s_fdTlv = open(TLV320_FILE,O_RDWR);
+     if (s_fdTlv < 0)
+     {
+         printf("can't open tlv320,%s\n", TLV320_FILE);
+         return -1;
+     }
+
+     audio_ctrl.chip_num = 0;
+     if (ioctl(s_fdTlv,SOFT_RESET,&audio_ctrl))
+     {
+         printf("[Func]:%s [Line]:%d [Info]:%s\n", __FUNCTION__, __LINE__, "tlv320aic31 reset failed");
+     }
+
+     /* 设置主从模式 1为主模式*/
+     audio_ctrl.ctrl_mode = bMaster;
+     audio_ctrl.if_44100hz_series = b44100HzSeries;
+     audio_ctrl.sample = s32Samplerate;
+     ioctl(s_fdTlv,SET_CTRL_MODE,&audio_ctrl);
+
+     /* set transfer mode 0:I2S 1:PCM */
+     audio_ctrl.trans_mode = bPCMmode;
+     if (ioctl(s_fdTlv,SET_TRANSFER_MODE,&audio_ctrl))
+     {
+         printf("set tlv320aic31 trans_mode err\n");
+         close(s_fdTlv);
+         return -1;
+     }
+
+     /*set sample of DAC and ADC */
+     if (ioctl(s_fdTlv,SET_DAC_SAMPLE,&audio_ctrl))
+     {
+         printf("ioctl err1\n");
+         close(s_fdTlv);
+         return -1;
+     }
+
+     if (ioctl(s_fdTlv,SET_ADC_SAMPLE,&audio_ctrl))
+     {
+         printf("ioctl err2\n");
+         close(s_fdTlv);
+         return -1;
+     }
+
+     /*set volume control of left and right DAC */
+     audio_ctrl.if_mute_route = 0;
+     audio_ctrl.input_level = 0;
+     ioctl(s_fdTlv,LEFT_DAC_VOL_CTRL,&audio_ctrl);
+     ioctl(s_fdTlv,RIGHT_DAC_VOL_CTRL,&audio_ctrl);
+
+     /*Right/Left DAC Datapath Control */
+     audio_ctrl.if_powerup = 1;/*Left/Right DAC datapath plays left/right channel input data*/
+     ioctl(s_fdTlv,LEFT_DAC_POWER_SETUP,&audio_ctrl);
+     ioctl(s_fdTlv,RIGHT_DAC_POWER_SETUP,&audio_ctrl);
+
+     /* 设置PCM标准模式和非标准模式 */
+     if ((AIO_MODE_PCM_MASTER_STD == enWorkmode)||(AIO_MODE_PCM_SLAVE_STD == enWorkmode))
+     {
+         bPCMStd = HI_TRUE;
+         audio_ctrl.data_offset = bPCMStd;
+         ioctl(s_fdTlv,SET_SERIAL_DATA_OFFSET,&audio_ctrl);
+     }
+     else if ((AIO_MODE_PCM_MASTER_NSTD == enWorkmode)||(AIO_MODE_PCM_SLAVE_NSTD == enWorkmode))
+     {
+         bPCMStd = HI_FALSE;
+         audio_ctrl.data_offset = bPCMStd;
+         ioctl(s_fdTlv,SET_SERIAL_DATA_OFFSET,&audio_ctrl);
+     }
+     else
+     {;}
+
+     /* 数据位宽 (0:16bit 1:20bit 2:24bit 3:32bit) */
+     audio_ctrl.data_length = 0;
+     ioctl(s_fdTlv,SET_DATA_LENGTH,&audio_ctrl);
+
+     /*DACL1 TO LEFT_LOP/RIGHT_LOP VOLUME CONTROL 82 92*/
+     audio_ctrl.if_mute_route = 1;/* route*/
+     audio_ctrl.input_level = vol; /*level control*/
+     ioctl(s_fdTlv,DACL1_2_LEFT_LOP_VOL_CTRL,&audio_ctrl);
+     ioctl(s_fdTlv,DACR1_2_RIGHT_LOP_VOL_CTRL,&audio_ctrl);
+
+     /* LEFT_LOP/RIGHT_LOP OUTPUT LEVEL CONTROL 86 93*/
+     audio_ctrl.if_mute_route = 1;
+     audio_ctrl.if_powerup = 1;
+     audio_ctrl.input_level = 0;
+     ioctl(s_fdTlv,LEFT_LOP_OUTPUT_LEVEL_CTRL,&audio_ctrl);
+     ioctl(s_fdTlv,RIGHT_LOP_OUTPUT_LEVEL_CTRL,&audio_ctrl);
+
+     /*配置AD*/
+     /* LEFT/RIGHT ADC PGA GAIN CONTROL 15 16*/
+     audio_ctrl.if_mute_route =0;
+     audio_ctrl.input_level = 0;
+     ioctl(s_fdTlv,LEFT_ADC_PGA_CTRL,&audio_ctrl);
+     ioctl(s_fdTlv,RIGHT_ADC_PGA_CTRL,&audio_ctrl);
+
+     /*INT2L TO LEFT/RIGTH ADCCONTROL 17 18*/
+     audio_ctrl.input_level = 0;
+     ioctl(s_fdTlv,IN2LR_2_LEFT_ADC_CTRL,&audio_ctrl);
+     ioctl(s_fdTlv,IN2LR_2_RIGTH_ADC_CTRL,&audio_ctrl);
+
+     /*IN1L_2_LEFT/RIGTH_ADC_CTRL 19 22*/
+     /*audio_ctrl.input_level = 0xf;
+     audio_ctrl.if_powerup = 1;
+     printf("audio_ctrl.input_level=0x%x,audio_ctrl.if_powerup=0x%x\n",audio_ctrl.input_level,audio_ctrl.if_powerup);
+     if (ioctl(s_fdTlv,IN1L_2_LEFT_ADC_CTRL,&audio_ctrl)==0)
+         perror("ioctl err\n");
+     getchar();
+     printf("audio_ctrl.input_level=0x%x,audio_ctrl.if_powerup=0x%x\n",audio_ctrl.input_level,audio_ctrl.if_powerup);
+     ioctl(s_fdTlv,IN1R_2_RIGHT_ADC_CTRL,&audio_ctrl);
+     getchar();
+     printf("set 19 22\n");*/
+     audio_ctrl.if_mute_route = 1;
+     audio_ctrl.input_level = 9;
+     audio_ctrl.if_powerup = 1;
+     ioctl(s_fdTlv,HPLOUT_OUTPUT_LEVEL_CTRL,&audio_ctrl);
+     ioctl(s_fdTlv,HPROUT_OUTPUT_LEVEL_CTRL,&audio_ctrl);
+     close(s_fdTlv);
+     printf("Set aic31 ok: bMaster = %d, enWorkmode = %d, enSamplerate = %d\n",
+             bMaster, enWorkmode, enSample);
+     return 0;
+ }
+
+
+HI_S32 SAMPLE_Tlv320_Disable()
+{
+    Audio_Ctrl audio_ctrl;
+    int s_fdTlv = -1;
+    HI_S32 s32Ret;
+
+    s_fdTlv = open(TLV320_FILE,O_RDWR);
+    if (s_fdTlv < 0)
+    {
+        printf("[Func]:%s [Line]:%d [Info]:%s\n", __FUNCTION__, __LINE__, "can't open /dev/tlv320aic31");
+        return HI_FAILURE;
+    }
+
+    /* reset transfer mode 0:I2S 1:PCM */
+    audio_ctrl.chip_num = 0;
+    s32Ret = ioctl(s_fdTlv,SOFT_RESET,&audio_ctrl);
+    if (HI_SUCCESS != s32Ret)
+    {
+        printf("[Func]:%s [Line]:%d [Info]:%s\n", __FUNCTION__, __LINE__, "tlv320aic31 reset failed");
+    }
+    close(s_fdTlv);
+
+    return s32Ret;
+}
+
+
+
+
+
+HI_S32 SAMPLE_NVP6114_SetChnNum(HI_U32 u32ChnNum)
+{
+    int fd;
+
+    fd = open(NVP6114_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        printf("open %s fail\n", NVP6114_FILE);
+        return HI_FAILURE;
+    }
+
+    if (ioctl(fd, IOC_AUDIO_SET_CHNNUM, &u32ChnNum))
+    {
+        printf("func(%s) line(%d): NVP6114 ioctl IOC_AUDIO_SET_CHNNUM err!\n",
+                    __FUNCTION__, __LINE__);
+        close(fd);
+        return HI_FAILURE;
+    }
+
+    printf("func(%s) line(%d): set nvp6114 chn num(%d) ok\n", __FUNCTION__, __LINE__, u32ChnNum);
+    close(fd);
+
+    return HI_SUCCESS;
+}
+
+
+
+
+
+HI_S32 SAMPLE_NVP6114_SetSmprate(AUDIO_SAMPLE_RATE_E enSample)
+{
+    int fd;
+    nvp6114_audio_samplerate_en eSamplerate;
+
+    fd = open(NVP6114_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        printf("open %s fail\n", NVP6114_FILE);
+        return HI_FAILURE;
+    }
+
+    if (AUDIO_SAMPLE_RATE_8000 == enSample)
+    {
+        eSamplerate = NVP6114_SAMPLE_RATE_8000;
+    }
+    else if (AUDIO_SAMPLE_RATE_16000 == enSample)
+    {
+        eSamplerate = NVP6114_SAMPLE_RATE_16000;
+    }
+    else
+    {
+        printf("func(%s) line(%d): nvp6114 not support enSample:%d\n",
+                __FUNCTION__, __LINE__, enSample);
+        return HI_FAILURE;
+    }
+
+    if (ioctl(fd, IOC_AUDIO_SET_SAMPLE_RATE, &eSamplerate))
+    {
+        printf("NVP6114 ioctl IOC_AUDIO_SET_SAMPLE_RATE err !!! \n");
+        close(fd);
+        return HI_FAILURE;
+    }
+
+    printf("\nfunc(%s) line(%d): set nvp6114 sample rate(%d) ok\n", __FUNCTION__, __LINE__, enSample);
+    close(fd);
+
+    return HI_SUCCESS;
+}
+
+
+
+
+HI_S32 SAMPLE_NVP6114_SetBitwidth(AUDIO_BIT_WIDTH_E enBitwidth)
+{
+    int fd;
+	nvp6114_audio_bites_en eBitwidth;
+
+    switch (enBitwidth)
+    {
+        case AUDIO_BIT_WIDTH_8:
+            eBitwidth = NVP6114_BITES_WIDTH_8;
+            break;
+
+        case AUDIO_BIT_WIDTH_16:
+            eBitwidth = NVP6114_BITES_WIDTH_16;
+            break;
+
+        default:
+            printf("func(%s) line(%d): nvp6114 not support bitwidth %d!\n",
+                    __FUNCTION__, __LINE__, enBitwidth);
+            return HI_FAILURE;
+    }
+
+    fd = open(NVP6114_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        printf("open %s fail\n", NVP6114_FILE);
+        return HI_FAILURE;
+    }
+
+    if (ioctl(fd, IOC_AUDIO_SET_BITWIDTH, &eBitwidth))
+    {
+        printf("func(%s) line(%d):NVP6114 ioctl IOC_AUDIO_SET_BITWIDTH err!\n",
+                    __FUNCTION__, __LINE__);
+        close(fd);
+        return HI_FAILURE;
+    }
+    close(fd);
+    return HI_SUCCESS;
+}
+
+
+
+
+
+
+
+
+
+/* config codec */
+HI_S32 SAMPLE_COMM_AUDIO_CfgAcodec(AIO_ATTR_S *pstAioAttr, HI_BOOL bMacIn)
+{
+    HI_S32 s32Ret = HI_FAILURE;
+
+#ifndef NVP_6114
+	#ifdef DEMO
+    /*** ACODEC_TYPE_CX26828 ***/
+    s32Ret  = SAMPLE_CX26828_SetSmprate(pstAioAttr->enSamplerate);
+    s32Ret |= SAMPLE_CX26828_SetFormat(pstAioAttr->enWorkmode);
+    s32Ret |= SAMPLE_CX26828_SetBitwidth(pstAioAttr->enBitwidth);
+    s32Ret |= SAMPLE_CX26828_SetChnNum(pstAioAttr->u32ChnCnt);
+	#else
+    /*** ACODEC_TYPE_TW2865 ***/
+    s32Ret = SAMPLE_TW2865_CfgAudio(pstAioAttr->enSamplerate);
+    s32Ret |= SAMPLE_TW2865_SetFormat(pstAioAttr->enWorkmode);
+    s32Ret |= SAMPLE_TW2865_SetBitwidth(pstAioAttr->enBitwidth);
+
+    /*** ACODEC_TYPE_TLV320 ***/
+    s32Ret = SAMPLE_Tlv320_CfgAudio(pstAioAttr->enWorkmode, pstAioAttr->enSamplerate);
+	#endif
+#else
+	/*** ACODEC_TYPE_NVP6114 ***/
+	s32Ret	= SAMPLE_NVP6114_SetSmprate(pstAioAttr->enSamplerate);
+	s32Ret |= SAMPLE_NVP6114_SetBitwidth(pstAioAttr->enBitwidth);
+	s32Ret |= SAMPLE_NVP6114_SetChnNum(pstAioAttr->u32ChnCnt);
+#endif
+
+    return s32Ret;
+}
+
+/******************************************************************************
+* function : get frame from Ai, send it  to Aenc or Ao
+******************************************************************************/
+void *SAMPLE_COMM_AUDIO_AiProc(void *parg)
+{
+    HI_S32 s32Ret;
+    HI_S32 AiFd;
+    SAMPLE_AI_S *pstAiCtl = (SAMPLE_AI_S *)parg;
+    AUDIO_FRAME_S stFrame;
+    fd_set read_fds;
+    struct timeval TimeoutVal;
+    AI_CHN_PARAM_S stAiChnPara;
+
+    s32Ret = HI_MPI_AI_GetChnParam(pstAiCtl->AiDev, pstAiCtl->AiChn, &stAiChnPara);
+    if (HI_SUCCESS != s32Ret)
+    {
+        printf("%s: Get ai chn param failed\n", __FUNCTION__);
+        return NULL;
+    }
+
+    stAiChnPara.u32UsrFrmDepth = 30;
+
+    s32Ret = HI_MPI_AI_SetChnParam(pstAiCtl->AiDev, pstAiCtl->AiChn, &stAiChnPara);
+    if (HI_SUCCESS != s32Ret)
+    {
+        printf("%s: set ai chn param failed\n", __FUNCTION__);
+        return NULL;
+    }
+
+    FD_ZERO(&read_fds);
+    AiFd = HI_MPI_AI_GetFd(pstAiCtl->AiDev, pstAiCtl->AiChn);
+    FD_SET(AiFd,&read_fds);
+
+    while (pstAiCtl->bStart)
+    {
+        TimeoutVal.tv_sec = 1;
+        TimeoutVal.tv_usec = 0;
+
+        FD_ZERO(&read_fds);
+        FD_SET(AiFd,&read_fds);
+
+        s32Ret = select(AiFd+1, &read_fds, NULL, NULL, &TimeoutVal);
+        if (s32Ret < 0)
+        {
+            break;
+        }
+        else if (0 == s32Ret)
+        {
+            printf("%s: get ai frame select time out\n", __FUNCTION__);
+            break;
+        }
+
+        if (FD_ISSET(AiFd, &read_fds))
+        {
+            /* get frame from ai chn */
+            s32Ret = HI_MPI_AI_GetFrame(pstAiCtl->AiDev, pstAiCtl->AiChn,
+                &stFrame, NULL, HI_FALSE);
+            if (HI_SUCCESS != s32Ret )
+            {
+                printf("%s: HI_MPI_AI_GetFrame(%d, %d), failed with %#x!\n",\
+                       __FUNCTION__, pstAiCtl->AiDev, pstAiCtl->AiChn, s32Ret);
+                pstAiCtl->bStart = HI_FALSE;
+                return NULL;
+            }
+
+            /* send frame to encoder */
+            if (HI_TRUE == pstAiCtl->bSendAenc)
+            {
+                HI_MPI_AENC_SendFrame(pstAiCtl->AencChn, &stFrame, NULL);
+            }
+
+            /* send frame to ao */
+            if (HI_TRUE == pstAiCtl->bSendAo)
+            {
+                HI_MPI_AO_SendFrame(pstAiCtl->AoDev, pstAiCtl->AoChn,
+                    &stFrame, HI_TRUE);
+            }
+
+            /* finally you must release the stream */
+            HI_MPI_AI_ReleaseFrame(pstAiCtl->AiDev, pstAiCtl->AiChn,
+                &stFrame, NULL);
+        }
+    }
+
+    pstAiCtl->bStart = HI_FALSE;
+    return NULL;
+}
+
+/******************************************************************************
+* function : get stream from Aenc, send it  to Adec & save it to file
+******************************************************************************/
+void *SAMPLE_COMM_AUDIO_AencProc(void *parg)
+{
+    HI_S32 s32Ret;
+    HI_S32 AencFd;
+    SAMPLE_AENC_S *pstAencCtl = (SAMPLE_AENC_S *)parg;
+    AUDIO_STREAM_S stStream;
+    fd_set read_fds;
+    struct timeval TimeoutVal;
+
+    FD_ZERO(&read_fds);
+    AencFd = HI_MPI_AENC_GetFd(pstAencCtl->AeChn);
+    FD_SET(AencFd, &read_fds);
+
+    while (pstAencCtl->bStart)
+    {
+        TimeoutVal.tv_sec = 1;
+        TimeoutVal.tv_usec = 0;
+
+        FD_ZERO(&read_fds);
+        FD_SET(AencFd,&read_fds);
+
+        s32Ret = select(AencFd+1, &read_fds, NULL, NULL, &TimeoutVal);
+        if (s32Ret < 0)
+        {
+            break;
+        }
+        else if (0 == s32Ret)
+        {
+            printf("%s: get aenc stream select time out\n", __FUNCTION__);
+            break;
+        }
+
+        if (FD_ISSET(AencFd, &read_fds))
+        {
+            /* get stream from aenc chn */
+            s32Ret = HI_MPI_AENC_GetStream(pstAencCtl->AeChn, &stStream, HI_FALSE);
+            if (HI_SUCCESS != s32Ret )
+            {
+                printf("%s: HI_MPI_AENC_GetStream(%d), failed with %#x!\n",\
+                       __FUNCTION__, pstAencCtl->AeChn, s32Ret);
+                pstAencCtl->bStart = HI_FALSE;
+                return NULL;
+            }
+
+            /* send stream to decoder and play for testing */
+            if (HI_TRUE == pstAencCtl->bSendAdChn)
+            {
+                HI_MPI_ADEC_SendStream(pstAencCtl->AdChn, &stStream, HI_TRUE);
+            }
+
+            /* save audio stream to file */
+            fwrite(stStream.pStream,1,stStream.u32Len, pstAencCtl->pfd);
+
+            /* finally you must release the stream */
+            HI_MPI_AENC_ReleaseStream(pstAencCtl->AeChn, &stStream);
+        }
+    }
+
+    fclose(pstAencCtl->pfd);
+    pstAencCtl->bStart = HI_FALSE;
+    return NULL;
+}
+
+/******************************************************************************
+* function : get stream from file, and send it  to Adec
+******************************************************************************/
+void *SAMPLE_COMM_AUDIO_AdecProc(void *parg)
+{
+    HI_S32 s32Ret;
+    AUDIO_STREAM_S stAudioStream;
+    HI_U32 u32Len = 640;
+    HI_U32 u32ReadLen;
+    HI_S32 s32AdecChn;
+    HI_U8 *pu8AudioStream = NULL;
+    SAMPLE_ADEC_S *pstAdecCtl = (SAMPLE_ADEC_S *)parg;
+    FILE *pfd = pstAdecCtl->pfd;
+    s32AdecChn = pstAdecCtl->AdChn;
+
+    pu8AudioStream = (HI_U8*)malloc(sizeof(HI_U8)*MAX_AUDIO_STREAM_LEN);
+    if (NULL == pu8AudioStream)
+    {
+        printf("%s: malloc failed!\n", __FUNCTION__);
+        return NULL;
+    }
+
+    while (HI_TRUE == pstAdecCtl->bStart)
+    {
+        /* read from file */
+        stAudioStream.pStream = pu8AudioStream;
+        u32ReadLen = fread(stAudioStream.pStream, 1, u32Len, pfd);
+        if (u32ReadLen <= 0)
+        {
+            fseek(pfd, 0, SEEK_SET);/*read file again*/
+            continue;
+        }
+
+        /* here only demo adec streaming sending mode, but pack sending mode is commended */
+        stAudioStream.u32Len = u32ReadLen;
+        s32Ret = HI_MPI_ADEC_SendStream(s32AdecChn, &stAudioStream, HI_TRUE);
+        if (s32Ret)
+        {
+            printf("%s: HI_MPI_ADEC_SendStream(%d) failed with %#x!\n",\
+                   __FUNCTION__, s32AdecChn, s32Ret);
+            break;
+        }
+    }
+
+    free(pu8AudioStream);
+    pu8AudioStream = NULL;
+    fclose(pfd);
+    pstAdecCtl->bStart = HI_FALSE;
+    return NULL;
+}
+
+/******************************************************************************
+* function : Create the thread to get frame from ai and send to ao
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_CreatTrdAiAo(AUDIO_DEV AiDev, AI_CHN AiChn, AUDIO_DEV AoDev, AO_CHN AoChn)
+{
+    SAMPLE_AI_S *pstAi = NULL;
+
+    pstAi = &gs_stSampleAi[AiDev*AIO_MAX_CHN_NUM + AiChn];
+    pstAi->bSendAenc = HI_FALSE;
+    pstAi->bSendAo = HI_TRUE;
+    pstAi->bStart= HI_TRUE;
+    pstAi->AiDev = AiDev;
+    pstAi->AiChn = AiChn;
+    pstAi->AoDev = AoDev;
+    pstAi->AoChn = AoChn;
+
+    pthread_create(&pstAi->stAiPid, 0, SAMPLE_COMM_AUDIO_AiProc, pstAi);
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Create the thread to get frame from ai and send to aenc
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_CreatTrdAiAenc(AUDIO_DEV AiDev, AI_CHN AiChn, AENC_CHN AeChn)
+{
+    SAMPLE_AI_S *pstAi = NULL;
+
+    pstAi = &gs_stSampleAi[AiDev*AIO_MAX_CHN_NUM + AiChn];
+    pstAi->bSendAenc = HI_TRUE;
+    pstAi->bSendAo = HI_FALSE;
+    pstAi->bStart= HI_TRUE;
+    pstAi->AiDev = AiDev;
+    pstAi->AiChn = AiChn;
+    pstAi->AencChn = AeChn;
+    pthread_create(&pstAi->stAiPid, 0, SAMPLE_COMM_AUDIO_AiProc, pstAi);
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Create the thread to get stream from aenc and send to adec
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_CreatTrdAencAdec(AENC_CHN AeChn, ADEC_CHN AdChn, FILE *pAecFd)
+{
+    SAMPLE_AENC_S *pstAenc = NULL;
+
+    if (NULL == pAecFd)
+    {
+        return HI_FAILURE;
+    }
+
+    pstAenc = &gs_stSampleAenc[AeChn];
+    pstAenc->AeChn = AeChn;
+    pstAenc->AdChn = AdChn;
+    pstAenc->bSendAdChn = HI_TRUE;
+    pstAenc->pfd = pAecFd;
+    pstAenc->bStart = HI_TRUE;
+    pthread_create(&pstAenc->stAencPid, 0, SAMPLE_COMM_AUDIO_AencProc, pstAenc);
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Create the thread to get stream from file and send to adec
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_CreatTrdFileAdec(ADEC_CHN AdChn, FILE *pAdcFd)
+{
+    SAMPLE_ADEC_S *pstAdec = NULL;
+
+    if (NULL == pAdcFd)
+    {
+        return HI_FAILURE;
+    }
+
+    pstAdec = &gs_stSampleAdec[AdChn];
+    pstAdec->AdChn = AdChn;
+    pstAdec->pfd = pAdcFd;
+    pstAdec->bStart = HI_TRUE;
+    pthread_create(&pstAdec->stAdPid, 0, SAMPLE_COMM_AUDIO_AdecProc, pstAdec);
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Destory the thread to get frame from ai and send to ao or aenc
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_DestoryTrdAi(AUDIO_DEV AiDev, AI_CHN AiChn)
+{
+    SAMPLE_AI_S *pstAi = NULL;
+
+    pstAi = &gs_stSampleAi[AiDev*AIO_MAX_CHN_NUM + AiChn];
+    pstAi->bStart= HI_FALSE;
+    pthread_join(pstAi->stAiPid, 0);
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Destory the thread to get stream from aenc and send to adec
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_DestoryTrdAencAdec(AENC_CHN AeChn)
+{
+    SAMPLE_AENC_S *pstAenc = NULL;
+
+    pstAenc = &gs_stSampleAenc[AeChn];
+    pstAenc->bStart = HI_FALSE;
+    pthread_join(pstAenc->stAencPid, 0);
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Destory the thread to get stream from file and send to adec
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_DestoryTrdFileAdec(ADEC_CHN AdChn)
+{
+    SAMPLE_ADEC_S *pstAdec = NULL;
+
+    pstAdec = &gs_stSampleAdec[AdChn];
+    pstAdec->bStart = HI_FALSE;
+    pthread_join(pstAdec->stAdPid, 0);
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Ao bind Adec
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_AoBindAdec(AUDIO_DEV AoDev, AO_CHN AoChn, ADEC_CHN AdChn)
+{
+    MPP_CHN_S stSrcChn,stDestChn;
+
+    stSrcChn.enModId = HI_ID_ADEC;
+    stSrcChn.s32DevId = 0;
+    stSrcChn.s32ChnId = AdChn;
+    stDestChn.enModId = HI_ID_AO;
+    stDestChn.s32DevId = AoDev;
+    stDestChn.s32ChnId = AoChn;
+
+    return HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+}
+
+/******************************************************************************
+* function : Ao unbind Adec
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_AoUnbindAdec(AUDIO_DEV AoDev, AO_CHN AoChn, ADEC_CHN AdChn)
+{
+    MPP_CHN_S stSrcChn,stDestChn;
+
+    stSrcChn.enModId = HI_ID_ADEC;
+    stSrcChn.s32ChnId = AdChn;
+    stSrcChn.s32DevId = 0;
+    stDestChn.enModId = HI_ID_AO;
+    stDestChn.s32DevId = AoDev;
+    stDestChn.s32ChnId = AoChn;
+
+    return HI_MPI_SYS_UnBind(&stSrcChn, &stDestChn);
+}
+
+/******************************************************************************
+* function : Ao bind Ai
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_AoBindAi(AUDIO_DEV AiDev, AI_CHN AiChn, AUDIO_DEV AoDev, AO_CHN AoChn)
+{
+    MPP_CHN_S stSrcChn,stDestChn;
+
+    stSrcChn.enModId = HI_ID_AI;
+    stSrcChn.s32ChnId = AiChn;
+    stSrcChn.s32DevId = AiDev;
+    stDestChn.enModId = HI_ID_AO;
+    stDestChn.s32DevId = AoDev;
+    stDestChn.s32ChnId = AoChn;
+
+    return HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+}
+
+/******************************************************************************
+* function : Ao unbind Ai
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_AoUnbindAi(AUDIO_DEV AiDev, AI_CHN AiChn, AUDIO_DEV AoDev, AO_CHN AoChn)
+{
+    MPP_CHN_S stSrcChn,stDestChn;
+
+    stSrcChn.enModId = HI_ID_AI;
+    stSrcChn.s32ChnId = AiChn;
+    stSrcChn.s32DevId = AiDev;
+    stDestChn.enModId = HI_ID_AO;
+    stDestChn.s32DevId = AoDev;
+    stDestChn.s32ChnId = AoChn;
+
+    return HI_MPI_SYS_UnBind(&stSrcChn, &stDestChn);
+}
+
+/******************************************************************************
+* function : Aenc bind Ai
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_AencBindAi(AUDIO_DEV AiDev, AI_CHN AiChn, AENC_CHN AeChn)
+{
+    MPP_CHN_S stSrcChn,stDestChn;
+
+    stSrcChn.enModId = HI_ID_AI;
+    stSrcChn.s32DevId = AiDev;
+    stSrcChn.s32ChnId = AiChn;
+    stDestChn.enModId = HI_ID_AENC;
+    stDestChn.s32DevId = 0;
+    stDestChn.s32ChnId = AeChn;
+
+    return HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+}
+
+/******************************************************************************
+* function : Aenc unbind Ai
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_AencUnbindAi(AUDIO_DEV AiDev, AI_CHN AiChn, AENC_CHN AeChn)
+{
+    MPP_CHN_S stSrcChn,stDestChn;
+
+    stSrcChn.enModId = HI_ID_AI;
+    stSrcChn.s32DevId = AiDev;
+    stSrcChn.s32ChnId = AiChn;
+    stDestChn.enModId = HI_ID_AENC;
+    stDestChn.s32DevId = 0;
+    stDestChn.s32ChnId = AeChn;
+
+    return HI_MPI_SYS_UnBind(&stSrcChn, &stDestChn);
+}
+
+#if 0
+/******************************************************************************
+* function : Acodec config [ s32Samplerate(0:8k, 1:16k ) ]
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_CfgAcodec(AUDIO_SAMPLE_RATE_E enSample, HI_BOOL bMicIn)
+{
+    HI_S32 fdAcodec = -1;
+    ACODEC_CTRL stAudioctrl = {0};
+
+    fdAcodec = open(ACODEC_FILE,O_RDWR);
+    if (fdAcodec < 0)
+    {
+        printf("%s: can't open acodec,%s\n", __FUNCTION__, ACODEC_FILE);
+        return HI_FAILURE;
+    }
+
+    if ((AUDIO_SAMPLE_RATE_8000 == enSample)
+        || (AUDIO_SAMPLE_RATE_11025 == enSample)
+        || (AUDIO_SAMPLE_RATE_12000 == enSample))
+    {
+        stAudioctrl.i2s_fs_sel = 0x18;
+    }
+    else if ((AUDIO_SAMPLE_RATE_16000 == enSample)
+        || (AUDIO_SAMPLE_RATE_22050 == enSample)
+        || (AUDIO_SAMPLE_RATE_24000 == enSample))
+    {
+        stAudioctrl.i2s_fs_sel = 0x19;
+    }
+    else if ((AUDIO_SAMPLE_RATE_32000 == enSample)
+        || (AUDIO_SAMPLE_RATE_44100 == enSample)
+        || (AUDIO_SAMPLE_RATE_48000 == enSample))
+    {
+        stAudioctrl.i2s_fs_sel = 0x1a;
+    }
+    else
+    {
+        printf("%s: not support enSample:%d\n", __FUNCTION__, enSample);
+        return HI_FAILURE;
+    }
+
+    if (ioctl(fdAcodec, ACODEC_SET_I2S1_FS, &stAudioctrl))
+    {
+        printf("%s: set acodec sample rate failed\n", __FUNCTION__);
+        return HI_FAILURE;
+    }
+
+    if (HI_TRUE == bMicIn)
+    {
+        stAudioctrl.mixer_mic_ctrl = ACODEC_MIXER_MICIN;
+        if (ioctl(fdAcodec, ACODEC_SET_MIXER_MIC, &stAudioctrl))
+        {
+            printf("%s: set acodec micin failed\n", __FUNCTION__);
+            return HI_FAILURE;
+        }
+
+        /* set volume plus (0~0x1f,default 0) */
+        stAudioctrl.gain_mic = 0;
+        if (ioctl(fdAcodec, ACODEC_SET_GAIN_MICL, &stAudioctrl))
+        {
+            printf("%s: set acodec micin volume failed\n", __FUNCTION__);
+            return HI_FAILURE;
+        }
+        if (ioctl(fdAcodec, ACODEC_SET_GAIN_MICR, &stAudioctrl))
+        {
+            printf("%s: set acodec micin volume failed\n", __FUNCTION__);
+            return HI_FAILURE;
+        }
+    }
+    close(fdAcodec);
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Disable Tlv320
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_DisableAcodec()
+{
+    return  SAMPLE_COMM_AUDIO_CfgAcodec(AUDIO_SAMPLE_RATE_48000, HI_FALSE);
+}
+
+#endif
+
+/******************************************************************************
+* function : Start Ai
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_StartAi(AUDIO_DEV AiDevId, HI_S32 s32AiChnCnt,
+        AIO_ATTR_S *pstAioAttr, HI_BOOL bAnrEn, AUDIO_RESAMPLE_ATTR_S *pstAiReSmpAttr)
+{
+    HI_S32 i, s32Ret;
+
+    s32Ret = HI_MPI_AI_SetPubAttr(AiDevId, pstAioAttr);
+    if (s32Ret)
+    {
+        printf("%s: HI_MPI_AI_SetPubAttr(%d) failed with %#x\n", __FUNCTION__, AiDevId, s32Ret);
+        return HI_FAILURE;
+    }
+    if (HI_MPI_AI_Enable(AiDevId))
+    {
+        printf("%s: HI_MPI_AI_Enable(%d) failed with %#x\n", __FUNCTION__, AiDevId, s32Ret);
+        return HI_FAILURE;
+    }
+    for (i=0; i<s32AiChnCnt; i++)
+    {
+        if (HI_MPI_AI_EnableChn(AiDevId, i))
+        {
+            printf("%s: HI_MPI_AI_EnableChn(%d,%d) failed with %#x\n", __FUNCTION__,\
+                    AiDevId, i, s32Ret);
+            return HI_FAILURE;
+        }
+
+        if (HI_TRUE == bAnrEn)
+        {
+            if (HI_MPI_AI_EnableAnr(AiDevId, i))
+            {
+                printf("%s: HI_MPI_AI_EnableAnr(%d,%d) failed with %#x\n", __FUNCTION__,\
+                    AiDevId, i, s32Ret);
+                return HI_FAILURE;
+            }
+        }
+
+        if (NULL != pstAiReSmpAttr)
+        {
+            if (HI_MPI_AI_EnableReSmp(AiDevId, i, pstAiReSmpAttr))
+            {
+                printf("%s: HI_MPI_AI_EnableReSmp(%d,%d) failed with %#x\n",\
+                        __FUNCTION__, AiDevId, i, s32Ret);
+                return HI_FAILURE;
+            }
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Stop Ai
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_StopAi(AUDIO_DEV AiDevId, HI_S32 s32AiChnCnt,
+        HI_BOOL bAnrEn, HI_BOOL bResampleEn)
+{
+    HI_S32 i;
+    for (i=0; i<s32AiChnCnt; i++)
+    {
+        if (HI_TRUE == bResampleEn)
+        {
+            HI_MPI_AI_DisableReSmp(AiDevId, i);
+        }
+        if (HI_TRUE == bAnrEn)
+        {
+            HI_MPI_AI_DisableAnr(AiDevId, i);
+        }
+        HI_MPI_AI_DisableChn(AiDevId, i);
+    }
+    HI_MPI_AI_Disable(AiDevId);
+    return HI_SUCCESS;
+}
+
+HI_S32 SAMPLE_COMM_AUDIO_StartHdmi(AIO_ATTR_S *pstAioAttr)
+{
+    HI_S32 s32Ret;
+    HI_HDMI_ATTR_S stHdmiAttr;
+    HI_HDMI_ID_E enHdmi = HI_HDMI_ID_0;
+    VO_PUB_ATTR_S stPubAttr;
+    VO_DEV VoDev = 0;
+
+    stPubAttr.u32BgColor = 0x0000ff00;
+    stPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA;
+    stPubAttr.bDoubleFrame = HI_FALSE;
+    stPubAttr.enIntfSync = VO_OUTPUT_1080P30;
+
+    if(HI_SUCCESS != SAMPLE_COMM_VO_StartDevLayer(VoDev, &stPubAttr, 25))
+    {
+        printf("[Func]:%s [Line]:%d [Info]:%s\n", __FUNCTION__, __LINE__, "failed");
+        return HI_FAILURE;
+    }
+
+    s32Ret = SAMPLE_COMM_VO_HdmiStart(stPubAttr.enIntfSync);
+    if(HI_SUCCESS != s32Ret)
+    {
+        printf("[Func]:%s [Line]:%d [Info]:%s\n", __FUNCTION__, __LINE__, "failed");
+        return HI_FAILURE;
+    }
+
+    HI_MPI_HDMI_SetAVMute(enHdmi, HI_TRUE);
+
+    s32Ret = HI_MPI_HDMI_GetAttr(enHdmi, &stHdmiAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        printf("[Func]:%s [Line]:%d [Info]:%s\n", __FUNCTION__, __LINE__, "failed");
+        return HI_FAILURE;
+    }
+    stHdmiAttr.bEnableAudio = HI_TRUE;        /**< 是否Enable音频 */
+    stHdmiAttr.enSoundIntf = HI_HDMI_SND_INTERFACE_I2S; /**< HDMI音频来源, 建议HI_HDMI_SND_INTERFACE_I2S,此参数需要与AO输入保持一致 */
+    stHdmiAttr.enSampleRate = pstAioAttr->enSamplerate;        /**< PCM音频采样率,此参数需要与AO的配置保持一致 */
+    stHdmiAttr.u8DownSampleParm = HI_FALSE;    /**< PCM音频向下downsample采样率的参数，默认为0 */
+
+    stHdmiAttr.enBitDepth = 8 * (pstAioAttr->enBitwidth+1);   /**< 音频位宽，默认为16,此参数需要与AO的配置保持一致 */
+    stHdmiAttr.u8I2SCtlVbit = 0;        /**< 保留，请配置为0, I2S control (0x7A:0x1D) */
+
+    stHdmiAttr.bEnableAviInfoFrame = HI_TRUE; /**< 是否使能 AVI InfoFrame，建议使能 */
+    stHdmiAttr.bEnableAudInfoFrame = HI_TRUE;; /**< 是否使能 AUDIO InfoFrame，建议使能 */
+
+    s32Ret = HI_MPI_HDMI_SetAttr(enHdmi, &stHdmiAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        printf("[Func]:%s [Line]:%d [Info]:%s\n", __FUNCTION__, __LINE__, "failed");
+        return HI_FAILURE;
+    }
+    HI_MPI_HDMI_SetAVMute(enHdmi, HI_FALSE);
+
+    return HI_SUCCESS;
+}
+
+inline HI_S32 SAMPLE_COMM_AUDIO_StopHdmi(HI_VOID)
+{
+    HI_S32 s32Ret;
+    VO_DEV VoDev = 0;
+
+    s32Ret =  SAMPLE_COMM_VO_HdmiStop();
+    s32Ret |= SAMPLE_COMM_VO_StopDevLayer(VoDev);
+    return s32Ret;
+}
+
+/******************************************************************************
+* function : Start Ao
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_StartAo(AUDIO_DEV AoDevId, AO_CHN AoChn,
+        AIO_ATTR_S *pstAioAttr, AUDIO_RESAMPLE_ATTR_S *pstAoReSmpAttr)
+{
+    HI_S32 s32Ret;
+
+#if (HICHIP != HI3532_V100)
+    if (SAMPLE_AUDIO_HDMI_AO_DEV == AoDevId)
+    {
+        SAMPLE_COMM_AUDIO_StartHdmi(pstAioAttr);
+    }
+#endif
+
+    s32Ret = HI_MPI_AO_SetPubAttr(AoDevId, pstAioAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        printf("%s: HI_MPI_AO_SetPubAttr(%d) failed with %#x!\n", __FUNCTION__, \
+               AoDevId,s32Ret);
+        return HI_FAILURE;
+    }
+    s32Ret = HI_MPI_AO_Enable(AoDevId);
+    if(HI_SUCCESS != s32Ret)
+    {
+        printf("%s: HI_MPI_AO_Enable(%d) failed with %#x!\n", __FUNCTION__, \
+               AoDevId, s32Ret);
+        return HI_FAILURE;
+    }
+    s32Ret = HI_MPI_AO_EnableChn(AoDevId, AoChn);
+    if(HI_SUCCESS != s32Ret)
+    {
+        printf("%s: HI_MPI_AO_EnableChn(%d) failed with %#x!\n", __FUNCTION__,\
+               AoChn, s32Ret);
+        return HI_FAILURE;
+    }
+
+    if (NULL != pstAoReSmpAttr)
+    {
+        s32Ret = HI_MPI_AO_DisableReSmp(AoDevId, AoChn);
+        s32Ret |= HI_MPI_AO_EnableReSmp(AoDevId, AoChn, pstAoReSmpAttr);
+        if(HI_SUCCESS != s32Ret)
+        {
+            printf("%s: HI_MPI_AO_EnableReSmp(%d,%d) failed with %#x!\n", \
+                   __FUNCTION__, AoDevId, AoChn, s32Ret);
+            return HI_FAILURE;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Stop Ao
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_StopAo(AUDIO_DEV AoDevId, AO_CHN AoChn, HI_BOOL bResampleEn)
+{
+    if (HI_TRUE == bResampleEn)
+    {
+        HI_MPI_AO_DisableReSmp(AoDevId, AoChn);
+    }
+    HI_MPI_AO_DisableChn(AoDevId, AoChn);
+    HI_MPI_AO_Disable(AoDevId);
+
+#if (HICHIP != HI3532_V100)
+    if (SAMPLE_AUDIO_HDMI_AO_DEV == AoDevId)
+    {
+        SAMPLE_COMM_AUDIO_StopHdmi();
+    }
+#endif
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Start Aenc
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_StartAenc(HI_S32 s32AencChnCnt, PAYLOAD_TYPE_E enType)
+{
+    AENC_CHN AeChn;
+    HI_S32 s32Ret, i;
+    AENC_CHN_ATTR_S stAencAttr;
+
+    /* set AENC chn attr */
+
+    stAencAttr.enType = enType;
+    stAencAttr.u32BufSize = 30;
+
+    if (PT_ADPCMA == stAencAttr.enType)
+    {
+        AENC_ATTR_ADPCM_S stAdpcmAenc;
+        stAencAttr.pValue       = &stAdpcmAenc;
+        stAdpcmAenc.enADPCMType = AUDIO_ADPCM_TYPE;
+    }
+    else if (PT_G711A == stAencAttr.enType || PT_G711U == stAencAttr.enType)
+    {
+        AENC_ATTR_G711_S stAencG711;
+        stAencAttr.pValue       = &stAencG711;
+    }
+    else if (PT_G726 == stAencAttr.enType)
+    {
+        AENC_ATTR_G726_S stAencG726;
+        stAencAttr.pValue       = &stAencG726;
+        stAencG726.enG726bps    = G726_BPS;
+    }
+    else if (PT_LPCM == stAencAttr.enType)
+    {
+        AENC_ATTR_LPCM_S stAencLpcm;
+        stAencAttr.pValue = &stAencLpcm;
+    }
+    else
+    {
+        printf("%s: invalid aenc payload type:%d\n", __FUNCTION__, stAencAttr.enType);
+        return HI_FAILURE;
+    }
+
+    for (i=0; i<s32AencChnCnt; i++)
+    {
+        AeChn = i;
+
+        /* create aenc chn*/
+        s32Ret = HI_MPI_AENC_CreateChn(AeChn, &stAencAttr);
+        if (s32Ret != HI_SUCCESS)
+        {
+            printf("%s: HI_MPI_AENC_CreateChn(%d) failed with %#x!\n", __FUNCTION__,
+                   AeChn, s32Ret);
+            return HI_FAILURE;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Stop Aenc
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_StopAenc(HI_S32 s32AencChnCnt)
+{
+    HI_S32 i;
+    for (i=0; i<s32AencChnCnt; i++)
+    {
+        HI_MPI_AENC_DestroyChn(i);
+    }
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Start Adec
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_StartAdec(ADEC_CHN AdChn, PAYLOAD_TYPE_E enType)
+{
+    HI_S32 s32Ret;
+    ADEC_CHN_ATTR_S stAdecAttr;
+
+    stAdecAttr.enType = enType;
+    stAdecAttr.u32BufSize = 20;
+    stAdecAttr.enMode = ADEC_MODE_STREAM;/* propose use pack mode in your app */
+
+    if (PT_ADPCMA == stAdecAttr.enType)
+    {
+        ADEC_ATTR_ADPCM_S stAdpcm;
+        stAdecAttr.pValue = &stAdpcm;
+        stAdpcm.enADPCMType = AUDIO_ADPCM_TYPE ;
+    }
+    else if (PT_G711A == stAdecAttr.enType || PT_G711U == stAdecAttr.enType)
+    {
+        ADEC_ATTR_G711_S stAdecG711;
+        stAdecAttr.pValue = &stAdecG711;
+    }
+    else if (PT_G726 == stAdecAttr.enType)
+    {
+        ADEC_ATTR_G726_S stAdecG726;
+        stAdecAttr.pValue = &stAdecG726;
+        stAdecG726.enG726bps = G726_BPS ;
+    }
+    else if (PT_LPCM == stAdecAttr.enType)
+    {
+        ADEC_ATTR_LPCM_S stAdecLpcm;
+        stAdecAttr.pValue = &stAdecLpcm;
+        stAdecAttr.enMode = ADEC_MODE_PACK;/* lpcm must use pack mode */
+    }
+    else
+    {
+        printf("%s: invalid aenc payload type:%d\n", __FUNCTION__, stAdecAttr.enType);
+        return HI_FAILURE;
+    }
+
+    /* create adec chn*/
+    s32Ret = HI_MPI_ADEC_CreateChn(AdChn, &stAdecAttr);
+    if (s32Ret)
+    {
+        printf("%s: HI_MPI_ADEC_CreateChn(%d) failed with %#x!\n", __FUNCTION__,\
+               AdChn,s32Ret);
+        return s32Ret;
+    }
+    return 0;
+}
+
+/******************************************************************************
+* function : Stop Adec
+******************************************************************************/
+HI_S32 SAMPLE_COMM_AUDIO_StopAdec(ADEC_CHN AdChn)
+{
+    HI_MPI_ADEC_DestroyChn(AdChn);
+    return HI_SUCCESS;
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+

--- a/libraries/mpp_sample/hi3520dv200/common/sample_comm_sys.c
+++ b/libraries/mpp_sample/hi3520dv200/common/sample_comm_sys.c
@@ -1,0 +1,384 @@
+/******************************************************************************
+  Some simple Hisilicon Hi3531 system functions.
+
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-2 Created
+******************************************************************************/
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/poll.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+#include <math.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "sample_comm.h"
+
+/******************************************************************************
+* function : get picture size(w*h), according Norm and enPicSize
+******************************************************************************/
+HI_S32 SAMPLE_COMM_SYS_GetPicSize(VIDEO_NORM_E enNorm, PIC_SIZE_E enPicSize, SIZE_S *pstSize)
+{
+    switch (enPicSize)
+    {
+        case PIC_QCIF:
+            pstSize->u32Width = D1_WIDTH / 4;
+            pstSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?144:120;
+            break;
+        case PIC_CIF:
+            pstSize->u32Width = D1_WIDTH / 2;
+            pstSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?288:240;
+            break;
+        case PIC_D1:
+            pstSize->u32Width = D1_WIDTH;
+            pstSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+            break;
+        case PIC_960H:
+            pstSize->u32Width = 960;
+            pstSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+            break;			
+        case PIC_2CIF:
+            pstSize->u32Width = D1_WIDTH / 2;
+            pstSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+            break;
+        case PIC_QVGA:    /* 320 * 240 */
+            pstSize->u32Width = 320;
+            pstSize->u32Height = 240;
+            break;
+        case PIC_VGA:     /* 640 * 480 */
+            pstSize->u32Width = 640;
+            pstSize->u32Height = 480;
+            break;
+        case PIC_XGA:     /* 1024 * 768 */
+            pstSize->u32Width = 1024;
+            pstSize->u32Height = 768;
+            break;
+        case PIC_SXGA:    /* 1400 * 1050 */
+            pstSize->u32Width = 1400;
+            pstSize->u32Height = 1050;
+            break;
+        case PIC_UXGA:    /* 1600 * 1200 */
+            pstSize->u32Width = 1600;
+            pstSize->u32Height = 1200;
+            break;
+        case PIC_QXGA:    /* 2048 * 1536 */
+            pstSize->u32Width = 2048;
+            pstSize->u32Height = 1536;
+            break;
+        case PIC_WVGA:    /* 854 * 480 */
+            pstSize->u32Width = 854;
+            pstSize->u32Height = 480;
+            break;
+        case PIC_WSXGA:   /* 1680 * 1050 */
+            pstSize->u32Width = 1680;
+            pstSize->u32Height = 1050;
+            break;
+        case PIC_WUXGA:   /* 1920 * 1200 */
+            pstSize->u32Width = 1920;
+            pstSize->u32Height = 1200;
+            break;
+        case PIC_WQXGA:   /* 2560 * 1600 */
+            pstSize->u32Width = 2560;
+            pstSize->u32Height = 1600;
+            break;
+        case PIC_HD720:   /* 1280 * 720 */
+            pstSize->u32Width = 1280;
+            pstSize->u32Height = 720;
+            break;
+        case PIC_HD1080:  /* 1920 * 1080 */
+            pstSize->u32Width = 1920;
+            pstSize->u32Height = 1080;
+            break;
+        default:
+            return HI_FAILURE;
+    }
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : calculate VB Block size of Histogram.
+******************************************************************************/
+HI_U32 SAMPLE_COMM_SYS_CalcHistVbBlkSize(VIDEO_NORM_E enNorm, PIC_SIZE_E enPicSize, SIZE_S *pstHistBlkSize, HI_U32 u32AlignWidth)
+{
+    HI_S32 s32Ret;
+    SIZE_S stPicSize;
+    
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(enNorm, enPicSize, &stPicSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("get picture size[%d] failed!\n", enPicSize);
+            return HI_FAILURE;
+    }
+
+   SAMPLE_PRT("stPicSize.u32Width%d,pstHistBlkSize->u32Width%d\n,stPicSize.u32Height%d,pstHistBlkSize->u32Height%d\n",
+   	stPicSize.u32Width,pstHistBlkSize->u32Width,
+   	stPicSize.u32Height,pstHistBlkSize->u32Height );
+    return (CEILING_2_POWER(44, u32AlignWidth)*CEILING_2_POWER(44, u32AlignWidth)*16*4);
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : calculate VB Block size of picture.
+******************************************************************************/
+HI_U32 SAMPLE_COMM_SYS_CalcPicVbBlkSize(VIDEO_NORM_E enNorm, PIC_SIZE_E enPicSize, PIXEL_FORMAT_E enPixFmt, HI_U32 u32AlignWidth)
+{
+    HI_S32 s32Ret = HI_FAILURE;
+    SIZE_S stSize;
+
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(enNorm, enPicSize, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("get picture size[%d] failed!\n", enPicSize);
+            return HI_FAILURE;
+    }
+
+    if (PIXEL_FORMAT_YUV_SEMIPLANAR_422 != enPixFmt && PIXEL_FORMAT_YUV_SEMIPLANAR_420 != enPixFmt)
+    {
+        SAMPLE_PRT("pixel format[%d] input failed!\n", enPixFmt);
+            return HI_FAILURE;
+    }
+
+    if (16!=u32AlignWidth && 32!=u32AlignWidth && 64!=u32AlignWidth)
+    {
+        SAMPLE_PRT("system align width[%d] input failed!\n",\
+               u32AlignWidth);
+            return HI_FAILURE;
+    }
+    if (704 == stSize.u32Width)
+    {
+        stSize.u32Width = 720;
+    }
+    
+    SAMPLE_PRT("w:%d, u32AlignWidth:%d\n", CEILING_2_POWER(stSize.u32Width,u32AlignWidth), u32AlignWidth);
+    return (CEILING_2_POWER(stSize.u32Width, u32AlignWidth) * \
+            CEILING_2_POWER(stSize.u32Height,u32AlignWidth) * \
+           ((PIXEL_FORMAT_YUV_SEMIPLANAR_422 == enPixFmt)?2:1.5));
+}
+
+/******************************************************************************
+* function : Set system memory location
+******************************************************************************/
+HI_S32 SAMPLE_COMM_SYS_MemConfig(HI_VOID)
+{
+    HI_S32 i = 0;
+    HI_S32 s32Ret = HI_SUCCESS;
+
+    HI_CHAR * pcMmzName;
+    MPP_CHN_S stMppChnVI;
+    MPP_CHN_S stMppChnVO;
+    MPP_CHN_S stMppChnVPSS;
+    MPP_CHN_S stMppChnGRP;
+    MPP_CHN_S stMppChnVENC;
+    MPP_CHN_S stMppChnRGN;
+    MPP_CHN_S stMppChnVDEC;
+
+    /*VI,VDEC最大通道数为32*/
+    for(i=0;i<32;i++)
+    {
+        stMppChnVI.enModId = HI_ID_VIU;
+        stMppChnVI.s32DevId = 0;
+        stMppChnVI.s32ChnId = i;
+        
+        stMppChnVDEC.enModId = HI_ID_VDEC;
+        stMppChnVDEC.s32DevId = 0;
+        stMppChnVDEC.s32ChnId = i;
+        
+        if(0 == (i%2))
+        {
+            pcMmzName = NULL;  
+        }
+        else
+        {
+            pcMmzName = "ddr1";
+        }
+
+        /*vi*/
+        s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnVI,pcMmzName);
+        if (s32Ret)
+        {
+            SAMPLE_PRT("HI_MPI_SYS_SetMemConf ERR !\n");
+            return HI_FAILURE;
+        }
+
+        /*vdec*/
+        s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnVDEC,pcMmzName);
+        if (s32Ret)
+        {
+            SAMPLE_PRT("HI_MPI_SYS_SetMemConf ERR !\n");
+            return HI_FAILURE;
+        }
+
+    }  
+
+    /*vpss,grp,venc最大通道为64*/
+    for(i=0;i<64;i++)
+    {
+        stMppChnVPSS.enModId  = HI_ID_VPSS;
+        stMppChnVPSS.s32DevId = i;
+        stMppChnVPSS.s32ChnId = 0;
+
+        stMppChnGRP.enModId  = HI_ID_GROUP;
+        stMppChnGRP.s32DevId = i;
+        stMppChnGRP.s32ChnId = 0;
+
+        stMppChnVENC.enModId = HI_ID_VENC;
+        stMppChnVENC.s32DevId = 0;
+        stMppChnVENC.s32ChnId = i;
+
+        if(0 == (i%2))
+        {
+            pcMmzName = NULL;  
+        }
+        else
+        {
+            pcMmzName = "ddr1";
+        }
+
+        /*vpss*/
+        s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnVPSS,pcMmzName);
+        if (s32Ret)
+        {
+            SAMPLE_PRT("HI_MPI_SYS_SetMemConf ERR !\n");
+            return HI_FAILURE;
+        }
+
+        /*grp*/
+        s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnGRP,pcMmzName);
+        if (s32Ret)
+        {
+            SAMPLE_PRT("HI_MPI_SYS_SetMemConf ERR !\n");
+            return HI_FAILURE;
+        } 
+
+        /*venc*/
+        s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnVENC,pcMmzName);
+        if (s32Ret)
+        {
+            SAMPLE_PRT("HI_MPI_SYS_SetMemConf ERR !\n");
+            return HI_FAILURE;
+        }
+
+    }
+    
+    stMppChnRGN.enModId  = HI_ID_RGN;
+    stMppChnRGN.s32DevId = 0;
+    stMppChnRGN.s32ChnId = 0;
+        
+    /*配置VO内存*/
+    stMppChnVO.enModId  = HI_ID_VOU;
+    stMppChnVO.s32DevId = 0;
+    stMppChnVO.s32ChnId = 0;
+    s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnVO,"ddr1");
+    if (s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_SYS_SetMemConf ERR !\n");
+        return HI_FAILURE;
+    } 
+    
+    return s32Ret;
+}
+
+/******************************************************************************
+* function : vb init & MPI system init
+******************************************************************************/
+HI_S32 SAMPLE_COMM_SYS_Init(VB_CONF_S *pstVbConf)
+{
+    MPP_SYS_CONF_S stSysConf = {0};
+    HI_S32 s32Ret = HI_FAILURE;
+
+    HI_MPI_SYS_Exit();
+    HI_MPI_VB_Exit();
+
+    if (NULL == pstVbConf)
+    {
+        SAMPLE_PRT("input parameter is null, it is invaild!\n");
+        return HI_FAILURE;
+    }
+
+    s32Ret = HI_MPI_VB_SetConf(pstVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VB_SetConf failed!\n");
+        return HI_FAILURE;
+    }
+
+    s32Ret = HI_MPI_VB_Init();
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VB_Init failed!\n");
+        return HI_FAILURE;
+    }
+
+    stSysConf.u32AlignWidth = SAMPLE_SYS_ALIGN_WIDTH;
+    s32Ret = HI_MPI_SYS_SetConf(&stSysConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_SYS_SetConf failed\n");
+        return HI_FAILURE;
+    }
+
+    s32Ret = HI_MPI_SYS_Init();
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_SYS_Init failed!\n");
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : vb init & MPI system init
+******************************************************************************/
+HI_S32 SAMPLE_COMM_SYS_Payload2FilePostfix(PAYLOAD_TYPE_E enPayload, HI_CHAR* szFilePostfix)
+{
+    if (PT_H264 == enPayload)
+    {
+        strcpy(szFilePostfix, ".h264");
+    }
+    else if (PT_JPEG == enPayload)
+    {
+        strcpy(szFilePostfix, ".jpg");
+    }
+    else if (PT_MJPEG == enPayload)
+    {
+        strcpy(szFilePostfix, ".mjp");
+    }
+    else
+    {
+        SAMPLE_PRT("payload type err!\n");
+        return HI_FAILURE;
+    }
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : vb exit & MPI system exit
+******************************************************************************/
+HI_VOID SAMPLE_COMM_SYS_Exit(void)
+{
+    HI_MPI_SYS_Exit();
+    HI_MPI_VB_Exit();
+    return;
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */

--- a/libraries/mpp_sample/hi3520dv200/common/sample_comm_vda.c
+++ b/libraries/mpp_sample/hi3520dv200/common/sample_comm_vda.c
@@ -1,0 +1,553 @@
+/******************************************************************************
+  Some simple Hisilicon HI3516 vda functions.
+
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-2 Created
+******************************************************************************/
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/poll.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+#include <math.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "sample_comm.h"
+
+typedef struct hiVDA_OD_PARAM_S
+{
+    HI_BOOL bThreadStart;
+    VDA_CHN VdaChn;
+}VDA_OD_PARAM_S;
+typedef struct hiVDA_MD_PARAM_S
+{
+    HI_BOOL bThreadStart;
+    VDA_CHN VdaChn;
+}VDA_MD_PARAM_S;
+
+#define SAMPLE_VDA_MD_CHN 0
+#define SAMPLE_VDA_OD_CHN 1
+
+static pthread_t gs_VdaPid[2];
+static VDA_MD_PARAM_S gs_stMdParam;
+static VDA_OD_PARAM_S gs_stOdParam;
+
+/******************************************************************************
+* funciton : vda MD mode print -- Md OBJ
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VDA_MdPrtObj(FILE *fp, VDA_DATA_S *pstVdaData)
+{
+    VDA_OBJ_S *pstVdaObj;
+    HI_S32 i;
+	
+    fprintf(fp, "===== %s =====\n", __FUNCTION__);
+    
+    if (HI_TRUE != pstVdaData->unData.stMdData.bObjValid)
+    {
+        fprintf(fp, "bMbObjValid = FALSE.\n");
+        return HI_SUCCESS;
+    }
+	
+    fprintf(fp, "ObjNum=%d, IndexOfMaxObj=%d, SizeOfMaxObj=%d, SizeOfTotalObj=%d\n", \
+                   pstVdaData->unData.stMdData.stObjData.u32ObjNum, \
+		     pstVdaData->unData.stMdData.stObjData.u32IndexOfMaxObj, \
+		     pstVdaData->unData.stMdData.stObjData.u32SizeOfMaxObj,\
+		     pstVdaData->unData.stMdData.stObjData.u32SizeOfTotalObj);
+    for (i=0; i<pstVdaData->unData.stMdData.stObjData.u32ObjNum; i++)
+    {
+        pstVdaObj = pstVdaData->unData.stMdData.stObjData.pstAddr + i;
+        fprintf(fp, "[%d]\t left=%d, top=%d, right=%d, bottom=%d\n", i, \
+			  pstVdaObj->u16Left, pstVdaObj->u16Top, \
+			  pstVdaObj->u16Right, pstVdaObj->u16Bottom);
+    }
+    fflush(fp);
+    return HI_SUCCESS;
+}
+/******************************************************************************
+* funciton : vda MD mode print -- Alarm Pixel Count
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VDA_MdPrtAp(FILE *fp, VDA_DATA_S *pstVdaData)
+{
+    fprintf(fp, "===== %s =====\n", __FUNCTION__);
+    
+    if (HI_TRUE != pstVdaData->unData.stMdData.bPelsNumValid)
+    {
+        fprintf(fp, "bMbObjValid = FALSE.\n");
+        return HI_SUCCESS;
+    }
+	
+    fprintf(fp, "AlarmPixelCount=%d\n", pstVdaData->unData.stMdData.u32AlarmPixCnt);
+    fflush(fp);
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : vda MD mode print -- SAD
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VDA_MdPrtSad(FILE *fp, VDA_DATA_S *pstVdaData)
+{
+    HI_S32 i, j;
+    HI_VOID *pAddr;
+	
+    fprintf(fp, "===== %s =====\n", __FUNCTION__);
+    if (HI_TRUE != pstVdaData->unData.stMdData.bMbSadValid)
+    {
+        fprintf(fp, "bMbSadValid = FALSE.\n");
+        return HI_SUCCESS;
+    }
+
+    for(i=0; i<pstVdaData->u32MbHeight; i++)
+    {
+		pAddr = (HI_VOID *)((HI_U32)pstVdaData->unData.stMdData.stMbSadData.pAddr
+		  			+ i * pstVdaData->unData.stMdData.stMbSadData.u32Stride);
+	
+		for(j=0; j<pstVdaData->u32MbWidth; j++)
+		{
+	        HI_U8  *pu8Addr;
+	        HI_U16 *pu16Addr;
+		
+	        if(VDA_MB_SAD_8BIT == pstVdaData->unData.stMdData.stMbSadData.enMbSadBits)
+	        {
+	            pu8Addr = (HI_U8 *)pAddr + j;
+
+	            fprintf(fp, "%-2d ",*pu8Addr);
+
+	        }
+	        else
+	        {
+	            pu16Addr = (HI_U16 *)pAddr + j;
+
+				fprintf(fp, "%-4d ",*pu16Addr);
+	        }
+		}
+		
+        printf("\n");
+    }
+	
+    fflush(fp);
+    return HI_SUCCESS;
+}
+/******************************************************************************
+* funciton : vda MD mode thread process
+******************************************************************************/
+HI_VOID *SAMPLE_COMM_VDA_MdGetResult(HI_VOID *pdata)
+{
+    HI_S32 s32Ret;
+    VDA_CHN VdaChn;
+    VDA_DATA_S stVdaData;
+    VDA_MD_PARAM_S *pgs_stMdParam;
+    HI_S32 maxfd = 0;
+    FILE *fp = stdout;
+    HI_S32 VdaFd;
+    fd_set read_fds;
+    struct timeval TimeoutVal;
+
+    pgs_stMdParam = (VDA_MD_PARAM_S *)pdata;
+
+    VdaChn   = pgs_stMdParam->VdaChn;
+
+    /* decide the stream file name, and open file to save stream */
+    /* Set Venc Fd. */
+    VdaFd = HI_MPI_VDA_GetFd(VdaChn);
+    if (VdaFd < 0)
+    {
+        SAMPLE_PRT("HI_MPI_VDA_GetFd failed with %#x!\n", 
+               VdaFd);
+        return NULL;
+    }
+    if (maxfd <= VdaFd)
+    {
+        maxfd = VdaFd;
+    }
+    system("clear");
+    while (HI_TRUE == pgs_stMdParam->bThreadStart)
+    {
+        FD_ZERO(&read_fds);
+        FD_SET(VdaFd, &read_fds);
+
+        TimeoutVal.tv_sec  = 2;
+        TimeoutVal.tv_usec = 0;
+        s32Ret = select(maxfd + 1, &read_fds, NULL, NULL, &TimeoutVal);
+        if (s32Ret < 0)
+        {
+            SAMPLE_PRT("select failed!\n");
+            break;
+        }
+        else if (s32Ret == 0)
+        {
+            SAMPLE_PRT("get venc stream time out, exit thread\n");
+            break;
+        }
+        else
+        {
+            if (FD_ISSET(VdaFd, &read_fds))
+            {
+                /*******************************************************
+                   step 2.3 : call mpi to get one-frame stream
+                   *******************************************************/
+                s32Ret = HI_MPI_VDA_GetData(VdaChn, &stVdaData, HI_TRUE);
+                if(s32Ret != HI_SUCCESS)
+                {
+                    SAMPLE_PRT("HI_MPI_VDA_GetData failed with %#x!\n", s32Ret);
+                    return NULL;
+                }
+                /*******************************************************
+                   *step 2.4 : save frame to file
+                   *******************************************************/
+                printf("\033[0;0H");/*move cursor*/
+		        SAMPLE_COMM_VDA_MdPrtSad(fp, &stVdaData);
+		        SAMPLE_COMM_VDA_MdPrtObj(fp, &stVdaData);
+                SAMPLE_COMM_VDA_MdPrtAp(fp, &stVdaData);
+                /*******************************************************
+                   *step 2.5 : release stream
+                   *******************************************************/
+                s32Ret = HI_MPI_VDA_ReleaseData(VdaChn,&stVdaData);
+                if(s32Ret != HI_SUCCESS)
+	            {
+	                SAMPLE_PRT("HI_MPI_VDA_ReleaseData failed with %#x!\n", s32Ret);
+	                return NULL;
+	            }
+            }
+        }
+    }
+
+    return HI_NULL;
+}
+
+/******************************************************************************
+* funciton : vda OD mode thread process
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VDA_OdPrt(FILE *fp, VDA_DATA_S *pstVdaData)
+{
+    HI_S32 i;
+
+    fprintf(fp, "===== %s =====\n", __FUNCTION__);
+    fprintf(fp, "OD region total count =%d\n", pstVdaData->unData.stOdData.u32RgnNum);
+    for(i=0; i<pstVdaData->unData.stOdData.u32RgnNum; i++)
+    {
+        fprintf(fp, "OD region[%d]: %d\n", i, pstVdaData->unData.stOdData.abRgnAlarm[i]);
+    }
+    fflush(fp);
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : vda OD mode thread process
+******************************************************************************/
+HI_VOID *SAMPLE_COMM_VDA_OdGetResult(HI_VOID *pdata)
+{
+    HI_S32 i;
+    HI_S32 s32Ret;
+    VDA_CHN VdaChn;
+    VDA_DATA_S stVdaData;
+    HI_U32 u32RgnNum;
+    VDA_OD_PARAM_S *pgs_stOdParam;
+    //FILE *fp=stdout;
+
+    pgs_stOdParam = (VDA_OD_PARAM_S *)pdata;
+
+    VdaChn    = pgs_stOdParam->VdaChn;
+    
+
+    while(HI_TRUE == pgs_stOdParam->bThreadStart)
+    {
+        s32Ret = HI_MPI_VDA_GetData(VdaChn,&stVdaData,HI_TRUE);
+        if(s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("HI_MPI_VDA_GetData failed with %#x!\n", s32Ret);
+            return NULL;
+        }
+
+	    //SAMPLE_COMM_VDA_OdPrt(fp, &stVdaData);
+
+		u32RgnNum = stVdaData.unData.stOdData.u32RgnNum;
+		
+        for(i=0; i<u32RgnNum; i++)
+        {
+            if(HI_TRUE == stVdaData.unData.stOdData.abRgnAlarm[i])
+            { 
+                printf("################VdaChn--%d,Rgn--%d,Occ!\n",VdaChn,i);
+                s32Ret = HI_MPI_VDA_ResetOdRegion(VdaChn,i);
+                if(s32Ret != HI_SUCCESS)
+                {
+		            SAMPLE_PRT("HI_MPI_VDA_ResetOdRegion failed with %#x!\n", s32Ret);
+                    return NULL;
+                }
+            }
+        }
+
+        s32Ret = HI_MPI_VDA_ReleaseData(VdaChn,&stVdaData);
+        if(s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("HI_MPI_VDA_ReleaseData failed with %#x!\n", s32Ret);
+            return NULL;
+        }
+
+        usleep(200*1000);
+    }
+
+    return HI_NULL;
+}
+
+/******************************************************************************
+* funciton : start vda MD mode
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VDA_MdStart(VDA_CHN VdaChn, VI_CHN ViChn, SIZE_S *pstSize)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    VDA_CHN_ATTR_S stVdaChnAttr;
+    MPP_CHN_S stSrcChn, stDestChn;
+	
+    if (VDA_MAX_WIDTH < pstSize->u32Width || VDA_MAX_HEIGHT < pstSize->u32Height)
+    {
+        SAMPLE_PRT("Picture size invaild!\n");
+        return HI_FAILURE;
+    }
+	
+    /* step 1 create vda channel */
+    stVdaChnAttr.enWorkMode = VDA_WORK_MODE_MD;
+    stVdaChnAttr.u32Width   = pstSize->u32Width;
+    stVdaChnAttr.u32Height  = pstSize->u32Height;
+
+    stVdaChnAttr.unAttr.stMdAttr.enVdaAlg      = VDA_ALG_REF;
+    stVdaChnAttr.unAttr.stMdAttr.enMbSize      = VDA_MB_16PIXEL;
+    stVdaChnAttr.unAttr.stMdAttr.enMbSadBits   = VDA_MB_SAD_8BIT;
+    stVdaChnAttr.unAttr.stMdAttr.enRefMode     = VDA_REF_MODE_DYNAMIC;
+    stVdaChnAttr.unAttr.stMdAttr.u32MdBufNum   = 8;
+    stVdaChnAttr.unAttr.stMdAttr.u32VdaIntvl   = 4;  
+    stVdaChnAttr.unAttr.stMdAttr.u32BgUpSrcWgt = 128;
+    stVdaChnAttr.unAttr.stMdAttr.u32SadTh      = 100;
+    stVdaChnAttr.unAttr.stMdAttr.u32ObjNumMax  = 128;
+
+    s32Ret = HI_MPI_VDA_CreateChn(VdaChn, &stVdaChnAttr);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err!\n");
+        return s32Ret;
+    }
+
+    /* step 2: vda chn bind vi chn */
+    stSrcChn.enModId = HI_ID_VIU;
+    stSrcChn.s32ChnId = ViChn;
+    stSrcChn.s32DevId = 0;
+
+    stDestChn.enModId = HI_ID_VDA;
+    stDestChn.s32ChnId = VdaChn;
+    stDestChn.s32DevId = 0;
+
+    s32Ret = HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err!\n");
+        return s32Ret;
+    }
+
+    /* step 3: vda chn start recv picture */
+    s32Ret = HI_MPI_VDA_StartRecvPic(VdaChn);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err!\n");
+        return s32Ret;
+    }
+    /* step 4: create thread to get result */
+    gs_stMdParam.bThreadStart = HI_TRUE;
+    gs_stMdParam.VdaChn   = VdaChn;
+
+    pthread_create(&gs_VdaPid[SAMPLE_VDA_MD_CHN],0, SAMPLE_COMM_VDA_MdGetResult, (HI_VOID *)&gs_stMdParam);
+
+    return HI_SUCCESS;
+}
+/******************************************************************************
+* funciton : start vda OD mode
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VDA_OdStart(VDA_CHN VdaChn, VI_CHN ViChn, SIZE_S *pstSize)
+{
+    VDA_CHN_ATTR_S stVdaChnAttr;
+    MPP_CHN_S stSrcChn, stDestChn;
+    HI_S32 s32Ret = HI_SUCCESS;
+    
+    if (VDA_MAX_WIDTH < pstSize->u32Width || VDA_MAX_HEIGHT < pstSize->u32Height)
+    {
+        SAMPLE_PRT("Picture size invaild!\n");
+        return HI_FAILURE;
+    }
+    
+    /********************************************
+     step 1 : create vda channel
+    ********************************************/
+    stVdaChnAttr.enWorkMode = VDA_WORK_MODE_OD;
+    stVdaChnAttr.u32Width   = pstSize->u32Width;
+    stVdaChnAttr.u32Height  = pstSize->u32Height;
+
+    stVdaChnAttr.unAttr.stOdAttr.enVdaAlg      = VDA_ALG_REF;
+    stVdaChnAttr.unAttr.stOdAttr.enMbSize      = VDA_MB_8PIXEL;
+    stVdaChnAttr.unAttr.stOdAttr.enMbSadBits   = VDA_MB_SAD_8BIT;
+    stVdaChnAttr.unAttr.stOdAttr.enRefMode     = VDA_REF_MODE_DYNAMIC;
+    stVdaChnAttr.unAttr.stOdAttr.u32VdaIntvl   = 4;
+    stVdaChnAttr.unAttr.stOdAttr.u32BgUpSrcWgt = 128;
+    
+    stVdaChnAttr.unAttr.stOdAttr.u32RgnNum = 1;
+    
+    stVdaChnAttr.unAttr.stOdAttr.astOdRgnAttr[0].stRect.s32X = 0;
+    stVdaChnAttr.unAttr.stOdAttr.astOdRgnAttr[0].stRect.s32Y = 0;
+    stVdaChnAttr.unAttr.stOdAttr.astOdRgnAttr[0].stRect.u32Width  = pstSize->u32Width;
+    stVdaChnAttr.unAttr.stOdAttr.astOdRgnAttr[0].stRect.u32Height = pstSize->u32Height;
+
+    stVdaChnAttr.unAttr.stOdAttr.astOdRgnAttr[0].u32SadTh      = 100;
+    stVdaChnAttr.unAttr.stOdAttr.astOdRgnAttr[0].u32AreaTh     = 60;
+    stVdaChnAttr.unAttr.stOdAttr.astOdRgnAttr[0].u32OccCntTh   = 6;
+    stVdaChnAttr.unAttr.stOdAttr.astOdRgnAttr[0].u32UnOccCntTh = 2;
+    
+    s32Ret = HI_MPI_VDA_CreateChn(VdaChn, &stVdaChnAttr);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err!\n");
+        return(s32Ret);
+    }
+
+    /********************************************
+     step 2 : bind vda channel to vi channel
+    ********************************************/
+    stSrcChn.enModId = HI_ID_VIU;
+    stSrcChn.s32ChnId = ViChn;
+
+    stDestChn.enModId = HI_ID_VDA;
+    stDestChn.s32ChnId = VdaChn;
+	stDestChn.s32DevId = 0;
+
+    s32Ret = HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err!\n");
+        return s32Ret;
+    }
+
+    /* vda start rcv picture */
+    s32Ret = HI_MPI_VDA_StartRecvPic(VdaChn);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err!\n");
+        return(s32Ret);
+    }
+
+    /*........*/
+    gs_stOdParam.bThreadStart = HI_TRUE;
+    gs_stOdParam.VdaChn   = VdaChn;
+
+    pthread_create(&gs_VdaPid[SAMPLE_VDA_OD_CHN], 0, SAMPLE_COMM_VDA_OdGetResult, (HI_VOID *)&gs_stOdParam);
+
+    return HI_SUCCESS;
+}
+/******************************************************************************
+* funciton : stop vda, and stop vda thread -- MD
+******************************************************************************/
+HI_VOID SAMPLE_COMM_VDA_MdStop(VDA_CHN VdaChn, VI_CHN ViChn)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    
+    MPP_CHN_S stSrcChn, stDestChn;
+
+    /* join thread */
+    if (HI_TRUE == gs_stMdParam.bThreadStart)
+    {
+        gs_stMdParam.bThreadStart = HI_FALSE;
+        pthread_join(gs_VdaPid[SAMPLE_VDA_MD_CHN], 0);
+    }
+    
+    /* vda stop recv picture */
+    s32Ret = HI_MPI_VDA_StopRecvPic(VdaChn);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err(0x%x)!!!!\n",s32Ret);
+    }
+
+    /* unbind vda chn & vi chn */
+
+    stSrcChn.enModId = HI_ID_VIU;
+    stSrcChn.s32ChnId = ViChn;
+    stSrcChn.s32DevId = 0;
+    stDestChn.enModId = HI_ID_VDA;
+    stDestChn.s32ChnId = VdaChn;
+    stDestChn.s32DevId = 0;
+    
+    s32Ret = HI_MPI_SYS_UnBind(&stSrcChn, &stDestChn);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err(0x%x)!!!!\n", s32Ret);
+    }
+	
+    /* destroy vda chn */
+    s32Ret = HI_MPI_VDA_DestroyChn(VdaChn);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err(0x%x)!!!!\n", s32Ret);
+    }
+    
+    return;
+}
+
+/******************************************************************************
+* funciton : stop vda, and stop vda thread -- OD
+******************************************************************************/
+HI_VOID SAMPLE_COMM_VDA_OdStop(VDA_CHN VdaChn, VI_CHN ViChn)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    MPP_CHN_S stSrcChn, stDestChn;
+
+    /* join thread */
+    if (HI_TRUE == gs_stOdParam.bThreadStart)
+    {
+        gs_stOdParam.bThreadStart = HI_FALSE;
+        pthread_join(gs_VdaPid[SAMPLE_VDA_OD_CHN], 0);
+    }
+	
+    /* vda stop recv picture */
+    s32Ret = HI_MPI_VDA_StopRecvPic(VdaChn);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err(0x%x)!!!!\n", s32Ret);
+    }
+
+    /* unbind vda chn & vi chn */
+    stSrcChn.enModId = HI_ID_VIU;
+    stSrcChn.s32ChnId = ViChn;
+    stSrcChn.s32DevId = 0;
+    stDestChn.enModId = HI_ID_VDA;
+    stDestChn.s32ChnId = VdaChn;
+    stDestChn.s32DevId = 0;
+    s32Ret = HI_MPI_SYS_UnBind(&stSrcChn, &stDestChn);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err(0x%x)!!!!\n", s32Ret);
+    }
+
+    /* destroy vda chn */
+    s32Ret = HI_MPI_VDA_DestroyChn(VdaChn);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("err(0x%x)!!!!\n",s32Ret);
+    }
+    return;
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+

--- a/libraries/mpp_sample/hi3520dv200/common/sample_comm_vdec.c
+++ b/libraries/mpp_sample/hi3520dv200/common/sample_comm_vdec.c
@@ -1,0 +1,181 @@
+/******************************************************************************
+  Some simple Hisilicon Hi3531 system functions.
+
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-2 Created
+******************************************************************************/
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/poll.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+#include <math.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "sample_comm.h"
+
+/******************************************************************************
+* function : vdec group bind vpss chn
+******************************************************************************/
+HI_S32 SAMLE_COMM_VDEC_BindVpss(VDEC_CHN VdChn, VPSS_GRP VpssGrp)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    MPP_CHN_S stSrcChn;
+    MPP_CHN_S stDestChn;
+
+    stSrcChn.enModId = HI_ID_VDEC;
+    stSrcChn.s32DevId = 0;
+    stSrcChn.s32ChnId = VdChn;
+
+    stDestChn.enModId = HI_ID_VPSS;
+    stDestChn.s32DevId = VpssGrp;
+    stDestChn.s32ChnId = 0;
+
+    s32Ret = HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_SYS_Bind failed with %#x!\n",s32Ret);
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : vdec group unbind vpss chn
+******************************************************************************/
+HI_S32 SAMLE_COMM_VDEC_UnBindVpss(VDEC_CHN VdChn, VPSS_GRP VpssGrp)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    MPP_CHN_S stSrcChn;
+    MPP_CHN_S stDestChn;
+
+    stSrcChn.enModId = HI_ID_VDEC;
+    stSrcChn.s32DevId = 0;
+    stSrcChn.s32ChnId = VdChn;
+
+    stDestChn.enModId = HI_ID_VPSS;
+    stDestChn.s32DevId = VpssGrp;
+    stDestChn.s32ChnId = 0;
+
+    s32Ret = HI_MPI_SYS_UnBind(&stSrcChn, &stDestChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_SYS_UnBind failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : vdec group bind vo chn
+******************************************************************************/
+HI_S32 SAMLE_COMM_VDEC_BindVo(VDEC_CHN VdChn, VO_DEV VoDev, VO_CHN VoChn)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    MPP_CHN_S stSrcChn;
+    MPP_CHN_S stDestChn;
+
+    stSrcChn.enModId = HI_ID_VDEC;
+    stSrcChn.s32DevId = 0;
+    stSrcChn.s32ChnId = VdChn;
+
+    stDestChn.enModId = HI_ID_VOU;
+    stDestChn.s32DevId = VoDev;
+    stDestChn.s32ChnId = VoChn;
+
+    s32Ret = HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_SYS_Bind failed with %#x!\n",s32Ret);
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : vdec group unbind vo chn
+******************************************************************************/
+HI_S32 SAMLE_COMM_VDEC_UnBindVo(VDEC_CHN VdChn, VO_DEV VoDev, VO_CHN VoChn)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    MPP_CHN_S stSrcChn;
+    MPP_CHN_S stDestChn;
+
+    stSrcChn.enModId = HI_ID_VDEC;
+    stSrcChn.s32DevId = 0;
+    stSrcChn.s32ChnId = VdChn;
+
+    stDestChn.enModId = HI_ID_VOU;
+    stDestChn.s32DevId = VoDev;
+    stDestChn.s32ChnId = VoChn;
+
+    s32Ret = HI_MPI_SYS_UnBind(&stSrcChn, &stDestChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_SYS_UnBind failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Set system memory location
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VDEC_MemConfig(HI_VOID)
+{
+    HI_S32 i = 0;
+    HI_S32 s32Ret = HI_SUCCESS;
+
+    HI_CHAR * pcMmzName;
+    MPP_CHN_S stMppChnVDEC;
+
+    /* VDEC chn max is 32*/
+    for(i=0;i<32;i++)
+    {
+        stMppChnVDEC.enModId = HI_ID_VDEC;
+        stMppChnVDEC.s32DevId = 0;
+        stMppChnVDEC.s32ChnId = i;
+        
+        if(0 == (i%2))
+        {
+            pcMmzName = NULL;  
+        }
+        else
+        {
+            pcMmzName = "ddr1";
+        }
+
+        s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnVDEC,pcMmzName);
+        if (s32Ret)
+        {
+            SAMPLE_PRT("HI_MPI_SYS_SetMemConf ERR !\n");
+            return HI_FAILURE;
+        }
+    }  
+
+    return HI_SUCCESS;
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */

--- a/libraries/mpp_sample/hi3520dv200/common/sample_comm_venc.c
+++ b/libraries/mpp_sample/hi3520dv200/common/sample_comm_venc.c
@@ -1,0 +1,1285 @@
+/******************************************************************************
+  Some simple Hisilicon Hi3531 video encode functions.
+
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-2 Created
+******************************************************************************/
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/poll.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+#include <math.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "sample_comm.h"
+ 
+const HI_U8 g_SOI[2] = {0xFF, 0xD8};
+const HI_U8 g_EOI[2] = {0xFF, 0xD9};
+static pthread_t gs_VencPid;
+static SAMPLE_VENC_GETSTREAM_PARA_S gs_stPara;
+static HI_S32 gs_s32SnapCnt = 0;
+
+/******************************************************************************
+* function : Set venc memory location
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_MemConfig(HI_VOID)
+{
+    HI_S32 i = 0;
+    HI_S32 s32Ret;
+
+    HI_CHAR * pcMmzName;
+    MPP_CHN_S stMppChnVENC;
+    MPP_CHN_S stMppChnGRP;
+
+    /* group, venc max chn is 64*/
+    for(i=0;i<64;i++)
+    {
+        stMppChnGRP.enModId  = HI_ID_GROUP;
+        stMppChnGRP.s32DevId = i;
+        stMppChnGRP.s32ChnId = 0;
+
+        stMppChnVENC.enModId = HI_ID_VENC;
+        stMppChnVENC.s32DevId = 0;
+        stMppChnVENC.s32ChnId = i;
+
+        if(0 == (i%2))
+        {
+            pcMmzName = NULL;  
+        }
+        else
+        {
+            pcMmzName = "ddr1";
+        }
+
+        /*grp*/
+        s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnGRP,pcMmzName);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("HI_MPI_SYS_SetMemConf failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+        } 
+
+        /*venc*/
+        s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnVENC,pcMmzName);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("HI_MPI_SYS_SetMemConf with %#x!\n", s32Ret);
+            return HI_FAILURE;
+        }
+    }
+    
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : venc bind vpss           
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_BindVpss(VENC_GRP GrpChn,VPSS_GRP VpssGrp,VPSS_CHN VpssChn)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    MPP_CHN_S stSrcChn;
+    MPP_CHN_S stDestChn;
+
+    stSrcChn.enModId = HI_ID_VPSS;
+    stSrcChn.s32DevId = VpssGrp;
+    stSrcChn.s32ChnId = VpssChn;
+
+    stDestChn.enModId = HI_ID_GROUP;
+    stDestChn.s32DevId = GrpChn;
+    stDestChn.s32ChnId = 0;
+
+    s32Ret = HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return s32Ret;
+}
+
+/******************************************************************************
+* function : venc unbind vpss           
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_UnBindVpss(VENC_GRP GrpChn,VPSS_GRP VpssGrp,VPSS_CHN VpssChn)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    MPP_CHN_S stSrcChn;
+    MPP_CHN_S stDestChn;
+
+    stSrcChn.enModId = HI_ID_VPSS;
+    stSrcChn.s32DevId = VpssGrp;
+    stSrcChn.s32ChnId = VpssChn;
+
+    stDestChn.enModId = HI_ID_GROUP;
+    stDestChn.s32DevId = GrpChn;
+    stDestChn.s32ChnId = 0;
+
+    s32Ret = HI_MPI_SYS_UnBind(&stSrcChn, &stDestChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return s32Ret;
+}
+
+/******************************************************************************
+* funciton : get file postfix according palyload_type.
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_GetFilePostfix(PAYLOAD_TYPE_E enPayload, char *szFilePostfix)
+{
+    if (PT_H264 == enPayload)
+    {
+        strcpy(szFilePostfix, ".h264");
+    }
+    else if (PT_JPEG == enPayload)
+    {
+        strcpy(szFilePostfix, ".jpg");
+    }
+    else if (PT_MJPEG == enPayload)
+    {
+        strcpy(szFilePostfix, ".mjp");
+    }
+    else if (PT_MP4VIDEO == enPayload)
+    {
+        strcpy(szFilePostfix, ".mp4");
+    }
+    else
+    {
+        SAMPLE_PRT("payload type err!\n");
+        return HI_FAILURE;
+    }
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : save mjpeg stream. 
+* WARNING: in Hi3531, user needn't write SOI & EOI.
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_SaveMJpeg(FILE* fpJpegFile, VENC_STREAM_S *pstStream)
+{
+    VENC_PACK_S*  pstData;
+    HI_U32 i;
+
+    //fwrite(g_SOI, 1, sizeof(g_SOI), fpJpegFile); //in Hi3531, user needn't write SOI!
+
+    for (i = 0; i < pstStream->u32PackCount; i++)
+    {
+        pstData = &pstStream->pstPack[i];
+        fwrite(pstData->pu8Addr[0], pstData->u32Len[0], 1, fpJpegFile);
+        fwrite(pstData->pu8Addr[1], pstData->u32Len[1], 1, fpJpegFile);
+    }
+
+    //fwrite(g_EOI, 1, sizeof(g_EOI), fpJpegFile);//in Hi3531, user needn't write SOI!
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : save H264 stream
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_SaveH264(FILE* fpH264File, VENC_STREAM_S *pstStream)
+{
+    HI_S32 i;
+
+    
+    for (i = 0; i < pstStream->u32PackCount; i++)
+    {
+        fwrite(pstStream->pstPack[i].pu8Addr[0],
+               pstStream->pstPack[i].u32Len[0], 1, fpH264File);
+
+        fflush(fpH264File);
+
+        if (pstStream->pstPack[i].u32Len[1] > 0)
+        {
+            fwrite(pstStream->pstPack[i].pu8Addr[1],
+                   pstStream->pstPack[i].u32Len[1], 1, fpH264File);
+
+            fflush(fpH264File);
+        }
+    }
+    
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : save jpeg stream
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_SaveJPEG(FILE *fpJpegFile, VENC_STREAM_S *pstStream)
+{
+    VENC_PACK_S*  pstData;
+    HI_U32 i;
+
+    for (i = 0; i < pstStream->u32PackCount; i++)
+    {
+        pstData = &pstStream->pstPack[i];
+        fwrite(pstData->pu8Addr[0], pstData->u32Len[0], 1, fpJpegFile);
+        fwrite(pstData->pu8Addr[1], pstData->u32Len[1], 1, fpJpegFile);
+    }
+
+    return HI_SUCCESS;
+}
+/******************************************************************************
+* funciton : save snap stream
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_SaveSnap(VENC_STREAM_S *pstStream)
+{
+    char acFile[128]  = {0};
+    FILE *pFile;
+    HI_S32 s32Ret;
+
+    sprintf(acFile, "snap_%d.jpg", gs_s32SnapCnt);
+    pFile = fopen(acFile, "wb");
+    if (pFile == NULL)
+    {
+        SAMPLE_PRT("open file err\n");
+        return HI_FAILURE;
+    }
+    s32Ret = SAMPLE_COMM_VENC_SaveJPEG(pFile, pstStream);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("save snap picture failed!\n");
+        return HI_FAILURE;
+    }
+    fclose(pFile);
+    gs_s32SnapCnt++;
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : save stream
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_SaveStream(PAYLOAD_TYPE_E enType,FILE *pFd, VENC_STREAM_S *pstStream)
+{
+    HI_S32 s32Ret;
+
+    if (PT_H264 == enType)
+    {
+        s32Ret = SAMPLE_COMM_VENC_SaveH264(pFd, pstStream);
+    }
+    else if (PT_MJPEG == enType)
+    {
+        s32Ret = SAMPLE_COMM_VENC_SaveMJpeg(pFd, pstStream);
+    }
+    else
+    {
+        return HI_FAILURE;
+    }
+    return s32Ret;
+}
+
+/******************************************************************************
+* funciton : Start venc stream mode (h264, mjpeg)
+* note      : rate control parameter need adjust, according your case.
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_Start(VENC_GRP VencGrp,VENC_CHN VencChn, PAYLOAD_TYPE_E enType, VIDEO_NORM_E enNorm, PIC_SIZE_E enSize, SAMPLE_RC_E enRcMode)
+{
+    HI_S32 s32Ret;
+    VENC_CHN_ATTR_S stVencChnAttr;
+    VENC_ATTR_H264_S stH264Attr;
+    VENC_ATTR_H264_CBR_S    stH264Cbr;
+    VENC_ATTR_H264_VBR_S    stH264Vbr;
+    VENC_ATTR_H264_FIXQP_S  stH264FixQp;
+    VENC_ATTR_MJPEG_S stMjpegAttr;
+    VENC_ATTR_MJPEG_FIXQP_S stMjpegeFixQp;
+    VENC_ATTR_JPEG_S stJpegAttr;
+    SIZE_S stPicSize;
+
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(enNorm, enSize, &stPicSize);
+     if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Get picture size failed!\n");
+        return HI_FAILURE;
+    }
+    /******************************************
+     step 1: Greate Venc Group
+    ******************************************/
+    s32Ret = HI_MPI_VENC_CreateGroup(VencGrp);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_CreateGroup[%d] failed with %#x!\n",\
+                 VencGrp, s32Ret);
+        return HI_FAILURE;
+    }
+
+    /******************************************
+     step 2:  Create Venc Channel
+    ******************************************/
+    stVencChnAttr.stVeAttr.enType = enType;
+    switch(enType)
+    {
+        case PT_H264:
+        {
+            stH264Attr.u32MaxPicWidth = stPicSize.u32Width;
+            stH264Attr.u32MaxPicHeight = stPicSize.u32Height;
+            stH264Attr.u32PicWidth = stPicSize.u32Width;/*the picture width*/
+            stH264Attr.u32PicHeight = stPicSize.u32Height;/*the picture height*/
+            stH264Attr.u32BufSize  = stPicSize.u32Width * stPicSize.u32Height * 2;/*stream buffer size*/
+            stH264Attr.u32Profile  = 0;/*0: baseline; 1:MP; 2:HP   ? */
+            stH264Attr.bByFrame = HI_TRUE;/*get stream mode is slice mode or frame mode?*/
+            stH264Attr.bField = HI_FALSE;  /* surpport frame code only for hi3516, bfield = HI_FALSE */
+            stH264Attr.bMainStream = HI_TRUE; /* surpport main stream only for hi3516, bMainStream = HI_TRUE */
+            stH264Attr.u32Priority = 0; /*channels precedence level. invalidate for hi3516*/
+            stH264Attr.bVIField = HI_FALSE;/*the sign of the VI picture is field or frame. Invalidate for hi3516*/
+            memcpy(&stVencChnAttr.stVeAttr.stAttrH264e, &stH264Attr, sizeof(VENC_ATTR_H264_S));
+
+            if(SAMPLE_RC_CBR == enRcMode)
+            {
+                stVencChnAttr.stRcAttr.enRcMode = VENC_RC_MODE_H264CBR;
+                stH264Cbr.u32Gop            = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+                stH264Cbr.u32StatTime       = 1; /* stream rate statics time(s) */
+                stH264Cbr.u32ViFrmRate      = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;/* input (vi) frame rate */
+                stH264Cbr.fr32TargetFrmRate = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;/* target frame rate */
+                switch (enSize)
+                {
+                  case PIC_QCIF:
+                	   stH264Cbr.u32BitRate = 256; /* average bit rate */
+                	   break;
+                  case PIC_QVGA:    /* 320 * 240 */
+                  case PIC_CIF:	
+
+                	   stH264Cbr.u32BitRate = 512;
+                       break;
+
+                  case PIC_D1:
+                  case PIC_VGA:	   /* 640 * 480 */
+                	   stH264Cbr.u32BitRate = 1024*2;
+                       break;
+                  case PIC_HD720:   /* 1280 * 720 */
+                	   stH264Cbr.u32BitRate = 1024*3;
+                	   break;
+                  case PIC_HD1080:  /* 1920 * 1080 */
+                  	   stH264Cbr.u32BitRate = 1024*6;
+                	   break;
+                  default :
+                       stH264Cbr.u32BitRate = 1024*4;
+                       break;
+                }
+                
+                stH264Cbr.u32FluctuateLevel = 0; /* average bit rate */
+                memcpy(&stVencChnAttr.stRcAttr.stAttrH264Cbr, &stH264Cbr, sizeof(VENC_ATTR_H264_CBR_S));
+            }
+            else if (SAMPLE_RC_FIXQP == enRcMode) 
+            {
+                stVencChnAttr.stRcAttr.enRcMode = VENC_RC_MODE_H264FIXQP;
+                stH264FixQp.u32Gop = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+                stH264FixQp.u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+                stH264FixQp.fr32TargetFrmRate = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+                stH264FixQp.u32IQp = 20;
+                stH264FixQp.u32PQp = 23;
+                memcpy(&stVencChnAttr.stRcAttr.stAttrH264FixQp, &stH264FixQp,sizeof(VENC_ATTR_H264_FIXQP_S));
+            }
+            else if (SAMPLE_RC_VBR == enRcMode) 
+            {
+                stVencChnAttr.stRcAttr.enRcMode = VENC_RC_MODE_H264VBR;
+                stH264Vbr.u32Gop = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+                stH264Vbr.u32StatTime = 1;
+                stH264Vbr.u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+                stH264Vbr.fr32TargetFrmRate = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+                stH264Vbr.u32MinQp = 10;
+                stH264Vbr.u32MaxQp = 40;
+                switch (enSize)
+                {
+                  case PIC_QCIF:
+                	   stH264Vbr.u32MaxBitRate= 256*3; /* average bit rate */
+                	   break;
+                  case PIC_QVGA:    /* 320 * 240 */
+                  case PIC_CIF:
+                	   stH264Vbr.u32MaxBitRate = 512*3;
+                       break;
+                  case PIC_D1:
+                  case PIC_VGA:	   /* 640 * 480 */
+                	   stH264Vbr.u32MaxBitRate = 1024*2;
+                       break;
+                  case PIC_HD720:   /* 1280 * 720 */
+                	   stH264Vbr.u32MaxBitRate = 1024*3;
+                	   break;
+                  case PIC_HD1080:  /* 1920 * 1080 */
+                  	   stH264Vbr.u32MaxBitRate = 1024*6;
+                	   break;
+                  default :
+                       stH264Vbr.u32MaxBitRate = 1024*4*3;
+                       break;
+                }
+                memcpy(&stVencChnAttr.stRcAttr.stAttrH264Vbr, &stH264Vbr, sizeof(VENC_ATTR_H264_VBR_S));
+            }
+            else
+            {
+                return HI_FAILURE;
+            }
+        }
+        break;
+        
+        case PT_MJPEG:
+        {
+            stMjpegAttr.u32MaxPicWidth = stPicSize.u32Width;
+            stMjpegAttr.u32MaxPicHeight = stPicSize.u32Height;
+            stMjpegAttr.u32PicWidth = stPicSize.u32Width;
+            stMjpegAttr.u32PicHeight = stPicSize.u32Height;
+            stMjpegAttr.u32BufSize = stPicSize.u32Width * stPicSize.u32Height * 2;
+            stMjpegAttr.bByFrame = HI_TRUE;  /*get stream mode is field mode  or frame mode*/
+            stMjpegAttr.bMainStream = HI_TRUE;  /*main stream or minor stream types?*/
+            stMjpegAttr.bVIField = HI_FALSE;  /*the sign of the VI picture is field or frame?*/
+            stMjpegAttr.u32Priority = 0;/*channels precedence level*/
+            memcpy(&stVencChnAttr.stVeAttr.stAttrMjpeg, &stMjpegAttr, sizeof(VENC_ATTR_MJPEG_S));
+
+            if(SAMPLE_RC_FIXQP == enRcMode)
+            {
+                stVencChnAttr.stRcAttr.enRcMode = VENC_RC_MODE_MJPEGFIXQP;
+                stMjpegeFixQp.u32Qfactor        = 90;
+                stMjpegeFixQp.u32ViFrmRate      = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+                stMjpegeFixQp.fr32TargetFrmRate = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+                memcpy(&stVencChnAttr.stRcAttr.stAttrMjpegeFixQp, &stMjpegeFixQp,
+                       sizeof(VENC_ATTR_MJPEG_FIXQP_S));
+            }
+            else if (SAMPLE_RC_CBR == enRcMode)
+            {
+                stVencChnAttr.stRcAttr.enRcMode = VENC_RC_MODE_MJPEGCBR;
+                stVencChnAttr.stRcAttr.stAttrMjpegeCbr.u32StatTime       = 1;
+                stVencChnAttr.stRcAttr.stAttrMjpegeCbr.u32ViFrmRate      = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+                stVencChnAttr.stRcAttr.stAttrMjpegeCbr.fr32TargetFrmRate = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+                stVencChnAttr.stRcAttr.stAttrMjpegeCbr.u32FluctuateLevel = 0;
+                switch (enSize)
+                {
+                  case PIC_QCIF:
+                	   stVencChnAttr.stRcAttr.stAttrMjpegeCbr.u32BitRate = 384*3; /* average bit rate */
+                	   break;
+                  case PIC_QVGA:    /* 320 * 240 */
+                  case PIC_CIF:
+                	   stVencChnAttr.stRcAttr.stAttrMjpegeCbr.u32BitRate = 768*3;
+                       break;
+                  case PIC_D1:
+                  case PIC_VGA:	   /* 640 * 480 */
+                	   stVencChnAttr.stRcAttr.stAttrMjpegeCbr.u32BitRate = 1024*3*3;
+                       break;
+                  case PIC_HD720:   /* 1280 * 720 */
+                	   stVencChnAttr.stRcAttr.stAttrMjpegeCbr.u32BitRate = 1024*5*3;
+                	   break;
+                  case PIC_HD1080:  /* 1920 * 1080 */
+                  	   stVencChnAttr.stRcAttr.stAttrMjpegeCbr.u32BitRate = 1024*10*3;
+                	   break;
+                  default :
+                       stVencChnAttr.stRcAttr.stAttrMjpegeCbr.u32BitRate = 1024*7*3;
+                       break;
+                }
+            }
+            else if (SAMPLE_RC_VBR == enRcMode) 
+            {
+                stVencChnAttr.stRcAttr.enRcMode = VENC_RC_MODE_MJPEGVBR;
+                stVencChnAttr.stRcAttr.stAttrMjpegeVbr.u32StatTime = 1;
+                stVencChnAttr.stRcAttr.stAttrMjpegeVbr.u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL == enNorm)?25:30;
+                stVencChnAttr.stRcAttr.stAttrMjpegeVbr.fr32TargetFrmRate = 5;
+                stVencChnAttr.stRcAttr.stAttrMjpegeVbr.u32MinQfactor = 50;
+                stVencChnAttr.stRcAttr.stAttrMjpegeVbr.u32MaxQfactor = 95;
+                switch (enSize)
+                {
+                  case PIC_QCIF:
+                	   stVencChnAttr.stRcAttr.stAttrMjpegeVbr.u32MaxBitRate= 256*3; /* average bit rate */
+                	   break;
+                  case PIC_QVGA:    /* 320 * 240 */
+                  case PIC_CIF:
+                	   stVencChnAttr.stRcAttr.stAttrMjpegeVbr.u32MaxBitRate = 512*3;
+                       break;
+                  case PIC_D1:
+                  case PIC_VGA:	   /* 640 * 480 */
+                	   stVencChnAttr.stRcAttr.stAttrMjpegeVbr.u32MaxBitRate = 1024*2*3;
+                       break;
+                  case PIC_HD720:   /* 1280 * 720 */
+                	   stVencChnAttr.stRcAttr.stAttrMjpegeVbr.u32MaxBitRate = 1024*3*3;
+                	   break;
+                  case PIC_HD1080:  /* 1920 * 1080 */
+                  	   stVencChnAttr.stRcAttr.stAttrMjpegeVbr.u32MaxBitRate = 1024*6*3;
+                	   break;
+                  default :
+                       stVencChnAttr.stRcAttr.stAttrMjpegeVbr.u32MaxBitRate = 1024*4*3;
+                       break;
+                }
+            }
+            else 
+            {
+                SAMPLE_PRT("cann't support other mode in this version!\n");
+
+                return HI_FAILURE;
+            }
+        }
+        break;
+            
+        case PT_JPEG:
+            stJpegAttr.u32PicWidth  = stPicSize.u32Width;
+            stJpegAttr.u32PicHeight = stPicSize.u32Height;
+            stJpegAttr.u32BufSize = stPicSize.u32Width * stPicSize.u32Height * 2;
+            stJpegAttr.bByFrame = HI_TRUE;/*get stream mode is field mode  or frame mode*/
+            stJpegAttr.bVIField = HI_FALSE;/*the sign of the VI picture is field or frame?*/
+            stJpegAttr.u32Priority = 0;/*channels precedence level*/
+            memcpy(&stVencChnAttr.stVeAttr.stAttrMjpeg, &stMjpegAttr, sizeof(VENC_ATTR_MJPEG_S));
+            break;
+        default:
+            return HI_ERR_VENC_NOT_SUPPORT;
+    }
+
+    s32Ret = HI_MPI_VENC_CreateChn(VencChn, &stVencChnAttr);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_CreateChn [%d] faild with %#x!\n",\
+                VencChn, s32Ret);
+        return s32Ret;
+    }
+
+    /******************************************
+     step 3:  Regist Venc Channel to VencGrp
+    ******************************************/
+    s32Ret = HI_MPI_VENC_RegisterChn(VencGrp, VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_RegisterChn faild with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    /******************************************
+     step 4:  Start Recv Venc Pictures
+    ******************************************/
+    s32Ret = HI_MPI_VENC_StartRecvPic(VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_StartRecvPic faild with%#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+
+}
+
+/******************************************************************************
+* funciton : Stop venc ( stream mode -- H264, MJPEG )
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_Stop(VENC_GRP VencGrp,VENC_CHN VencChn)
+{
+    HI_S32 s32Ret;
+
+    /******************************************
+     step 1:  Stop Recv Pictures
+    ******************************************/
+    s32Ret = HI_MPI_VENC_StopRecvPic(VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_StopRecvPic vechn[%d] failed with %#x!\n",\
+               VencChn, s32Ret);
+        return HI_FAILURE;
+    }
+
+    /******************************************
+     step 2:  UnRegist Venc Channel
+    ******************************************/
+    s32Ret = HI_MPI_VENC_UnRegisterChn(VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_UnRegisterChn vechn[%d] failed with %#x!\n",\
+               VencChn, s32Ret);
+        return HI_FAILURE;
+    }
+
+    /******************************************
+     step 3:  Distroy Venc Channel
+    ******************************************/
+    s32Ret = HI_MPI_VENC_DestroyChn(VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_DestroyChn vechn[%d] failed with %#x!\n",\
+               VencChn, s32Ret);
+        return HI_FAILURE;
+    }
+
+    /******************************************
+     step 4:  Distroy Venc Group
+    ******************************************/
+    s32Ret = HI_MPI_VENC_DestroyGroup(VencGrp);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_DestroyGroup group[%d] failed with %#x!\n",\
+               VencGrp, s32Ret);
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : Start snap
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_SnapStart(VENC_GRP VencGrp,VENC_CHN VencChn, SIZE_S *pstSize)
+{
+    HI_S32 s32Ret;
+    VENC_CHN_ATTR_S stVencChnAttr;
+    VENC_ATTR_JPEG_S stJpegAttr;
+
+    /******************************************
+     step 1: Greate Venc Group
+    ******************************************/
+    s32Ret = HI_MPI_VENC_CreateGroup(VencGrp);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_CreateGroup[%d] failed with %#x!\n",\
+                 VencGrp, s32Ret);
+        return HI_FAILURE;
+    }
+
+    /******************************************
+     step 2:  Create Venc Channel
+    ******************************************/
+    stVencChnAttr.stVeAttr.enType = PT_JPEG;
+    
+    stJpegAttr.u32MaxPicWidth  = pstSize->u32Width;
+    stJpegAttr.u32MaxPicHeight = pstSize->u32Height;
+    stJpegAttr.u32PicWidth  = pstSize->u32Width;
+    stJpegAttr.u32PicHeight = pstSize->u32Height;
+    stJpegAttr.u32BufSize = pstSize->u32Width * pstSize->u32Height * 2;
+    stJpegAttr.bByFrame = HI_TRUE;/*get stream mode is field mode  or frame mode*/
+    stJpegAttr.bVIField = HI_FALSE;/*the sign of the VI picture is field or frame?*/
+    stJpegAttr.u32Priority = 0;/*channels precedence level*/
+    memcpy(&stVencChnAttr.stVeAttr.stAttrJpeg, &stJpegAttr, sizeof(VENC_ATTR_JPEG_S));
+
+    s32Ret = HI_MPI_VENC_CreateChn(VencChn, &stVencChnAttr);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_CreateChn [%d] faild with %#x!\n",\
+                VencChn, s32Ret);
+        return s32Ret;
+    }
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : Stop snap
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_SnapStop(VENC_GRP VencGrp,VENC_CHN VencChn)
+{
+    HI_S32 s32Ret;
+    
+    s32Ret = HI_MPI_VENC_DestroyChn(VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_DestroyChn vechn[%d] failed with %#x!\n", VencChn, s32Ret);
+        return HI_FAILURE;
+    }
+
+    s32Ret = HI_MPI_VENC_DestroyGroup(VencGrp);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_DestroyGroup group[%d] failed with %#x!\n",\
+               VencGrp, s32Ret);
+        return HI_FAILURE;
+    }
+    
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : snap process
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_SnapProcess(VENC_GRP VencGrp, VENC_CHN VencChn, VPSS_GRP VpssGrp, VPSS_CHN VpssChn)
+{
+    struct timeval TimeoutVal;
+    fd_set read_fds;
+    HI_S32 s32VencFd;
+    VENC_CHN_STAT_S stStat;
+    VENC_STREAM_S stStream;
+    HI_S32 s32Ret;
+
+    printf("press any key to snap one pic\n");  
+	getchar();    
+    /******************************************
+     step 1:  Regist Venc Channel to VencGrp
+    ******************************************/
+    s32Ret = HI_MPI_VENC_RegisterChn(VencGrp, VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_RegisterChn faild with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+    
+    /******************************************
+     step 2:  Venc Chn bind to Vpss Chn
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VENC_BindVpss(VencGrp, VpssGrp, VpssChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VENC_BindVpss failed!\n");
+        return HI_FAILURE;
+    }
+    /******************************************
+     step 3:  Start Recv Venc Pictures
+    ******************************************/
+    s32Ret = HI_MPI_VENC_StartRecvPic(VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_StartRecvPic faild with%#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+    /******************************************
+     step 4:  recv picture
+    ******************************************/
+    s32VencFd = HI_MPI_VENC_GetFd(VencChn);
+    if (s32VencFd < 0)
+    {
+    	 SAMPLE_PRT("HI_MPI_VENC_GetFd faild with%#x!\n", s32VencFd);
+        return HI_FAILURE;
+    }
+
+
+    FD_ZERO(&read_fds);
+    FD_SET(s32VencFd, &read_fds);
+    
+    TimeoutVal.tv_sec  = 2;
+    TimeoutVal.tv_usec = 0;
+    s32Ret = select(s32VencFd+1, &read_fds, NULL, NULL, &TimeoutVal);
+    if (s32Ret < 0) 
+    {
+        SAMPLE_PRT("snap select failed!\n");
+        return HI_FAILURE;
+    }
+    else if (0 == s32Ret) 
+    {
+        SAMPLE_PRT("snap time out!\n");
+        return HI_FAILURE;
+    }
+    else
+    {
+        if (FD_ISSET(s32VencFd, &read_fds))
+        {
+            s32Ret = HI_MPI_VENC_Query(VencChn, &stStat);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_PRT("HI_MPI_VENC_Query failed with %#x!\n", s32Ret);
+                return HI_FAILURE;
+            }
+
+            stStream.pstPack = (VENC_PACK_S*)malloc(sizeof(VENC_PACK_S) * stStat.u32CurPacks);
+            if (NULL == stStream.pstPack)
+            {
+                SAMPLE_PRT("malloc memory failed!\n");
+                return HI_FAILURE;
+            }
+
+            stStream.u32PackCount = stStat.u32CurPacks;
+            s32Ret = HI_MPI_VENC_GetStream(VencChn, &stStream, HI_TRUE);
+            if (HI_SUCCESS != s32Ret)
+            {
+                SAMPLE_PRT("HI_MPI_VENC_GetStream failed with %#x!\n", s32Ret);
+                free(stStream.pstPack);
+                stStream.pstPack = NULL;
+                return HI_FAILURE;
+            }
+
+            s32Ret = SAMPLE_COMM_VENC_SaveSnap(&stStream);
+            if (HI_SUCCESS != s32Ret)
+            {
+                SAMPLE_PRT("HI_MPI_VENC_GetStream failed with %#x!\n", s32Ret);
+                free(stStream.pstPack);
+                stStream.pstPack = NULL;
+                return HI_FAILURE;
+            }
+
+            s32Ret = HI_MPI_VENC_ReleaseStream(VencChn, &stStream);
+            if (s32Ret)
+            {
+                SAMPLE_PRT("HI_MPI_VENC_ReleaseStream failed with %#x!\n", s32Ret);
+                free(stStream.pstPack);
+                stStream.pstPack = NULL;
+                return HI_FAILURE;
+            }
+
+            free(stStream.pstPack);
+            stStream.pstPack = NULL;
+	    }
+    }
+    /******************************************
+     step 5:  stop recv picture
+    ******************************************/
+    s32Ret = HI_MPI_VENC_StopRecvPic(VencChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_StopRecvPic failed with %#x!\n",  s32Ret);
+        return HI_FAILURE;
+    }
+    /******************************************
+     step 6:  unbind
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VENC_UnBindVpss(VencGrp, VpssGrp, VpssChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VENC_UnBindVpss failed!\n");
+        return HI_FAILURE;
+    }
+    printf("press any key to continue\n");  
+	getchar(); 
+    
+    /******************************************
+     step 7:  UnRegister
+    ******************************************/
+    s32Ret = HI_MPI_VENC_UnRegisterChn(VencChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_UnRegisterChn failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : snap process with HI_MPI_VENC_StartRecvPicEx
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_SnapProcessEx(VENC_GRP VencGrp, VENC_CHN VencChn, VPSS_GRP VpssGrp, VPSS_CHN VpssChn)
+{
+    struct timeval TimeoutVal;
+    fd_set read_fds;
+    HI_S32 s32VencFd;
+    VENC_CHN_STAT_S stStat;
+    VENC_STREAM_S stStream;
+    VENC_RECV_PIC_PARAM_S stRecvParam;
+    HI_S32 s32Ret;
+
+    printf("press any key to snap one pic\n");  
+	getchar();    
+    /******************************************
+     step 1:  Regist Venc Channel to VencGrp
+    ******************************************/
+    s32Ret = HI_MPI_VENC_RegisterChn(VencGrp, VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_RegisterChn faild with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+    
+    /******************************************
+     step 2:  Venc Chn bind to Vpss Chn
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VENC_BindVpss(VencGrp, VpssGrp, VpssChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VENC_BindVpss failed!\n");
+        return HI_FAILURE;
+    }
+    /******************************************
+     step 3:  Start Recv Venc Pictures
+    ******************************************/
+    stRecvParam.s32RecvPicNum = 1;
+    s32Ret = HI_MPI_VENC_StartRecvPicEx(VencChn, &stRecvParam);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_StartRecvPic faild with%#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+    /******************************************
+     step 4:  recv picture
+    ******************************************/
+    s32VencFd = HI_MPI_VENC_GetFd(VencChn);
+    if (s32VencFd < 0)
+    {
+    	 SAMPLE_PRT("HI_MPI_VENC_GetFd faild with%#x!\n", s32VencFd);
+        return HI_FAILURE;
+    }
+
+
+    FD_ZERO(&read_fds);
+    FD_SET(s32VencFd, &read_fds);
+    
+    TimeoutVal.tv_sec  = 2;
+    TimeoutVal.tv_usec = 0;
+    s32Ret = select(s32VencFd+1, &read_fds, NULL, NULL, &TimeoutVal);
+    if (s32Ret < 0) 
+    {
+        SAMPLE_PRT("snap select failed!\n");
+        return HI_FAILURE;
+    }
+    else if (0 == s32Ret) 
+    {
+        SAMPLE_PRT("snap time out!\n");
+        return HI_FAILURE;
+    }
+    else
+    {
+        if (FD_ISSET(s32VencFd, &read_fds))
+        {
+            s32Ret = HI_MPI_VENC_Query(VencChn, &stStat);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_PRT("HI_MPI_VENC_Query failed with %#x!\n", s32Ret);
+                return HI_FAILURE;
+            }
+
+            stStream.pstPack = (VENC_PACK_S*)malloc(sizeof(VENC_PACK_S) * stStat.u32CurPacks);
+            if (NULL == stStream.pstPack)
+            {
+                SAMPLE_PRT("malloc memory failed!\n");
+                return HI_FAILURE;
+            }
+
+            stStream.u32PackCount = stStat.u32CurPacks;
+            s32Ret = HI_MPI_VENC_GetStream(VencChn, &stStream, HI_TRUE);
+            if (HI_SUCCESS != s32Ret)
+            {
+                SAMPLE_PRT("HI_MPI_VENC_GetStream failed with %#x!\n", s32Ret);
+                free(stStream.pstPack);
+                stStream.pstPack = NULL;
+                return HI_FAILURE;
+            }
+
+            s32Ret = SAMPLE_COMM_VENC_SaveSnap(&stStream);
+            if (HI_SUCCESS != s32Ret)
+            {
+                SAMPLE_PRT("HI_MPI_VENC_GetStream failed with %#x!\n", s32Ret);
+                free(stStream.pstPack);
+                stStream.pstPack = NULL;
+                return HI_FAILURE;
+            }
+
+            s32Ret = HI_MPI_VENC_ReleaseStream(VencChn, &stStream);
+            if (s32Ret)
+            {
+                SAMPLE_PRT("HI_MPI_VENC_ReleaseStream failed with %#x!\n", s32Ret);
+                free(stStream.pstPack);
+                stStream.pstPack = NULL;
+                return HI_FAILURE;
+            }
+
+            free(stStream.pstPack);
+            stStream.pstPack = NULL;
+        }
+    }
+    /******************************************
+     step 5:  stop recv picture
+    ******************************************/
+    s32Ret = HI_MPI_VENC_StopRecvPic(VencChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_StopRecvPic failed with %#x!\n",  s32Ret);
+        return HI_FAILURE;
+    }
+    /******************************************
+     step 6:  unbind
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VENC_UnBindVpss(VencGrp, VpssGrp, VpssChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VENC_UnBindVpss failed!\n");
+        return HI_FAILURE;
+    }
+    printf("press any key to continue\n");  
+	getchar(); 
+    
+    /******************************************
+     step 7:  UnRegister
+    ******************************************/
+    s32Ret = HI_MPI_VENC_UnRegisterChn(VencChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_VENC_UnRegisterChn failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+
+/******************************************************************************
+* funciton : get stream from each channels and save them
+******************************************************************************/
+HI_VOID* SAMPLE_COMM_VENC_GetVencStreamProc(HI_VOID *p)
+{
+    HI_S32 i;
+    HI_S32 s32ChnTotal;
+    VENC_CHN_ATTR_S stVencChnAttr;
+    SAMPLE_VENC_GETSTREAM_PARA_S *pstPara;
+    HI_S32 maxfd = 0;
+    struct timeval TimeoutVal;
+    fd_set read_fds;
+    HI_S32 VencFd[VENC_MAX_CHN_NUM];
+    HI_CHAR aszFileName[VENC_MAX_CHN_NUM][64];
+    FILE *pFile[VENC_MAX_CHN_NUM];
+    char szFilePostfix[10];
+    VENC_CHN_STAT_S stStat;
+    VENC_STREAM_S stStream;
+    HI_S32 s32Ret;
+    VENC_CHN VencChn;
+    PAYLOAD_TYPE_E enPayLoadType[VENC_MAX_CHN_NUM];
+    
+    pstPara = (SAMPLE_VENC_GETSTREAM_PARA_S*)p;
+    s32ChnTotal = pstPara->s32Cnt;
+
+    /******************************************
+     step 1:  check & prepare save-file & venc-fd
+    ******************************************/
+    if (s32ChnTotal >= VENC_MAX_CHN_NUM)
+    {
+        SAMPLE_PRT("input count invaild\n");
+        return NULL;
+    }
+    for (i = 0; i < s32ChnTotal; i++)
+    {
+        /* decide the stream file name, and open file to save stream */
+        VencChn = i;
+        s32Ret = HI_MPI_VENC_GetChnAttr(VencChn, &stVencChnAttr);
+        if(s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("HI_MPI_VENC_GetChnAttr chn[%d] failed with %#x!\n", \
+                   VencChn, s32Ret);
+            return NULL;
+        }
+        enPayLoadType[i] = stVencChnAttr.stVeAttr.enType;
+
+        s32Ret = SAMPLE_COMM_VENC_GetFilePostfix(enPayLoadType[i], szFilePostfix);
+        if(s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("SAMPLE_COMM_VENC_GetFilePostfix [%d] failed with %#x!\n", \
+                   stVencChnAttr.stVeAttr.enType, s32Ret);
+            return NULL;
+        }
+        sprintf(aszFileName[i], "stream_chn%d%s", i, szFilePostfix);
+        pFile[i] = fopen(aszFileName[i], "wb");
+        if (!pFile[i])
+        {
+            SAMPLE_PRT("open file[%s] failed!\n", 
+                   aszFileName[i]);
+            return NULL;
+        }
+
+        /* Set Venc Fd. */
+        VencFd[i] = HI_MPI_VENC_GetFd(i);
+        if (VencFd[i] < 0)
+        {
+            SAMPLE_PRT("HI_MPI_VENC_GetFd failed with %#x!\n", 
+                   VencFd[i]);
+            return NULL;
+        }
+        if (maxfd <= VencFd[i])
+        {
+            maxfd = VencFd[i];
+        }
+    }
+
+    /******************************************
+     step 2:  Start to get streams of each channel.
+    ******************************************/
+    while (HI_TRUE == pstPara->bThreadStart)
+    {
+        FD_ZERO(&read_fds);
+        for (i = 0; i < s32ChnTotal; i++)
+        {
+            FD_SET(VencFd[i], &read_fds);
+        }
+
+        TimeoutVal.tv_sec  = 2;
+        TimeoutVal.tv_usec = 0;
+        s32Ret = select(maxfd + 1, &read_fds, NULL, NULL, &TimeoutVal);
+        if (s32Ret < 0)
+        {
+            SAMPLE_PRT("select failed!\n");
+            break;
+        }
+        else if (s32Ret == 0)
+        {
+            SAMPLE_PRT("get venc stream time out, exit thread\n");
+            continue;
+        }
+        else
+        {
+            for (i = 0; i < s32ChnTotal; i++)
+            {
+                if (FD_ISSET(VencFd[i], &read_fds))
+                {
+                    /*******************************************************
+                     step 2.1 : query how many packs in one-frame stream.
+                    *******************************************************/
+                    memset(&stStream, 0, sizeof(stStream));
+                    s32Ret = HI_MPI_VENC_Query(i, &stStat);
+                    if (HI_SUCCESS != s32Ret)
+                    {
+                        SAMPLE_PRT("HI_MPI_VENC_Query chn[%d] failed with %#x!\n", i, s32Ret);
+                        break;
+                    }
+
+                    /*******************************************************
+                     step 2.2 : malloc corresponding number of pack nodes.
+                    *******************************************************/
+                    stStream.pstPack = (VENC_PACK_S*)malloc(sizeof(VENC_PACK_S) * stStat.u32CurPacks);
+                    if (NULL == stStream.pstPack)
+                    {
+                        SAMPLE_PRT("malloc stream pack failed!\n");
+                        break;
+                    }
+                    
+                    /*******************************************************
+                     step 2.3 : call mpi to get one-frame stream
+                    *******************************************************/
+                    stStream.u32PackCount = stStat.u32CurPacks;
+                    s32Ret = HI_MPI_VENC_GetStream(i, &stStream, HI_TRUE);
+                    if (HI_SUCCESS != s32Ret)
+                    {
+                        free(stStream.pstPack);
+                        stStream.pstPack = NULL;
+                        SAMPLE_PRT("HI_MPI_VENC_GetStream failed with %#x!\n", \
+                               s32Ret);
+                        break;
+                    }
+
+                    /*******************************************************
+                     step 2.4 : save frame to file
+                    *******************************************************/
+                    s32Ret = SAMPLE_COMM_VENC_SaveStream(enPayLoadType[i], pFile[i], &stStream);
+                    if (HI_SUCCESS != s32Ret)
+                    {
+                        free(stStream.pstPack);
+                        stStream.pstPack = NULL;
+                        SAMPLE_PRT("save stream failed!\n");
+                        break;
+                    }
+                    /*******************************************************
+                     step 2.5 : release stream
+                    *******************************************************/
+                    s32Ret = HI_MPI_VENC_ReleaseStream(i, &stStream);
+                    if (HI_SUCCESS != s32Ret)
+                    {
+                        free(stStream.pstPack);
+                        stStream.pstPack = NULL;
+                        break;
+                    }
+                    /*******************************************************
+                     step 2.6 : free pack nodes
+                    *******************************************************/
+                    free(stStream.pstPack);
+                    stStream.pstPack = NULL;
+                }
+            }
+        }
+    }
+
+    /*******************************************************
+    * step 3 : close save-file
+    *******************************************************/
+    for (i = 0; i < s32ChnTotal; i++)
+    {
+        fclose(pFile[i]);
+    }
+
+    return NULL;
+}
+
+/******************************************************************************
+* funciton : start get venc stream process thread
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_StartGetStream(HI_S32 s32Cnt)
+{
+    gs_stPara.bThreadStart = HI_TRUE;
+    gs_stPara.s32Cnt = s32Cnt;
+
+    return pthread_create(&gs_VencPid, 0, SAMPLE_COMM_VENC_GetVencStreamProc, (HI_VOID*)&gs_stPara);
+}
+
+/******************************************************************************
+* funciton : stop get venc stream process.
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VENC_StopGetStream()
+{
+    if (HI_TRUE == gs_stPara.bThreadStart)
+    {
+        gs_stPara.bThreadStart = HI_FALSE;
+        pthread_join(gs_VencPid, 0);
+    }
+    return HI_SUCCESS;
+}
+
+
+HI_VOID SAMPLE_COMM_VENC_ReadOneFrame( FILE * fp, HI_U8 * pY, HI_U8 * pU, HI_U8 * pV,
+                                              HI_U32 width, HI_U32 height, HI_U32 stride, HI_U32 stride2)
+{
+    HI_U8 * pDst;
+
+    HI_U32 u32Row;
+    
+
+    pDst = pY;
+    for ( u32Row = 0; u32Row < height; u32Row++ )
+    {
+        fread( pDst, width, 1, fp );
+        pDst += stride;
+    }
+    
+    pDst = pU;
+    for ( u32Row = 0; u32Row < height/2; u32Row++ )
+    {
+        fread( pDst, width/2, 1, fp );
+        pDst += stride2;
+    }
+    
+    pDst = pV;
+    for ( u32Row = 0; u32Row < height/2; u32Row++ )
+    {
+        fread( pDst, width/2, 1, fp );
+        pDst += stride2;
+    }
+   
+}
+
+HI_S32 SAMPLE_COMM_VENC_PlanToSemi(HI_U8 *pY, HI_S32 yStride, 
+                       HI_U8 *pU, HI_S32 uStride,
+					   HI_U8 *pV, HI_S32 vStride, 
+					   HI_S32 picWidth, HI_S32 picHeight)
+{
+    HI_S32 i;
+    HI_U8* pTmpU, *ptu;
+    HI_U8* pTmpV, *ptv;
+    
+    HI_S32 s32HafW = uStride >>1 ;
+    HI_S32 s32HafH = picHeight >>1 ;
+    HI_S32 s32Size = s32HafW*s32HafH;
+        
+    pTmpU = malloc( s32Size ); ptu = pTmpU;
+    pTmpV = malloc( s32Size ); ptv = pTmpV;
+    
+    memcpy(pTmpU,pU,s32Size);
+    memcpy(pTmpV,pV,s32Size);
+    
+    for(i = 0;i<s32Size>>1;i++)
+    {
+        *pU++ = *pTmpV++;
+        *pU++ = *pTmpU++;
+        
+    }
+    for(i = 0;i<s32Size>>1;i++)
+    {
+        *pV++ = *pTmpV++;
+        *pV++ = *pTmpU++;        
+    }
+
+    free( ptu );
+    free( ptv );
+
+    return HI_SUCCESS;
+}
+
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */

--- a/libraries/mpp_sample/hi3520dv200/common/sample_comm_vi.c
+++ b/libraries/mpp_sample/hi3520dv200/common/sample_comm_vi.c
@@ -1,0 +1,1549 @@
+/******************************************************************************
+  Some simple Hisilicon HI3531 video input functions.
+
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-8 Created
+******************************************************************************/
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/poll.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+#include <math.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "sample_comm.h"
+
+VI_DEV_ATTR_S DEV_ATTR_BT656D1_4MUX =
+{
+    /*接口模式*/
+    VI_MODE_BT656,
+    /*1、2、4路工作模式*/
+    VI_WORK_MODE_4Multiplex,
+    /* r_mask    g_mask    b_mask*/
+    {0xFF000000,    0x0},
+    /*逐行or隔行输入*/
+    VI_SCAN_INTERLACED,
+    /*AdChnId*/
+    {-1, -1, -1, -1}
+};
+
+VI_DEV_ATTR_S DEV_ATTR_BT656D1_2MUX =
+{
+    /*接口模式*/
+    VI_MODE_BT656,
+    /*1、2、4路工作模式*/
+    VI_WORK_MODE_2Multiplex,
+    /* r_mask    g_mask    b_mask*/
+    {0xFF000000,    0x0},
+    /*逐行or隔行输入*/
+    VI_SCAN_INTERLACED,
+    /*AdChnId*/
+    {-1, -1, -1, -1}
+};
+
+VI_DEV_ATTR_S DEV_ATTR_BT656D1_1MUX =
+{
+    /*接口模式*/
+    VI_MODE_BT656,
+    /*1、2、4路工作模式*/
+    VI_WORK_MODE_1Multiplex,
+    /* r_mask    g_mask    b_mask*/
+    {0xFF000000,    0x0},
+    /*逐行or隔行输入*/
+    VI_SCAN_INTERLACED,
+    /*AdChnId*/
+    {-1, -1, -1, -1}
+};
+
+VI_DEV_ATTR_S DEV_ATTR_BT656_720P_2MUX =
+{
+    /*接口模式*/
+    VI_MODE_BT656,
+    /*1、2、4路工作模式*/
+    VI_WORK_MODE_2Multiplex,
+    /* r_mask    g_mask    b_mask*/
+    {0xFF000000,    0x0},
+    /*逐行or隔行输入*/
+    VI_SCAN_PROGRESSIVE,
+    /*AdChnId*/
+    {-1, -1, -1, -1}	
+};
+
+
+
+VI_DEV_ATTR_S DEV_ATTR_7441_BT1120_1080P =
+/* 典型时序3:7441 BT1120 1080P@60fps典型时序 (对接时序: 时序)*/
+{
+    /*接口模式*/
+    VI_MODE_BT1120_STANDARD,
+    /*1、2、4路工作模式*/
+    VI_WORK_MODE_1Multiplex,
+    /* r_mask    g_mask    b_mask*/
+    {0xFF000000,    0xFF0000},
+    /*逐行or隔行输入*/
+    VI_SCAN_PROGRESSIVE,
+    /*AdChnId*/
+    {-1, -1, -1, -1},
+    /*enDataSeq, 仅支持YUV格式*/
+    VI_INPUT_DATA_UVUV,
+     
+    /*同步信息，对应reg手册的如下配置, --bt1120时序无效*/
+    {
+    /*port_vsync   port_vsync_neg     port_hsync        port_hsync_neg        */
+    VI_VSYNC_PULSE, VI_VSYNC_NEG_HIGH, VI_HSYNC_VALID_SINGNAL,VI_HSYNC_NEG_HIGH,VI_VSYNC_NORM_PULSE,VI_VSYNC_VALID_NEG_HIGH,
+    
+    /*timing信息，对应reg手册的如下配置*/
+    /*hsync_hfb    hsync_act    hsync_hhb*/
+    {0,            1920,        0,
+    /*vsync0_vhb vsync0_act vsync0_hhb*/
+     0,            1080,        0,
+    /*vsync1_vhb vsync1_act vsync1_hhb*/ 
+     0,            0,            0}
+    }
+};
+
+
+VI_DEV_ATTR_S DEV_ATTR_7441_BT1120_720P =
+/* 典型时序3:7441 BT1120 720P@60fps典型时序 (对接时序: 时序)*/
+{
+    /*接口模式*/
+    VI_MODE_BT1120_STANDARD,
+    /*1、2、4路工作模式*/
+    VI_WORK_MODE_1Multiplex,
+    /* r_mask    g_mask    b_mask*/
+    {0xFF00,    0xFF},
+    /*逐行or隔行输入*/
+    VI_SCAN_PROGRESSIVE,
+    /*AdChnId*/
+    {-1, -1, -1, -1},
+    /*enDataSeq, 仅支持YUV格式*/
+    VI_INPUT_DATA_UVUV,
+     
+    /*同步信息，对应reg手册的如下配置, --bt1120时序无效*/
+    {
+    /*port_vsync   port_vsync_neg     port_hsync        port_hsync_neg        */
+    VI_VSYNC_PULSE, VI_VSYNC_NEG_HIGH, VI_HSYNC_VALID_SINGNAL,VI_HSYNC_NEG_HIGH,VI_VSYNC_NORM_PULSE,VI_VSYNC_VALID_NEG_HIGH,
+    
+    /*timing信息，对应reg手册的如下配置*/
+    /*hsync_hfb    hsync_act    hsync_hhb*/
+    {0,            1280,        0,
+    /*vsync0_vhb vsync0_act vsync0_hhb*/
+     0,            720,        0,
+    /*vsync1_vhb vsync1_act vsync1_hhb*/ 
+     0,            0,            0}
+    }
+};
+
+VI_DEV_ATTR_S DEV_ATTR_7441_INTERLEAVED_720P =
+/* 典型时序3:7441 BT1120 720P@60fps典型时序 (对接时序: 时序)*/
+{
+    /*接口模式*/
+    VI_MODE_BT1120_INTERLEAVED,
+    /*1、2、4路工作模式*/
+    VI_WORK_MODE_1Multiplex,
+    /* r_mask    g_mask    b_mask*/
+    {0xFF000000,    0x0},
+    /*逐行or隔行输入*/
+    VI_SCAN_PROGRESSIVE,
+    /*AdChnId*/
+    {-1, -1, -1, -1},
+    /*enDataSeq, 仅支持YUV格式*/
+    VI_INPUT_DATA_UVUV,
+     
+    /*同步信息，对应reg手册的如下配置, --bt1120时序无效*/
+    {
+    /*port_vsync   port_vsync_neg     port_hsync        port_hsync_neg        */
+    VI_VSYNC_PULSE, VI_VSYNC_NEG_HIGH, VI_HSYNC_VALID_SINGNAL,VI_HSYNC_NEG_HIGH,VI_VSYNC_NORM_PULSE,VI_VSYNC_VALID_NEG_HIGH,
+    
+    /*timing信息，对应reg手册的如下配置*/
+    /*hsync_hfb    hsync_act    hsync_hhb*/
+    {0,            1280,        0,
+    /*vsync0_vhb vsync0_act vsync0_hhb*/
+     0,            720,        0,
+    /*vsync1_vhb vsync1_act vsync1_hhb*/ 
+     0,            0,            0}
+    }
+};
+
+VI_DEV g_as32ViDev[VIU_MAX_DEV_NUM];
+VI_CHN g_as32MaxChn[VIU_MAX_CHN_NUM];
+VI_CHN g_as32SubChn[VIU_MAX_CHN_NUM];
+
+
+HI_S32 SAMPLE_TW2865_CfgV(VIDEO_NORM_E enVideoMode,VI_WORK_MODE_E enWorkMode)
+{
+    int fd, i;
+    int video_mode;
+    tw2865_video_norm stVideoMode;
+    tw2865_work_mode work_mode;
+
+    int chip_cnt = 2;
+
+    fd = open(TW2865_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        SAMPLE_PRT("open 2865 (%s) fail\n", TW2865_FILE);
+        return -1;
+    }
+
+    video_mode = (VIDEO_ENCODING_MODE_PAL == enVideoMode) ? TW2865_PAL : TW2865_NTSC ;
+
+    for (i=0; i<chip_cnt; i++)
+    {
+        stVideoMode.chip    = i;
+        stVideoMode.mode    = video_mode;
+        if (ioctl(fd, TW2865_SET_VIDEO_NORM, &stVideoMode))
+        {
+            SAMPLE_PRT("set tw2865(%d) video mode fail\n", i);
+            close(fd);
+            return -1;
+        }
+    }
+
+    for (i=0; i<chip_cnt; i++)
+    {
+        work_mode.chip = i;
+        if (VI_WORK_MODE_4Multiplex== enWorkMode)
+        {
+            work_mode.mode = TW2865_4D1_MODE;
+        }
+        else if (VI_WORK_MODE_2Multiplex== enWorkMode)
+        {
+            work_mode.mode = TW2865_2D1_MODE;
+        }
+        else if (VI_WORK_MODE_1Multiplex == enWorkMode)
+        {
+            work_mode.mode = TW2865_1D1_MODE;
+        }
+        else
+        {
+            SAMPLE_PRT("work mode not support\n");
+            return -1;
+        }
+        ioctl(fd, TW2865_SET_WORK_MODE, &work_mode);
+    }
+
+    close(fd);
+    return 0;
+}
+
+
+HI_S32 SAMPLE_TW2960_CfgV(VIDEO_NORM_E enVideoMode,VI_WORK_MODE_E enWorkMode)
+{
+    int fd, i;
+    int video_mode;
+    tw2865_video_norm stVideoMode;
+    tw2865_work_mode work_mode;
+
+    int chip_cnt = 4;
+
+    fd = open(TW2960_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        SAMPLE_PRT("open 2960(%s) fail\n", TW2960_FILE);
+        return -1;
+    }
+
+    video_mode = (VIDEO_ENCODING_MODE_PAL == enVideoMode) ? TW2960_PAL : TW2960_NTSC ;
+
+    for (i=0; i<chip_cnt; i++)
+    {
+        stVideoMode.chip    = i;
+        stVideoMode.mode    = video_mode;
+        if (ioctl(fd, TW2960_SET_VIDEO_NORM, &stVideoMode))
+        {
+            SAMPLE_PRT("set tw2865(%d) video mode fail\n", i);
+            close(fd);
+            return -1;
+        }
+    }
+
+    for (i=0; i<chip_cnt; i++)
+    {
+        work_mode.chip = i;
+        if (VI_WORK_MODE_4Multiplex== enWorkMode)
+        {
+            work_mode.mode = TW2960_4D1_MODE;
+        }
+        else if (VI_WORK_MODE_2Multiplex== enWorkMode)
+        {
+            work_mode.mode = TW2960_2D1_MODE;
+        }
+        else if (VI_WORK_MODE_1Multiplex == enWorkMode)
+        {
+            work_mode.mode = TW2960_1D1_MODE;
+        }
+        else
+        {
+            SAMPLE_PRT("work mode not support\n");
+            return -1;
+        }
+        ioctl(fd, TW2960_SET_WORK_MODE, &work_mode);
+    }
+
+    close(fd);
+    return 0;
+}
+
+
+HI_S32 SAMPLE_CX26828_CfgV(VIDEO_NORM_E enVideoMode, int resolution_ratio, 
+                                      VI_WORK_MODE_E enWorkMode)
+{
+    int fd, i;
+    int video_mode;
+    int chip_cnt = 1;
+    cx26828_video_norm stVideoMode;
+    cx26828_work_mode work_mode;
+    cx26828_Multiplex_mode multiplex_mode;
+    
+    fd = open(CX26828_FILE, O_RDWR);
+    if (fd < 0)
+    {
+        printf("open %s fail\n", CX26828_FILE);
+        return -1;
+    }
+
+    video_mode = (VIDEO_ENCODING_MODE_PAL == enVideoMode) ? CX26828_MODE_PAL : CX26828_MODE_NTSC;
+    for (i=0; i<chip_cnt; i++)
+    {
+        stVideoMode.chip    = i;
+        stVideoMode.mode    = video_mode;
+        if (ioctl(fd, CX26828_SET_VIDEO_NORM, &stVideoMode))
+        {
+            printf("set cx26828(%d) video mode fail\n", i);
+            close(fd);
+            return -1;
+        }
+    }
+
+    for (i=0; i<chip_cnt; i++)
+    {
+        work_mode.chip = i;
+        if (0 == resolution_ratio)
+        {
+            work_mode.mode = CX26828_16D1;
+        }
+        else if (1 == resolution_ratio)
+        {
+            work_mode.mode = CX26828_16E1;
+        }
+        else
+        {
+            printf("work mode not support.\n");
+            return -1;
+        }
+        ioctl(fd, CX26828_SET_WORK_MODE, &work_mode);
+    }
+
+    for (i=0; i<chip_cnt; i++)
+    {
+        multiplex_mode.chip = i;
+        if (VI_WORK_MODE_4Multiplex== enWorkMode)
+        {
+            multiplex_mode.mode = CX26828_4D1_MODE;
+        }
+        else if (VI_WORK_MODE_2Multiplex== enWorkMode)
+        {
+            multiplex_mode.mode = CX26828_2D1_MODE;
+        }
+        else if (VI_WORK_MODE_1Multiplex== enWorkMode)
+        {
+            multiplex_mode.mode = CX26828_1D1_MODE;
+        }
+        else
+        {
+            printf("multiplex mode not support\n");
+            return -1;
+        }
+        ioctl(fd, CX26828_SET_Multiplex_MODE, &multiplex_mode);
+    }
+
+    close(fd);
+   
+    return 0;
+}
+
+
+HI_S32 SAMPLE_AD_CfgV_D1(VIDEO_NORM_E enVideoMode,VI_WORK_MODE_E enWorkMode)
+{
+#ifdef DEMO
+    return SAMPLE_CX26828_CfgV(enVideoMode, 0, enWorkMode);
+#else
+    return SAMPLE_TW2865_CfgV(enVideoMode, enWorkMode);
+#endif
+    
+}
+
+HI_S32 SAMPLE_AD_CfgV_960H(VIDEO_NORM_E enVideoMode,VI_WORK_MODE_E enWorkMode)
+{
+#ifdef DEMO
+    return SAMPLE_CX26828_CfgV(enVideoMode, 1, enWorkMode);
+#else
+    return SAMPLE_TW2960_CfgV(enVideoMode, enWorkMode);
+#endif
+}
+    
+
+
+
+/*****************************************************************************
+* function : set vi mask.
+*****************************************************************************/
+HI_VOID SAMPLE_COMM_VI_SetMask(VI_DEV ViDev, VI_DEV_ATTR_S *pstDevAttr)
+{
+    switch (ViDev % 4)
+    {
+        case 0:
+            pstDevAttr->au32CompMask[0] = 0xFF000000;
+            if (VI_MODE_BT1120_STANDARD == pstDevAttr->enIntfMode)
+            {
+                pstDevAttr->au32CompMask[1] = 0x00FF0000;
+            }
+            else if (VI_MODE_BT1120_INTERLEAVED == pstDevAttr->enIntfMode)
+            {
+                pstDevAttr->au32CompMask[1] = 0x0;
+            }
+            break;
+        case 1:
+            pstDevAttr->au32CompMask[0] = 0xFF0000;
+            if (VI_MODE_BT1120_INTERLEAVED == pstDevAttr->enIntfMode)
+            {
+                pstDevAttr->au32CompMask[1] = 0x0;
+            }
+            break;
+        case 2:
+            pstDevAttr->au32CompMask[0] = 0xFF00;
+            if (VI_MODE_BT1120_STANDARD == pstDevAttr->enIntfMode)
+            {
+                pstDevAttr->au32CompMask[1] = 0xFF;
+            }
+            else if (VI_MODE_BT1120_INTERLEAVED == pstDevAttr->enIntfMode)
+            {
+                pstDevAttr->au32CompMask[1] = 0x0;
+            }
+
+            #if HICHIP == HI3531_V100
+                #ifndef HI_FPGA
+                    if ((VI_MODE_BT1120_STANDARD != pstDevAttr->enIntfMode)
+                        && (VI_MODE_BT1120_INTERLEAVED != pstDevAttr->enIntfMode))
+                    {
+                        /* 3531的ASIC板是两个BT1120口出16D1，此时dev2/6要设成dev1/5的MASK */
+                        pstDevAttr->au32CompMask[0] = 0xFF0000; 
+                    }
+                #endif
+            #endif
+            
+            break;
+        case 3:
+            pstDevAttr->au32CompMask[0] = 0xFF;
+            if (VI_MODE_BT1120_INTERLEAVED == pstDevAttr->enIntfMode)
+            {
+                pstDevAttr->au32CompMask[1] = 0x0;
+            }
+            break;
+        default:
+            HI_ASSERT(0);
+    }
+}
+
+HI_S32 SAMPLE_COMM_VI_Mode2Param(SAMPLE_VI_MODE_E enViMode, SAMPLE_VI_PARAM_S *pstViParam)
+{
+    switch (enViMode)
+    {
+        case SAMPLE_VI_MODE_1_D1:
+		case SAMPLE_VI_MODE_1_D1Cif:
+            pstViParam->s32ViDevCnt = 1;
+            pstViParam->s32ViDevInterval = 1;
+            pstViParam->s32ViChnCnt = 1;
+            pstViParam->s32ViChnInterval = 1;
+            break;
+        case SAMPLE_VI_MODE_16_D1:
+            pstViParam->s32ViDevCnt = 4;
+            pstViParam->s32ViDevInterval = 2;
+            pstViParam->s32ViChnCnt = 16;
+            pstViParam->s32ViChnInterval = 1;
+            break;
+        case SAMPLE_VI_MODE_16_960H:
+            pstViParam->s32ViDevCnt = 4;
+            pstViParam->s32ViDevInterval = 2;
+            pstViParam->s32ViChnCnt = 16;
+            pstViParam->s32ViChnInterval = 1;
+            break;
+        case SAMPLE_VI_MODE_4_720P:
+            pstViParam->s32ViDevCnt = 2;
+            pstViParam->s32ViDevInterval = 1;
+            pstViParam->s32ViChnCnt = 4;
+            pstViParam->s32ViChnInterval = 2;
+            break;
+        
+        case SAMPLE_VI_MODE_4_1080P:
+            pstViParam->s32ViDevCnt = 4;
+            pstViParam->s32ViDevInterval = 2;
+            pstViParam->s32ViChnCnt = 4;
+            pstViParam->s32ViChnInterval = 4;            
+            break;
+        case SAMPLE_VI_MODE_1_1080P:    
+            pstViParam->s32ViDevCnt = 1;
+            pstViParam->s32ViDevInterval = 1;
+            pstViParam->s32ViChnCnt = 1;
+            pstViParam->s32ViChnInterval = 1;
+            break;
+
+        /*For Hi3521*/
+		case SAMPLE_VI_MODE_8_D1:
+            pstViParam->s32ViDevCnt = 2;
+            pstViParam->s32ViDevInterval = 1;
+            pstViParam->s32ViChnCnt = 8;
+            pstViParam->s32ViChnInterval = 1;	
+			break;
+		case SAMPLE_VI_MODE_1_720P:
+            pstViParam->s32ViDevCnt = 1;
+            pstViParam->s32ViDevInterval = 1;
+            pstViParam->s32ViChnCnt = 1;
+            pstViParam->s32ViChnInterval = 1;	
+			break;
+		case SAMPLE_VI_MODE_16_Cif:
+        case SAMPLE_VI_MODE_16_2Cif:
+		case SAMPLE_VI_MODE_16_D1Cif:
+            pstViParam->s32ViDevCnt = 4;
+            pstViParam->s32ViDevInterval = 1;
+            pstViParam->s32ViChnCnt = 16;
+            pstViParam->s32ViChnInterval = 1;	
+			break;
+        case SAMPLE_VI_MODE_4_D1:
+            pstViParam->s32ViDevCnt = 1;
+            pstViParam->s32ViDevInterval = 1;
+            pstViParam->s32ViChnCnt = 4;
+            pstViParam->s32ViChnInterval = 1;	
+			break; 
+        case SAMPLE_VI_MODE_8_2Cif:
+        case SAMPLE_VI_MODE_8_D1Cif:
+            pstViParam->s32ViDevCnt = 2;
+            pstViParam->s32ViDevInterval = 1;
+            pstViParam->s32ViChnCnt = 8;
+            pstViParam->s32ViChnInterval = 1;	
+			break;  
+        default:
+            SAMPLE_PRT("ViMode invaild!\n");
+            return HI_FAILURE;
+    }
+    return HI_SUCCESS;
+}
+
+/*****************************************************************************
+* function : get vi parameter, according to vi type
+*****************************************************************************/
+HI_S32 SAMPLE_COMM_VI_ADStart(SAMPLE_VI_MODE_E enViMode, VIDEO_NORM_E enNorm)
+{
+    VI_WORK_MODE_E enWorkMode;
+    HI_S32 s32Ret;
+    
+    switch (enViMode)
+    {
+        case SAMPLE_VI_MODE_1_D1:
+		case SAMPLE_VI_MODE_1_D1Cif:
+            enWorkMode = VI_WORK_MODE_4Multiplex;
+            s32Ret = SAMPLE_AD_CfgV_D1(enNorm, enWorkMode);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_PRT("SAMPLE_TW2865_CfgV failed with %#x!\n",\
+                        s32Ret);
+                return HI_FAILURE;
+            }
+            break;
+        case SAMPLE_VI_MODE_16_D1:
+		case SAMPLE_VI_MODE_8_D1:
+        case SAMPLE_VI_MODE_4_D1:
+        case SAMPLE_VI_MODE_16_Cif:
+		case SAMPLE_VI_MODE_16_2Cif:
+        case SAMPLE_VI_MODE_8_2Cif:
+        case SAMPLE_VI_MODE_8_D1Cif:
+		case SAMPLE_VI_MODE_16_D1Cif:
+            enWorkMode = VI_WORK_MODE_4Multiplex;
+            s32Ret = SAMPLE_AD_CfgV_D1(enNorm, enWorkMode);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_PRT("SAMPLE_TW2865_CfgV failed with %#x!\n",\
+                        s32Ret);
+                return HI_FAILURE;
+            }
+            break;
+        case SAMPLE_VI_MODE_16_960H:
+            enWorkMode = VI_WORK_MODE_4Multiplex;
+            s32Ret = SAMPLE_AD_CfgV_960H(enNorm, enWorkMode);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_PRT("SAMPLE_TW2960_CfgV failed with %#x!\n",\
+                        s32Ret);
+                return HI_FAILURE;
+            }
+            break;
+        case SAMPLE_VI_MODE_4_720P:
+		case SAMPLE_VI_MODE_1_720P:
+            break;
+        case SAMPLE_VI_MODE_4_1080P:
+        case SAMPLE_VI_MODE_1_1080P:
+            break;
+        default:
+            SAMPLE_PRT("AD not support!\n");
+            return HI_FAILURE;
+    }
+    
+    return HI_SUCCESS;
+}
+
+
+/*****************************************************************************
+* function : get vi parameter, according to vi type
+*****************************************************************************/
+HI_S32 SAMPLE_COMM_VI_Mode2Size(SAMPLE_VI_MODE_E enViMode, VIDEO_NORM_E enNorm, RECT_S *pstCapRect, SIZE_S *pstDestSize)
+{
+    pstCapRect->s32X = 0;
+    pstCapRect->s32Y = 0;
+    switch (enViMode)
+    {
+        case SAMPLE_VI_MODE_1_D1:
+        case SAMPLE_VI_MODE_16_D1:
+		case SAMPLE_VI_MODE_8_D1:
+            pstDestSize->u32Width = D1_WIDTH;
+            pstDestSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+            pstCapRect->u32Width = D1_WIDTH;
+            pstCapRect->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+            break;
+        case SAMPLE_VI_MODE_16_960H:
+            pstDestSize->u32Width = 960;
+            pstDestSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+            pstCapRect->u32Width = 960;
+            pstCapRect->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+            break;
+        case SAMPLE_VI_MODE_4_720P:
+		case SAMPLE_VI_MODE_1_720P:	
+            pstDestSize->u32Width = 1280;
+            pstDestSize->u32Height = 720;
+            pstCapRect->u32Width = 1280;
+            pstCapRect->u32Height = 720;
+            break;
+        case SAMPLE_VI_MODE_4_1080P:
+        case SAMPLE_VI_MODE_1_1080P:
+            pstDestSize->u32Width = 1920;
+            pstDestSize->u32Height = 1080;
+            pstCapRect->u32Width = 1920;
+            pstCapRect->u32Height = 1080;
+            break;
+		/*For Hi3521*/
+		case SAMPLE_VI_MODE_16_2Cif:
+		    pstDestSize->u32Width = D1_WIDTH / 2;
+            pstDestSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+            pstCapRect->u32Width = D1_WIDTH;
+            pstCapRect->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+			break;
+        /*For Hi3520A*/
+		case SAMPLE_VI_MODE_16_Cif:
+		    pstDestSize->u32Width = D1_WIDTH /2 ;
+            pstDestSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?288:240;
+            pstCapRect->u32Width = D1_WIDTH;
+            pstCapRect->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+			break;
+        case SAMPLE_VI_MODE_4_D1:
+            pstDestSize->u32Width = D1_WIDTH;
+            pstDestSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+            pstCapRect->u32Width = D1_WIDTH;
+            pstCapRect->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+            break;
+        case SAMPLE_VI_MODE_8_2Cif:
+		    pstDestSize->u32Width = D1_WIDTH / 2;
+            pstDestSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+            pstCapRect->u32Width = D1_WIDTH;
+            pstCapRect->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+			break;
+        default:
+            SAMPLE_PRT("vi mode invaild!\n");
+            return HI_FAILURE;
+    }
+    
+    return HI_SUCCESS;
+}
+
+HI_S32 SAMPLE_COMM_VI_GetSubChnSize(VI_CHN ViChn_Sub, VIDEO_NORM_E enNorm, SIZE_S *pstSize)
+{
+    VI_CHN ViChn;
+    
+    ViChn = ViChn_Sub - 16;
+
+    if (0==(ViChn%4)) //(0,4,8,12) subchn max size is 960x1600
+    {
+        pstSize->u32Width = 720;
+        pstSize->u32Height = (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+    }
+    else if (0==(ViChn%2)) //(2,6,10,14) subchn max size is 640x720
+    {
+        pstSize->u32Width = SAMPLE_VI_SUBCHN_2_W;
+        pstSize->u32Height = SAMPLE_VI_SUBCHN_2_H;
+    }
+    else
+    {
+        SAMPLE_PRT("Vi odd sub_chn(%d) is invaild!\n", ViChn_Sub);
+        return HI_FAILURE;
+    }
+    return HI_SUCCESS;
+}
+/*****************************************************************************
+* function : vi input is hd or not.
+*****************************************************************************/
+HI_BOOL SAMPLE_COMM_VI_IsHd(SAMPLE_VI_MODE_E enViMode)
+{
+        return HI_FALSE;
+}
+
+/*****************************************************************************
+* function : Get Vi Dev No. according to Vi_Chn No.
+*****************************************************************************/
+VI_DEV SAMPLE_COMM_VI_GetDev(SAMPLE_VI_MODE_E enViMode, VI_CHN ViChn)
+{
+    HI_S32 s32Ret, s32ChnPerDev;
+    SAMPLE_VI_PARAM_S stViParam;
+
+    s32Ret = SAMPLE_COMM_VI_Mode2Param(enViMode, &stViParam);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("vi get param failed!\n");
+        return (VI_DEV)-1;
+    }
+
+    s32ChnPerDev = stViParam.s32ViChnCnt / stViParam.s32ViDevCnt;
+    return (VI_DEV)(ViChn /stViParam.s32ViChnInterval / s32ChnPerDev * stViParam.s32ViDevInterval);
+}
+
+/******************************************************************************
+* function : Set vi system memory location
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VI_MemConfig(SAMPLE_VI_MODE_E enViMode)
+{
+    HI_CHAR * pcMmzName;
+    MPP_CHN_S stMppChnVI;
+    SAMPLE_VI_PARAM_S stViParam;
+    VI_DEV ViDev;
+    VI_CHN ViChn;
+
+    HI_S32 i, j, s32Ret;
+
+    s32Ret = SAMPLE_COMM_VI_Mode2Param(enViMode, &stViParam);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("vi get param failed!\n");
+        return HI_FAILURE;
+    }
+
+    j = 0;
+    for(i=0; i<stViParam.s32ViChnCnt; i++)
+    {
+        ViChn = i * stViParam.s32ViChnInterval;
+        ViDev = SAMPLE_COMM_VI_GetDev(enViMode, ViChn);
+        //printf("dev:%d, chn:%d\n", ViDev, ViChn);
+        if (ViDev < 0)
+        {
+            SAMPLE_PRT("get vi dev failed !\n");
+            return HI_FAILURE;
+        }
+
+        pcMmzName = (0==i%2)?NULL: "ddr1";
+        stMppChnVI.enModId = HI_ID_VIU;
+        stMppChnVI.s32DevId = 0; //For VIU mode, this item must be set to zero
+        stMppChnVI.s32ChnId = ViChn;
+        s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnVI,pcMmzName);
+        if (s32Ret)
+        {
+            SAMPLE_PRT("VI HI_MPI_SYS_SetMemConf failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+        }
+        
+        /* HD mode, we will start vi sub-chn */
+        if (HI_TRUE == SAMPLE_COMM_VI_IsHd(enViMode))
+        {
+            ViChn += 16;
+            
+            pcMmzName = (0==j%2)?NULL: "ddr1";
+            stMppChnVI.enModId = HI_ID_VIU;
+            stMppChnVI.s32DevId = 0; //For VIU mode, this item must be set to zero
+            stMppChnVI.s32ChnId = ViChn;
+            s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnVI, pcMmzName);
+            if (s32Ret)
+            {
+                SAMPLE_PRT("VI subchn HI_MPI_SYS_SetMemConf failed with %#x!\n", s32Ret);
+                return HI_FAILURE;
+            }
+            j++;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+/*****************************************************************************
+* function : star vi dev (cfg vi_dev_attr; set_dev_cfg; enable dev)
+*****************************************************************************/
+HI_S32 SAMPLE_COMM_VI_StartDev(VI_DEV ViDev, SAMPLE_VI_MODE_E enViMode)
+{
+    HI_S32 s32Ret;
+    VI_DEV_ATTR_S    stViDevAttr;
+	
+    memset(&stViDevAttr,0,sizeof(stViDevAttr));
+
+    switch (enViMode)
+    {
+        case SAMPLE_VI_MODE_1_D1:
+		case SAMPLE_VI_MODE_1_D1Cif:
+            memcpy(&stViDevAttr,&DEV_ATTR_BT656D1_4MUX,sizeof(stViDevAttr));
+            SAMPLE_COMM_VI_SetMask(ViDev,&stViDevAttr);
+            break;
+        case SAMPLE_VI_MODE_16_D1:
+		case SAMPLE_VI_MODE_8_D1:
+        case SAMPLE_VI_MODE_4_D1:
+        case SAMPLE_VI_MODE_16_Cif:
+		case SAMPLE_VI_MODE_16_2Cif:
+        case SAMPLE_VI_MODE_8_2Cif:
+        case SAMPLE_VI_MODE_8_D1Cif:
+		case SAMPLE_VI_MODE_16_D1Cif:
+            memcpy(&stViDevAttr,&DEV_ATTR_BT656D1_4MUX,sizeof(stViDevAttr));
+            SAMPLE_COMM_VI_SetMask(ViDev,&stViDevAttr);
+            break;
+        case SAMPLE_VI_MODE_16_960H:
+            memcpy(&stViDevAttr,&DEV_ATTR_BT656D1_4MUX,sizeof(stViDevAttr));
+            SAMPLE_COMM_VI_SetMask(ViDev,&stViDevAttr);
+            break;
+        case SAMPLE_VI_MODE_4_720P:
+            memcpy(&stViDevAttr,&DEV_ATTR_BT656_720P_2MUX,sizeof(stViDevAttr));
+            SAMPLE_COMM_VI_SetMask(ViDev,&stViDevAttr);
+            break;			
+		case SAMPLE_VI_MODE_1_720P:
+            memcpy(&stViDevAttr,&DEV_ATTR_7441_BT1120_720P,sizeof(stViDevAttr));
+            SAMPLE_COMM_VI_SetMask(ViDev,&stViDevAttr);
+            break;
+        case SAMPLE_VI_MODE_4_1080P:
+        case SAMPLE_VI_MODE_1_1080P:
+            memcpy(&stViDevAttr,&DEV_ATTR_7441_BT1120_1080P,sizeof(stViDevAttr));
+            SAMPLE_COMM_VI_SetMask(ViDev,&stViDevAttr);
+            break;
+        default:
+            SAMPLE_PRT("vi input type[%d] is invalid!\n", enViMode);
+            return HI_FAILURE;
+    }
+
+#ifdef DEMO
+    stViDevAttr.bDataRev = HI_TRUE;
+#else
+    stViDevAttr.bDataRev = HI_FALSE;
+#endif
+    
+    s32Ret = HI_MPI_VI_SetDevAttr(ViDev, &stViDevAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_VI_SetDevAttr failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+	if(SAMPLE_VI_MODE_4_720P == enViMode)
+	{
+		s32Ret = HI_MPI_VI_SetPortMode(ViDev, VI_PORTMODE_720P);
+	    if (s32Ret != HI_SUCCESS)
+	    {
+	        SAMPLE_PRT("HI_MPI_VI_SetPortMode failed with %#x!\n", s32Ret);
+	        return HI_FAILURE;
+	    }				
+	}
+
+    s32Ret = HI_MPI_VI_EnableDev(ViDev);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_VI_EnableDev failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+/*****************************************************************************
+* function : star vi chn
+*****************************************************************************/
+HI_S32 SAMPLE_COMM_VI_StartChn(VI_CHN ViChn, RECT_S *pstCapRect, SIZE_S *pstTarSize, 
+    SAMPLE_VI_MODE_E enViMode, SAMPLE_VI_CHN_SET_E enViChnSet)
+{
+    HI_S32 s32Ret;
+    VI_CHN_ATTR_S stChnAttr;
+	VI_CHN_BIND_ATTR_S stChnBindAttr;
+
+	if(SAMPLE_VI_MODE_4_720P == enViMode)
+	{
+		if(2 == ViChn)
+		{
+			s32Ret = HI_MPI_VI_ChnUnBind(ViChn);
+		    if (s32Ret != HI_SUCCESS)
+		    {
+		        SAMPLE_PRT("HI_MPI_VI_ChnUnBind failed with %#x!\n", s32Ret);
+		        return HI_FAILURE;
+		    }
+			stChnBindAttr.ViDev = 0;
+			stChnBindAttr.ViWay = 1;
+			s32Ret = HI_MPI_VI_ChnBind(ViChn, &stChnBindAttr);
+		    if (s32Ret != HI_SUCCESS)
+		    {
+		        SAMPLE_PRT("HI_MPI_VI_ChnBind failed with %#x!\n", s32Ret);
+		        return HI_FAILURE;
+		    }			
+		}
+		else if(6 == ViChn)
+		{
+			s32Ret = HI_MPI_VI_ChnUnBind(ViChn);
+		    if (s32Ret != HI_SUCCESS)
+		    {
+		        SAMPLE_PRT("HI_MPI_VI_ChnUnBind failed with %#x!\n", s32Ret);
+		        return HI_FAILURE;
+		    }
+			stChnBindAttr.ViDev = 1;
+			stChnBindAttr.ViWay = 1;
+			s32Ret = HI_MPI_VI_ChnBind(ViChn, &stChnBindAttr);
+		    if (s32Ret != HI_SUCCESS)
+		    {
+		        SAMPLE_PRT("HI_MPI_VI_ChnBind failed with %#x!\n", s32Ret);
+		        return HI_FAILURE;
+		    }			
+		}			
+	}
+
+    /* step  5: config & start vicap dev */
+    memcpy(&stChnAttr.stCapRect, pstCapRect, sizeof(RECT_S));
+    if (SAMPLE_VI_MODE_16_Cif == enViMode)
+    {
+        stChnAttr.enCapSel = VI_CAPSEL_BOTTOM;
+    }
+    else
+    {
+        stChnAttr.enCapSel = VI_CAPSEL_BOTH;
+    }
+    /* to show scale. this is a sample only, we want to show dist_size = D1 only */
+    stChnAttr.stDestSize.u32Width = pstTarSize->u32Width;
+    stChnAttr.stDestSize.u32Height = pstTarSize->u32Height;
+    stChnAttr.enPixFormat = SAMPLE_PIXEL_FORMAT;   /* sp420 or sp422 */
+    stChnAttr.bMirror = (VI_CHN_SET_MIRROR == enViChnSet)?HI_TRUE:HI_FALSE;
+    stChnAttr.bFlip = (VI_CHN_SET_FILP == enViChnSet)?HI_TRUE:HI_FALSE;
+
+    stChnAttr.bChromaResample = HI_FALSE;
+    stChnAttr.s32SrcFrameRate = -1;
+    stChnAttr.s32FrameRate = -1;
+
+    s32Ret = HI_MPI_VI_SetChnAttr(ViChn, &stChnAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+	if((SAMPLE_VI_MODE_4_720P == enViMode)&& (2==ViChn || 6==ViChn))
+	{	
+		s32Ret = HI_MPI_VI_EnableChn422to420(ViChn);
+	    if (s32Ret != HI_SUCCESS)
+	    {
+	        SAMPLE_PRT("HI_MPI_VI_EnableChn422to420 failed with %#x!\n", s32Ret);
+	        return HI_FAILURE;
+	    }	
+		s32Ret = HI_MPI_VI_EnableChn422to420(ViChn);
+	    if (s32Ret != HI_SUCCESS)
+	    {
+	        SAMPLE_PRT("HI_MPI_VI_EnableChn422to420 failed with %#x!\n", s32Ret);
+	        return HI_FAILURE;
+	    }		
+	}
+	
+    s32Ret = HI_MPI_VI_EnableChn(ViChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+/*****************************************************************************
+* function : star vi according to product type
+*            if vi input is hd, we will start sub-chn for cvbs preview
+*****************************************************************************/
+HI_S32 SAMPLE_COMM_VI_Start(SAMPLE_VI_MODE_E enViMode, VIDEO_NORM_E enNorm)
+{
+    VI_DEV ViDev;
+    VI_CHN ViChn, ViChn_Sub;
+    HI_S32 i;
+    HI_S32 s32Ret;
+    SAMPLE_VI_PARAM_S stViParam;
+    SIZE_S stMainTargetSize;
+    SIZE_S stSubTargetSize;
+    RECT_S stCapRect;
+    
+    /*** get parameter from Sample_Vi_Mode ***/
+    s32Ret = SAMPLE_COMM_VI_Mode2Param(enViMode, &stViParam);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("vi get param failed!\n");
+        return HI_FAILURE;
+    }
+    s32Ret = SAMPLE_COMM_VI_Mode2Size(enViMode, enNorm, &stCapRect, &stMainTargetSize);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("vi get size failed!\n");
+        return HI_FAILURE;
+    }
+    
+    /*** Start AD ***/
+    s32Ret = SAMPLE_COMM_VI_ADStart(enViMode, enNorm);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("Start AD failed!\n");
+        return HI_FAILURE;
+    }
+    
+    /*** Start VI Dev ***/
+    for(i=0; i<stViParam.s32ViDevCnt; i++)
+    {
+        ViDev = i * stViParam.s32ViDevInterval;
+        s32Ret = SAMPLE_COMM_VI_StartDev(ViDev, enViMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SAMPLE_COMM_VI_StartDev failed with %#x\n", s32Ret);
+            return HI_FAILURE;
+        }
+    }
+    
+    /*** Start VI Chn ***/
+    for(i=0; i<stViParam.s32ViChnCnt; i++)
+    {
+        ViChn = i * stViParam.s32ViChnInterval;
+        
+        s32Ret = SAMPLE_COMM_VI_StartChn(ViChn, &stCapRect, &stMainTargetSize, enViMode, VI_CHN_SET_NORMAL);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("call SAMPLE_COMM_VI_StarChn failed with %#x\n", s32Ret);
+            return HI_FAILURE;
+        } 
+        /* HD mode, we will start vi sub-chn */
+        if (HI_TRUE == SAMPLE_COMM_VI_IsHd(enViMode))
+        {
+            ViChn_Sub = SUBCHN(ViChn);
+            s32Ret = SAMPLE_COMM_VI_GetSubChnSize(ViChn_Sub, enNorm, &stSubTargetSize);
+            if (HI_SUCCESS != s32Ret)
+            {
+                SAMPLE_PRT("SAMPLE_COMM_VI_GetSubChnSize(%d) failed!\n", ViChn_Sub);
+                return HI_FAILURE;
+            }
+            s32Ret = SAMPLE_COMM_VI_StartChn(ViChn_Sub, &stCapRect, &stSubTargetSize,enViMode, VI_CHN_SET_NORMAL);
+            if (HI_SUCCESS != s32Ret)
+            {
+                SAMPLE_PRT("SAMPLE_COMM_VI_StartChn (Sub_Chn-%d) failed!\n", ViChn_Sub);
+                return HI_FAILURE;
+            }
+        }
+    }
+
+    return HI_SUCCESS;
+}
+/*****************************************************************************
+* function : stop vi accroding to product type
+*****************************************************************************/
+HI_S32 SAMPLE_COMM_VI_Stop(SAMPLE_VI_MODE_E enViMode)
+{
+    VI_DEV ViDev;
+    VI_CHN ViChn;
+    HI_S32 i;
+    HI_S32 s32Ret;
+    SAMPLE_VI_PARAM_S stViParam;
+
+    /*** get parameter from Sample_Vi_Mode ***/
+    s32Ret = SAMPLE_COMM_VI_Mode2Param(enViMode, &stViParam);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VI_Mode2Param failed!\n");
+        return HI_FAILURE;
+    }
+
+    /*** Stop VI Chn ***/
+    for(i=0;i<stViParam.s32ViChnCnt;i++)
+    {
+        /* Stop vi phy-chn */
+        ViChn = i * stViParam.s32ViChnInterval;
+        s32Ret = HI_MPI_VI_DisableChn(ViChn);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SAMPLE_COMM_VI_StopChn failed with %#x\n",s32Ret);
+            return HI_FAILURE;
+        }
+        /* HD mode, we will stop vi sub-chn */
+        if (HI_TRUE == SAMPLE_COMM_VI_IsHd(enViMode))
+        {
+            ViChn += 16;
+            s32Ret = HI_MPI_VI_DisableChn(ViChn);
+            if (HI_SUCCESS != s32Ret)
+            {
+                SAMPLE_PRT("SAMPLE_COMM_VI_StopChn failed with %#x\n", s32Ret);
+                return HI_FAILURE;
+            }
+        }
+    }
+
+    /*** Stop VI Dev ***/
+    for(i=0; i<stViParam.s32ViDevCnt; i++)
+    {
+        ViDev = i * stViParam.s32ViDevInterval;
+        s32Ret = HI_MPI_VI_DisableDev(ViDev);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SAMPLE_COMM_VI_StopDev failed with %#x\n", s32Ret);
+            return HI_FAILURE;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+/*****************************************************************************
+* function : Vi chn bind vpss group
+*****************************************************************************/
+HI_S32 SAMPLE_COMM_VI_BindVpss(SAMPLE_VI_MODE_E enViMode)
+{
+    HI_S32 j, s32Ret;
+    VPSS_GRP VpssGrp;
+    MPP_CHN_S stSrcChn;
+    MPP_CHN_S stDestChn;
+    SAMPLE_VI_PARAM_S stViParam;
+    VI_CHN ViChn;
+
+    s32Ret = SAMPLE_COMM_VI_Mode2Param(enViMode, &stViParam);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VI_Mode2Param failed!\n");
+        return HI_FAILURE;
+    }
+    
+    VpssGrp = 0;
+    for (j=0; j<stViParam.s32ViChnCnt; j++)
+    {
+        ViChn = j * stViParam.s32ViChnInterval;
+        
+        stSrcChn.enModId = HI_ID_VIU;
+        stSrcChn.s32DevId = 0;
+        stSrcChn.s32ChnId = ViChn;
+    
+        stDestChn.enModId = HI_ID_VPSS;
+        stDestChn.s32DevId = VpssGrp;
+        stDestChn.s32ChnId = 0;
+    
+        s32Ret = HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+        }
+        
+        VpssGrp ++;
+    }
+    return HI_SUCCESS;
+}
+
+
+/*****************************************************************************
+* function : Vi chn unbind vpss group
+*****************************************************************************/
+HI_S32 SAMPLE_COMM_VI_UnBindVpss(SAMPLE_VI_MODE_E enViMode)
+{
+    HI_S32 i, j, s32Ret;
+    VPSS_GRP VpssGrp;
+    MPP_CHN_S stSrcChn;
+    MPP_CHN_S stDestChn;
+    SAMPLE_VI_PARAM_S stViParam;
+    VI_DEV ViDev;
+    VI_CHN ViChn;
+
+    s32Ret = SAMPLE_COMM_VI_Mode2Param(enViMode, &stViParam);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VI_Mode2Param failed!\n");
+        return HI_FAILURE;
+    }
+    
+    VpssGrp = 0;    
+    for (i=0; i<stViParam.s32ViDevCnt; i++)
+    {
+        ViDev = i * stViParam.s32ViDevInterval;
+
+        for (j=0; j<stViParam.s32ViChnCnt; j++)
+        {
+            ViChn = j * stViParam.s32ViChnInterval;
+            
+            stSrcChn.enModId = HI_ID_VIU;
+            stSrcChn.s32DevId = ViDev;
+            stSrcChn.s32ChnId = ViChn;
+        
+            stDestChn.enModId = HI_ID_VPSS;
+            stDestChn.s32DevId = VpssGrp;
+            stDestChn.s32ChnId = 0;
+        
+            s32Ret = HI_MPI_SYS_UnBind(&stSrcChn, &stDestChn);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_PRT("failed with %#x!\n", s32Ret);
+                return HI_FAILURE;
+            }
+            
+            VpssGrp ++;
+        }
+    }
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : read frame
+******************************************************************************/
+HI_VOID SAMPLE_COMM_VI_ReadFrame(FILE * fp, HI_U8 * pY, HI_U8 * pU, HI_U8 * pV, HI_U32 width, HI_U32 height, HI_U32 stride, HI_U32 stride2)
+{
+    HI_U8 * pDst;
+
+    HI_U32 u32Row;
+
+    pDst = pY;
+    for ( u32Row = 0; u32Row < height; u32Row++ )
+    {
+        fread( pDst, width, 1, fp );
+        pDst += stride;
+    }
+
+    pDst = pU;
+    for ( u32Row = 0; u32Row < height/2; u32Row++ )
+    {
+        fread( pDst, width/2, 1, fp );
+        pDst += stride2;
+    }
+
+    pDst = pV;
+    for ( u32Row = 0; u32Row < height/2; u32Row++ )
+    {
+        fread( pDst, width/2, 1, fp );
+        pDst += stride2;
+    }
+}
+ 
+/******************************************************************************
+* function : Plan to Semi
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VI_PlanToSemi(HI_U8 *pY, HI_S32 yStride,
+                       HI_U8 *pU, HI_S32 uStride,
+                       HI_U8 *pV, HI_S32 vStride,
+                       HI_S32 picWidth, HI_S32 picHeight)
+{
+    HI_S32 i;
+    HI_U8* pTmpU, *ptu;
+    HI_U8* pTmpV, *ptv;
+    HI_S32 s32HafW = uStride >>1 ;
+    HI_S32 s32HafH = picHeight >>1 ;
+    HI_S32 s32Size = s32HafW*s32HafH;
+
+    pTmpU = malloc( s32Size ); ptu = pTmpU;
+    pTmpV = malloc( s32Size ); ptv = pTmpV;
+
+    memcpy(pTmpU,pU,s32Size);
+    memcpy(pTmpV,pV,s32Size);
+
+    for(i = 0;i<s32Size>>1;i++)
+    {
+        *pU++ = *pTmpV++;
+        *pU++ = *pTmpU++;
+
+    }
+    for(i = 0;i<s32Size>>1;i++)
+    {
+        *pV++ = *pTmpV++;
+        *pV++ = *pTmpU++;
+    }
+
+    free( ptu );
+    free( ptv );
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : Get from YUV
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VI_GetVFrameFromYUV(FILE *pYUVFile, HI_U32 u32Width, HI_U32 u32Height,HI_U32 u32Stride, VIDEO_FRAME_INFO_S *pstVFrameInfo)
+{
+    HI_U32             u32LStride;
+    HI_U32             u32CStride;
+    HI_U32             u32LumaSize;
+    HI_U32             u32ChrmSize;
+    HI_U32             u32Size;
+    VB_BLK VbBlk;
+    HI_U32 u32PhyAddr;
+    HI_U8 *pVirAddr;
+
+    u32LStride  = u32Stride;
+    u32CStride  = u32Stride;
+
+    u32LumaSize = (u32LStride * u32Height);
+    u32ChrmSize = (u32CStride * u32Height) >> 2;/* YUV 420 */
+    u32Size = u32LumaSize + (u32ChrmSize << 1);
+
+    /* alloc video buffer block ---------------------------------------------------------- */
+    VbBlk = HI_MPI_VB_GetBlock(VB_INVALID_POOLID, u32Size, NULL);
+    if (VB_INVALID_HANDLE == VbBlk)
+    {
+        SAMPLE_PRT("HI_MPI_VB_GetBlock err! size:%d\n",u32Size);
+        return -1;
+    }
+    u32PhyAddr = HI_MPI_VB_Handle2PhysAddr(VbBlk);
+    if (0 == u32PhyAddr)
+    {
+        return -1;
+    }
+
+    pVirAddr = (HI_U8 *) HI_MPI_SYS_Mmap(u32PhyAddr, u32Size);
+    if (NULL == pVirAddr)
+    {
+        return -1;
+    }
+
+    pstVFrameInfo->u32PoolId = HI_MPI_VB_Handle2PoolId(VbBlk);
+    if (VB_INVALID_POOLID == pstVFrameInfo->u32PoolId)
+    {
+        return -1;
+    }
+    SAMPLE_PRT("pool id :%d, phyAddr:%x,virAddr:%x\n" ,pstVFrameInfo->u32PoolId,u32PhyAddr,(int)pVirAddr);
+
+    pstVFrameInfo->stVFrame.u32PhyAddr[0] = u32PhyAddr;
+    pstVFrameInfo->stVFrame.u32PhyAddr[1] = pstVFrameInfo->stVFrame.u32PhyAddr[0] + u32LumaSize;
+    pstVFrameInfo->stVFrame.u32PhyAddr[2] = pstVFrameInfo->stVFrame.u32PhyAddr[1] + u32ChrmSize;
+
+    pstVFrameInfo->stVFrame.pVirAddr[0] = pVirAddr;
+    pstVFrameInfo->stVFrame.pVirAddr[1] = pstVFrameInfo->stVFrame.pVirAddr[0] + u32LumaSize;
+    pstVFrameInfo->stVFrame.pVirAddr[2] = pstVFrameInfo->stVFrame.pVirAddr[1] + u32ChrmSize;
+
+    pstVFrameInfo->stVFrame.u32Width  = u32Width;
+    pstVFrameInfo->stVFrame.u32Height = u32Height;
+    pstVFrameInfo->stVFrame.u32Stride[0] = u32LStride;
+    pstVFrameInfo->stVFrame.u32Stride[1] = u32CStride;
+    pstVFrameInfo->stVFrame.u32Stride[2] = u32CStride;
+    pstVFrameInfo->stVFrame.enPixelFormat = PIXEL_FORMAT_YUV_SEMIPLANAR_420;
+    pstVFrameInfo->stVFrame.u32Field = VIDEO_FIELD_INTERLACED;/* Intelaced D1,otherwise VIDEO_FIELD_FRAME */
+
+    /* read Y U V data from file to the addr ----------------------------------------------*/
+    SAMPLE_COMM_VI_ReadFrame(pYUVFile, pstVFrameInfo->stVFrame.pVirAddr[0],
+       pstVFrameInfo->stVFrame.pVirAddr[1], pstVFrameInfo->stVFrame.pVirAddr[2],
+       pstVFrameInfo->stVFrame.u32Width, pstVFrameInfo->stVFrame.u32Height,
+       pstVFrameInfo->stVFrame.u32Stride[0], pstVFrameInfo->stVFrame.u32Stride[1] >> 1 );
+
+    /* convert planar YUV420 to sem-planar YUV420 -----------------------------------------*/
+    SAMPLE_COMM_VI_PlanToSemi(pstVFrameInfo->stVFrame.pVirAddr[0], pstVFrameInfo->stVFrame.u32Stride[0],
+      pstVFrameInfo->stVFrame.pVirAddr[1], pstVFrameInfo->stVFrame.u32Stride[1],
+      pstVFrameInfo->stVFrame.pVirAddr[2], pstVFrameInfo->stVFrame.u32Stride[1],
+      pstVFrameInfo->stVFrame.u32Width, pstVFrameInfo->stVFrame.u32Height);
+
+    HI_MPI_SYS_Munmap(pVirAddr, u32Size);
+    return 0;
+}
+
+HI_S32 SAMPLE_COMM_VI_ChangeCapSize(VI_CHN ViChn, HI_U32 u32CapWidth, HI_U32 u32CapHeight,HI_U32 u32Width, HI_U32 u32Height)
+{
+    VI_CHN_ATTR_S stChnAttr;
+	HI_S32 S32Ret = HI_SUCCESS;
+	S32Ret = HI_MPI_VI_GetChnAttr(ViChn, &stChnAttr);
+	if(HI_SUCCESS!= S32Ret)
+	{
+	    SAMPLE_PRT( "HI_MPI_VI_GetChnAttr failed\n");
+	}
+    stChnAttr.stCapRect.u32Width = u32CapWidth;
+    stChnAttr.stCapRect.u32Height = u32CapHeight;
+    stChnAttr.stDestSize.u32Width = u32Width;
+    stChnAttr.stDestSize.u32Height = u32Height;
+
+    S32Ret = HI_MPI_VI_SetChnAttr(ViChn, &stChnAttr);
+	if(HI_SUCCESS!= S32Ret)
+	{
+	    SAMPLE_PRT( "HI_MPI_VI_SetChnAttr failed\n");
+	}
+
+    return HI_SUCCESS;
+}
+
+HI_S32 SAMPLE_COMM_VI_ChangeDestSize(VI_CHN ViChn, HI_U32 u32Width, HI_U32 u32Height)
+{
+    VI_CHN_ATTR_S stChnAttr;
+	HI_S32 S32Ret = HI_SUCCESS;
+	S32Ret = HI_MPI_VI_GetChnAttr(ViChn, &stChnAttr);
+	if(HI_SUCCESS!= S32Ret)
+	{
+	    SAMPLE_PRT( "HI_MPI_VI_GetChnAttr failed\n");
+	}
+    stChnAttr.stDestSize.u32Width = u32Width;
+    stChnAttr.stDestSize.u32Height = u32Height;
+
+    S32Ret = HI_MPI_VI_SetChnAttr(ViChn, &stChnAttr);
+	if(HI_SUCCESS!= S32Ret)
+	{
+	    SAMPLE_PRT( "HI_MPI_VI_SetChnAttr failed\n");
+	}
+
+    return HI_SUCCESS;
+}
+
+
+/*****************************************************************************
+* function : star vi according to product type
+*           only for Hi3520D MixCap 
+*****************************************************************************/
+HI_S32 SAMPLE_COMM_VI_MixCap_Start(SAMPLE_VI_MODE_E enViMode, VIDEO_NORM_E enNorm)
+{
+    VI_DEV ViDev;
+    VI_CHN ViChn;
+    HI_S32 i;
+    HI_S32 s32Ret;
+    SAMPLE_VI_PARAM_S stViParam;
+    VI_CHN_ATTR_S stChnAttr,stChnMinorAttr;
+	
+    /*** get parameter from Sample_Vi_Mode ***/
+    s32Ret = SAMPLE_COMM_VI_Mode2Param(enViMode, &stViParam);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("vi get param failed!\n");
+        return HI_FAILURE;
+    }
+    
+    /*** Start AD ***/
+    s32Ret = SAMPLE_COMM_VI_ADStart(enViMode, enNorm);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("Start AD failed!\n");
+        return HI_FAILURE;
+    }
+    
+    /*** Start VI Dev ***/
+    for(i=0; i<stViParam.s32ViDevCnt; i++)
+    {
+        ViDev = i * stViParam.s32ViDevInterval;
+        s32Ret = SAMPLE_COMM_VI_StartDev(ViDev, enViMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SAMPLE_COMM_VI_StartDev failed with %#x\n", s32Ret);
+            return HI_FAILURE;
+        }
+    }
+    
+    /*** Start VI Chn ***/
+    for(i=0; i<stViParam.s32ViChnCnt; i++)
+    {
+        ViChn = i * stViParam.s32ViChnInterval;
+
+	    stChnAttr.stCapRect.s32X = 0;
+	    stChnAttr.stCapRect.s32Y = 0;
+	    stChnAttr.enCapSel = VI_CAPSEL_BOTH;                      
+	    stChnAttr.enPixFormat = SAMPLE_PIXEL_FORMAT;   /* sp420 or sp422 */
+	    stChnAttr.bMirror = HI_FALSE;                             
+	    stChnAttr.bFlip   = HI_FALSE;                              
+	    stChnAttr.bChromaResample = HI_FALSE;                      
+	    stChnAttr.s32SrcFrameRate = -1;
+	    stChnAttr.s32FrameRate = -1;
+		stChnAttr.stCapRect.u32Width= D1_WIDTH;
+	    stChnAttr.stCapRect.u32Height= (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;	
+	    stChnAttr.stDestSize.u32Width= D1_WIDTH;
+	    stChnAttr.stDestSize.u32Height= (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+		
+		memcpy(&stChnMinorAttr, &stChnAttr, sizeof(VI_CHN_ATTR_S));
+	    stChnMinorAttr.stDestSize.u32Width= D1_WIDTH / 2;
+	    stChnMinorAttr.stDestSize.u32Height= (VIDEO_ENCODING_MODE_PAL==enNorm)?576:480;
+
+		stChnAttr.s32SrcFrameRate = (VIDEO_ENCODING_MODE_PAL== enNorm)?25:30;
+		stChnAttr.s32FrameRate = 6;
+		
+		s32Ret = HI_MPI_VI_SetChnAttr(ViChn, &stChnAttr);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("call HI_MPI_VI_SetChnAttr failed with %#x\n", s32Ret);
+            return HI_FAILURE;
+        } 
+		s32Ret = HI_MPI_VI_SetChnMinorAttr(ViChn, &stChnMinorAttr);
+		if (HI_SUCCESS != s32Ret)
+		{
+			SAMPLE_PRT("call HI_MPI_VI_SetChnMinorAttr failed with %#x\n", s32Ret);
+			return HI_FAILURE;
+		} 
+		s32Ret = HI_MPI_VI_EnableChn(ViChn);
+		if (s32Ret != HI_SUCCESS)
+		{
+			SAMPLE_PRT("HI_MPI_VI_EnableChn failed with %#x!\n", s32Ret);
+			return HI_FAILURE;
+		}
+
+    }
+
+    return HI_SUCCESS;
+}
+
+HI_S32 SAMPLE_COMM_VI_ChangeMixCap(VI_CHN ViChn,HI_BOOL bMixCap,HI_U32 FrameRate)
+{
+    VI_CHN_ATTR_S stChnAttr,stChnMinorAttr;
+	HI_S32 S32Ret = HI_SUCCESS;
+	S32Ret = HI_MPI_VI_GetChnAttr(ViChn, &stChnAttr);
+	if(HI_SUCCESS!= S32Ret)
+	{
+	    SAMPLE_PRT( "HI_MPI_VI_GetChnAttr failed");
+	}
+	
+	if(HI_TRUE == bMixCap)
+	{
+		memcpy(&stChnMinorAttr, &stChnAttr, sizeof(VI_CHN_ATTR_S));
+	    stChnMinorAttr.stDestSize.u32Width = D1_WIDTH / 2;
+		
+		stChnAttr.s32FrameRate = FrameRate;
+		
+		S32Ret = HI_MPI_VI_SetChnAttr(ViChn, &stChnAttr);
+        if (HI_SUCCESS != S32Ret)
+        {
+            SAMPLE_PRT("call HI_MPI_VI_SetChnAttr failed with %#x\n", S32Ret);
+            return HI_FAILURE;
+        } 
+		S32Ret = HI_MPI_VI_SetChnMinorAttr(ViChn, &stChnMinorAttr);
+		if (HI_SUCCESS != S32Ret)
+		{
+			SAMPLE_PRT("call HI_MPI_VI_SetChnMinorAttr failed with %#x\n", S32Ret);
+			return HI_FAILURE;
+		} 
+	}
+	else
+	{
+		stChnAttr.s32FrameRate = stChnAttr.s32SrcFrameRate;
+		S32Ret = HI_MPI_VI_SetChnAttr(ViChn, &stChnAttr);
+        if (HI_SUCCESS != S32Ret)
+        {
+            SAMPLE_PRT("call HI_MPI_VI_SetChnAttr failed with %#x\n", S32Ret);
+            return HI_FAILURE;
+        } 
+	}
+	return HI_SUCCESS;
+}
+	
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */

--- a/libraries/mpp_sample/hi3520dv200/common/sample_comm_vo.c
+++ b/libraries/mpp_sample/hi3520dv200/common/sample_comm_vo.c
@@ -1,0 +1,525 @@
+/******************************************************************************
+  Some simple Hisilicon Hi3531 video output functions.
+
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-2 Created
+******************************************************************************/
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/poll.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+#include <math.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "sample_comm.h"
+
+
+HI_S32 SAMPLE_COMM_VO_GetWH(VO_INTF_SYNC_E enIntfSync, HI_U32 *pu32W,HI_U32 *pu32H, HI_U32 *pu32Frm)
+{
+    switch (enIntfSync)
+    {
+        case VO_OUTPUT_PAL       :  *pu32W = 720;  *pu32H = 576; *pu32Frm = 25; break;
+        case VO_OUTPUT_NTSC      :  *pu32W = 720;  *pu32H = 480; *pu32Frm = 30; break;
+        case VO_OUTPUT_800x600_60:  *pu32W = 800;  *pu32H = 600;  *pu32Frm = 60; break;
+        case VO_OUTPUT_720P50    :  *pu32W = 1280; *pu32H = 720;  *pu32Frm = 50; break;
+        case VO_OUTPUT_1080P24  : *pu32W = 1920; *pu32H = 1080;  *pu32Frm = 24; break;
+        case VO_OUTPUT_720P60    : *pu32W = 1280; *pu32H = 720;  *pu32Frm = 60; break;
+        case VO_OUTPUT_1080P30   :  *pu32W = 1920; *pu32H = 1080; *pu32Frm = 30; break;
+        case VO_OUTPUT_1080P25   :  *pu32W = 1920; *pu32H = 1080; *pu32Frm = 25; break;
+        case VO_OUTPUT_1080P50   :  *pu32W = 1920; *pu32H = 1080; *pu32Frm = 50; break;
+        case VO_OUTPUT_1080P60   :  *pu32W = 1920; *pu32H = 1080; *pu32Frm = 60; break;
+        case VO_OUTPUT_1024x768_60:  *pu32W = 1024; *pu32H = 768;  *pu32Frm = 60; break;
+        case VO_OUTPUT_1280x1024_60:  *pu32W = 1280; *pu32H = 1024;  *pu32Frm = 60; break;
+        case VO_OUTPUT_1366x768_60:   *pu32W = 1366; *pu32H = 768;  *pu32Frm = 60; break;
+        case VO_OUTPUT_1440x900_60: *pu32W = 1440; *pu32H = 900;  *pu32Frm = 60; break;
+        case VO_OUTPUT_1280x800_60: *pu32W = 1280; *pu32H = 800;  *pu32Frm = 60; break;
+        default: 
+            SAMPLE_PRT("vo enIntfSync not support!\n");
+            return HI_FAILURE;
+    }
+    return HI_SUCCESS;
+}
+
+
+/******************************************************************************
+* function : Set system memory location
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VO_MemConfig(VO_DEV VoDev, HI_CHAR *pcMmzName)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    MPP_CHN_S stMppChnVO;
+
+    /* config vo dev */
+    stMppChnVO.enModId  = HI_ID_VOU;
+    stMppChnVO.s32DevId = VoDev;
+    stMppChnVO.s32ChnId = 0;
+    s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnVO, pcMmzName);
+    if (s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_SYS_SetMemConf ERR !\n");
+        return HI_FAILURE;
+    } 
+    
+    return HI_SUCCESS;
+}
+
+HI_S32 SAMPLE_COMM_VO_StartDevLayer(VO_DEV VoDev, VO_PUB_ATTR_S *pstPubAttr, HI_U32 u32SrcFrmRate)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32Width = 0;
+    HI_U32 u32Height = 0;
+    HI_U32 u32Frm = 0;
+    VO_VIDEO_LAYER_ATTR_S stLayerAttr;
+
+    if ( 0 == u32SrcFrmRate )
+    {
+        SAMPLE_PRT("vo u32SrcFrmRate invaild! %d!\n", u32SrcFrmRate);
+        return HI_FAILURE;
+    }
+    //printf("-----------------dev:%d\n", VoDev);
+    s32Ret = HI_MPI_VO_SetPubAttr(VoDev, pstPubAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    s32Ret = HI_MPI_VO_Enable(VoDev);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    s32Ret = SAMPLE_COMM_VO_GetWH(pstPubAttr->enIntfSync, &u32Width, &u32Height, &u32Frm);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    stLayerAttr.enPixFormat = SAMPLE_PIXEL_FORMAT;
+    stLayerAttr.u32DispFrmRt = u32SrcFrmRate;
+
+    stLayerAttr.stDispRect.s32X       = 0;
+    stLayerAttr.stDispRect.s32Y       = 0;
+    stLayerAttr.stDispRect.u32Width   = u32Width;
+    stLayerAttr.stDispRect.u32Height  = u32Height;
+    stLayerAttr.stImageSize.u32Width  = u32Width;
+    stLayerAttr.stImageSize.u32Height = u32Height;
+    
+    s32Ret = HI_MPI_VO_SetVideoLayerAttr(VoDev, &stLayerAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    s32Ret = HI_MPI_VO_EnableVideoLayer(VoDev);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+    
+    return s32Ret;
+}
+
+HI_S32 SAMPLE_COMM_VO_StopDevLayer(VO_DEV VoDev)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    
+    s32Ret = HI_MPI_VO_DisableVideoLayer(VoDev);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    s32Ret = HI_MPI_VO_Disable(VoDev);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return s32Ret;
+}
+HI_S32 SAMPLE_COMM_VO_StartChn(VO_DEV VoDev,VO_PUB_ATTR_S *pstPubAttr,SAMPLE_VO_MODE_E enMode)
+{
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32WndNum = 0;
+    HI_U32 u32Square = 0;
+    HI_U32 u32Width = 0;
+    HI_U32 u32Height = 0;
+    HI_U32 u32Frm = 0;
+    VO_CHN_ATTR_S stChnAttr;
+    
+    switch (enMode)
+    {
+        case VO_MODE_1MUX:
+            u32WndNum = 1;
+            u32Square = 1;
+            break;
+        case VO_MODE_4MUX:
+            u32WndNum = 4;
+            u32Square = 2;
+            break;
+        case VO_MODE_9MUX:
+            u32WndNum = 9;
+            u32Square = 3;
+            break;
+        case VO_MODE_16MUX:
+            u32WndNum = 16;
+            u32Square = 4;
+            break;
+        default:
+            SAMPLE_PRT("failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+    }
+
+    s32Ret = SAMPLE_COMM_VO_GetWH(pstPubAttr->enIntfSync, &u32Width,&u32Height,&u32Frm);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+    printf("u32Width:%d, u32Square:%d\n", u32Width, u32Square);
+    for (i=0; i<u32WndNum; i++)
+    {
+        stChnAttr.stRect.s32X       = ALIGN_BACK((u32Width/u32Square) * (i%u32Square), 2);
+        stChnAttr.stRect.s32Y       = ALIGN_BACK((u32Height/u32Square) * (i/u32Square), 2);
+        stChnAttr.stRect.u32Width   = ALIGN_BACK(u32Width/u32Square, 2);
+        stChnAttr.stRect.u32Height  = ALIGN_BACK(u32Height/u32Square, 2);
+        stChnAttr.u32Priority       = 0;
+        stChnAttr.bDeflicker        = HI_FALSE;
+
+        s32Ret = HI_MPI_VO_SetChnAttr(VoDev, i, &stChnAttr);
+        if (s32Ret != HI_SUCCESS)
+        {
+            printf("%s(%d):failed with %#x!\n",\
+                   __FUNCTION__,__LINE__,  s32Ret);
+            return HI_FAILURE;
+        }
+
+        s32Ret = HI_MPI_VO_EnableChn(VoDev, i);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+HI_S32 SAMPLE_COMM_VO_StopChn(VO_DEV VoDev,SAMPLE_VO_MODE_E enMode)
+{
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32WndNum = 0;
+
+    switch (enMode)
+    {
+        case VO_MODE_1MUX:
+        {
+            u32WndNum = 1;
+            break;
+        }
+
+        case VO_MODE_4MUX:
+        {
+            u32WndNum = 4;
+            break;
+        }
+
+        case VO_MODE_9MUX:
+        {
+            u32WndNum = 9;
+            break;
+        }
+
+        case VO_MODE_16MUX:
+        {
+            u32WndNum = 16;
+            break;
+        }
+        
+        default:
+            SAMPLE_PRT("failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+    }
+
+
+    for (i=0; i<u32WndNum; i++)
+    {
+        s32Ret = HI_MPI_VO_DisableChn(VoDev, i);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+        }
+    }
+    
+    return s32Ret;
+}
+
+HI_S32 SAMPLE_COMM_VO_BindVpss(VO_DEV VoDev,VO_CHN VoChn,VPSS_GRP VpssGrp,VPSS_CHN VpssChn)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    MPP_CHN_S stSrcChn;
+    MPP_CHN_S stDestChn;
+
+    stSrcChn.enModId = HI_ID_VPSS;
+    stSrcChn.s32DevId = VpssGrp;
+    stSrcChn.s32ChnId = VpssChn;
+
+    stDestChn.enModId = HI_ID_VOU;
+    stDestChn.s32DevId = VoDev;
+    stDestChn.s32ChnId = VoChn;
+
+    s32Ret = HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return s32Ret;
+}
+HI_S32 SAMPLE_COMM_VO_UnBindVpss(VO_DEV VoDev,VO_CHN VoChn,VPSS_GRP VpssGrp,VPSS_CHN VpssChn)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    MPP_CHN_S stSrcChn;
+    MPP_CHN_S stDestChn;
+
+    stSrcChn.enModId = HI_ID_VPSS;
+    stSrcChn.s32DevId = VpssGrp;
+    stSrcChn.s32ChnId = VpssChn;
+
+    stDestChn.enModId = HI_ID_VOU;
+    stDestChn.s32DevId = VoDev;
+    stDestChn.s32ChnId = VoChn;
+
+    s32Ret = HI_MPI_SYS_UnBind(&stSrcChn, &stDestChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    return s32Ret;
+}
+
+HI_S32 SAMPLE_COMM_VO_BindVi(VO_DEV VoDev, VO_CHN VoChn, VI_CHN ViChn)
+{
+    MPP_CHN_S stSrcChn, stDestChn;
+
+    stSrcChn.enModId    = HI_ID_VIU;
+    stSrcChn.s32DevId   = 0;
+    stSrcChn.s32ChnId   = ViChn;
+
+    stDestChn.enModId   = HI_ID_VOU;
+    stDestChn.s32ChnId  = VoChn;
+    stDestChn.s32DevId  = VoDev;
+
+    return HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+}
+
+HI_S32 SAMPLE_COMM_VO_UnBindVi(VO_DEV VoDev, VO_CHN VoChn)
+{
+    MPP_CHN_S stDestChn;
+
+    stDestChn.enModId   = HI_ID_VOU;
+    stDestChn.s32DevId  = VoDev;
+    stDestChn.s32ChnId  = VoChn;
+
+    return HI_MPI_SYS_UnBind(NULL, &stDestChn);
+}
+
+HI_S32 SAMPLE_COMM_VO_BindVoWbc(VO_DEV VoWbcDev, VO_DEV VoDev, VO_CHN VoChn)
+{
+    MPP_CHN_S stSrcChn, stDestChn;
+
+    stSrcChn.enModId    = HI_ID_VOU;
+    stSrcChn.s32DevId   = VoWbcDev;
+    stSrcChn.s32ChnId   = 0;
+
+    stDestChn.enModId   = HI_ID_VOU;
+    stDestChn.s32ChnId  = VoChn;
+    stDestChn.s32DevId  = VoDev;
+
+    return HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+}
+
+HI_S32 SAMPLE_COMM_VO_UnBindVoWbc(VO_DEV VoDev, VO_CHN VoChn)
+{
+    MPP_CHN_S stDestChn;
+
+    stDestChn.enModId   = HI_ID_VOU;
+    stDestChn.s32DevId  = VoDev;
+    stDestChn.s32ChnId  = VoChn;
+
+    return HI_MPI_SYS_UnBind(NULL, &stDestChn);
+}
+
+static HI_VOID SAMPLE_COMM_VO_HdmiConvertSync(VO_INTF_SYNC_E enIntfSync,
+    HI_HDMI_VIDEO_FMT_E *penVideoFmt)
+{
+    switch (enIntfSync)
+    {
+        case VO_OUTPUT_PAL:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_PAL;
+            break;
+        case VO_OUTPUT_NTSC:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_NTSC;
+            break;
+        case VO_OUTPUT_1080P24:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_1080P_24;
+            break;
+        case VO_OUTPUT_1080P25:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_1080P_25;
+            break;
+        case VO_OUTPUT_1080P30:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_1080P_30;
+            break;
+        case VO_OUTPUT_720P50:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_720P_50;
+            break;
+        case VO_OUTPUT_720P60:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_720P_60;
+            break;
+        case VO_OUTPUT_1080I50:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_1080i_50;
+            break;
+        case VO_OUTPUT_1080I60:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_1080i_60;
+            break;
+        case VO_OUTPUT_1080P50:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_1080P_50;
+            break;
+        case VO_OUTPUT_1080P60:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_1080P_60;
+            break;
+        case VO_OUTPUT_576P50:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_576P_50;
+            break;
+        case VO_OUTPUT_480P60:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_480P_60;
+            break;
+        case VO_OUTPUT_800x600_60:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_VESA_800X600_60;
+            break;
+        case VO_OUTPUT_1024x768_60:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_VESA_1024X768_60;
+            break;
+        case VO_OUTPUT_1280x1024_60:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_VESA_1280X1024_60;
+            break;
+        case VO_OUTPUT_1366x768_60:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_VESA_1366X768_60;
+            break;
+        case VO_OUTPUT_1440x900_60:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_VESA_1440X900_60;
+            break;
+        case VO_OUTPUT_1280x800_60:
+            *penVideoFmt = HI_HDMI_VIDEO_FMT_VESA_1280X800_60;
+            break;
+        default :
+            SAMPLE_PRT("Unkonw VO_INTF_SYNC_E value!\n");
+            break;
+    }
+
+    return;
+}
+
+HI_S32 SAMPLE_COMM_VO_HdmiStart(VO_INTF_SYNC_E enIntfSync)
+{
+    HI_HDMI_INIT_PARA_S stHdmiPara;
+    HI_HDMI_ATTR_S      stAttr;
+    HI_HDMI_VIDEO_FMT_E enVideoFmt;
+
+    SAMPLE_COMM_VO_HdmiConvertSync(enIntfSync, &enVideoFmt);
+
+    stHdmiPara.enForceMode = HI_HDMI_FORCE_HDMI;
+    stHdmiPara.pCallBackArgs = NULL;
+    stHdmiPara.pfnHdmiEventCallback = NULL;
+    HI_MPI_HDMI_Init(&stHdmiPara);
+
+    HI_MPI_HDMI_Open(HI_HDMI_ID_0);
+
+    HI_MPI_HDMI_GetAttr(HI_HDMI_ID_0, &stAttr);
+
+    stAttr.bEnableHdmi = HI_TRUE;
+    
+    stAttr.bEnableVideo = HI_TRUE;
+    stAttr.enVideoFmt = enVideoFmt;
+
+    stAttr.enVidOutMode = HI_HDMI_VIDEO_MODE_YCBCR444;
+    stAttr.enDeepColorMode = HI_HDMI_DEEP_COLOR_OFF;
+    stAttr.bxvYCCMode = HI_FALSE;
+
+    stAttr.bEnableAudio = HI_FALSE;
+    stAttr.enSoundIntf = HI_HDMI_SND_INTERFACE_I2S;
+    stAttr.bIsMultiChannel = HI_FALSE;
+
+    stAttr.enBitDepth = HI_HDMI_BIT_DEPTH_16;
+
+    stAttr.bEnableAviInfoFrame = HI_TRUE;
+    stAttr.bEnableAudInfoFrame = HI_TRUE;
+    stAttr.bEnableSpdInfoFrame = HI_FALSE;
+    stAttr.bEnableMpegInfoFrame = HI_FALSE;
+
+    stAttr.bDebugFlag = HI_FALSE;          
+    stAttr.bHDCPEnable = HI_FALSE;
+
+    stAttr.b3DEnable = HI_FALSE;
+
+    /* It's recommended to use DVI transmission for VESA standard Timing */
+    if (enIntfSync > VO_OUTPUT_480P60)
+    {
+        stAttr.bEnableHdmi = HI_FALSE;
+        stAttr.bEnableAudInfoFrame = HI_FALSE;
+        stAttr.enVidOutMode = HI_HDMI_VIDEO_MODE_RGB444;
+        stAttr.bEnableAviInfoFrame = HI_FALSE;
+    }
+    
+    HI_MPI_HDMI_SetAttr(HI_HDMI_ID_0, &stAttr);
+
+    HI_MPI_HDMI_Start(HI_HDMI_ID_0);
+    
+    printf("HDMI start success.\n");
+    return HI_SUCCESS;
+}
+
+HI_S32 SAMPLE_COMM_VO_HdmiStop(HI_VOID)
+{
+    HI_MPI_HDMI_Stop(HI_HDMI_ID_0);
+    HI_MPI_HDMI_Close(HI_HDMI_ID_0);
+    HI_MPI_HDMI_DeInit();
+
+    return HI_SUCCESS;
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */

--- a/libraries/mpp_sample/hi3520dv200/common/sample_comm_vpss.c
+++ b/libraries/mpp_sample/hi3520dv200/common/sample_comm_vpss.c
@@ -1,0 +1,252 @@
+/******************************************************************************
+  Some simple Hisilicon HI3531 video input functions.
+
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-2 Created
+******************************************************************************/
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/poll.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+#include <math.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "sample_comm.h"
+
+/******************************************************************************
+* function : Set vpss system memory location
+******************************************************************************/
+HI_S32 SAMPLE_COMM_VPSS_MemConfig()
+{
+    HI_CHAR * pcMmzName;
+    MPP_CHN_S stMppChnVpss;
+    HI_S32 s32Ret, i;
+
+    /*vpss group max is 64, not need config vpss chn.*/
+    for(i=0;i<64;i++)
+    {
+        stMppChnVpss.enModId  = HI_ID_VPSS;
+        stMppChnVpss.s32DevId = i;
+        stMppChnVpss.s32ChnId = 0;
+
+        if(0 == (i%2))
+        {
+            pcMmzName = NULL;  
+        }
+        else
+        {
+            pcMmzName = "ddr1";
+        }
+
+        /*vpss*/
+        s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnVpss, pcMmzName);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Vpss HI_MPI_SYS_SetMemConf ERR !\n");
+            return HI_FAILURE;
+        }
+    }
+    return HI_SUCCESS;
+}
+
+/*****************************************************************************
+* function : start vpss. VPSS chn with frame
+*****************************************************************************/
+HI_S32 SAMPLE_COMM_VPSS_Start(HI_S32 s32GrpCnt, SIZE_S *pstSize, HI_S32 s32ChnCnt,VPSS_GRP_ATTR_S *pstVpssGrpAttr)
+{
+    VPSS_GRP VpssGrp;
+    VPSS_CHN VpssChn;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VPSS_CHN_ATTR_S stChnAttr;
+    VPSS_GRP_PARAM_S stVpssParam;
+    HI_S32 s32Ret;
+    HI_S32 i, j;
+
+    /*** Set Vpss Grp Attr ***/
+
+    if(NULL == pstVpssGrpAttr)
+    {
+        stGrpAttr.u32MaxW = pstSize->u32Width;
+        stGrpAttr.u32MaxH = pstSize->u32Height;
+        stGrpAttr.bDrEn = HI_FALSE;
+        stGrpAttr.bDbEn = HI_FALSE;
+        stGrpAttr.bIeEn = HI_TRUE;
+        stGrpAttr.bNrEn = HI_TRUE;
+        stGrpAttr.bHistEn = HI_FALSE;
+        stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+        stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+    }
+    else
+    {
+        memcpy(&stGrpAttr,pstVpssGrpAttr,sizeof(VPSS_GRP_ATTR_S));
+    }
+    
+
+    for(i=0; i<s32GrpCnt; i++)
+    {
+        VpssGrp = i;
+        /*** create vpss group ***/
+        s32Ret = HI_MPI_VPSS_CreateGrp(VpssGrp, &stGrpAttr);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("HI_MPI_VPSS_CreateGrp failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+        }
+
+        /*** set vpss param ***/
+        s32Ret = HI_MPI_VPSS_GetGrpParam(VpssGrp, &stVpssParam);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+        }
+        
+        stVpssParam.u32MotionThresh = 0;
+        
+        s32Ret = HI_MPI_VPSS_SetGrpParam(VpssGrp, &stVpssParam);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+        }
+
+        /*** enable vpss chn, with frame ***/
+        for(j=0; j<s32ChnCnt; j++)
+        {
+            VpssChn = j;
+            /* Set Vpss Chn attr */
+            stChnAttr.bSpEn = HI_FALSE;
+            stChnAttr.bFrameEn = HI_TRUE;
+            stChnAttr.stFrame.u32Color[VPSS_FRAME_WORK_LEFT] = 0xff00;
+            stChnAttr.stFrame.u32Color[VPSS_FRAME_WORK_RIGHT] = 0xff00;
+            stChnAttr.stFrame.u32Color[VPSS_FRAME_WORK_BOTTOM] = 0xff00;
+            stChnAttr.stFrame.u32Color[VPSS_FRAME_WORK_TOP] = 0xff00;
+            stChnAttr.stFrame.u32Width[VPSS_FRAME_WORK_LEFT] = 2;
+            stChnAttr.stFrame.u32Width[VPSS_FRAME_WORK_RIGHT] = 2;
+            stChnAttr.stFrame.u32Width[VPSS_FRAME_WORK_TOP] = 2;
+            stChnAttr.stFrame.u32Width[VPSS_FRAME_WORK_BOTTOM] = 2;
+            
+            s32Ret = HI_MPI_VPSS_SetChnAttr(VpssGrp, VpssChn, &stChnAttr);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_PRT("HI_MPI_VPSS_SetChnAttr failed with %#x\n", s32Ret);
+                return HI_FAILURE;
+            }
+    
+            s32Ret = HI_MPI_VPSS_EnableChn(VpssGrp, VpssChn);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_PRT("HI_MPI_VPSS_EnableChn failed with %#x\n", s32Ret);
+                return HI_FAILURE;
+            }
+        }
+
+        /*** start vpss group ***/
+        s32Ret = HI_MPI_VPSS_StartGrp(VpssGrp);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("HI_MPI_VPSS_StartGrp failed with %#x\n", s32Ret);
+            return HI_FAILURE;
+        }
+
+    }
+    return HI_SUCCESS;
+}
+
+/*****************************************************************************
+* function : disable vi dev
+*****************************************************************************/
+HI_S32 SAMPLE_COMM_VPSS_Stop(HI_S32 s32GrpCnt, HI_S32 s32ChnCnt)
+{
+    HI_S32 i, j;
+    HI_S32 s32Ret = HI_SUCCESS;
+    VPSS_GRP VpssGrp;
+    VPSS_CHN VpssChn;
+
+    for(i=0; i<s32GrpCnt; i++)
+    {
+        VpssGrp = i;
+        s32Ret = HI_MPI_VPSS_StopGrp(VpssGrp);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+        }
+        for(j=0; j<s32ChnCnt; j++)
+        {
+            VpssChn = j;
+            s32Ret = HI_MPI_VPSS_DisableChn(VpssGrp, VpssChn);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_PRT("failed with %#x!\n", s32Ret);
+                return HI_FAILURE;
+            }
+        }
+    
+        s32Ret = HI_MPI_VPSS_DestroyGrp(VpssGrp);
+        if (s32Ret != HI_SUCCESS)
+        {
+            SAMPLE_PRT("failed with %#x!\n", s32Ret);
+            return HI_FAILURE;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+HI_S32 SAMPLE_COMM_DisableVpssPreScale(VPSS_GRP VpssGrp,SIZE_S stSize)
+{
+    HI_S32 s32Ret;
+    VPSS_PRESCALE_INFO_S stPreScaleInfo;
+        
+    stPreScaleInfo.bPreScale = HI_FALSE;
+    stPreScaleInfo.enCapSel = VPSS_CAPSEL_BOTH;
+    stPreScaleInfo.stDestSize.u32Width = stSize.u32Width;
+    stPreScaleInfo.stDestSize.u32Height = stSize.u32Height;
+    s32Ret = HI_MPI_VPSS_SetPreScale(VpssGrp, &stPreScaleInfo);
+    if (s32Ret != HI_SUCCESS)
+	{
+	    SAMPLE_PRT("HI_MPI_VPSS_SetPreScale failed with %#x!\n", s32Ret);
+	    return HI_FAILURE;
+	}
+
+    return s32Ret;
+}
+HI_S32 SAMPLE_COMM_EnableVpssPreScale(VPSS_GRP VpssGrp,SIZE_S stSize)
+{
+    HI_S32 s32Ret;
+    VPSS_PRESCALE_INFO_S stPreScaleInfo;
+        
+    stPreScaleInfo.bPreScale = HI_TRUE;
+    stPreScaleInfo.enCapSel = VPSS_CAPSEL_BOTH;
+    stPreScaleInfo.stDestSize.u32Width = stSize.u32Width;
+    stPreScaleInfo.stDestSize.u32Height = stSize.u32Height;
+    s32Ret = HI_MPI_VPSS_SetPreScale(VpssGrp, &stPreScaleInfo);
+    if (s32Ret != HI_SUCCESS)
+	{
+	    SAMPLE_PRT("HI_MPI_VPSS_SetPreScale failed with %#x!\n", s32Ret);
+	    return HI_FAILURE;
+	}
+
+    return s32Ret;
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */

--- a/libraries/mpp_sample/hi3520dv200/hifb/Makefile
+++ b/libraries/mpp_sample/hi3520dv200/hifb/Makefile
@@ -1,0 +1,32 @@
+# Hisilicon Hi3516 sample Makefile
+
+include ../Makefile.param
+#ifeq ($(SAMPLE_PARAM_FILE), )
+#     SAMPLE_PARAM_FILE:=../Makefile.param
+#     include $(SAMPLE_PARAM_FILE)
+#endif
+
+# target source
+SRC  := $(wildcard *.c) 
+OBJ  := $(SRC:%.c=%.o)
+MPI_LIBS := $(REL_LIB)/libmpi.a
+MPI_LIBS += $(REL_LIB)/libhdmi.a
+MPI_LIBS += $(REL_LIB)/libtde.a
+TARGET := $(OBJ:%.o=%)
+.PHONY : clean all
+
+all: $(TARGET)
+
+$(TARGET):%:%.o $(COMM_OBJ)
+	$(CC) $(CFLAGS) -lpthread -lm -o $@ $^ $(MPI_LIBS) $(AUDIO_LIBA) $(JPEGD_LIBA)  
+
+clean:
+	@rm -f $(TARGET)
+	@rm -f $(OBJ)
+	@rm -f $(COMM_OBJ)
+
+cleanstream:
+	@rm -f *.h264
+	@rm -f *.jpg
+	@rm -f *.mjp
+	@rm -f *.mp4

--- a/libraries/mpp_sample/hi3520dv200/hifb/sample_hifb.c
+++ b/libraries/mpp_sample/hi3520dv200/hifb/sample_hifb.c
@@ -1,0 +1,1106 @@
+/******************************************************************************
+
+  Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : sample_hifb.c
+  Version       : Initial Draft
+  Author        : Hisilicon multimedia software group
+  Created       : 2011/10/15
+  Description   : 
+  History       :
+  1.Date        : 2011/10/15
+    Author      : s00187460
+    Modification: Created file
+
+******************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/poll.h>
+#include <sys/time.h>
+#include <sys/mman.h>   //mmap
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+#include <assert.h>
+#include <signal.h>
+
+#include "hi_common.h"
+#include "hi_type.h"
+#include "hi_comm_vb.h"
+#include "hi_comm_sys.h"
+#include "hi_comm_venc.h"
+#include "hi_comm_vi.h"
+#include "hi_comm_vo.h"
+//#include "hi_comm_group.h"
+#include "hi_comm_region.h"
+
+#include "mpi_vb.h"
+#include "mpi_sys.h"
+#include "mpi_venc.h"
+#include "mpi_vi.h"
+#include "mpi_vo.h"
+#include "mpi_region.h"
+#include "sample_comm.h"
+
+#include <linux/fb.h>
+#include "hifb.h"
+#include "loadbmp.h"
+
+
+#include "hi_tde_api.h"
+#include "hi_tde_type.h"
+#include "hi_tde_errcode.h"
+
+
+static VO_DEV VoDev = SAMPLE_VO_DEV_DHD0;
+
+
+void SAMPLE_VIO_HandleSig(HI_S32 signo)
+{
+    if (SIGINT == signo || SIGTSTP == signo)
+    {
+        SAMPLE_COMM_SYS_Exit();
+        printf("\033[0;31mprogram exit abnormally!\033[0;39m\n");
+    }
+
+    exit(0);
+}
+
+
+HI_S32 SAMPLE_HIFB_VO_Start(void)
+{
+#define HIFB_HD_WIDTH  1280
+#define HIFB_HD_HEIGHT 720
+
+    HI_S32 s32Ret = HI_SUCCESS;
+    
+    VO_PUB_ATTR_S stPubAttr;
+    VO_VIDEO_LAYER_ATTR_S stLayerAttr;
+    VO_CHN_ATTR_S stChnAttr;
+
+    HI_MPI_VO_Disable(VoDev);
+
+    stPubAttr.enIntfType = VO_INTF_VGA;
+    stPubAttr.enIntfSync = VO_OUTPUT_720P50;
+    stPubAttr.u32BgColor = 0xff0000ff;
+       
+    /* Attr of video layer */
+    stLayerAttr.stDispRect.s32X       = 0;
+    stLayerAttr.stDispRect.s32Y       = 0;
+    stLayerAttr.stDispRect.u32Width   = HIFB_HD_WIDTH;
+    stLayerAttr.stDispRect.u32Height  = HIFB_HD_HEIGHT;
+    stLayerAttr.stImageSize.u32Width  = HIFB_HD_WIDTH;
+    stLayerAttr.stImageSize.u32Height = HIFB_HD_HEIGHT;
+    stLayerAttr.u32DispFrmRt          = 50;
+    stLayerAttr.enPixFormat           = PIXEL_FORMAT_YUV_SEMIPLANAR_422;
+
+    /* Attr of vo chn */    
+    stChnAttr.stRect.s32X               = 0;
+    stChnAttr.stRect.s32Y               = 0;
+    stChnAttr.stRect.u32Width           = HIFB_HD_WIDTH;
+    stChnAttr.stRect.u32Height          = HIFB_HD_HEIGHT;
+    stChnAttr.bDeflicker                = HI_FALSE;
+    stChnAttr.u32Priority               = 1;
+    
+    /* set public attr of VO*/
+    if (HI_SUCCESS != HI_MPI_VO_SetPubAttr(VoDev, &stPubAttr))
+    {
+        printf("set VO pub attr failed !\n");
+        return -1;
+    }
+
+    if (HI_SUCCESS != HI_MPI_VO_Enable(VoDev))
+    {
+        printf("enable vo device failed!\n");
+        return -1;
+    }
+
+	s32Ret = HI_MPI_VO_SetVideoLayerAttr(VoDev, &stLayerAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        printf("set video layer attr failed with %#x!\n", s32Ret);
+        return -1;
+    }
+
+    if (HI_SUCCESS != HI_MPI_VO_EnableVideoLayer(VoDev))
+    {
+        printf("enable video layer failed!\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+HI_S32 SAMPLE_HIFB_VO_Stop(void)
+{   
+  if (HI_SUCCESS != HI_MPI_VO_DisableVideoLayer(VoDev))
+    {
+        printf("Disable video layer failed!\n");
+        return -1;
+    }
+
+    if (HI_SUCCESS != HI_MPI_VO_Disable(VoDev))
+    {
+        printf("Disable vo device failed!\n");
+        return -1;
+    }    
+
+    return 0;    
+}
+
+#define SAMPLE_IMAGE_WIDTH     300
+#define SAMPLE_IMAGE_HEIGHT    150
+#define SAMPLE_IMAGE_SIZE      (300*150*2)
+#define SAMPLE_IMAGE_NUM       20
+ 
+#define SAMPLE_IMAGE_PATH		"./res/%d.bmp"
+#define SAMPLE_CURSOR_PATH		"./res/cursor.bmp"
+ 
+#define DIF_LAYER_NAME_LEN 20
+#define HIL_MMZ_NAME_LEN 32
+#define HIFB_RED_1555   0xfc00
+#define SAMPLE_VIR_SCREEN_WIDTH	    SAMPLE_IMAGE_WIDTH			/*virtual screen width*/
+#define SAMPLE_VIR_SCREEN_HEIGHT	SAMPLE_IMAGE_HEIGHT*2		/*virtual screen height*/
+#define s32fd 0
+#define HIL_MMB_NAME_LEN 16
+#define g_s32fd  0
+/*if you want to use standard mode ,please delete this define*/
+//#define ExtendMode
+
+
+static struct fb_bitfield g_r16 = {10, 5, 0};
+static struct fb_bitfield g_g16 = {5, 5, 0};
+static struct fb_bitfield g_b16 = {0, 5, 0};
+static struct fb_bitfield g_a16 = {15, 1, 0};
+
+typedef enum 
+{
+    HIFB_LAYER_0 = 0x0,
+    HIFB_LAYER_1,
+    HIFB_LAYER_2,
+    HIFB_LAYER_CURSOR_0,
+    HIFB_LAYER_ID_BUTT
+} HIFB_LAYER_ID_E;
+
+typedef struct _LayerID_NAME_S
+{
+    HIFB_LAYER_ID_E     sLayerID;
+    HI_CHAR             sLayerName[DIF_LAYER_NAME_LEN];     
+}LayerID_NAME_S;
+
+typedef struct hiPTHREAD_HIFB_SAMPLE
+{
+    int fd;
+    int layer;
+    int ctrlkey;
+}PTHREAD_HIFB_SAMPLE_INFO;
+
+
+
+HI_S32 SAMPLE_HIFB_LoadBmp(const char *filename, HI_U8 *pAddr)
+{
+    OSD_SURFACE_S Surface;
+    OSD_BITMAPFILEHEADER bmpFileHeader;
+    OSD_BITMAPINFO bmpInfo;
+
+    if(GetBmpInfo(filename,&bmpFileHeader,&bmpInfo) < 0)
+    {
+		printf("GetBmpInfo err!\n");
+        return HI_FAILURE;
+    }
+    
+    Surface.enColorFmt = OSD_COLOR_FMT_RGB1555;
+
+    CreateSurfaceByBitMap(filename,&Surface,pAddr);
+    
+    return HI_SUCCESS;
+}
+
+HI_VOID *SAMPLE_HIFB_REFRESH(void *pData)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    HIFB_LAYER_INFO_S stLayerInfo = {0};
+    HIFB_BUFFER_S stCanvasBuf;
+    HI_U16 *pBuf;
+	HI_U8 *pDst = NULL;
+    HI_U32 x, y,i;
+	char image_name[128];
+	HI_BOOL Show; 
+	HI_BOOL bCompress = HI_TRUE; 
+    HIFB_POINT_S stPoint = {0};
+    struct fb_var_screeninfo stVarInfo;
+	char file[12] = "/dev/fb0";
+    HI_U32 maxW,maxH;
+	PTHREAD_HIFB_SAMPLE_INFO *pstInfo;
+	pstInfo = (PTHREAD_HIFB_SAMPLE_INFO *)pData;
+	HIFB_COLORKEY_S stColorKey;
+	TDE2_RECT_S stSrcRect,stDstRect;
+	TDE2_SURFACE_S stSrc,stDst;
+	HI_U32 Phyaddr;
+	HI_VOID *Viraddr;
+	TDE_HANDLE s32Handle;
+	
+	switch (pstInfo->layer)
+	{
+		case 0 :
+			strcpy(file, "/dev/fb0");
+			break;
+		case 1 :
+			strcpy(file, "/dev/fb1");
+			break;
+		case 2 :
+			strcpy(file, "/dev/fb2");
+			break;
+		case 3 :
+			strcpy(file, "/dev/fb3");
+			break;
+		case 4 :
+			strcpy(file, "/dev/fb4");
+			break;
+		
+		default:
+			strcpy(file, "/dev/fb0");
+			break;
+	}
+	
+		/* 1. open framebuffer device overlay 0 */
+	pstInfo->fd = open(file, O_RDWR, 0);
+	if(pstInfo->fd < 0)
+	{
+		printf("open %s failed!\n",file);
+		return HI_NULL;
+	}  
+
+	if(pstInfo->layer == HIFB_LAYER_0 )
+	{  
+		if (ioctl(pstInfo->fd, FBIOPUT_COMPRESSION_HIFB, &bCompress) < 0)
+		{
+			printf("FBIOPUT_COMPRESSION_HIFB failed!\n");
+			close(pstInfo->fd);
+			return HI_NULL;
+		}
+	}
+	/*all layer surport colorkey*/  
+	stColorKey.bKeyEnable = HI_TRUE;
+	stColorKey.u32Key = 0x0;
+	if (ioctl(pstInfo->fd, FBIOPUT_COLORKEY_HIFB, &stColorKey) < 0)
+	{
+	printf("FBIOPUT_COLORKEY_HIFB!\n");
+	close(pstInfo->fd);
+	return HI_NULL;
+	}	
+    s32Ret = ioctl(pstInfo->fd, FBIOGET_VSCREENINFO, &stVarInfo);
+	if(s32Ret < 0)
+	{
+		printf("GET_VSCREENINFO failed!\n");
+		return HI_NULL;
+	} 
+	
+    if (ioctl(pstInfo->fd, FBIOPUT_SCREEN_ORIGIN_HIFB, &stPoint) < 0)
+    {
+        printf("set screen original show position failed!\n");
+        return HI_NULL;
+    }
+    maxW = 1280;
+	maxH = 720;
+    stVarInfo.xres = stVarInfo.xres_virtual = maxW;
+    stVarInfo.yres = stVarInfo.yres_virtual = maxH;
+    s32Ret = ioctl(pstInfo->fd, FBIOPUT_VSCREENINFO, &stVarInfo);
+    if(s32Ret < 0)
+	{
+		printf("PUT_VSCREENINFO failed!\n");
+		return HI_NULL;
+	} 
+    switch (pstInfo->ctrlkey)
+	{
+		case 0 :
+		{  
+			stLayerInfo.BufMode = HIFB_LAYER_BUF_ONE;
+			stLayerInfo.u32Mask = HIFB_LAYERMASK_BUFMODE;
+			break;
+		}
+		
+		case 1 :
+		{
+			stLayerInfo.BufMode = HIFB_LAYER_BUF_DOUBLE;
+		    stLayerInfo.u32Mask = HIFB_LAYERMASK_BUFMODE;
+			break;
+		}
+
+		default:
+		{
+			stLayerInfo.BufMode = HIFB_LAYER_BUF_NONE;
+			stLayerInfo.u32Mask = HIFB_LAYERMASK_BUFMODE;
+		}		
+	}
+    s32Ret = ioctl(pstInfo->fd, FBIOPUT_LAYER_INFO, &stLayerInfo);
+    if(s32Ret < 0)
+	{
+		printf("PUT_LAYER_INFO failed!\n");
+		return HI_NULL;
+	} 
+	Show = HI_TRUE;
+    if (ioctl(pstInfo->fd, FBIOPUT_SHOW_HIFB, &Show) < 0)
+    {
+        printf("FBIOPUT_SHOW_HIFB failed!\n");
+        return HI_NULL;
+    }
+	if (HI_FAILURE == HI_MPI_SYS_MmzAlloc(&(stCanvasBuf.stCanvas.u32PhyAddr), ((void**)&pBuf), 
+            NULL, NULL, maxW*maxH*2))
+    {
+        printf("allocate memory (maxW*maxH*2 bytes) failed\n");
+        return HI_NULL;
+    }   
+    stCanvasBuf.stCanvas.u32Height = maxH;
+    stCanvasBuf.stCanvas.u32Width = maxW;
+    stCanvasBuf.stCanvas.u32Pitch = maxW*2;
+    stCanvasBuf.stCanvas.enFmt = HIFB_FMT_ARGB1555; 
+    memset(pBuf, 0x00, stCanvasBuf.stCanvas.u32Pitch*stCanvasBuf.stCanvas.u32Height);
+
+    /*change bmp*/
+	if (HI_FAILURE == HI_MPI_SYS_MmzAlloc(&Phyaddr, ((void**)&Viraddr), 
+	NULL, NULL, SAMPLE_IMAGE_WIDTH*SAMPLE_IMAGE_HEIGHT*2))
+	{
+		printf("allocate memory  failed\n");
+		return HI_NULL;
+	}          
+
+	s32Ret = HI_TDE2_Open();
+	if(s32Ret < 0)
+	{
+		printf("HI_TDE2_Open failed :%d!\n",s32Ret);
+		HI_MPI_SYS_MmzFree(Phyaddr, Viraddr); 
+		return HI_FALSE;
+	}
+	
+	printf("expected:two red  line!\n");
+	/*time to play*/
+	for(i = 0; i < SAMPLE_IMAGE_NUM; i++)
+	{ 
+		for (y = 358; y < 362; y++)
+		{
+			for (x = 0; x < maxW; x++)
+			{
+				*(pBuf + y * maxW + x) = HIFB_RED_1555;
+			}
+		}
+		for (y = 0; y < maxH; y++)
+		{
+			for (x = 638; x < 642; x++)
+			{
+				*(pBuf + y * maxW + x) = HIFB_RED_1555;
+			}
+		}
+
+		sprintf(image_name, SAMPLE_IMAGE_PATH, i%2);
+		pDst = (HI_U8 *)Viraddr;
+	    SAMPLE_HIFB_LoadBmp(image_name,pDst);
+
+		/* 0. open tde */
+		stSrcRect.s32Xpos = 0;
+		stSrcRect.s32Ypos = 0;
+		stSrcRect.u32Height = SAMPLE_IMAGE_HEIGHT;
+		stSrcRect.u32Width = SAMPLE_IMAGE_WIDTH;
+		stDstRect.s32Xpos = 0;
+		stDstRect.s32Ypos = 0;
+		stDstRect.u32Height = stSrcRect.u32Width;
+		stDstRect.u32Width = stSrcRect.u32Width;
+
+		
+		stDst.enColorFmt = TDE2_COLOR_FMT_ARGB1555;
+		stDst.u32Width = 1280;
+		stDst.u32Height = 720;
+		stDst.u32Stride = maxW*2;			
+		stDst.u32PhyAddr = stCanvasBuf.stCanvas.u32PhyAddr;
+	
+		stSrc.enColorFmt = TDE2_COLOR_FMT_ARGB1555;
+		stSrc.u32Width = SAMPLE_IMAGE_WIDTH;
+		stSrc.u32Height = SAMPLE_IMAGE_HEIGHT;
+		stSrc.u32Stride = 2*SAMPLE_IMAGE_WIDTH;
+		stSrc.u32PhyAddr = Phyaddr;
+		stSrc.bAlphaExt1555 = HI_TRUE;
+		stSrc.bAlphaMax255 = HI_TRUE;
+		stSrc.u8Alpha0 = 0XFF;
+		stSrc.u8Alpha1 = 0XFF;
+		
+		/* 1. start job */
+		s32Handle = HI_TDE2_BeginJob();
+		if(HI_ERR_TDE_INVALID_HANDLE == s32Handle)
+		{
+			printf("start job failed!\n");
+			HI_MPI_SYS_MmzFree(Phyaddr, Viraddr);
+			HI_MPI_SYS_MmzFree(stCanvasBuf.stCanvas.u32PhyAddr, pBuf);
+			return HI_FALSE;
+		}
+
+		s32Ret = HI_TDE2_QuickCopy(s32Handle, &stSrc, &stSrcRect,&stDst, &stDstRect);
+		if(s32Ret < 0)
+		{
+			printf("HI_TDE2_QuickCopy:%d failed,ret=0x%x!\n", __LINE__, s32Ret);
+			HI_TDE2_CancelJob(s32Handle);
+			HI_MPI_SYS_MmzFree(Phyaddr, Viraddr);		
+			HI_MPI_SYS_MmzFree(stCanvasBuf.stCanvas.u32PhyAddr, pBuf);
+			return HI_FALSE;
+		}
+
+		/* 3. submit job */
+		s32Ret = HI_TDE2_EndJob(s32Handle, HI_FALSE, HI_TRUE, 10);
+		if(s32Ret < 0)
+		{
+			printf("Line:%d,HI_TDE2_EndJob failed,ret=0x%x!\n", __LINE__, s32Ret);
+			HI_TDE2_CancelJob(s32Handle);
+			HI_MPI_SYS_MmzFree(Phyaddr, Viraddr); 		
+			HI_MPI_SYS_MmzFree(stCanvasBuf.stCanvas.u32PhyAddr, pBuf);
+			return HI_FALSE;
+		}
+
+	    stCanvasBuf.UpdateRect.x = 0;
+	    stCanvasBuf.UpdateRect.y = 0;
+	    stCanvasBuf.UpdateRect.w = maxW;
+	    stCanvasBuf.UpdateRect.h = maxH;  
+	    s32Ret = ioctl(pstInfo->fd, FBIO_REFRESH, &stCanvasBuf);
+	    if(s32Ret < 0)
+		{
+			printf("REFRESH failed!\n");
+			HI_MPI_SYS_MmzFree(Phyaddr, Viraddr); 
+			HI_MPI_SYS_MmzFree(stCanvasBuf.stCanvas.u32PhyAddr, pBuf);
+			return HI_NULL;
+		}
+
+		sleep(1);
+	}
+    HI_MPI_SYS_MmzFree(Phyaddr, Viraddr); 
+	HI_MPI_SYS_MmzFree(stCanvasBuf.stCanvas.u32PhyAddr, pBuf);
+    close(pstInfo->fd);
+	return HI_NULL;   
+}
+
+HI_VOID *SAMPLE_HIFB_PANDISPLAY(void *pData)
+{
+    HI_S32 i,x,y,s32Ret;
+	TDE_HANDLE s32Handle;
+    struct fb_fix_screeninfo fix;
+    struct fb_var_screeninfo var;
+    HI_U32 u32FixScreenStride = 0;
+    unsigned char *pShowScreen;
+    unsigned char *pHideScreen;
+	HI_U32 u32HideScreenPhy = 0;
+	HI_U16 *pShowLine;
+    HIFB_ALPHA_S stAlpha;
+    HIFB_POINT_S stPoint = {40, 112};
+    char file[12] = "/dev/fb0";
+	HI_BOOL g_bCompress = HI_FALSE;
+
+    char image_name[128];
+	HI_U8 *pDst = NULL;
+    HI_BOOL bShow;
+    PTHREAD_HIFB_SAMPLE_INFO *pstInfo;
+	HIFB_COLORKEY_S stColorKey;
+	TDE2_RECT_S stSrcRect,stDstRect;
+	TDE2_SURFACE_S stSrc,stDst;
+	HI_U32 Phyaddr;
+	HI_VOID *Viraddr;
+
+    if(HI_NULL == pData)
+    {
+        return HI_NULL;
+    }
+    pstInfo = (PTHREAD_HIFB_SAMPLE_INFO *)pData;
+    switch (pstInfo->layer)
+    {
+        case 0 :
+            strcpy(file, "/dev/fb0");
+            break;
+        case 1 :
+            strcpy(file, "/dev/fb1");
+            break;
+        case 2 :
+            strcpy(file, "/dev/fb2");
+            break;
+        case 3 :
+            strcpy(file, "/dev/fb3");
+            break;
+        default:
+            strcpy(file, "/dev/fb0");
+            break;
+    }
+
+    /* 1. open framebuffer device overlay 0 */
+    pstInfo->fd = open(file, O_RDWR, 0);
+    if(pstInfo->fd < 0)
+    {
+        printf("open %s failed!\n",file);
+        return HI_NULL;
+    } 
+
+	if(pstInfo->layer == HIFB_LAYER_0  )
+	{
+		if (ioctl(pstInfo->fd, FBIOPUT_COMPRESSION_HIFB, &g_bCompress) < 0)
+		{
+			printf("Func:%s line:%d FBIOPUT_COMPRESSION_HIFB failed!\n", 
+			__FUNCTION__, __LINE__);
+			close(pstInfo->fd);
+			return HI_NULL;
+		}
+	}
+
+    bShow = HI_FALSE;
+    if (ioctl(pstInfo->fd, FBIOPUT_SHOW_HIFB, &bShow) < 0)
+    {
+        printf("FBIOPUT_SHOW_HIFB failed!\n");
+        return HI_NULL;
+    }
+    /* 2. set the screen original position */
+    switch(pstInfo->ctrlkey)
+    {
+        case 3:
+        {
+            stPoint.s32XPos = 150;
+            stPoint.s32YPos = 150;
+        }
+		break;
+        default:
+        {
+			stPoint.s32XPos = 0;
+            stPoint.s32YPos = 0;
+        }
+    }
+    
+    if (ioctl(pstInfo->fd, FBIOPUT_SCREEN_ORIGIN_HIFB, &stPoint) < 0)
+    {
+        printf("set screen original show position failed!\n");
+		close(pstInfo->fd);
+        return HI_NULL;
+    }
+
+    /* 3.set alpha */
+    stAlpha.bAlphaEnable = HI_FALSE;
+    stAlpha.bAlphaChannel = HI_FALSE;
+    stAlpha.u8Alpha0 = 0x0;
+    stAlpha.u8Alpha1 = 0xff;
+    stAlpha.u8GlobalAlpha = 0x80;
+    if (ioctl(pstInfo->fd, FBIOPUT_ALPHA_HIFB,  &stAlpha) < 0)
+    {
+        printf("Set alpha failed!\n");
+		close(pstInfo->fd);
+        return HI_NULL;
+    }
+	/*all layer surport colorkey*/  
+	stColorKey.bKeyEnable = HI_TRUE;
+	stColorKey.u32Key = 0x0;
+	if (ioctl(pstInfo->fd, FBIOPUT_COLORKEY_HIFB, &stColorKey) < 0)
+	{
+	printf("FBIOPUT_COLORKEY_HIFB!\n");
+	close(pstInfo->fd);
+	return HI_NULL;
+	}	  
+
+    /* 4. get the variable screen info */
+    if (ioctl(pstInfo->fd, FBIOGET_VSCREENINFO, &var) < 0)
+    {
+        printf("Get variable screen info failed!\n");
+		close(pstInfo->fd);
+        return HI_NULL;
+    }
+
+    /* 5. modify the variable screen info
+          the screen size: IMAGE_WIDTH*IMAGE_HEIGHT
+          the virtual screen size: VIR_SCREEN_WIDTH*VIR_SCREEN_HEIGHT
+          (which equals to VIR_SCREEN_WIDTH*(IMAGE_HEIGHT*2))
+          the pixel format: ARGB1555
+    */
+    usleep(4*1000*1000);
+    switch(pstInfo->ctrlkey)
+    {
+        case 3:
+        {
+            var.xres_virtual = 48;
+            var.yres_virtual = 48;
+            var.xres = 48;
+            var.yres = 48;
+        }
+		break;
+        default:
+        {
+            var.xres_virtual = 1280;
+            var.yres_virtual = 720*2;
+            var.xres = 1280;
+            var.yres = 720;
+        }
+    }
+
+    var.transp= g_a16;
+    var.red = g_r16;
+    var.green = g_g16;
+    var.blue = g_b16;
+    var.bits_per_pixel = 16;
+    var.activate = FB_ACTIVATE_NOW;
+    
+    /* 6. set the variable screeninfo */
+    if (ioctl(pstInfo->fd, FBIOPUT_VSCREENINFO, &var) < 0)
+    {
+        printf("Put variable screen info failed!\n");
+		close(pstInfo->fd);
+        return HI_NULL;
+    }
+
+    /* 7. get the fix screen info */
+    if (ioctl(pstInfo->fd, FBIOGET_FSCREENINFO, &fix) < 0)
+    {
+        printf("Get fix screen info failed!\n");
+		close(pstInfo->fd);
+        return HI_NULL;
+    }
+    u32FixScreenStride = fix.line_length;   /*fix screen stride*/
+
+    /* 8. map the physical video memory for user use */
+    pShowScreen = mmap(HI_NULL, fix.smem_len, PROT_READ|PROT_WRITE, MAP_SHARED, pstInfo->fd, 0);
+    if(MAP_FAILED == pShowScreen)
+    {
+        printf("mmap framebuffer failed!\n");
+		close(pstInfo->fd);
+        return HI_NULL;
+    }
+
+    memset(pShowScreen, 0x00, fix.smem_len);
+
+    /* time to paly*/
+    bShow = HI_TRUE;
+    if (ioctl(pstInfo->fd, FBIOPUT_SHOW_HIFB, &bShow) < 0)
+    {
+        printf("FBIOPUT_SHOW_HIFB failed!\n");
+        munmap(pShowScreen, fix.smem_len);
+        return HI_NULL;
+    } 
+	/* show bitmap or cosor*/
+    switch(pstInfo->ctrlkey)
+    {
+        case 0:
+        {
+            /*change color*/
+            pHideScreen = pShowScreen + u32FixScreenStride*var.yres;
+            for(i=0; i<SAMPLE_IMAGE_NUM; i++) //IMAGE_NUM
+            {
+                if(i%2)
+                {
+                    var.yoffset = 0;
+                }
+                else
+                {
+                    var.yoffset = var.yres;
+                }
+
+                if (ioctl(pstInfo->fd, FBIOPAN_DISPLAY, &var) < 0)
+                {
+                    printf("FBIOPAN_DISPLAY failed!\n");
+                    munmap(pShowScreen, fix.smem_len);
+					close(pstInfo->fd);
+                    return HI_NULL;
+                }
+
+                usleep(1000*1000);
+            }
+        }
+        break;
+        
+        case 1:
+        {
+            /*move*/
+			HI_U32 u32PosXtemp;
+			u32PosXtemp = stPoint.s32XPos;	
+			
+            for(i=0;i<400;i++)
+            {
+                if(i > 200)
+                {
+                    stPoint.s32XPos = u32PosXtemp + i%20;
+                    stPoint.s32YPos--;
+                }
+                else
+                {
+                    stPoint.s32XPos = u32PosXtemp - i%20;
+                    stPoint.s32YPos++;
+                }                
+                if(ioctl(pstInfo->fd, FBIOPUT_SCREEN_ORIGIN_HIFB, &stPoint) < 0)
+                {
+                    printf("set screen original show position failed!\n");
+					munmap(pShowScreen, fix.smem_len);
+					close(pstInfo->fd);
+                    return HI_NULL;
+                }
+
+                usleep(70*1000);				
+            }
+		}
+        break;     
+        case 2:
+        {
+            /*change bmp*/
+			if (HI_FAILURE == HI_MPI_SYS_MmzAlloc(&Phyaddr, ((void**)&Viraddr), 
+			NULL, NULL, SAMPLE_IMAGE_WIDTH*SAMPLE_IMAGE_HEIGHT*2))
+			{
+				printf("allocate memory (maxW*maxH*2 bytes) failed\n");
+				return HI_NULL;
+			}          
+
+			s32Ret = HI_TDE2_Open();
+			if(s32Ret < 0)
+			{
+				printf("HI_TDE2_Open failed :%d!\n",s32Ret);
+				HI_MPI_SYS_MmzFree(Phyaddr, Viraddr); 
+				return HI_FALSE;
+			}
+				
+		    for(i = 0; i < SAMPLE_IMAGE_NUM; i++)
+			{ 
+				/* step1: draw two red line*/
+				if(i%2)
+                {
+                    var.yoffset = var.yres;
+                }
+                else
+                {
+                    var.yoffset = 0;
+                }
+				
+				pHideScreen = pShowScreen + (u32FixScreenStride*var.yres)*(i%2);
+				memset(pHideScreen, 0x00, u32FixScreenStride*var.yres);
+				u32HideScreenPhy = fix.smem_start + (i%2)*u32FixScreenStride*var.yres;
+				
+				pShowLine = (HI_U16*)pHideScreen;
+				for (y = 358; y < 362; y++)
+				{
+					for (x = 0; x < 1280; x++)
+					{
+						*(pShowLine + y * var.xres + x) = HIFB_RED_1555;
+					}
+				}
+				for (y = 0; y < 720; y++)
+				{
+					for (x = 638; x < 642; x++)
+					{
+						*(pShowLine + y * var.xres + x) = HIFB_RED_1555;
+					}
+				}
+
+				/* step2: draw gui picture*/
+				sprintf(image_name, SAMPLE_IMAGE_PATH, i%2);
+                pDst = (HI_U8 *)Viraddr;
+                SAMPLE_HIFB_LoadBmp(image_name,pDst);
+				
+				/* 0. open tde */
+				stSrcRect.s32Xpos = 0;
+				stSrcRect.s32Ypos = 0;
+				stSrcRect.u32Height = SAMPLE_IMAGE_HEIGHT;
+				stSrcRect.u32Width = SAMPLE_IMAGE_WIDTH;
+				stDstRect.s32Xpos = 0;
+				stDstRect.s32Ypos = 0;
+				stDstRect.u32Height = stSrcRect.u32Width;
+				stDstRect.u32Width = stSrcRect.u32Width;
+
+				
+				stDst.enColorFmt = TDE2_COLOR_FMT_ARGB1555;
+				stDst.u32Width = 1280;
+				stDst.u32Height = 720;
+				stDst.u32Stride = u32FixScreenStride;			
+				stDst.u32PhyAddr = u32HideScreenPhy;
+			
+				stSrc.enColorFmt = TDE2_COLOR_FMT_ARGB1555;
+				stSrc.u32Width = SAMPLE_IMAGE_WIDTH;
+				stSrc.u32Height = SAMPLE_IMAGE_HEIGHT;
+				stSrc.u32Stride = 2*SAMPLE_IMAGE_WIDTH;
+				stSrc.u32PhyAddr = Phyaddr;
+				stSrc.bAlphaExt1555 = HI_TRUE;
+				stSrc.bAlphaMax255 = HI_TRUE;
+				stSrc.u8Alpha0 = 0XFF;
+				stSrc.u8Alpha1 = 0XFF;
+				
+				/* 1. start job */
+				s32Handle = HI_TDE2_BeginJob();
+				if(HI_ERR_TDE_INVALID_HANDLE == s32Handle)
+				{
+					printf("start job failed!\n");
+					HI_MPI_SYS_MmzFree(Phyaddr, Viraddr); 
+					return HI_FALSE;
+				}
+
+				s32Ret = HI_TDE2_QuickCopy(s32Handle, &stSrc, &stSrcRect,&stDst, &stDstRect);
+				if(s32Ret < 0)
+				{
+					printf("HI_TDE2_QuickCopy:%d failed,ret=0x%x!\n", __LINE__, s32Ret);
+					HI_TDE2_CancelJob(s32Handle);
+					HI_MPI_SYS_MmzFree(Phyaddr, Viraddr); 
+					return HI_FALSE;
+				}
+
+			    /* 3. submit job */
+			    s32Ret = HI_TDE2_EndJob(s32Handle, HI_FALSE, HI_TRUE, 10);
+				if(s32Ret < 0)
+				{
+					printf("Line:%d,HI_TDE2_EndJob failed,ret=0x%x!\n", __LINE__, s32Ret);
+					HI_TDE2_CancelJob(s32Handle);
+					HI_MPI_SYS_MmzFree(Phyaddr, Viraddr); 
+					return HI_FALSE;
+				}
+
+                if (ioctl(pstInfo->fd, FBIOPAN_DISPLAY, &var) < 0)
+                {
+                    printf("FBIOPAN_DISPLAY failed!\n");
+                    HI_MPI_SYS_MmzFree(Phyaddr, Viraddr); 
+                    return HI_NULL;
+                }			   
+				sleep(1);
+			
+            } 
+			HI_TDE2_Close();
+			HI_MPI_SYS_MmzFree(Phyaddr, Viraddr);  
+        }
+        break;
+
+		case 3:
+		{
+			/* move cursor */
+			SAMPLE_HIFB_LoadBmp(SAMPLE_CURSOR_PATH,pShowScreen);
+			if (ioctl(pstInfo->fd, FBIOPAN_DISPLAY, &var) < 0)
+			{
+				printf("FBIOPAN_DISPLAY failed!\n");
+				munmap(pShowScreen, fix.smem_len);
+				close(pstInfo->fd);
+				return HI_FALSE;
+			}    
+			printf("show cursor\n");
+			sleep(2);
+			for(i=0;i<100;i++)
+			{		
+				stPoint.s32XPos += 2;
+				stPoint.s32YPos += 2;	
+				if(ioctl(pstInfo->fd, FBIOPUT_SCREEN_ORIGIN_HIFB, &stPoint) < 0)
+				{
+					printf("set screen original show position failed!\n");
+					munmap(pShowScreen, fix.smem_len);
+					close(pstInfo->fd);
+					return HI_FALSE;
+				}
+				usleep(70*1000);
+			}
+			for(i=0;i<100;i++)
+			{		
+				stPoint.s32XPos += 2;
+				stPoint.s32YPos -= 2;	
+				if(ioctl(pstInfo->fd, FBIOPUT_SCREEN_ORIGIN_HIFB, &stPoint) < 0)
+				{
+					printf("set screen original show position failed!\n");
+					munmap(pShowScreen, fix.smem_len);
+					close(pstInfo->fd);
+					return HI_NULL;
+				}
+				usleep(70*1000);
+			}		
+			printf("move the cursor\n");
+			sleep(1);		
+		}
+		break;
+        default:
+        {
+        }  
+    }
+    
+    /* unmap the physical memory */
+    munmap(pShowScreen, fix.smem_len);
+    bShow = HI_FALSE;
+    if (ioctl(pstInfo->fd, FBIOPUT_SHOW_HIFB, &bShow) < 0)
+	{
+		printf("FBIOPUT_SHOW_HIFB failed!\n");
+		return HI_NULL;
+	}
+    close(pstInfo->fd);
+    return HI_NULL;
+}
+
+
+int main(int argc, char *argv[])
+{
+	pthread_t phifb0 = -1;	
+	pthread_t phifb1 = -1;
+		
+	PTHREAD_HIFB_SAMPLE_INFO stInfo0;
+	PTHREAD_HIFB_SAMPLE_INFO stInfo1;	
+	VO_PUB_ATTR_S stPubAttr;
+	VB_CONF_S stVbConf;
+	HI_S32 s32Ret = HI_SUCCESS;
+    HI_S32 i;
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_D1;
+	SAMPLE_VO_MODE_E stVoMode = VO_MODE_1MUX;
+	HI_BOOL bExtendedMode;
+	HI_CHAR ch;
+	
+	memset(&stVbConf, 0, sizeof(VB_CONF_S));
+    stVbConf.u32MaxPoolCnt             = 16;
+	stVbConf.astCommPool[0].u32BlkSize = 720*576*2;
+	stVbConf.astCommPool[0].u32BlkCnt  = 16;
+	
+	stPubAttr.u32BgColor = 0xff00ff00;
+	stPubAttr.enIntfType = VO_INTF_VGA;
+    stPubAttr.enIntfSync = VO_OUTPUT_720P50;
+	stPubAttr.bDoubleFrame = HI_FALSE;
+	
+	signal(SIGINT, SAMPLE_VIO_HandleSig);
+    signal(SIGTERM, SAMPLE_VIO_HandleSig);
+    
+	if(HI_SUCCESS != SAMPLE_COMM_SYS_Init(&stVbConf))
+	{
+		printf("func:%s,line:%d\n", __FUNCTION__, __LINE__);
+		return -1;	
+	}
+	
+	/******************************************
+	1 start Vi
+	******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, VIDEO_ENCODING_MODE_PAL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        printf("%s: Start Vi failed!\n", __FUNCTION__);
+		SAMPLE_COMM_SYS_Exit();
+        return -1;
+    }
+	
+	/******************************************
+	2 start HD
+	******************************************/                       
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev,&stPubAttr,25);                         
+	if (HI_SUCCESS != s32Ret)
+	{	
+		printf("%s: Start DevLayer failed!\n", __FUNCTION__);
+		SAMPLE_COMM_SYS_Exit();
+		return -1;
+	}
+	
+    if(HI_SUCCESS != SAMPLE_COMM_VO_StartChn(VoDev, &stPubAttr, stVoMode))
+	{	
+		printf("%s: Start VOChn failed!\n", __FUNCTION__);
+		SAMPLE_COMM_SYS_Exit();
+		return -1;
+	}
+
+    /* if it's displayed on HDMI, we should start HDMI */
+    if (stPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stPubAttr.enIntfSync))
+        {
+            printf("%s: Start HDMI failed!\n", __FUNCTION__);
+    		SAMPLE_COMM_SYS_Exit();
+    		return -1;
+        }
+    }
+   
+	for(i=0; i<4; i++)
+	{
+        s32Ret = SAMPLE_COMM_VO_BindVi(VoDev, i, i);
+		if (HI_SUCCESS != s32Ret)
+		{	
+			printf("%s: VI Bind to VO failed!\n", __FUNCTION__);
+			SAMPLE_COMM_SYS_Exit();
+			return -1;
+		}
+	}
+
+	/******************************************
+	 3 start hifb  
+	  there are two mode to utilize hifb,one is 
+	  standard mode another is extend  mode
+	******************************************/
+    printf("please choose hifb mode:\n");
+    printf("\t0) extended mode.\n");
+    printf("\t1) standard mode.\n");
+	while(1)
+	{
+	    ch = getchar();
+	    if ('0' == ch)
+	    {
+	        bExtendedMode = HI_TRUE;
+	        break;
+	    }
+	    else if ('1' == ch)
+	    {
+	        bExtendedMode = HI_FALSE;
+	        break;
+	    }
+	    else
+	    {
+	        printf("input invaild! please try again.\n");
+	        continue;
+	    }
+	}
+    stInfo0.layer   =  0;
+    stInfo0.fd      = -1;
+    stInfo0.ctrlkey =  2;
+	if(HI_TRUE == bExtendedMode)
+	{
+		pthread_create(&phifb0,0,SAMPLE_HIFB_REFRESH,(void *)(&stInfo0));
+	}
+	else
+	{
+		pthread_create(&phifb0, 0, SAMPLE_HIFB_PANDISPLAY, (void *)(&stInfo0));
+	}
+
+	stInfo1.layer   =  3;
+	stInfo1.fd      = -1;
+	stInfo1.ctrlkey =  3;
+	/*should unbind first*/
+	if(HI_SUCCESS != HI_MPI_VO_GfxLayerUnBindDev(GRAPHICS_LAYER_HC0, SAMPLE_VO_DEV_DHD0))
+	{
+		printf("%s: Graphic UnBind to VODev failed!,line:%d\n", __FUNCTION__, __LINE__);
+		SAMPLE_COMM_SYS_Exit();
+		SAMPLE_HIFB_VO_Stop();
+		return -1;
+	}
+
+	if (HI_SUCCESS != HI_MPI_VO_GfxLayerBindDev(GRAPHICS_LAYER_HC0, SAMPLE_VO_DEV_DHD0))
+	{
+		printf("%s: Graphic Bind to VODev failed!,line:%d\n", __FUNCTION__, __LINE__);
+		SAMPLE_COMM_SYS_Exit();
+		SAMPLE_HIFB_VO_Stop();
+		return -1;
+	}
+    pthread_create(&phifb1,0,SAMPLE_HIFB_PANDISPLAY,(void *)(&stInfo1));	
+
+	/******************************************
+	4  exit process
+	******************************************/
+
+    if(-1 != phifb0)
+    {
+        pthread_join(phifb0,0);
+    }   
+    if(-1 != phifb1)
+    {
+        pthread_join(phifb1,0);	
+    }
+    for(i=0;i<4;i++)
+    {
+        SAMPLE_COMM_VO_UnBindVi(SAMPLE_VO_DEV_DHD0,i);
+    }
+	
+    SAMPLE_COMM_VO_StopChn(SAMPLE_VO_DEV_DHD0, stVoMode);
+    SAMPLE_COMM_VO_StopDevLayer(SAMPLE_VO_DEV_DHD0);
+	
+    if (stPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        SAMPLE_COMM_VO_HdmiStop();
+    }
+    
+    SAMPLE_COMM_VI_Stop(enViMode);
+    
+    /*mpi exit */
+	HI_MPI_SYS_Exit();
+	HI_MPI_VB_Exit();
+    return 0;
+}
+

--- a/libraries/mpp_sample/hi3520dv200/ive/Makefile
+++ b/libraries/mpp_sample/hi3520dv200/ive/Makefile
@@ -1,0 +1,33 @@
+# Hisilicon Hi3520D sample Makefile
+
+include ../Makefile.param
+#ifeq ($(SAMPLE_PARAM_FILE), )
+#     SAMPLE_PARAM_FILE:=../Makefile.param
+#     include $(SAMPLE_PARAM_FILE)
+#endif
+
+# target source
+SRC  := $(wildcard *.c) 
+OBJ  := $(SRC:%.c=%.o)
+
+TARGET := $(OBJ:%.o=%)
+.PHONY : clean all
+
+all: $(TARGET)
+
+MPI_LIBS := $(REL_LIB)/libmpi.a
+MPI_LIBS += $(REL_LIB)/libhdmi.a
+
+$(TARGET):%:%.o $(COMM_OBJ)
+	$(CC) $(CFLAGS) -lpthread -lm -o $@ $^ $(MPI_LIBS) $(AUDIO_LIBA) $(JPEGD_LIBA)
+
+clean:
+	@rm -f $(TARGET)
+	@rm -f $(OBJ)
+	@rm -f $(COMM_OBJ)
+
+cleanstream:
+	@rm -f *.h264
+	@rm -f *.jpg
+	@rm -f *.mjp
+	@rm -f *.mp4

--- a/libraries/mpp_sample/hi3520dv200/ive/readme.txt
+++ b/libraries/mpp_sample/hi3520dv200/ive/readme.txt
@@ -1,0 +1,38 @@
+1.  the sample in IVE_test_memory is check whether memory is modified by other modules exclude cpu or whether there is error when loading and saving data.It is useful for demo board test. It has several step.  
+	ImageDst(i,j)=ImageOri(i,j);		// copy operation
+	ImageHist(i,j)=ImageOri(i,j)-ImageDst(i,j); // sub operation
+	Hist(i)=Histogram(ImageHist(i,j));			// get image's histogram
+	if(Hist(0)!=image_width*image_height)		// if zero data count is not equal image size,then there's error happen within ive runing.
+	{
+		// error process
+	}
+ 	
+	s32Ret=HI_MPI_IVE_DMA(&IveHandleDMA,&stOri,&stDst,bInstant);					// copy data from const data array to destination memory area. bInstant is HI_FALSE,it allows add another node to current list for it is not our last operation.
+	s32Ret=HI_MPI_IVE_SUB(&IveHandleSUB,&stOri,&stSubInfo,&stSub,eOutFmt,bInstant);			// compare const data array and destination memory area's data,if there are any difference,then sub result has none zero data. bInstant is HI_FALSE,it allows add another 																// node to current list for it is not our last operation.
+	s32Ret=HI_MPI_IVE_HIST(&IveHandleHIST,&stHistInfo,&stHist,HI_TRUE);					// check sub result,if sub result has none zero data,then the first element in histogram array is not equal to image size. bInstant is HI_TRUE,this operation will be last 																// node in any  list.
+	s32Ret=HI_MPI_IVE_Query(IveHandleHIST,&bFinished,1);							// check whether the job of histogram operation is finished. In this function call,bInstant is HI_TRUE,it will block until operation is 																// finished.
+		
+	In this sample,cache is not used, cache flush operation is not necessary.
+	
+	
+	
+	
+2. the sample in ive_detect is a simple occlusion detection using mean and variance of image block.
+	mean(i,j)= sum(Image(i*block_w,j*block_h),block_w,block_h);
+	variance(i,j)= sum( (Image(i*block_w,j*block_h)-mean(i,j))*(Image(i*block_w,j*block_h)-mean(i,j)),block_w,block_h);
+	if mean and variance meet the rules,then it generate alarm.   
+    when blocks is large, it can use integral operations to accelerate calculation. 	
+	s32Ret=HI_MPI_VI_GetFrameTimeOut(0,&stFrameInfo,0);							// get frame from vi, u32MilliSec is 0 means this is block operation. it will block until it get's vi frame. if use vpss frame,then it 																// need to sleep to wait  when it return the failure while get vpss frame.   
+															// while(1)
+															// {
+ 															//	s32Ret=HI_MPI_VPSS_UserGetFrame(0,0,&stFrameInfo);
+															//     if(s32Ret!=HI_FAILURE)
+															//     {
+															//		break;
+															//	 }
+															//      usleep(40000);
+															// }
+	s32Ret=HI_MPI_IVE_INTEG(&hIveHandle, &stSrc, &stDst, HI_TRUE);					// get integral data of image.bInstant is HI_TRUE,this operation will be last  node in any  list.	
+	s32Ret=HI_MPI_IVE_Query(hIveHandle,&bFinished,1);							// check whether the job of integral operation is finished. In this function call,bInstant is HI_TRUE,it will block until operation is 																// finished.	
+	// process by cpu to check data
+	s32Ret=HI_MPI_SYS_MmzFlushCache(stDst.u32PhyAddr , pu64VirData , stSrc.u32Height * stSrc.u32Width*8);  //flush data when cpu operation is finished.

--- a/libraries/mpp_sample/hi3520dv200/ive/sample_ive_detect.c
+++ b/libraries/mpp_sample/hi3520dv200/ive/sample_ive_detect.c
@@ -1,0 +1,725 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <math.h>
+#include <signal.h>
+
+#if 0
+#include "hi_common.h"
+#include "hi_comm_vi.h"
+#include "hi_comm_video.h"
+#include "hi_comm_sys.h"
+
+#include "mpi_vb.h"
+#include "mpi_sys.h"
+#include "mpi_vi.h"
+#endif
+
+#include "mpi_ive.h"
+#include "hi_comm_ive.h"
+
+#include "sample_comm.h"
+
+
+#define IVECHARCALH 8
+#define IVECHARCALW 8
+#define IVECHARNUM IVECHARCALW*IVECHARCALH
+
+#define CLIP(a, maxv, minv)      (((a)>(maxv)) ? (maxv) : (((a) < (minv)) ? (minv) : (a)))
+
+VIDEO_NORM_E gs_enNorm = VIDEO_ENCODING_MODE_PAL;
+HI_U32 gs_u32ViFrmRate = 0; 
+
+HI_S32   SAMPLE_IVE_MST_INIT_MPI()
+{
+    HI_S32 sRet = HI_FAILURE;
+    VB_CONF_S       stVbConf;
+    MPP_SYS_CONF_S   stSysConf;
+	HI_BOOL bMpiInit=HI_FALSE;
+    if(HI_TRUE == bMpiInit)
+    {
+        printf("MPI has been inited \n ");
+        return sRet;
+    }
+    /*初始化之前先确定系统已退出*/
+    HI_MPI_SYS_Exit();
+    HI_MPI_VB_Exit();
+
+    /*VB初始化之前先配置VB*/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    /*1080p*/
+    stVbConf.u32MaxPoolCnt = 64;
+    stVbConf.astCommPool[0].u32BlkSize   = 1920*1088*2;
+    stVbConf.astCommPool[0].u32BlkCnt    = 0;
+
+     /*720p*/
+
+    stVbConf.astCommPool[1].u32BlkSize   = 1280*720*2;
+    stVbConf.astCommPool[1].u32BlkCnt    = 0;
+
+
+     /*D1*/
+
+    stVbConf.astCommPool[2].u32BlkSize   = 768*576*2;
+    stVbConf.astCommPool[2].u32BlkCnt    = 0;
+
+
+     /*Cif*/
+
+    stVbConf.astCommPool[3].u32BlkSize   = 384*288*2;
+    stVbConf.astCommPool[3].u32BlkCnt    = 0;
+
+
+  #if 1
+    stVbConf.astCommPool[4].u32BlkSize   = 176*144*2;
+    stVbConf.astCommPool[4].u32BlkCnt    = 0;
+
+   #endif
+    sRet = HI_MPI_VB_SetConf(&stVbConf);
+    if(HI_SUCCESS != sRet)
+    {
+        printf("Config VB fail!\n");
+        return sRet;
+    }
+
+
+    sRet = HI_MPI_VB_Init();
+    if(HI_SUCCESS != sRet)
+    {
+        printf("Init VB fail!\n");
+        return sRet;
+    }
+
+
+    memset(&stSysConf,0,sizeof(MPP_SYS_CONF_S));
+    stSysConf.u32AlignWidth = 16;
+
+    sRet = HI_MPI_SYS_SetConf(&stSysConf);
+    if(HI_SUCCESS != sRet)
+    {
+        printf("Config sys fail!\n");
+        HI_MPI_VB_Exit();
+        return sRet;
+    }
+
+
+    sRet = HI_MPI_SYS_Init();
+     if(HI_SUCCESS != sRet)
+    {
+        printf("Init sys fail!\n");
+        HI_MPI_VB_Exit();
+        return sRet;
+    }
+
+    bMpiInit = HI_TRUE;
+
+    return sRet;
+}
+
+
+HI_BOOL g_bStopSignal;
+
+typedef struct hiIVE_LINEAR_DATA_S
+{
+	HI_S32 s32LinearNum;
+	HI_S32 s32ThreshNum;
+	POINT_S *pstLinearPoint;
+}IVE_LINEAR_DATA_S;
+
+
+HI_S32 SAMPLE_IVE_Linear2DClassifer(POINT_S *pstChar, HI_S32 s32CharNum, 
+                                            POINT_S *pstLinearPoint, HI_S32 s32Linearnum )
+{
+	HI_S32 s32ResultNum;
+	HI_S32 i,j;
+	HI_BOOL bTestFlag;
+	POINT_S *pstNextLinearPoint;
+    
+	s32ResultNum=0;
+	pstNextLinearPoint=&pstLinearPoint[1];
+    
+	for(i=0;i<s32CharNum;i++)
+	{
+		bTestFlag=HI_TRUE;
+		for(j=0;j<(s32Linearnum-1);j++)
+		{
+
+			if(   ( (pstChar[i].s32Y-pstLinearPoint[j].s32Y)*(pstNextLinearPoint[j].s32X-pstLinearPoint[j].s32X)>
+				  (pstChar[i].s32X-pstLinearPoint[j].s32X)*(pstNextLinearPoint[j].s32Y-pstLinearPoint[j].s32Y) 
+				   && (pstNextLinearPoint[j].s32X!=pstLinearPoint[j].s32X))
+			   || ( (pstChar[i].s32X>pstLinearPoint[j].s32X) && (pstNextLinearPoint[j].s32X==pstLinearPoint[j].s32X) ))	
+			{
+				bTestFlag=HI_FALSE;
+				break;
+			}
+		}
+		if(bTestFlag==HI_TRUE)
+		{
+			s32ResultNum++;
+		}
+	}
+	return s32ResultNum;
+}
+
+HI_VOID * SAMPLE_IVE_BlockDetect(HI_VOID *pArgs)
+{
+	VIDEO_FRAME_INFO_S stFrameInfo;
+	HI_S32 s32Ret,s32LinearNum;
+	HI_S32 s32ThreshNum;
+	IVE_MEM_INFO_S stDst;
+	IVE_LINEAR_DATA_S *pstIveLinerData;
+	POINT_S *pstLinearPoint;
+
+    FILE *fp1=HI_NULL, *fp2=HI_NULL, *fp3=HI_NULL;
+    HI_U8 *puSrc;
+    HI_U32 tic=0;
+	
+	pstIveLinerData=(IVE_LINEAR_DATA_S * )pArgs;
+	s32LinearNum=pstIveLinerData->s32LinearNum;
+	pstLinearPoint=pstIveLinerData->pstLinearPoint;
+	s32ThreshNum=pstIveLinerData->s32ThreshNum;
+	
+	stDst.u32PhyAddr=0;
+
+	while(1)
+	{
+		IVE_SRC_INFO_S stSrc;
+		IVE_HANDLE hIveHandle;
+		HI_U64 *pu64VirData;
+		HI_S32 i,j;
+		POINT_S stChar[IVECHARNUM];
+		HI_S32 w,h;
+        HI_U32 u32Depth = 2;
+
+        
+        s32Ret = HI_MPI_VI_SetFrameDepth(0, u32Depth);
+        if (HI_SUCCESS != s32Ret)
+        {
+            printf("set max depth err:0x%x\n", s32Ret);
+            return s32Ret;
+        }
+        
+		s32Ret = HI_MPI_VI_GetFrameTimeOut(0, &stFrameInfo, 0);
+        
+		if(s32Ret!=HI_SUCCESS)
+		{
+			 printf("can't get vi frame for %x\n",s32Ret);
+			 return HI_NULL;
+		}
+
+
+        stSrc.u32Width = stFrameInfo.stVFrame.u32Width;
+		stSrc.u32Height = stFrameInfo.stVFrame.u32Height;
+		stSrc.stSrcMem.u32PhyAddr = stFrameInfo.stVFrame.u32PhyAddr[0];
+		stSrc.stSrcMem.u32Stride = stFrameInfo.stVFrame.u32Stride[0];
+		stSrc.enSrcFmt = IVE_SRC_FMT_SINGLE;
+
+        w = stFrameInfo.stVFrame.u32Width/IVECHARCALW;
+		h = stSrc.u32Height/IVECHARCALH;
+        
+		if(stDst.u32PhyAddr==0)
+		{
+			s32Ret = HI_MPI_SYS_MmzAlloc_Cached(&stDst.u32PhyAddr, (HI_VOID *)&pu64VirData, 
+				"User", HI_NULL, stSrc.u32Height * stSrc.u32Width*8);
+			if(s32Ret!=HI_SUCCESS)
+			{
+				 printf("can't alloc intergal memory for %x\n",s32Ret);
+				 return HI_NULL;
+			}			
+			stDst.u32Stride = stFrameInfo.stVFrame.u32Width;
+		}	
+		else if(stDst.u32Stride!=stSrc.u32Width)
+		{
+			HI_MPI_SYS_MmzFree(stDst.u32PhyAddr, pu64VirData);
+			s32Ret = HI_MPI_SYS_MmzAlloc_Cached(&stDst.u32PhyAddr,(HI_VOID *)&pu64VirData, 
+				"User", HI_NULL, stSrc.u32Height * stSrc.u32Width*8);
+			if(s32Ret!=HI_SUCCESS)
+			{
+				 printf("can't alloc intergal memory for %x\n",s32Ret);
+				 return HI_NULL;
+			}			
+			stDst.u32Stride = stFrameInfo.stVFrame.u32Width;
+            
+		}
+		s32Ret = HI_MPI_IVE_INTEG(&hIveHandle, &stSrc, &stDst, HI_TRUE);
+        tic++;
+		if(s32Ret != HI_SUCCESS)
+		{
+			HI_MPI_SYS_MmzFree(stDst.u32PhyAddr, pu64VirData);
+            HI_MPI_VI_ReleaseFrame(0, &stFrameInfo);
+			printf(" ive integal function can't submmit for %x\n",s32Ret);
+			return HI_NULL;
+		}        
+      
+		for(i=0; i<IVECHARCALW; i++)
+		{
+            
+            HI_U64 u64TopLeft, u64TopRight, u64BtmLeft, u64BtmRight;
+            HI_U64 *u64TopRow, *u64BtmRow;
+
+            u64TopRow = (0 == i) ? (pu64VirData) : ( pu64VirData + (i * h -1) * stDst.u32Stride);
+            u64BtmRow = pu64VirData + ((i + 1) * h - 1) * stDst.u32Stride;
+            
+			for(j=0;j<IVECHARCALH;j++)
+			{                
+				HI_U64 u64BlockSum,u64BlockSq;
+
+                u64TopLeft  = (0 == i) ? (0) : ((0 == j) ? (0) : (u64TopRow[j * w-1]));
+                u64TopRight = (0 == i) ? (0) : (u64TopRow[(j + 1) * w - 1]);
+                u64BtmLeft  = (0 == j) ? (0) : (u64BtmRow[j * w - 1]);
+                u64BtmRight = u64BtmRow[(j + 1) * w -1];
+                              
+                u64BlockSum = (u64TopLeft & 0xfffffffLL) + (u64BtmRight & 0xfffffffLL)
+                            - (u64BtmLeft & 0xfffffffLL) - (u64TopRight & 0xfffffffLL);
+
+                u64BlockSq  = (u64TopLeft >> 28) + (u64BtmRight >> 28)
+                            - (u64BtmLeft >> 28) - (u64TopRight >> 28);
+               // mean
+				stChar[i * IVECHARCALW + j].s32X = u64BlockSum/(w*h);
+               // sigma=sqrt(1/(w*h)*sum((x(i,j)-mean)^2)= sqrt(sum(x(i,j)^2)/(w*h)-mean^2)
+				stChar[i * IVECHARCALW + j].s32Y = sqrt(u64BlockSq/(w*h) - stChar[i * IVECHARCALW + j].s32X * stChar[i * IVECHARCALW + j].s32X);
+                 	
+               //printf(" area = %llu; mean=%d, var=%d; w=%d, h=%d\n", u64BlockSum, stChar[i*IVECHARCALW+j].s32X, stChar[i*IVECHARCALW+j].s32Y, w, h);
+               //printf("mean=%d, var=%d; ", stChar[i * IVECHARCALW + j].s32X, stChar[i * IVECHARCALW + j].s32Y);
+                
+			}
+		}
+		s32Ret=SAMPLE_IVE_Linear2DClassifer(&stChar[0], IVECHARNUM, pstLinearPoint, s32LinearNum);
+
+        
+        if(s32Ret>s32ThreshNum)
+		{
+			printf("\n\033[0;31mOcclusion detected in the %dth frame!\033[0;39m Please input 'q' to stop sample ...... \n", tic);
+		}
+        else
+        {
+            printf("The %dth frame's occlusion blocks is %d. Please input 'q' to stop sample ...... \n", tic, s32Ret);
+        }        
+		if(g_bStopSignal == HI_TRUE)
+		{
+			HI_MPI_SYS_MmzFree(stDst.u32PhyAddr, pu64VirData);
+            HI_MPI_VI_ReleaseFrame(0, &stFrameInfo);
+			break;
+		}
+
+        s32Ret=HI_MPI_SYS_MmzFlushCache(stDst.u32PhyAddr , pu64VirData , stSrc.u32Height * stSrc.u32Width*8);
+		if(s32Ret!=HI_SUCCESS)
+		{
+			HI_MPI_SYS_MmzFree(stDst.u32PhyAddr, pu64VirData);
+            HI_MPI_VI_ReleaseFrame(0, &stFrameInfo);
+			printf(" ive integal function can't flush cache for %x\n",s32Ret);
+			return HI_NULL;
+		}
+
+        HI_MPI_VI_ReleaseFrame(0, &stFrameInfo);
+			
+	}
+	return HI_NULL;
+}
+
+#define SAMPLE_IVE_ExitMpp()\
+do{\
+    if (HI_MPI_SYS_Exit())\
+    {\
+        printf("sys exit fail\n");\
+        return -1;\
+    }\
+    if (HI_MPI_VB_Exit())\
+    {\
+        printf("vb exit fail\n");\
+        return -1;\
+    }\
+    return 0;\
+}while(0)
+
+#define SAMPLE_IVE_NOT_PASS(err)\
+	do\
+	{\
+		printf("\033[0;31mtest case <%s>not pass at line:%d.\033[0;39m\n",__FUNCTION__,__LINE__);\
+	}while(0)
+
+
+#define SAMPLE_IVE_CHECK_RET(express,name)\
+do{\
+    HI_S32 s32Ret;\
+    s32Ret = express;\
+    if (HI_SUCCESS != s32Ret)\
+    {\
+        printf("%s failed at %s: LINE: %d with %#x!\n", name, __FUNCTION__, __LINE__, s32Ret);\
+		SAMPLE_IVE_NOT_PASS(err);\
+	    SAMPLE_IVE_ExitMpp();\
+	    return HI_FAILURE;\
+    }\
+}while(0)
+
+
+void SAMPLE_IVE_HandleSig(HI_S32 signo)
+{
+    if (SIGINT == signo || SIGTSTP == signo)
+    {
+        printf("\033[0;31mprogram exit abnormally!\033[0;39m\n");
+
+        HI_MPI_SYS_Exit();
+	    HI_MPI_VB_Exit();
+    }
+
+    exit(0);
+}
+
+#if 0	
+VI_DEV_ATTR_S DEV_ATTR_BT656D1_1MUX =
+{
+	/*interface mode*/
+	VI_MODE_BT656,
+	/*1\2\4 chnl mode*/
+	VI_WORK_MODE_1Multiplex,
+	/* r_mask	 g_mask    b_mask*/
+	{0xFF000000,	0x0},
+	/*prog or interlace mode input*/
+	VI_SCAN_INTERLACED,
+	/*AdChnId*/
+	{-1, -1, -1, -1}
+};
+#endif 
+
+VI_CHN_ATTR_S CHN_ATTR_720x576_422 =
+/*classic chnl attr 2:720x576@xxfps format 422*/
+{
+    /*crop_x crop_y */  
+    {0,     0, 720,   576}, 
+    /*crop_w  crop_h  */
+    {720,   576 },
+    /*enCapSel*/
+    VI_CAPSEL_BOTH,
+    /* chnl format */
+    PIXEL_FORMAT_YUV_SEMIPLANAR_422,
+    /*bMirr  bFilp   bChromaResample*/
+    0,      0,      0,
+    /*s32SrcFrameRate   s32FrameRate*/
+	-1, -1
+};
+
+
+HI_VOID SAMPLE_IVE_SetViMask(VI_DEV ViDev, VI_DEV_ATTR_S *pstDevAttr)
+{
+    pstDevAttr->au32CompMask[0] = 0x0;
+    pstDevAttr->au32CompMask[1] = 0x0;
+	switch (ViDev % 4)
+	{
+		case 0:
+			pstDevAttr->au32CompMask[0] = 0xFF000000;
+			if (VI_MODE_BT1120_STANDARD == pstDevAttr->enIntfMode)
+			{
+				pstDevAttr->au32CompMask[1] = 0x00FF0000;
+			}
+			else if (VI_MODE_BT1120_INTERLEAVED == pstDevAttr->enIntfMode)
+			{
+				pstDevAttr->au32CompMask[1] = 0x0;
+			}
+			break;
+		case 1:
+			pstDevAttr->au32CompMask[0] = 0xFF0000;
+			if (VI_MODE_BT1120_INTERLEAVED == pstDevAttr->enIntfMode)
+			{
+				pstDevAttr->au32CompMask[1] = 0x0;
+			}
+			break;
+		case 2:
+			pstDevAttr->au32CompMask[0] = 0xFF00;
+			if (VI_MODE_BT1120_STANDARD == pstDevAttr->enIntfMode)
+			{
+				pstDevAttr->au32CompMask[1] = 0xFF;
+			}
+			else if (VI_MODE_BT1120_INTERLEAVED == pstDevAttr->enIntfMode)
+			{
+				pstDevAttr->au32CompMask[1] = 0x0;
+			}
+            #if (VI_MST_TEST_CHIP==3531 || VI_MST_TEST_CHIP==3532)
+                #ifndef HI_FPGA
+                    if ((VI_MODE_BT1120_STANDARD != pstDevAttr->enIntfMode)
+                        && (VI_MODE_BT1120_INTERLEAVED != pstDevAttr->enIntfMode)
+                        && (VI_WORK_MODE_4Multiplex == pstDevAttr->enWorkMode || VI_WORK_MODE_2Multiplex == pstDevAttr->enWorkMode))
+                    {
+                        if (HI_FALSE == g_b4x960H)//16x960H还是采用原来的方案，设为自己的mask，与16D1不同
+                        {
+                            /* 3531的ASIC板是两个BT1120口出16D1，此时dev2/6要设成dev1/5的MASK */
+                            pstDevAttr->au32CompMask[0] = 0xFF0000; 
+                        }
+                    }
+                #endif
+            #endif
+			break;
+		case 3:
+			pstDevAttr->au32CompMask[0] = 0xFF;
+			if (VI_MODE_BT1120_INTERLEAVED == pstDevAttr->enIntfMode)
+			{
+				pstDevAttr->au32CompMask[1] = 0x0;
+			}
+			break;
+		default:
+			HI_ASSERT(0);
+	}
+}
+
+
+HI_S32 SAMPLE_IVE_StartViDevAndWay(HI_S32 u32StartDevNum, HI_U32 u32FistDev, const VI_DEV_ATTR_S *pstDevAttr)
+{
+    VI_DEV_ATTR_S stDevAttr;
+    int i = 0;
+ 
+    for (i = u32FistDev; i < VIU_MAX_DEV_NUM; i+=VIU_MAX_DEV_NUM/u32StartDevNum)
+    {
+    	memcpy(&stDevAttr, pstDevAttr, sizeof(VI_DEV_ATTR_S));
+    	SAMPLE_IVE_SetViMask(i, &stDevAttr);
+        SAMPLE_IVE_CHECK_RET(HI_MPI_VI_SetDevAttr(i, &stDevAttr),"SetDevAttr");
+        SAMPLE_IVE_CHECK_RET(HI_MPI_VI_EnableDev(i),"Enable Dev");
+    }
+    
+    return HI_SUCCESS;
+}
+
+HI_S32 SAMPLE_VI_1_D1(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_D1;
+    HI_U32 u32ViChnCnt = 1;
+    HI_S32 s32VpssGrpCnt = 1;
+    VPSS_GRP VpssGrp = 0;
+    VPSS_GRP VpssGrp_Clip = 1;
+    VO_DEV VoDev = SAMPLE_VO_DEV_DHD0;
+    VO_CHN VoChn = 0;
+    VO_CHN VoChn_Clip = 1;
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    SAMPLE_VO_MODE_E enVoMode;
+    SIZE_S stSize;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_CHAR ch;
+    HI_U32 u32WndNum;
+	pthread_t hIveThread;
+	IVE_LINEAR_DATA_S stIveLinerData;
+	
+    /******************************************
+     step  1: init variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL== gs_enNorm)?25:30;
+    
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /*ddr0 video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 6;
+    memset(stVbConf.astCommPool[0].acMmzName,0,
+        sizeof(stVbConf.astCommPool[0].acMmzName));
+
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_0;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_MemConfig(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VI_MemConfig failed with %d!\n", s32Ret);
+        goto END_0;
+    }
+
+    s32Ret = SAMPLE_COMM_VPSS_MemConfig();
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VPSS_MemConfig failed with %d!\n", s32Ret);
+        goto END_0;
+    }
+
+    s32Ret = SAMPLE_COMM_VO_MemConfig(SAMPLE_VO_DEV_DHD0, NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_MemConfig failed with %d!\n", s32Ret);
+        goto END_0;
+    }
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_0;
+    }
+
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_0;
+    }
+
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    // start 2 vpss group. group-1 for clip use.
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_1;
+    }
+
+    // bind vi to vpss group 0
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_2;
+    }
+
+    /******************************************
+     step 5: start VO to preview
+    ******************************************/
+    printf("start vo hd0\n");
+    u32WndNum = 1;
+    enVoMode = VO_MODE_1MUX;
+    
+    if(VIDEO_ENCODING_MODE_PAL == gs_enNorm)
+    {
+        stVoPubAttr.enIntfSync = VO_OUTPUT_1080P50;
+    }
+    else
+    {
+        stVoPubAttr.enIntfSync = VO_OUTPUT_1080P60;
+    }
+    
+    stVoPubAttr.enIntfType = VO_INTF_HDMI;
+    stVoPubAttr.u32BgColor = 0x000000ff;
+    stVoPubAttr.bDoubleFrame = HI_TRUE;
+
+    s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+        goto END_3;
+    }
+    
+    s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+        goto END_4;
+    }
+    /* if it's displayed on HDMI, we should start HDMI */
+    if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+        {
+            SAMPLE_PRT("Start SAMPLE_COMM_VO_HdmiStart failed!\n");
+            goto END_4;
+        }
+    }
+    s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+        goto END_4;
+    }
+    
+
+	g_bStopSignal = HI_FALSE;
+
+	stIveLinerData.pstLinearPoint = malloc(sizeof(POINT_S)*10);
+	stIveLinerData.s32LinearNum = 2;
+	stIveLinerData.s32ThreshNum = IVECHARNUM/2;
+	stIveLinerData.pstLinearPoint[0].s32X = 25;
+	stIveLinerData.pstLinearPoint[0].s32Y = 0;
+	stIveLinerData.pstLinearPoint[1].s32X = 25;
+	stIveLinerData.pstLinearPoint[1].s32Y = 256;
+
+	pthread_create(&hIveThread, 0, SAMPLE_IVE_BlockDetect, (HI_VOID *)&stIveLinerData);
+
+    
+    printf("\nPress 'q' to stop sample ... ... \n");
+    while('q' != (ch = getchar()) )  {}
+
+    g_bStopSignal = HI_TRUE;
+	pthread_join(hIveThread,HI_NULL);
+	free(stIveLinerData.pstLinearPoint);
+    
+    /******************************************
+     step 7: exit process
+    ******************************************/
+
+END_4:    
+    if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        SAMPLE_COMM_VO_HdmiStop();
+    }
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    HI_MPI_VO_DisableChn(VoDev, VoChn_Clip);
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        VpssGrp = i;
+        SAMPLE_COMM_VO_UnBindVpss(VoDev, VoChn, VpssGrp, VPSS_PRE0_CHN);
+    }
+    SAMPLE_COMM_VO_UnBindVpss(VoDev, VoChn_Clip, VpssGrp_Clip, VPSS_PRE0_CHN);
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+END_3:
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+    
+END_2:
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_1:
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_0:
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+    
+}
+
+HI_S32 main(int argc, char *argv[])
+{	
+	signal(SIGINT, SAMPLE_IVE_HandleSig);
+    signal(SIGTERM, SAMPLE_IVE_HandleSig);
+    
+#if 0
+    SAMPLE_IVE_CHECK_RET(SAMPLE_IVE_StartViDevAndWay(1,0,&DEV_ATTR_BT656D1_1MUX), "startDev");	
+	SAMPLE_IVE_CHECK_RET(HI_MPI_VI_SetChnAttr(0, &CHN_ATTR_720x576_422),"setChnAttr");	
+	SAMPLE_IVE_CHECK_RET(HI_MPI_VI_EnableChn(0),"EnableChn");
+#endif
+    
+    SAMPLE_VI_1_D1();
+   
+	return 0;
+}
+
+
+

--- a/libraries/mpp_sample/hi3520dv200/ive/sample_ive_test_memory.c
+++ b/libraries/mpp_sample/hi3520dv200/ive/sample_ive_test_memory.c
@@ -1,0 +1,438 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+
+
+#include "hi_common.h"
+#include "hi_comm_video.h"
+#include "hi_comm_sys.h"
+#include "hi_comm_ive.h"
+
+#include "mpi_vb.h"
+#include "mpi_sys.h"
+#include "mpi_ive.h"
+
+#define SAMPLE_IVE_DATA_WIDTH  448
+#define SAMPLE_IVE_DATA_HEIGHT 256
+#define SAMPLE_IVE_DATA_STRIDE 448
+#define SAMPLE_IVE_HIST_STRIDE 1024
+
+
+HI_S32   SAMPLE_IVE_INIT()
+{
+    HI_S32 sRet = HI_FAILURE;
+    VB_CONF_S       stVbConf;
+    MPP_SYS_CONF_S   stSysConf;
+	HI_BOOL bMpiInit=HI_FALSE;
+    if(HI_TRUE == bMpiInit)
+    {
+        printf("MPI has been inited \n ");
+        return sRet;
+    }
+    /*初始化之前先确定系统已退出*/
+    HI_MPI_SYS_Exit();
+    HI_MPI_VB_Exit();
+
+    /*VB初始化之前先配置VB*/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    /*1080p*/
+    stVbConf.u32MaxPoolCnt = 64;
+    stVbConf.astCommPool[0].u32BlkSize   = 1920*1088*2;
+    stVbConf.astCommPool[0].u32BlkCnt    = 0;
+
+     /*720p*/
+
+    stVbConf.astCommPool[1].u32BlkSize   = 1280*720*2;
+    stVbConf.astCommPool[1].u32BlkCnt    = 0;
+
+
+     /*D1*/
+
+    stVbConf.astCommPool[2].u32BlkSize   = 768*576*2;
+    stVbConf.astCommPool[2].u32BlkCnt    = 0;
+
+
+     /*Cif*/
+
+    stVbConf.astCommPool[3].u32BlkSize   = 384*288*2;
+    stVbConf.astCommPool[3].u32BlkCnt    = 0;
+
+
+  #if 1
+    stVbConf.astCommPool[4].u32BlkSize   = 176*144*2;
+    stVbConf.astCommPool[4].u32BlkCnt    = 0;
+
+   #endif
+    sRet = HI_MPI_VB_SetConf(&stVbConf);
+    if(HI_SUCCESS != sRet)
+    {
+        printf("Config VB fail!\n");
+        return sRet;
+    }
+
+
+    sRet = HI_MPI_VB_Init();
+    if(HI_SUCCESS != sRet)
+    {
+        printf("Init VB fail!\n");
+        return sRet;
+    }
+
+
+    memset(&stSysConf,0,sizeof(MPP_SYS_CONF_S));
+    stSysConf.u32AlignWidth = 16;
+
+    sRet = HI_MPI_SYS_SetConf(&stSysConf);
+    if(HI_SUCCESS != sRet)
+    {
+        printf("Config sys fail!\n");
+        HI_MPI_VB_Exit();
+        return sRet;
+    }
+
+
+    sRet = HI_MPI_SYS_Init();
+     if(HI_SUCCESS != sRet)
+    {
+        printf("Init sys fail!\n");
+        HI_MPI_VB_Exit();
+        return sRet;
+    }
+
+    bMpiInit = HI_TRUE;
+
+    return sRet;
+}
+
+void SAMPLE_IVE_HandleSig(HI_S32 signo)
+{
+    if (SIGINT == signo || SIGTSTP == signo)
+    {
+        printf("\033[0;31mprogram exit abnormally!\033[0;39m\n");
+        HI_MPI_SYS_Exit();
+	    HI_MPI_VB_Exit();
+    }
+
+    exit(0);
+}
+
+
+HI_S32 main(int argc, char *argv[])
+{
+    HI_S32 s32Ret = 0;
+    HI_U32 u32stride, u32height, u32width;
+    HI_U32 Srcdata = 0, Dstdata = 0,Subdata = 0,u32testmode = 0;
+    
+    IVE_HANDLE IveHandleDMA;
+	IVE_HANDLE IveHandleSUB;
+	IVE_HANDLE IveHandleHIST;
+	IVE_HANDLE IveHandleCheck;
+    
+	IVE_SRC_INFO_S stSrc;
+    IVE_MEM_INFO_S stDst;
+	IVE_MEM_INFO_S stSub;
+	IVE_MEM_INFO_S stHist;
+    IVE_MEM_INFO_S stCheck;
+
+    IVE_SRC_INFO_S stDma;
+    
+    HI_VOID *pVirtSrc;
+    HI_VOID *pVirtDst;
+	HI_VOID *pVirSub;
+	HI_VOID *pVirHist;    
+	volatile HI_U8 *pVirtCheck;
+    
+    IVE_SUB_OUT_FMT_E eOutFmt;;
+    HI_BOOL bInstant,bFinished;    
+	HI_S32 s32RunCircle;
+
+	int histval[256];
+    int i ,j=0;;		
+	HI_U32 u32Counting=0;
+
+    
+	signal(SIGINT, SAMPLE_IVE_HandleSig);
+    signal(SIGTERM, SAMPLE_IVE_HandleSig);
+    SAMPLE_IVE_INIT();
+        
+	memset(histval, 0, sizeof(histval));
+    eOutFmt = IVE_SUB_OUT_FMT_ABS;        
+
+    u32stride = SAMPLE_IVE_DATA_STRIDE;
+    u32height = SAMPLE_IVE_DATA_HEIGHT;
+    u32width = SAMPLE_IVE_DATA_WIDTH;
+
+    stSrc.stSrcMem.u32Stride  = u32stride;
+    stSrc.u32Height           = u32height;
+    stSrc.u32Width            = u32width;
+    stSrc.enSrcFmt            = IVE_SRC_FMT_SINGLE;    
+	bInstant = HI_FALSE;
+    
+	printf("in ivetest %d\n",argc);
+	stCheck.u32Stride = SAMPLE_IVE_DATA_STRIDE;
+
+
+    s32Ret = HI_MPI_SYS_MmzAlloc(&stSrc.stSrcMem.u32PhyAddr, &pVirtSrc,     //alloc source memory
+        "User", HI_NULL, stSrc.u32Height * stSrc.stSrcMem.u32Stride);
+    if (s32Ret != HI_SUCCESS)
+    {
+        printf("alloc src mem error\n");
+        return s32Ret;
+    }
+    memset(pVirtSrc, 4, stSrc.u32Height * stSrc.stSrcMem.u32Stride);
+    
+    s32Ret = HI_MPI_SYS_MmzAlloc(&stHist.u32PhyAddr, &pVirHist,            //alloc memory for histogram
+        "User", HI_NULL, SAMPLE_IVE_HIST_STRIDE);
+    if (s32Ret != HI_SUCCESS)
+    {
+        printf("alloc hist mem error\n");
+        goto fail0;
+    }
+    memset(pVirHist, 0x5a, SAMPLE_IVE_HIST_STRIDE);   
+    
+    s32Ret = HI_MPI_SYS_MmzAlloc(&stCheck.u32PhyAddr, (void**)&pVirtCheck,          //alloc memory for check  
+    "User", HI_NULL, stSrc.u32Height * stSrc.stSrcMem.u32Stride);
+    if (s32Ret != HI_SUCCESS)
+    {
+        printf("alloc check mem error\n");
+        goto fail1;
+    }   
+    
+	if(argc < 2)
+	{
+	    s32RunCircle=1;        		
+        
+        s32Ret = HI_MPI_SYS_MmzAlloc(&stDst.u32PhyAddr, &pVirtDst,              //alloc destination memory
+            "User", HI_NULL, stSrc.u32Height * stSrc.stSrcMem.u32Stride);
+        if (s32Ret != HI_SUCCESS)
+        {
+            printf("alloc dst mem error\n");
+            goto fail2;
+        }
+        memset(pVirtDst,0x5a,stSrc.u32Height * stSrc.stSrcMem.u32Stride);
+        
+	    s32Ret = HI_MPI_SYS_MmzAlloc(&stSub.u32PhyAddr, &pVirSub,              //alloc memory for result of sub
+	        "User", HI_NULL, stSrc.u32Height * stSrc.stSrcMem.u32Stride);
+	    if (s32Ret != HI_SUCCESS)
+	    {
+	        printf("alloc sub mem error\n");
+            HI_MPI_SYS_MmzFree(stDst.u32PhyAddr,pVirtDst);
+			goto fail2;
+	    }
+	    memset(pVirSub,0x5a,stSrc.u32Height * stSrc.stSrcMem.u32Stride);	
+
+	}
+	else
+	{ 		
+		HI_U32 u32endaddr;
+		FILE *fp;
+        
+		stDma.stSrcMem.u32PhyAddr = (HI_U32)(strtol(argv[1],NULL,16))+0x80000000;
+		u32endaddr = strtol(argv[2],NULL,16) + 0x80000000;
+		printf("ivetest [begin_addr] [end_addr] [filename] [stride] [height]\n");
+		if(argc>4)
+			u32testmode = strtol(argv[4],NULL,10);
+		if(argc>5)
+			u32height = strtol(argv[5],NULL,10);
+
+        stDma.stSrcMem.u32Stride  = u32stride;
+        stDma.u32Height           = u32height;
+        stDma.u32Width            = u32width;
+        stDma.enSrcFmt            = IVE_SRC_FMT_SINGLE;
+    
+		printf("begin_addr: %x end_addr:%x filename %s stride:%d  height:%d\n",
+				stDma.stSrcMem.u32PhyAddr, u32endaddr, argv[3], u32stride, u32height);
+	        
+		s32RunCircle = (HI_U32)(u32endaddr - stDma.stSrcMem.u32PhyAddr)/(stDma.u32Height * stDma.stSrcMem.u32Stride);
+		s32RunCircle -= 1;
+	
+		fp = fopen(argv[3], "rb");
+		if(fp == NULL)
+		{
+			int testval = strtol(argv[3], NULL, 16);		
+			printf("open file :%s error\n", argv[3]);
+			printf("use val: %x instead file\n", testval);
+			memset(pVirtSrc, testval, stSrc.u32Height * stSrc.stSrcMem.u32Stride);
+		}
+		else
+		{
+			fread(pVirtSrc, 1, stSrc.u32Height * stSrc.stSrcMem.u32Stride, fp);
+			fclose(fp);
+		}	
+
+	}
+
+    stDst.u32Stride = stSrc.stSrcMem.u32Stride;
+	stSub.u32Stride = stSrc.stSrcMem.u32Stride;
+    stCheck.u32Stride = stSrc.stSrcMem.u32Stride;
+	stHist.u32Stride = SAMPLE_IVE_HIST_STRIDE;	
+
+    while(1)
+	{
+		j++;
+		if(argc >= 2)
+		{		
+            stDst.u32PhyAddr = stDma.stSrcMem.u32PhyAddr; //destination address of copy operation 
+			stSub.u32PhyAddr = stDst.u32PhyAddr + stSrc.u32Height * stSrc.stSrcMem.u32Stride;//destionation address of sub operation with source data & copy data
+		}
+        
+		for(i=0; i<s32RunCircle; i++)
+		{
+			IVE_SRC_INFO_S stSubInfo, stHistInfo;
+                       
+                                 
+    		s32Ret = HI_MPI_IVE_DMA(&IveHandleDMA, &stSrc, &stDst, bInstant);	
+            
+			if(s32Ret)
+			{
+				printf("stSrc: %d %x %d %d %d\n",stSrc.enSrcFmt, stSrc.stSrcMem.u32PhyAddr,
+								stSrc.stSrcMem.u32Stride, stSrc.u32Height, stSrc.u32Width);
+				printf("stDst: %x %d\n",stDst.u32PhyAddr, stDst.u32Stride);
+		        printf("DMA error %x\n",s32Ret);
+                goto ive_end;	
+			}
+            
+			memcpy(&stSubInfo, &stSrc, sizeof(IVE_SRC_INFO_S));
+			stSubInfo.stSrcMem.u32PhyAddr = stDst.u32PhyAddr;
+			s32Ret=HI_MPI_IVE_SUB(&IveHandleSUB, &stSrc, &stSubInfo, &stSub, eOutFmt, bInstant);			
+			if(s32Ret)
+			{
+		        printf("SUB error %x\n",s32Ret);
+				goto ive_end;			
+			}	
+
+            
+			memcpy(&stHistInfo, &stSrc, sizeof(IVE_SRC_INFO_S));
+			stHistInfo.stSrcMem.u32PhyAddr = stSub.u32PhyAddr;		
+			s32Ret=HI_MPI_IVE_HIST(&IveHandleHIST, &stHistInfo, &stHist, HI_TRUE);
+			if(s32Ret)
+			{
+				
+				printf("HistSrc: %d %x %d %d %d\n",stHistInfo.enSrcFmt,stHistInfo.stSrcMem.u32PhyAddr,
+								stHistInfo.stSrcMem.u32Stride,stHistInfo.u32Height,stHistInfo.u32Width);
+				printf("Hist: %x %d\n",stHist.u32PhyAddr,stHist.u32Stride);			
+		        printf("HIST error %x\n",s32Ret);		
+				goto ive_end;			
+			}
+            
+			s32Ret=HI_MPI_IVE_Query(IveHandleHIST, &bFinished, HI_TRUE);
+			if(s32Ret)
+			{
+		        printf("QUERY error %x\n",s32Ret);
+				goto ive_end;		
+			}
+            
+			if(bFinished)
+			{
+				volatile HI_S32 *ps32Hist;
+				ps32Hist = (volatile HI_S32 *)pVirHist;
+				if(ps32Hist[0] != stSrc.u32Height * stSrc.u32Width)//if hist[0] is not equal to image size,then there is error happen when ive runing. 
+				{
+					int k;
+					printf("error at %x %x val:%d\n", stSubInfo.stSrcMem.u32PhyAddr, stSub.u32PhyAddr, ps32Hist[0]);
+                    if(1 == u32testmode)
+                    {
+                       goto ive_end;
+                    }
+					for(k=1;k<255;k++)
+					{
+						if(ps32Hist[k]!=0)                               //print out difference of error data and source data
+                        {                  
+                            printf("Hist error value:%d Hist error number:%d \n", k, ps32Hist[k]);
+							histval[k] += ps32Hist[k];
+                        }
+					}
+                    
+					s32Ret=HI_MPI_IVE_DMA(&IveHandleCheck, &stHistInfo, &stCheck, HI_TRUE);
+					if(s32Ret)
+					{
+						printf("check dma %x\n",s32Ret);
+						goto ive_end;		
+					}
+                    
+					s32Ret=HI_MPI_IVE_Query(IveHandleCheck,&bFinished,1);
+					if(s32Ret && !bFinished)
+					{
+						printf("check query error %x %d\n",s32Ret,bFinished);
+						goto ive_end;		
+					}
+                    
+					u32Counting++;
+                    
+					for(k=0; k<stSrc.u32Height * stSrc.stSrcMem.u32Stride; k++)
+					{						
+							if(pVirtCheck[k]!=0)                        //print out error data and source data
+                                {                     
+
+                                s32Ret = HI_MPI_SYS_GetReg(stSrc.stSrcMem.u32PhyAddr + k, &Srcdata);
+
+                                s32Ret = HI_MPI_SYS_GetReg(stDst.u32PhyAddr + k, &Dstdata);
+
+                                s32Ret = HI_MPI_SYS_GetReg(stSub.u32PhyAddr + k, &Subdata);
+                            
+								printf("check error at %x %x %x %x %x %x\n",stSrc.stSrcMem.u32PhyAddr + k, stDst.u32PhyAddr + k,
+															stSub.u32PhyAddr + k, Srcdata, Dstdata, Subdata);
+                                }
+
+					}
+					sleep(10);
+                    
+				}
+			}
+			else
+			{
+				printf("no block\n");
+				goto ive_end;	
+			}
+            
+            if(argc>=2)
+            {
+                stDst.u32PhyAddr = stSub.u32PhyAddr;
+                stSub.u32PhyAddr = stDst.u32PhyAddr + stSrc.u32Height * stSrc.stSrcMem.u32Stride;
+            }
+            
+		}
+        if((j&0xf)==0)
+        {
+            printf("ive pass one\n");
+        }
+        
+        if((j&0xf)==0)
+        {
+            printf("ive pass one\n");
+        }
+        if(j/0xf == 5)
+        {
+            printf("----End----\n");
+            break;
+        }
+
+	}
+
+    ive_end:
+        if(argc<2)
+        {
+            HI_MPI_SYS_MmzFree(stSub.u32PhyAddr, pVirSub);
+            HI_MPI_SYS_MmzFree(stDst.u32PhyAddr, pVirtDst);
+        }
+        
+    fail2:
+        HI_MPI_SYS_MmzFree(stCheck.u32PhyAddr, (void*)pVirtCheck);
+    fail1:
+        HI_MPI_SYS_MmzFree(stHist.u32PhyAddr, pVirHist); 
+    fail0:
+        HI_MPI_SYS_MmzFree(stSrc.stSrcMem.u32PhyAddr, pVirtSrc);            
+            
+    return s32Ret;
+}
+

--- a/libraries/mpp_sample/hi3520dv200/region/Makefile
+++ b/libraries/mpp_sample/hi3520dv200/region/Makefile
@@ -1,0 +1,33 @@
+# Hisilicon Hi3516 sample Makefile
+
+include ../Makefile.param
+#ifeq ($(SAMPLE_PARAM_FILE), )
+#     SAMPLE_PARAM_FILE:=../Makefile.param
+#     include $(SAMPLE_PARAM_FILE)
+#endif
+
+# target source
+SRC  := $(wildcard *.c) 
+OBJ  := $(SRC:%.c=%.o)
+
+TARGET := $(OBJ:%.o=%)
+.PHONY : clean all
+
+all: $(TARGET)
+
+MPI_LIBS := $(REL_LIB)/libmpi.a
+MPI_LIBS += $(REL_LIB)/libhdmi.a
+
+$(TARGET):%:%.o $(COMM_OBJ)
+	$(CC) $(CFLAGS) -lpthread -lm -o $@ $^ $(MPI_LIBS) $(AUDIO_LIBA) $(JPEGD_LIBA)
+
+clean:
+	@rm -f $(TARGET)
+	@rm -f $(OBJ)
+	@rm -f $(COMM_OBJ)
+
+cleanstream:
+	@rm -f *.h264
+	@rm -f *.jpg
+	@rm -f *.mjp
+	@rm -f *.mp4

--- a/libraries/mpp_sample/hi3520dv200/region/sample_region.c
+++ b/libraries/mpp_sample/hi3520dv200/region/sample_region.c
@@ -1,0 +1,1582 @@
+/******************************************************************************
+  A simple program of Hisilicon HI3531 osd implementation.
+  the flow as follows:
+    1) init mpp system.
+    2) start vi ( internal isp, ViDev 0, 2 vichn)                  
+    3) start venc
+    4) osd process, you can see video from some H264 streams files. the video will show as follows step:
+        4.1) create some cover/osd regions
+        4.2) display  cover/osd regions ( One Region -- Multi-VencGroup )
+        4.3) change all vencGroups Regions' Layer
+        4.4) change all vencGroups Regions' position
+        4.5) change all vencGroups Regions' color
+        4.6) change all vencGroups Regions' alpha (front and backgroud)
+        4.7) load bmp form bmp-file to Region-0
+        4.8) change BmpRegion-0
+    6) stop venc
+    7) stop vi and system.
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-2 Created
+******************************************************************************/
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <signal.h>
+#include "loadbmp.h"
+
+#include "sample_comm.h"
+
+HI_BOOL bCase0 = HI_FALSE;
+HI_BOOL bCase1 = HI_FALSE;
+
+VI_SCAN_MODE_E    gs_enViScanMode = VI_SCAN_INTERLACED;
+
+static HI_U32 gs_s32ChnCnt = 1;		/* vi, venc chn count */
+static HI_S32 gs_s32RgnCntCur = 0;
+static HI_S32 gs_s32RgnCnt = 5;
+VIDEO_NORM_E gs_enNorm = VIDEO_ENCODING_MODE_PAL;
+
+
+#define SAMPLE_RGN_SLEEP_TIME (200*1000)
+#define SAMPLE_RGN_LOOP_COUNT 6
+HI_U32    gs_u32ViFrmRate = 0;
+
+#define SAMPLE_RGN_NOT_PASS(err)\
+do {\
+	printf("\033[0;31mtest case <%s>not pass at line:%d err:%x\033[0;39m\n",\
+		__FUNCTION__,__LINE__,err);\
+    exit(-1);\
+}while(0)
+
+/******************************************************************************
+* function : Set region memory location
+******************************************************************************/
+HI_S32 SAMPLE_RGN_MemConfig(HI_VOID)
+{
+    HI_S32 i = 0;
+    HI_S32 s32Ret = HI_SUCCESS;
+
+    HI_CHAR * pcMmzName;
+    MPP_CHN_S stMppChnRGN;
+
+	/*the max chn of vpss,grp and venc is 64*/
+    for(i=0; i<RGN_HANDLE_MAX; i++)
+    {
+        stMppChnRGN.enModId  = HI_ID_RGN;
+        stMppChnRGN.s32DevId = 0;
+        stMppChnRGN.s32ChnId = 0;
+
+        if(0 == (i%2))
+        {
+            pcMmzName = NULL;  
+        }
+        else
+        {
+            pcMmzName = "ddr1";
+        }
+
+        s32Ret = HI_MPI_SYS_SetMemConf(&stMppChnRGN,pcMmzName);
+        if (s32Ret)
+        {
+            SAMPLE_PRT("HI_MPI_SYS_SetMemConf ERR !\n");
+            return HI_FAILURE;
+        }
+    }
+    
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : osd region change position
+******************************************************************************/
+HI_S32 SAMPLE_RGN_ChgPosition(RGN_HANDLE RgnHandle, VENC_GRP VencGrp, POINT_S *pstPoint)
+{
+    MPP_CHN_S stChn;
+    RGN_CHN_ATTR_S stChnAttr;
+    HI_S32 s32Ret;
+
+    stChn.enModId = HI_ID_GROUP;
+    stChn.s32DevId = VencGrp;
+    stChn.s32ChnId = 0;
+
+    if (NULL == pstPoint)
+    {
+        SAMPLE_PRT("input parameter is null. it is invaild!\n");
+        return HI_FAILURE;
+    }
+        
+    s32Ret = HI_MPI_RGN_GetDisplayAttr(RgnHandle, &stChn, &stChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_GetDisplayAttr (%d)) failed with %#x!\n",\
+               RgnHandle, s32Ret);
+        return HI_FAILURE;
+    }
+
+    stChnAttr.unChnAttr.stOverlayChn.stPoint.s32X = pstPoint->s32X;
+    stChnAttr.unChnAttr.stOverlayChn.stPoint.s32Y = pstPoint->s32Y;
+    s32Ret = HI_MPI_RGN_SetDisplayAttr(RgnHandle,&stChn,&stChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_SetDisplayAttr (%d)) failed with %#x!\n",\
+               RgnHandle, s32Ret);
+        return HI_FAILURE;
+    }
+    
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* funciton : osd region show or hide
+******************************************************************************/
+HI_S32 SAMPLE_RGN_ShowOrHide(RGN_HANDLE RgnHandle, VENC_GRP VencGrp, HI_BOOL bShow)
+{
+    MPP_CHN_S stChn;
+    RGN_CHN_ATTR_S stChnAttr;
+    HI_S32 s32Ret;
+
+    stChn.enModId = HI_ID_GROUP;
+    stChn.s32DevId = VencGrp;
+    stChn.s32ChnId = 0;
+        
+    s32Ret = HI_MPI_RGN_GetDisplayAttr(RgnHandle, &stChn, &stChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_GetDisplayAttr (%d)) failed with %#x!\n",\
+               RgnHandle, s32Ret);
+        return HI_FAILURE;
+    }
+
+    stChnAttr.bShow = bShow;
+    
+    s32Ret = HI_MPI_RGN_SetDisplayAttr(RgnHandle,&stChn,&stChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_SetDisplayAttr (%d)) failed with %#x!\n",\
+               RgnHandle, s32Ret);
+        return HI_FAILURE;
+    }
+    
+    return HI_SUCCESS;
+}
+    
+/******************************************************************************
+* funciton : osd region change color
+******************************************************************************/
+HI_S32 SAMPLE_RGN_ChgColor(RGN_HANDLE RgnHandle, HI_U32 u32Color)
+{
+    RGN_ATTR_S stRgnAttr;
+    HI_S32 s32Ret;
+
+    s32Ret = HI_MPI_RGN_GetAttr(RgnHandle,&stRgnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_GetAttr (%d)) failed with %#x!\n",\
+               RgnHandle, s32Ret);
+        return HI_FAILURE;
+    }
+
+    stRgnAttr.unAttr.stOverlay.u32BgColor = u32Color;
+
+    s32Ret = HI_MPI_RGN_SetAttr(RgnHandle,&stRgnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_SetAttr (%d)) failed with %#x!\n",\
+               RgnHandle, s32Ret);
+        return HI_FAILURE;
+    }
+    return HI_SUCCESS;
+}
+/******************************************************************************
+* funciton : osd region change (bgAlpha, fgAlpha, layer)
+******************************************************************************/
+HI_S32 SAMPLE_RGN_Change(RGN_HANDLE RgnHandle, VENC_GRP VencGrp, SAMPLE_RGN_CHANGE_TYPE_EN enChangeType, HI_U32 u32Val)
+{
+    MPP_CHN_S stChn;
+    RGN_CHN_ATTR_S stChnAttr;
+    HI_S32 s32Ret;
+
+    stChn.enModId = HI_ID_GROUP;
+    stChn.s32DevId = VencGrp;
+    stChn.s32ChnId = 0;
+    s32Ret = HI_MPI_RGN_GetDisplayAttr(RgnHandle,&stChn,&stChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_GetDisplayAttr (%d)) failed with %#x!\n",\
+               RgnHandle, s32Ret);
+        return HI_FAILURE;
+    }
+
+    switch (enChangeType)
+    {
+        case RGN_CHANGE_TYPE_FGALPHA:
+            stChnAttr.unChnAttr.stOverlayChn.u32FgAlpha = u32Val;
+            break;
+        case RGN_CHANGE_TYPE_BGALPHA:
+            stChnAttr.unChnAttr.stOverlayChn.u32BgAlpha = u32Val;
+            break;
+        case RGN_CHANGE_TYPE_LAYER:
+            stChnAttr.unChnAttr.stOverlayChn.u32Layer = u32Val;
+            break;
+        default:
+            SAMPLE_PRT("input paramter invaild!\n");
+            return HI_FAILURE;
+    }
+    s32Ret = HI_MPI_RGN_SetDisplayAttr(RgnHandle,&stChn,&stChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_SetDisplayAttr (%d)) failed with %#x!\n",\
+               RgnHandle, s32Ret);
+        return HI_FAILURE;
+    }
+    return HI_SUCCESS;
+}
+ 
+/******************************************************************************
+* funciton : load bmp from file
+******************************************************************************/
+HI_S32 SAMPLE_RGN_LoadBmp(const HI_CHAR *filename, BITMAP_S *pstBitmap)
+{
+    OSD_SURFACE_S Surface;
+    OSD_BITMAPFILEHEADER bmpFileHeader;
+    OSD_BITMAPINFO bmpInfo;
+
+    if(GetBmpInfo(filename,&bmpFileHeader,&bmpInfo) < 0)
+    {
+		SAMPLE_PRT("GetBmpInfo err!\n");
+        return HI_FAILURE;
+    }
+
+    Surface.enColorFmt = OSD_COLOR_FMT_RGB1555;
+    
+    pstBitmap->pData = malloc(2*(bmpInfo.bmiHeader.biWidth)*(bmpInfo.bmiHeader.biHeight));
+	
+    if(NULL == pstBitmap->pData)
+    {
+        SAMPLE_PRT("malloc osd memroy err!\n");        
+        return HI_FAILURE;
+    }
+
+    CreateSurfaceByBitMap(filename,&Surface,(HI_U8*)(pstBitmap->pData));
+	
+    pstBitmap->u32Width = Surface.u16Width;
+    pstBitmap->u32Height = Surface.u16Height;
+    pstBitmap->enPixelFormat = PIXEL_FORMAT_RGB_1555;		 
+    return HI_SUCCESS;
+}
+
+#define START_POINT_X_OFFSET 64
+#define START_POINT_Y_OFFSET 64
+
+/******************************************************************************
+  function : overlay process                
+             1) create some overlay regions
+             2) display overlay regions ( One Region -- Multi-VencGroup )
+             3) change all vencGroups Regions' Layer
+             4) change all vencGroups Regions' position
+             5) change all vencGroups Regions' color
+             6) load bmp form bmp-file to Region-0 
+             7) change all vencGroups Regions' front alpha 
+             8) change all vencGroups Regions' backgroud alpha
+             9) update bitmap(not support now)
+             10) show or hide overlay regions
+             11) Detach overlay regions from chn
+             12) Detroy overlay regions
+******************************************************************************/
+HI_S32 SAMPLE_RGN_OverlayProcess(VENC_GRP VencGrpStart,HI_S32 grpcnt)
+{
+    HI_S32 i, j;
+    HI_S32 s32Ret = HI_FAILURE;
+    RGN_HANDLE RgnHandle;
+    RGN_ATTR_S stRgnAttr;
+    MPP_CHN_S stChn;
+    VENC_GRP VencGrp;
+    RGN_CHN_ATTR_S stChnAttr;
+    HI_U32 u32Layer;
+    HI_U32 u32Color;
+    HI_U32 u32Alpha;
+    POINT_S stPoint;
+    BITMAP_S stBitmap;
+    SAMPLE_RGN_CHANGE_TYPE_EN enChangeType;
+    HI_BOOL bShow = HI_FALSE;
+
+    /****************************************
+     step 1: create overlay regions
+    ****************************************/
+    for (i=0; i<gs_s32RgnCnt; i++)
+    {
+        stRgnAttr.enType = OVERLAY_RGN;
+        stRgnAttr.unAttr.stOverlay.enPixelFmt = PIXEL_FORMAT_RGB_1555;
+        stRgnAttr.unAttr.stOverlay.stSize.u32Width  = 180;
+        stRgnAttr.unAttr.stOverlay.stSize.u32Height = 144;
+        stRgnAttr.unAttr.stOverlay.u32BgColor = 0x7c00*(i%2) + ((i+1)%2)*0x1f;
+
+        RgnHandle = i;
+
+        s32Ret = HI_MPI_RGN_Create(RgnHandle, &stRgnAttr);
+        if(HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("HI_MPI_RGN_Create (%d) failed with %#x!\n", \
+                   RgnHandle, s32Ret);
+            HI_MPI_RGN_Destroy(RgnHandle);
+            return HI_FAILURE;
+        }
+        gs_s32RgnCntCur ++;
+        SAMPLE_PRT("the handle:%d,creat success!\n",RgnHandle);
+    }
+    
+    /*********************************************
+     step 2: display overlay regions to venc groups
+    *********************************************/
+    for (i=0; i<gs_s32RgnCnt; i++)
+    {
+        RgnHandle = i;
+
+        for (j=0; j<gs_s32ChnCnt; j++)
+        {
+            VencGrp = j+VencGrpStart;
+            stChn.enModId = HI_ID_GROUP;
+            stChn.s32DevId = VencGrp;
+            stChn.s32ChnId = 0;
+            
+            memset(&stChnAttr,0,sizeof(stChnAttr));
+            stChnAttr.bShow = HI_TRUE;
+            stChnAttr.enType = OVERLAY_RGN;
+            stChnAttr.unChnAttr.stOverlayChn.stPoint.s32X =(i%3) * 200 + START_POINT_X_OFFSET;
+            stChnAttr.unChnAttr.stOverlayChn.stPoint.s32Y =(i/3)*160 + START_POINT_Y_OFFSET;
+            stChnAttr.unChnAttr.stOverlayChn.u32BgAlpha = 128;
+            stChnAttr.unChnAttr.stOverlayChn.u32FgAlpha = 128;
+            stChnAttr.unChnAttr.stOverlayChn.u32Layer = i;
+
+            stChnAttr.unChnAttr.stOverlayChn.stQpInfo.bAbsQp = HI_FALSE;
+            stChnAttr.unChnAttr.stOverlayChn.stQpInfo.s32Qp  = 0;
+
+            s32Ret = HI_MPI_RGN_AttachToChn(RgnHandle, &stChn, &stChnAttr);
+            if(HI_SUCCESS != s32Ret)
+            {
+                SAMPLE_PRT("HI_MPI_RGN_AttachToChn (%d) failed with %#x!\n",\
+                       RgnHandle, s32Ret);
+                return HI_FAILURE;
+            }
+        }
+    }
+    
+    usleep(SAMPLE_RGN_SLEEP_TIME*5);
+    printf("display region to chn success!\n");
+
+    /*********************************************
+     step 3: change overlay regions' position
+    *********************************************/
+    RgnHandle = 1;
+
+    for (i=0; i<gs_s32ChnCnt; i++)
+    {
+        VencGrp = i+VencGrpStart;
+        stPoint.s32X = 60 + START_POINT_X_OFFSET;
+        stPoint.s32Y = 0 + START_POINT_Y_OFFSET;
+        s32Ret = SAMPLE_RGN_ChgPosition(RgnHandle, VencGrp, &stPoint);
+        if(HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("change region(%d) position failed with %#x!\n",\
+                   RgnHandle, s32Ret);
+            return HI_FAILURE;
+        }
+    }
+    
+    printf("handle:%d,change point success,new point(x:%d,y:%d) !\n", 
+           RgnHandle,stPoint.s32X,stPoint.s32Y);
+    usleep(SAMPLE_RGN_SLEEP_TIME*5);
+
+    /*********************************************
+     step 4: change layer
+    *********************************************/
+    RgnHandle = 0;
+    enChangeType = RGN_CHANGE_TYPE_LAYER;
+
+    for (i=0; i<gs_s32ChnCnt; i++)
+    {
+        VencGrp = i+VencGrpStart;
+        u32Layer = 2;
+        s32Ret = SAMPLE_RGN_Change(RgnHandle, VencGrp, enChangeType, u32Layer);
+        if(HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("change region(%d) layer failed with %#x!\n",\
+                   RgnHandle, s32Ret);
+            return HI_FAILURE;
+        }
+    }
+
+    printf("handle:%d,change layer success,new layer(%d) !\n",RgnHandle,u32Layer);
+
+    usleep(SAMPLE_RGN_SLEEP_TIME*5);
+
+    /*********************************************
+     step 5: change color
+    *********************************************/
+    RgnHandle = 2;
+
+    u32Color = 0x7fff;
+    s32Ret = SAMPLE_RGN_ChgColor(RgnHandle, u32Color);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("change region(%d) color failed with %#x!\n",\
+               RgnHandle, s32Ret);
+        return HI_FAILURE;
+    }
+
+    printf("handle:%d,change color success,new bg color(0x%x)\n",RgnHandle,u32Color);
+
+    usleep(SAMPLE_RGN_SLEEP_TIME*5);
+
+    /*********************************************
+     step 6: show bitmap
+    *********************************************/
+    RgnHandle = 0;
+    
+    s32Ret = SAMPLE_RGN_LoadBmp("mm.bmp", &stBitmap);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("load bmp failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    s32Ret = HI_MPI_RGN_SetBitMap(RgnHandle,&stBitmap);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_SetBitMap failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+    
+    if (NULL != stBitmap.pData)
+    {
+        free(stBitmap.pData);
+        stBitmap.pData = NULL;
+    }
+
+    usleep(SAMPLE_RGN_SLEEP_TIME*5);
+    printf("handle:%d,load bmp success!\n",RgnHandle);
+    
+    /*********************************************
+     step 7: change front alpha
+    *********************************************/
+    RgnHandle = 0;
+    enChangeType = RGN_CHANGE_TYPE_FGALPHA;
+
+    for (i=0; i<gs_s32ChnCnt; i++)
+    {
+        VencGrp = i+VencGrpStart;
+        u32Alpha = 32;
+        s32Ret = SAMPLE_RGN_Change(RgnHandle, VencGrp, enChangeType, u32Alpha);
+        if(HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("change region(%d) f-alpha failed with %#x!\n",\
+                   RgnHandle, s32Ret);
+            return HI_FAILURE;
+        }
+    }
+
+    printf("handle:%d,change front alpha success,the new alpha:%d\n", RgnHandle,u32Alpha);
+
+    usleep(SAMPLE_RGN_SLEEP_TIME*5);
+    
+    /*********************************************
+     step 8: change backgroud alpha
+    *********************************************/
+    RgnHandle = 0;
+    enChangeType = RGN_CHANGE_TYPE_BGALPHA;
+
+    for (i=0; i<gs_s32ChnCnt; i++)
+    {
+        VencGrp = i+VencGrpStart;
+        u32Alpha = 32;
+        s32Ret = SAMPLE_RGN_Change(RgnHandle, VencGrp, enChangeType, u32Alpha);
+        if(HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("change region(%d) f-alpha failed with %#x!\n",\
+                   RgnHandle, s32Ret);
+            return HI_FAILURE;
+        }
+    }
+
+    printf("handle:%d,change backgroud alpha success,the new alpha:%d\n", RgnHandle,u32Alpha);
+
+    usleep(SAMPLE_RGN_SLEEP_TIME*5);
+
+    /*********************************************
+     step 9: update bitmap
+    *********************************************/
+    /*not support now*/
+
+    /*********************************************
+     step 10: show or hide overlay regions
+    *********************************************/
+    RgnHandle = 4;
+    bShow = HI_FALSE;
+    
+    for (i=0; i<SAMPLE_RGN_LOOP_COUNT; i++)
+    {
+        for (j=0; j<gs_s32ChnCnt; j++)
+        {
+            VencGrp = j+VencGrpStart;
+            
+            s32Ret = SAMPLE_RGN_ShowOrHide(RgnHandle, VencGrp, bShow);
+            if(HI_SUCCESS != s32Ret)
+            {
+                printf("region(%d) show failed with %#x!\n",\
+                       RgnHandle, s32Ret);
+                return HI_FAILURE;
+            }
+        }
+
+        bShow = !bShow;
+
+        usleep(SAMPLE_RGN_SLEEP_TIME*5);
+    }
+
+    printf("handle:%d,show or hide osd success\n", RgnHandle);
+
+    /*********************************************
+     step 11: Detach osd from chn
+    *********************************************/   
+    for (i=0; i<gs_s32RgnCnt; i++)
+    {
+        RgnHandle = i;
+
+        for (j=0; j<gs_s32ChnCnt; j++)
+        {
+            VencGrp = j+VencGrpStart;
+            stChn.enModId = HI_ID_GROUP;
+            stChn.s32DevId = VencGrp;
+            stChn.s32ChnId = 0;
+
+            s32Ret = HI_MPI_RGN_DetachFrmChn(RgnHandle, &stChn);
+            if(HI_SUCCESS != s32Ret)
+            {
+                SAMPLE_PRT("HI_MPI_RGN_DetachFrmChn (%d) failed with %#x!\n",\
+                       RgnHandle, s32Ret);
+                return HI_FAILURE;
+            }
+        }
+
+         printf("Detach handle:%d from chn success\n", RgnHandle);
+
+         usleep(SAMPLE_RGN_SLEEP_TIME*5);
+    }
+
+    /*********************************************
+     step 12: destory region
+    *********************************************/
+    for (i=0; i<gs_s32RgnCnt; i++)
+    {
+        RgnHandle = i;
+        s32Ret = HI_MPI_RGN_Destroy(RgnHandle);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("HI_MPI_RGN_Destroy [%d] failed with %#x\n",\
+                    RgnHandle, s32Ret);
+        }
+    }
+    SAMPLE_PRT("destory all region success!\n");
+    return HI_SUCCESS;
+}
+
+
+/******************************************************************************
+  function : cover process                
+             1) enable vpp, but disable IE
+             2) create an cover region and attach it to vi chn0
+             3) create an overlay region and attach it to venc group chn0
+             4) change the cover's position,size, color and layer
+             5) change the overlay's position and layer
+             6) change the overlay's alpha (front and backgroud) 
+             7) hide the cover and the overlay
+             8) release resource
+******************************************************************************/
+HI_S32 SAMPLE_RGN_CoverProcess(VI_DEV ViDev,VI_CHN ViChn)
+{
+    HI_S32 s32Ret = HI_FAILURE;
+    
+    RGN_HANDLE coverHandle;
+    RGN_ATTR_S stCoverAttr;
+    MPP_CHN_S stCoverChn;
+    RGN_CHN_ATTR_S stCoverChnAttr;
+    
+    /*******************************************************
+     step 2: create an cover region and attach it to vi chn0
+    ********************************************************/ 
+   
+    coverHandle = 0;
+    stCoverAttr.enType = COVER_RGN;
+    s32Ret = HI_MPI_RGN_Create(coverHandle, &stCoverAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    stCoverChn.enModId = HI_ID_VIU;
+    stCoverChn.s32ChnId = ViChn;
+    stCoverChn.s32DevId = ViDev;
+
+    stCoverChnAttr.bShow = HI_TRUE;
+    stCoverChnAttr.enType = COVER_RGN;
+    stCoverChnAttr.unChnAttr.stCoverChn.stRect.s32X = 12;
+    stCoverChnAttr.unChnAttr.stCoverChn.stRect.s32Y = 12;
+    stCoverChnAttr.unChnAttr.stCoverChn.stRect.u32Width = 160;
+    stCoverChnAttr.unChnAttr.stCoverChn.stRect.u32Height = 160;
+    stCoverChnAttr.unChnAttr.stCoverChn.u32Color = 0xff;
+    stCoverChnAttr.unChnAttr.stCoverChn.u32Layer = 0;       
+    s32Ret = HI_MPI_RGN_AttachToChn(coverHandle, &stCoverChn, &stCoverChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+       goto AttachCover_failed;
+    }
+    
+    //printf("create an cover region and attach it to vi chn0\n");
+    usleep(SAMPLE_RGN_SLEEP_TIME*50);
+    
+    /**********************************************************
+      step 4: change the cover's position, size, color and layer
+     **********************************************************/
+    stCoverChnAttr.unChnAttr.stCoverChn.stRect.s32X = 64;
+    stCoverChnAttr.unChnAttr.stCoverChn.stRect.s32Y = 64;
+    stCoverChnAttr.unChnAttr.stCoverChn.stRect.u32Width = 260;
+    stCoverChnAttr.unChnAttr.stCoverChn.stRect.u32Height = 260;
+    stCoverChnAttr.unChnAttr.stCoverChn.u32Color = 0xf800;
+    stCoverChnAttr.unChnAttr.stCoverChn.u32Layer = 1;
+    s32Ret = HI_MPI_RGN_SetDisplayAttr(coverHandle, &stCoverChn, &stCoverChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        goto exit;
+    }
+    
+    usleep(SAMPLE_RGN_SLEEP_TIME*30);
+    
+   /*********************************************
+     step 6: hide the cover and the overlay
+    *********************************************/
+    stCoverChnAttr.bShow = HI_FALSE;
+    s32Ret = HI_MPI_RGN_SetDisplayAttr(coverHandle, &stCoverChn, &stCoverChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        goto exit;
+    }
+    
+    //printf("hide the cover and the overlay success\n");
+    usleep(SAMPLE_RGN_SLEEP_TIME*30);
+
+   /*********************************************
+     step 7: release resource
+    *********************************************/
+
+exit:
+    HI_MPI_RGN_DetachFrmChn(coverHandle, &stCoverChn);  
+AttachCover_failed:
+    HI_MPI_RGN_Destroy(coverHandle);
+    return s32Ret;
+}
+
+HI_S32 SAMPLE_RGN_OverlayExProcess(VI_DEV ViDev,VI_CHN ViChn)
+{
+    HI_S32 s32Ret = HI_FAILURE;
+    
+    RGN_HANDLE OverlayExHandle = 0;
+    RGN_ATTR_S stOverlayExAttr;
+    MPP_CHN_S stOverlayExChn;
+    RGN_CHN_ATTR_S stOverlayExChnAttr;
+	BITMAP_S stBitmap;
+	
+	stOverlayExAttr.enType = OVERLAYEX_RGN;
+	stOverlayExAttr.unAttr.stOverlayEx.enPixelFmt = PIXEL_FORMAT_RGB_1555;
+	stOverlayExAttr.unAttr.stOverlayEx.u32BgColor =  0x00ffffff;
+	stOverlayExAttr.unAttr.stOverlayEx.stSize.u32Height = 128;
+	stOverlayExAttr.unAttr.stOverlayEx.stSize.u32Width= 128;
+	
+    s32Ret = HI_MPI_RGN_Create(OverlayExHandle, &stOverlayExAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_Create failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    stOverlayExChnAttr.enType = OVERLAYEX_RGN;
+	stOverlayExChnAttr.bShow = HI_TRUE;
+	stOverlayExChnAttr.unChnAttr.stOverlayExChn.stPoint.s32X = 128;
+	stOverlayExChnAttr.unChnAttr.stOverlayExChn.stPoint.s32Y = 128;
+	stOverlayExChnAttr.unChnAttr.stOverlayExChn.u32BgAlpha = 50;
+	stOverlayExChnAttr.unChnAttr.stOverlayExChn.u32FgAlpha = 130;
+	stOverlayExChnAttr.unChnAttr.stOverlayExChn.u32Layer = 1;
+
+    stOverlayExChn.enModId = HI_ID_VIU;
+    stOverlayExChn.s32DevId = ViDev;
+    stOverlayExChn.s32ChnId = ViChn;
+
+	s32Ret = HI_MPI_RGN_AttachToChn(OverlayExHandle,&stOverlayExChn,&stOverlayExChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_AttachToChn failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+	usleep(SAMPLE_RGN_SLEEP_TIME*5);
+	/*load bitmap*/
+	s32Ret = SAMPLE_RGN_LoadBmp("mm.bmp", &stBitmap);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("load bmp failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+
+    s32Ret = HI_MPI_RGN_SetBitMap(OverlayExHandle,&stBitmap);
+    if(s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_SetBitMap failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+    
+    if (NULL != stBitmap.pData)
+    {
+        free(stBitmap.pData);
+        stBitmap.pData = NULL;
+    }
+	usleep(SAMPLE_RGN_SLEEP_TIME*5);
+    //printf("handle:%d,load bmp success!\n",OverlayExHandle);
+
+	s32Ret = HI_MPI_RGN_GetDisplayAttr(OverlayExHandle,&stOverlayExChn,&stOverlayExChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_GetDisplayAttr (%d)) failed with %#x!\n",\
+               OverlayExHandle, s32Ret);
+        return HI_FAILURE;
+    }
+
+	stOverlayExChnAttr.unChnAttr.stOverlayExChn.u32BgAlpha = 200;
+	stOverlayExChnAttr.unChnAttr.stOverlayExChn.u32FgAlpha = 1;
+	stOverlayExChnAttr.unChnAttr.stOverlayExChn.stPoint.s32X = 256;
+	stOverlayExChnAttr.unChnAttr.stOverlayExChn.stPoint.s32Y = 256;
+
+    s32Ret = HI_MPI_RGN_SetDisplayAttr(OverlayExHandle,&stOverlayExChn,&stOverlayExChnAttr);
+    if(HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_RGN_SetDisplayAttr (%d)) failed with %#x!\n",\
+               OverlayExHandle, s32Ret);
+        return HI_FAILURE;
+    }
+	usleep(SAMPLE_RGN_SLEEP_TIME*5);
+
+	//printf("handle:%d,will be destroy!\n",OverlayExHandle);
+	s32Ret = HI_MPI_RGN_DetachFrmChn(OverlayExHandle,&stOverlayExChn);
+    if(HI_SUCCESS != s32Ret)
+	{
+        SAMPLE_PRT("HI_MPI_RGN_DetachFrmChn (%d)) failed with %#x!\n",\
+               OverlayExHandle, s32Ret);
+        return HI_FAILURE;
+    }
+	s32Ret = HI_MPI_RGN_Destroy(OverlayExHandle);
+    if(HI_SUCCESS != s32Ret)
+	{
+        SAMPLE_PRT("HI_MPI_RGN_Destroy (%d)) failed with %#x!\n",\
+               OverlayExHandle, s32Ret);
+        return HI_FAILURE;
+    }
+	return HI_SUCCESS;
+
+}
+
+void SAMPLE_RGN_Usage(HI_CHAR *sPrgNm)
+{
+    //printf("Usage : %s <index>\n", sPrgNm);
+    //printf("index:\n");
+    printf("press sample command as follows!\n");
+    printf("\t 0) D1 Vi cover region + OverlayEx + HD output\n");
+    printf("\t 1) MixCap Vi cover + HD output\n");
+	printf("\t 2) Overlay region + D1 Venc + HD output\n");
+    printf("\t q) exit this sample\n");
+    
+    return;
+}
+
+
+/******************************************************************************
+* function : to process abnormal case                                        
+******************************************************************************/
+void SAMPLE_RGN_HandleSig(HI_S32 signo)
+{
+    if (SIGINT == signo || SIGTSTP == signo)
+    {
+        HI_MPI_RGN_Destroy(gs_s32RgnCntCur);
+        SAMPLE_COMM_SYS_Exit();
+        printf("\033[0;31mprogram exit abnormally!\033[0;39m\n");
+    }
+
+    exit(0);
+}
+
+
+HI_VOID * SAMPLE_RGN_MixCap(HI_VOID * pdata)
+{
+	SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_D1Cif;
+	HI_U32 u32ViChnCnt = 16;
+	HI_S32 s32VpssGrpCnt = 16;
+
+	VI_DEV ViDev = 0;
+	VI_CHN ViChn = 0;
+	
+	VB_CONF_S stVbConf;
+	VPSS_GRP VpssGrp;
+	VPSS_GRP_ATTR_S stGrpAttr;
+	
+	HI_S32 i;
+	HI_S32 s32Ret = HI_SUCCESS;
+	HI_U32 u32BlkSize;
+	SIZE_S stSize;
+
+	VO_DEV VoDev;
+	VO_CHN VoChn;
+	VO_PUB_ATTR_S stVoPubAttr; 
+	SAMPLE_VO_MODE_E enVoMode;
+	HI_U32 u32WndNum;
+
+	/******************************************
+	 step  1: init variable 
+	******************************************/
+	gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL == gs_enNorm)?25:30;
+
+	memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+	/*video buffer*/
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 4;
+	
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_2CIF, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+    stVbConf.astCommPool[1].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 6;
+
+	/******************************************
+	 step 2: mpp system init. 
+	******************************************/
+	s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+		goto END_0;
+	}
+
+	/******************************************
+	 step 3: start vi dev & chn to capture
+	******************************************/
+	s32Ret = SAMPLE_COMM_VI_MixCap_Start(enViMode, gs_enNorm);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("start vi failed!\n");
+		goto END_0;
+	}
+	
+	/******************************************
+	 step 4: start vpss and vi bind vpss
+	******************************************/
+	s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+		goto END_0;
+	}
+	
+	stGrpAttr.u32MaxW = stSize.u32Width;
+	stGrpAttr.u32MaxH = stSize.u32Height;
+	stGrpAttr.bDrEn = HI_FALSE;
+	stGrpAttr.bDbEn = HI_FALSE;
+	stGrpAttr.bIeEn = HI_TRUE;
+	stGrpAttr.bNrEn = HI_TRUE;
+	stGrpAttr.bHistEn = HI_FALSE;
+	stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+	stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+	s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Start Vpss failed!\n");
+		goto END_1;
+	}
+	/*open pre-scale*/
+	s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_2CIF, &stSize);
+	if (HI_SUCCESS != s32Ret)
+	{
+	   SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+	   goto END_2;
+	}
+	for(i=0;i<s32VpssGrpCnt;i++)
+	{   
+	   s32Ret = SAMPLE_COMM_EnableVpssPreScale(i,stSize);
+	   if(HI_SUCCESS != s32Ret)
+	   {
+	   SAMPLE_PRT("HI_MPI_VPSS_SetPreScale failed!\n");
+	   goto END_2;
+	   }
+	}
+	s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Vi bind Vpss failed!\n");
+		goto END_2;
+	}
+	/******************************************
+	 step 5: start vo
+	******************************************/
+	VoDev = SAMPLE_VO_DEV_DHD0;
+	u32WndNum = 16;
+	enVoMode = VO_MODE_9MUX;
+	
+	if(VIDEO_ENCODING_MODE_PAL == gs_enNorm)
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_720P50;
+	}
+	else
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_720P60;
+	}
+  
+	stVoPubAttr.enIntfType = VO_INTF_VGA;
+	stVoPubAttr.u32BgColor = 0x000000ff;
+	stVoPubAttr.bDoubleFrame = HI_TRUE;
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+		goto END_3;
+	}
+	
+	s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+		goto END_4;
+	}
+
+	/* if it's displayed on HDMI, we should start HDMI */
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+	{
+		if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+		{
+			goto END_4;
+		}
+	}
+
+	for(i=0;i<u32WndNum;i++)
+	{
+		VoChn = i;
+		VpssGrp = i;
+		s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+		if (HI_SUCCESS != s32Ret)
+		{
+			SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+			goto END_4;
+		}
+	}
+
+	printf("please press any key to wait stop!\n");
+	/*Cover Region Process*/
+       while(bCase1)
+        {
+        	ViChn = 0;
+        	s32Ret = SAMPLE_RGN_CoverProcess(ViDev,ViChn);
+        	if (HI_SUCCESS != s32Ret)
+        	{
+        		SAMPLE_PRT("cover process failed!\n");
+        		goto END_4;
+        	}
+              
+        }
+	printf("\nplease press any key to exit\n");
+	getchar();
+	
+END_4:
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+	{
+		SAMPLE_COMM_VO_HdmiStop();
+	}
+	VoDev = SAMPLE_VO_DEV_DHD0;
+	u32WndNum = 16;
+	enVoMode = VO_MODE_16MUX;
+	for(i=0;i<u32WndNum;i++)
+	{
+		VoChn = i;
+		VpssGrp = i;
+		SAMPLE_COMM_VO_UnBindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+	}
+	SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+	SAMPLE_COMM_VO_StopDevLayer(VoDev);
+
+END_3:	//vi unbind vpss
+	SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_2:	//vpss stop
+	SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_1:	//vi stop
+	SAMPLE_COMM_VI_Stop(enViMode);
+END_0:	//system exit
+	SAMPLE_COMM_SYS_Exit();
+
+    if(s32Ret != HI_SUCCESS)
+     {
+         SAMPLE_RGN_NOT_PASS(s32Ret);
+     }
+	
+	
+	return HI_NULL;
+	
+	
+
+}
+HI_S32 SAMPLE_RGN_VENC(HI_VOID)
+{
+	SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_D1;
+
+	HI_U32 u32ViChnCnt = 1;
+	HI_S32 s32VpssGrpCnt = 1;
+	PIC_SIZE_E enSize = PIC_D1;
+	
+    HI_S32 s32RgnCnt = 8;
+	
+	VB_CONF_S stVbConf;
+	VPSS_GRP VpssGrp;
+	VPSS_CHN VpssChn;
+	VPSS_GRP_ATTR_S stGrpAttr;
+
+	PAYLOAD_TYPE_E enPayLoad = PT_H264;
+	VENC_GRP VencGrp;
+    VENC_CHN VencChn;
+    SAMPLE_RC_E enRcMode;
+	
+	HI_S32 i;
+	HI_S32 s32Ret = HI_SUCCESS;
+	HI_U32 u32BlkSize;
+	SIZE_S stSize;
+
+	VO_DEV VoDev;
+	VO_CHN VoChn;
+	VO_PUB_ATTR_S stVoPubAttr; 
+	SAMPLE_VO_MODE_E enVoMode;
+	HI_U32 u32WndNum;
+
+	/******************************************
+	 step  1: init variable 
+	******************************************/
+	gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL == gs_enNorm)?25:30;
+
+	memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+	u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+				PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+	stVbConf.u32MaxPoolCnt = 128;
+
+	/*video buffer*/
+	stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+	stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 10;
+	memset(stVbConf.astCommPool[0].acMmzName,0,
+		sizeof(stVbConf.astCommPool[0].acMmzName));
+	
+    /* hist buf*/
+    stVbConf.astCommPool[1].u32BlkSize = (196*4);
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 10;
+    memset(stVbConf.astCommPool[1].acMmzName,0,
+        sizeof(stVbConf.astCommPool[1].acMmzName));
+
+	/******************************************
+	 step 2: mpp system init. 
+	******************************************/
+	s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+		goto END_0;
+	}
+
+	/******************************************
+	 step 3: start vi dev & chn to capture
+	******************************************/
+	s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("start vi failed!\n");
+		goto END_0;
+	}
+	
+	/******************************************
+	 step 4: start vpss and vi bind vpss
+	******************************************/
+	s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+		goto END_0;
+	}
+	
+	stGrpAttr.u32MaxW = stSize.u32Width;
+	stGrpAttr.u32MaxH = stSize.u32Height;
+	stGrpAttr.bDrEn = HI_FALSE;
+	stGrpAttr.bDbEn = HI_FALSE;
+	stGrpAttr.bIeEn = HI_TRUE;
+	stGrpAttr.bNrEn = HI_TRUE;
+	stGrpAttr.bHistEn = HI_TRUE;
+	stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+	stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+	s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Start Vpss failed!\n");
+		goto END_1;
+	}
+
+	s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Vi bind Vpss failed!\n");
+		goto END_2;
+	}
+	/******************************************
+	 step 5: start vo
+	******************************************/
+	VoDev = SAMPLE_VO_DEV_DHD0;
+	u32WndNum = 1;
+	enVoMode = VO_MODE_1MUX;
+	
+	if(VIDEO_ENCODING_MODE_PAL == gs_enNorm)
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_720P50;
+	}
+	else
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_720P60;
+	}
+  
+	stVoPubAttr.enIntfType = VO_INTF_VGA;
+	stVoPubAttr.u32BgColor = 0x000000ff;
+	stVoPubAttr.bDoubleFrame = HI_TRUE;
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+		goto END_3;
+	}
+	
+	s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+		goto END_4;
+	}
+
+	/* if it's displayed on HDMI, we should start HDMI */
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+	{
+		if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+		{
+			goto END_4;
+		}
+	}
+
+	for(i=0;i<u32WndNum;i++)
+	{
+		VoChn = i;
+		VpssGrp = i;
+		s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+		if (HI_SUCCESS != s32Ret)
+		{
+			SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+			goto END_4;
+		}
+	}
+
+	/******************************************
+     step 6: start stream venc
+    ******************************************/
+    enRcMode = SAMPLE_RC_CBR;
+
+    for (i=0; i<u32ViChnCnt; i++)
+    {
+        /*** main frame **/
+        VencGrp = i;
+        VencChn = i;
+        VpssGrp = i;
+        s32Ret = SAMPLE_COMM_VENC_Start(VencGrp, VencChn, enPayLoad,\
+                                    gs_enNorm, enSize, enRcMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_4;
+        }
+
+        s32Ret = SAMPLE_COMM_VENC_BindVpss(VencGrp, VpssGrp, VPSS_BSTR_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_5;
+        }
+    }
+    /******************************************
+     step 6: stream venc process -- get stream, then save it to file. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VENC_StartGetStream(u32ViChnCnt);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Venc failed!\n");
+        goto END_5;
+    }
+
+	/*Overlay Region Process*/
+	s32Ret = SAMPLE_RGN_OverlayProcess(VencChn, s32RgnCnt);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("overlay process failed!\n");
+		goto END_5;
+	}
+	
+	printf("please press any key to exit\n");
+	//getchar();
+    /******************************************
+     step 8: exit process
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VENC_StopGetStream();
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("SAMPLE_COMM_VENC_StopGetStream failed!\n");
+		goto END_5;
+	}
+	
+END_5:
+    for (i=0; i<u32ViChnCnt; i++)
+    {
+        VencGrp = i;
+        VencChn = i;
+        VpssGrp = i;
+        VpssChn =VPSS_BSTR_CHN;
+        SAMPLE_COMM_VENC_UnBindVpss(VencGrp, VpssGrp, VpssChn);
+        SAMPLE_COMM_VENC_Stop(VencGrp,VencChn);
+    }
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);	
+END_4:
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+	{
+		SAMPLE_COMM_VO_HdmiStop();
+	}
+	VoDev = SAMPLE_VO_DEV_DHD0;
+	u32WndNum = 16;
+	enVoMode = VO_MODE_1MUX;
+	for(i=0;i<u32WndNum;i++)
+	{
+		VoChn = i;
+		VpssGrp = i;
+		SAMPLE_COMM_VO_UnBindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+	}
+	SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+	SAMPLE_COMM_VO_StopDevLayer(VoDev);
+
+END_3:	//vi unbind vpss
+	SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_2:	//vpss stop
+	SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_1:	//vi stop
+	SAMPLE_COMM_VI_Stop(enViMode);
+END_0:	//system exit
+	SAMPLE_COMM_SYS_Exit();
+	
+	return s32Ret;
+	
+}
+
+HI_VOID * SAMPLE_RGN_D1(HI_VOID *pdata)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_D1;
+
+    HI_U32 u32ViChnCnt = 1;
+    HI_S32 s32VpssGrpCnt = 1;
+    VI_DEV ViDev = 0;
+    VI_CHN ViChn = 0;
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    SIZE_S stSize;
+
+    VO_DEV VoDev;
+    VO_CHN VoChn;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    SAMPLE_VO_MODE_E enVoMode;
+    HI_U32 u32WndNum;
+
+    /******************************************
+     step  1: init variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL == gs_enNorm)?25:30;
+
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /*video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 10;
+    memset(stVbConf.astCommPool[0].acMmzName,0,
+        sizeof(stVbConf.astCommPool[0].acMmzName));
+	/* hist buf*/
+    stVbConf.astCommPool[1].u32BlkSize = (196*4);
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 10;
+    memset(stVbConf.astCommPool[1].acMmzName,0,
+        sizeof(stVbConf.astCommPool[1].acMmzName));
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_0;
+    }
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_0;
+    }
+    
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_1;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_2;
+    }
+    /******************************************
+     step 5: start vo
+    ******************************************/
+    VoDev = SAMPLE_VO_DEV_DHD0;
+    u32WndNum = 1;
+    enVoMode = VO_MODE_1MUX;
+    
+    if(VIDEO_ENCODING_MODE_PAL == gs_enNorm)
+    {
+        stVoPubAttr.enIntfSync = VO_OUTPUT_720P50;
+    }
+    else
+    {
+        stVoPubAttr.enIntfSync = VO_OUTPUT_720P60;
+    }
+  
+    stVoPubAttr.enIntfType = VO_INTF_VGA;
+    stVoPubAttr.u32BgColor = 0x000000ff;
+    stVoPubAttr.bDoubleFrame = HI_TRUE;
+    s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+        goto END_3;
+    }
+    
+    s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+        goto END_4;
+    }
+
+    /* if it's displayed on HDMI, we should start HDMI */
+    if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+        {
+            goto END_4;
+        }
+    }
+
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        VpssGrp = i;
+        s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+            goto END_4;
+        }
+    }
+
+    printf("please press any key to wait stop!\n");
+     /******************************************
+      step 5: start region
+     ******************************************/
+      while(bCase0)
+     {  	
+        
+            /*Cover Region Process*/
+          s32Ret = SAMPLE_RGN_CoverProcess(ViDev,ViChn);
+          if (HI_SUCCESS != s32Ret)
+          {
+          	SAMPLE_PRT("cover process failed!\n");
+          	goto END_4;
+          }
+          /*OverlayEx Region Process*/
+          s32Ret = SAMPLE_RGN_OverlayExProcess(ViDev,ViChn);
+          if (HI_SUCCESS != s32Ret)
+          {
+          	SAMPLE_PRT("overlayex process failed!\n");
+          	goto END_4;
+          }
+      }
+    printf("\n please press any key to exit!\n");
+	
+	getchar();
+	
+END_4:
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+	{
+		SAMPLE_COMM_VO_HdmiStop();
+	}
+	VoDev = SAMPLE_VO_DEV_DHD0;
+	u32WndNum = 16;
+	enVoMode = VO_MODE_1MUX;
+	for(i=0;i<u32WndNum;i++)
+	{
+		VoChn = i;
+		VpssGrp = i;
+		SAMPLE_COMM_VO_UnBindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+	}
+	SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+	SAMPLE_COMM_VO_StopDevLayer(VoDev);
+
+END_3:	//vi unbind vpss
+	SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_2:	//vpss stop
+	SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_1:	//vi stop
+	SAMPLE_COMM_VI_Stop(enViMode);
+END_0:	//system exit
+	SAMPLE_COMM_SYS_Exit();
+
+    if(s32Ret != HI_SUCCESS)
+     {
+         SAMPLE_RGN_NOT_PASS(s32Ret);
+     }
+	
+	return HI_NULL;
+
+}
+
+/******************************************************************************
+* function    : main()
+* Description : region
+******************************************************************************/
+int main(int argc, char *argv[])
+{
+    HI_S32 s32Ret;
+    HI_S32 s32Tm = 2;
+    pthread_t SampRgnThread[3];
+    if ( (argc < 2) || (1 != strlen(argv[1])))
+    {
+        SAMPLE_RGN_Usage(argv[0]);
+        return HI_FAILURE;
+    }
+
+    signal(SIGINT, SAMPLE_RGN_HandleSig);
+    signal(SIGTERM, SAMPLE_RGN_HandleSig);
+
+    switch (*argv[1])
+    {
+        case '0':/* VI: D1 + Cover+ OverlayEx  */
+            s32Tm = 0;
+            bCase0 = HI_TRUE;
+            pthread_create(&SampRgnThread[0], 0, SAMPLE_RGN_D1, (HI_VOID *)HI_NULL);
+            //s32Ret = SAMPLE_RGN_D1();
+            break;
+        case '1':/* Mix Cap + Cover */
+            s32Tm = 1;
+            bCase1 = HI_TRUE;
+            pthread_create(&SampRgnThread[1], 0, SAMPLE_RGN_MixCap, (HI_VOID *)HI_NULL);
+            //s32Ret = SAMPLE_RGN_MixCap();
+            break;
+	 case '2':/* VI: D1 + Overlay(venc) */
+	     s32Ret = SAMPLE_RGN_VENC();
+			break;
+
+        default:
+            SAMPLE_RGN_Usage(argv[0]);
+            return HI_FAILURE;
+    }
+
+    getchar();   
+    
+
+    bCase0= HI_FALSE;
+    bCase1= HI_FALSE;
+
+    if(0 == s32Tm || 1 == s32Tm)
+    {
+        fprintf(stderr,"please wait ,program is exiting...");
+        pthread_join(SampRgnThread[s32Tm], 0);
+    }
+    
+    if (HI_SUCCESS == s32Ret)
+        printf("program exit normally!\n");
+    else
+        printf("program exit abnormally!\n");
+    exit(s32Ret);
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */

--- a/libraries/mpp_sample/hi3520dv200/tde/Makefile
+++ b/libraries/mpp_sample/hi3520dv200/tde/Makefile
@@ -1,0 +1,22 @@
+# Hisilicon Hi3531 sample Makefile
+
+include ../Makefile.param
+
+
+# target source
+SRC  := $(wildcard *.c) 
+OBJ  := $(SRC:%.c=%.o)
+
+LIBS += $(REL_LIB)/libmpi.a $(REL_LIB)/libtde.a $(REL_LIB)/libhdmi.a $(AUDIO_LIBA) $(JPEGD_LIBA)
+
+TARGET := $(OBJ:%.o=%)
+.PHONY : clean all
+
+all: $(TARGET)
+
+$(TARGET):%:%.o $(COMM_OBJ)
+	$(CC) $(CFLAGS) -lpthread -lm -o $@ $^ $(LIBS) 
+
+clean:
+	@-rm -f $(TARGET)
+	@-rm -f $(OBJ)

--- a/libraries/mpp_sample/hi3520dv200/tde/sample_tde.c
+++ b/libraries/mpp_sample/hi3520dv200/tde/sample_tde.c
@@ -1,0 +1,420 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <math.h>
+#include <sys/time.h>
+#include <sys/ioctl.h>
+#include <linux/fb.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+
+#include "hi_tde_api.h"
+#include "hi_tde_type.h"
+#include "hi_tde_errcode.h"
+#include "hifb.h"
+
+#include "hi_comm_vo.h"
+#include "mpi_sys.h"
+
+#include "mpi_vo.h"
+#include "sample_comm.h"
+
+
+#define TDE_PRINT printf
+
+#define VoDev 0
+#define VoChn 0
+
+
+#define MIN(x,y) ((x) > (y) ? (y) : (x))
+#define MAX(x,y) ((x) > (y) ? (x) : (y))
+
+static const HI_CHAR *pszImageNames[] =
+{
+    "res/apple.bits",
+    "res/applets.bits",
+    "res/calendar.bits",
+    "res/foot.bits",
+    "res/gmush.bits",
+    "res/gimp.bits",
+    "res/gsame.bits",
+    "res/keys.bits"
+};
+
+#define N_IMAGES (HI_S32)((sizeof (pszImageNames) / sizeof (pszImageNames[0])))
+
+
+#define BACKGROUND_NAME  "res/background.bits"
+
+#define PIXFMT  TDE2_COLOR_FMT_ARGB1555
+#define BPP     2
+#define SCREEN_WIDTH    720
+#define SCREEN_HEIGHT   576
+#define CYCLE_LEN       60
+
+#ifndef HI_FLOAT
+typedef float HI_FLOAT;
+#endif
+
+static HI_S32   g_s32FrameNum;
+static TDE2_SURFACE_S g_stScreen[2];
+static TDE2_SURFACE_S g_stBackGround;
+static TDE2_SURFACE_S g_stImgSur[N_IMAGES];
+
+static HI_S32 TDE_CreateSurfaceByFile(const HI_CHAR *pszFileName, TDE2_SURFACE_S *pstSurface, HI_U8 *pu8Virt)
+{
+    FILE *fp;
+    HI_U32 colorfmt, w, h, stride;
+
+    if((NULL == pszFileName) || (NULL == pstSurface))
+    {
+        printf("%s, LINE %d, NULL ptr!\n", __FUNCTION__, __LINE__);
+        return -1;
+    }
+
+    fp = fopen(pszFileName, "rb");
+    if(NULL == fp)
+    {
+        printf("error when open pszFileName %s, line:%d\n", pszFileName, __LINE__);
+        return -1;
+    }
+
+    fread(&colorfmt, 1, 4, fp);
+    fread(&w, 1, 4, fp);
+    fread(&h, 1, 4, fp);
+    fread(&stride, 1, 4, fp);
+
+    pstSurface->enColorFmt = colorfmt;
+    pstSurface->u32Width = w;
+    pstSurface->u32Height = h;
+    pstSurface->u32Stride = stride;
+    pstSurface->u8Alpha0 = 0xff;
+    pstSurface->u8Alpha1 = 0xff;
+    pstSurface->bAlphaMax255 = HI_TRUE;
+    pstSurface->bAlphaExt1555 = HI_TRUE;
+
+    fread(pu8Virt, 1, stride*h, fp);
+
+    fclose(fp);
+
+    return 0;
+}
+
+static HI_VOID circumrotate (HI_U32 u32CurOnShow)
+{
+    TDE_HANDLE s32Handle;
+    TDE2_OPT_S stOpt = {0};
+    HI_FLOAT eXMid, eYMid;
+    HI_FLOAT eRadius;
+    HI_U32 i;
+    HI_FLOAT f;
+    HI_U32 u32NextOnShow;
+    TDE2_RECT_S stSrcRect;
+    TDE2_RECT_S stDstRect;
+	HI_S32 s32Ret = HI_SUCCESS;
+
+    u32NextOnShow = !u32CurOnShow;
+
+    stOpt.enOutAlphaFrom = TDE2_OUTALPHA_FROM_FOREGROUND;
+    stOpt.enColorKeyMode = TDE2_COLORKEY_MODE_FOREGROUND;
+    stOpt.unColorKeyValue.struCkARGB.stAlpha.bCompIgnore = HI_TRUE;
+    
+    f = (float) (g_s32FrameNum % CYCLE_LEN) / CYCLE_LEN;
+
+    stSrcRect.s32Xpos = 0;
+    stSrcRect.s32Ypos = 0;
+    stSrcRect.u32Width = g_stBackGround.u32Width;
+    stSrcRect.u32Height = g_stBackGround.u32Height;
+
+    eXMid = g_stBackGround.u32Width/2.16f;
+    eYMid = g_stBackGround.u32Height/2.304f;
+
+    eRadius = MIN (eXMid, eYMid) / 2.0f;
+
+    /* 1. start job */
+    s32Handle = HI_TDE2_BeginJob();
+    if(HI_ERR_TDE_INVALID_HANDLE == s32Handle)
+    {
+        TDE_PRINT("start job failed!\n");
+        return ;
+    }
+
+    /* 2. bitblt background to screen */
+    s32Ret = HI_TDE2_QuickCopy(s32Handle, &g_stBackGround, &stSrcRect, 
+        &g_stScreen[u32NextOnShow], &stSrcRect);
+    if(s32Ret < 0)
+	{
+        TDE_PRINT("Line:%d failed,ret=0x%x!\n", __LINE__, s32Ret);
+		HI_TDE2_CancelJob(s32Handle);
+        return ;
+	}
+    
+    for(i = 0; i < N_IMAGES; i++)
+    {
+        HI_FLOAT ang;
+        HI_FLOAT r;
+
+        stSrcRect.s32Xpos = 0;
+        stSrcRect.s32Ypos = 0;
+        stSrcRect.u32Width = g_stImgSur[i].u32Width;
+        stSrcRect.u32Height = g_stImgSur[i].u32Height;
+
+        /* 3. calculate new pisition */
+        ang = 2.0f * (HI_FLOAT) M_PI * (HI_FLOAT) i / N_IMAGES - f * 2.0f * (HI_FLOAT) M_PI;
+        r = eRadius + (eRadius / 3.0f) * sinf (f * 2.0 * M_PI);
+
+        stDstRect.s32Xpos = eXMid + r * cosf (ang) - g_stImgSur[i].u32Width / 2.0f;;
+        stDstRect.s32Ypos = eYMid + r * sinf (ang) - g_stImgSur[i].u32Height / 2.0f;
+        stDstRect.u32Width = g_stImgSur[i].u32Width;
+        stDstRect.u32Height = g_stImgSur[i].u32Height;
+
+        /* 4. bitblt image to screen */
+        s32Ret = HI_TDE2_Bitblit(s32Handle, &g_stScreen[u32NextOnShow], &stDstRect, 
+            &g_stImgSur[i], &stSrcRect, &g_stScreen[u32NextOnShow], &stDstRect, &stOpt);
+		if(s32Ret < 0)
+		{
+			TDE_PRINT("Line:%d,HI_TDE2_Bitblit failed,ret=0x%x!\n", __LINE__, s32Ret);
+			HI_TDE2_CancelJob(s32Handle);
+			return ;
+		}
+    }
+
+    /* 5. submit job */
+    s32Ret = HI_TDE2_EndJob(s32Handle, HI_FALSE, HI_TRUE, 10);
+	if(s32Ret < 0)
+	{
+		TDE_PRINT("Line:%d,HI_TDE2_EndJob failed,ret=0x%x!\n", __LINE__, s32Ret);
+		HI_TDE2_CancelJob(s32Handle);
+		return ;
+	}
+
+    g_s32FrameNum++;
+    return;
+}
+
+HI_S32 TDE_DrawGraphicSample()
+{
+    HI_U32 u32Size;
+    HI_S32 s32Fd;
+    HI_U32 u32Times;
+    HI_U8* pu8Screen;
+    HI_U8* pu8BackGroundVir;
+
+    HI_U32 u32PhyAddr;
+    HI_S32 s32Ret = -1;
+    HI_U32 i = 0;
+    HI_BOOL bShow,bCompress;
+    HIFB_ALPHA_S stAlpha = {0};
+
+    struct fb_fix_screeninfo stFixInfo;
+    struct fb_var_screeninfo stVarInfo;
+    struct fb_bitfield stR32 = {10, 5, 0};
+    struct fb_bitfield stG32 = {5, 5, 0};
+    struct fb_bitfield stB32 = {0, 5, 0};
+    struct fb_bitfield stA32 = {15, 1, 0};
+
+    /* 1. open tde device */
+    HI_TDE2_Open();
+
+    /* 2. framebuffer operation */
+    s32Fd = open("/dev/fb0", O_RDWR);
+    if (s32Fd == -1)
+    {
+        printf("open frame buffer device error\n");
+        goto FB_OPEN_ERROR;
+    }
+
+	bCompress = HI_FALSE ;
+	if (ioctl(s32Fd, FBIOPUT_COMPRESSION_HIFB, &bCompress) < 0)
+	{
+		printf(" FBIOPUT_COMPRESSION_HIFB failed!\n");
+		close(s32Fd);
+		goto FB_PROCESS_ERROR2;
+	}
+    stAlpha.bAlphaChannel = HI_FALSE;
+    stAlpha.bAlphaEnable = HI_FALSE;
+    if (ioctl(s32Fd, FBIOPUT_ALPHA_HIFB, &stAlpha) < 0)
+    {
+   	    printf("Put alpha info failed!\n");
+        goto FB_PROCESS_ERROR0;
+    }
+
+	/* get the variable screen info */
+    if (ioctl(s32Fd, FBIOGET_VSCREENINFO, &stVarInfo) < 0)
+    {
+   	    printf("Get variable screen info failed!\n");
+        goto FB_PROCESS_ERROR0;
+    }
+	
+    stVarInfo.xres_virtual	 	= SCREEN_WIDTH;
+    stVarInfo.yres_virtual		= SCREEN_HEIGHT*2;
+    stVarInfo.xres      		= SCREEN_WIDTH;
+    stVarInfo.yres      		= SCREEN_HEIGHT;
+    stVarInfo.activate  		= FB_ACTIVATE_NOW;
+    stVarInfo.bits_per_pixel	= 16;
+    stVarInfo.xoffset = 0;
+    stVarInfo.yoffset = 0;
+    stVarInfo.red   = stR32;
+    stVarInfo.green = stG32;
+    stVarInfo.blue  = stB32;
+    stVarInfo.transp = stA32;
+
+    if (ioctl(s32Fd, FBIOPUT_VSCREENINFO, &stVarInfo) < 0)
+    {
+        printf("process frame buffer device error\n");
+        goto FB_PROCESS_ERROR0;
+    }
+
+    if (ioctl(s32Fd, FBIOGET_FSCREENINFO, &stFixInfo) < 0)
+    {
+        printf("process frame buffer device error\n");
+        goto FB_PROCESS_ERROR0;
+    }
+    
+    u32Size 	= stFixInfo.smem_len;
+    u32PhyAddr  = stFixInfo.smem_start;
+    pu8Screen   = mmap(NULL, u32Size, PROT_READ|PROT_WRITE, MAP_SHARED, s32Fd, 0);
+    if (NULL == pu8Screen)
+    {
+        printf("mmap fb0 failed!\n");
+        goto FB_PROCESS_ERROR0;
+    }
+    memset(pu8Screen, 0x00, stFixInfo.smem_len);
+
+    /* 3. create surface */
+    g_stScreen[0].enColorFmt = PIXFMT;
+    g_stScreen[0].u32PhyAddr = u32PhyAddr;
+    g_stScreen[0].u32Width = SCREEN_WIDTH;
+    g_stScreen[0].u32Height = SCREEN_HEIGHT;
+    g_stScreen[0].u32Stride = stFixInfo.line_length;
+    g_stScreen[0].bAlphaMax255 = HI_TRUE;
+	
+    g_stScreen[1] = g_stScreen[0];
+    g_stScreen[1].u32PhyAddr = g_stScreen[0].u32PhyAddr + g_stScreen[0].u32Stride * g_stScreen[0].u32Height;
+
+    /* allocate memory (720*576*2*N_IMAGES bytes) to save Images' infornation */
+    if (HI_FAILURE == HI_MPI_SYS_MmzAlloc(&(g_stBackGround.u32PhyAddr), ((void**)&pu8BackGroundVir), 
+            NULL, NULL, 720*576*2*N_IMAGES))
+    {
+        TDE_PRINT("allocate memory (720*576*2*N_IMAGES bytes) failed\n");
+        goto FB_PROCESS_ERROR1;
+    }
+    
+    TDE_CreateSurfaceByFile(BACKGROUND_NAME, &g_stBackGround, pu8BackGroundVir);
+
+    g_stImgSur[0].u32PhyAddr = g_stBackGround.u32PhyAddr + g_stBackGround.u32Stride * g_stBackGround.u32Height;
+    for(i = 0; i < N_IMAGES - 1; i++)
+    {
+      TDE_CreateSurfaceByFile(pszImageNames[i], &g_stImgSur[i], 
+            pu8BackGroundVir + ((HI_U32)g_stImgSur[i].u32PhyAddr - g_stBackGround.u32PhyAddr));
+      g_stImgSur[i+1].u32PhyAddr = g_stImgSur[i].u32PhyAddr + g_stImgSur[i].u32Stride * g_stImgSur[i].u32Height;
+    }
+    TDE_CreateSurfaceByFile(pszImageNames[i], &g_stImgSur[i], 
+            pu8BackGroundVir + ((HI_U32)g_stImgSur[i].u32PhyAddr - g_stBackGround.u32PhyAddr));
+
+    bShow = HI_TRUE;
+    if (ioctl(s32Fd, FBIOPUT_SHOW_HIFB, &bShow) < 0)
+    {
+        fprintf (stderr, "Couldn't show fb\n");
+        goto FB_PROCESS_ERROR2;
+    }
+
+    g_s32FrameNum = 0;
+
+    /* 3. use tde and framebuffer to realize rotational effect */
+    for (u32Times = 0; u32Times < 20; u32Times++)
+    {         
+        circumrotate(u32Times%2);
+        stVarInfo.yoffset = (u32Times%2)?0:576;
+
+        /*set frame buffer start position*/
+        if (ioctl(s32Fd, FBIOPAN_DISPLAY, &stVarInfo) < 0)
+        {
+            TDE_PRINT("process frame buffer device error\n");
+            goto FB_PROCESS_ERROR2;
+        }
+        sleep(1);
+    }
+
+    s32Ret = 0;
+    
+FB_PROCESS_ERROR2:    
+    HI_MPI_SYS_MmzFree(g_stBackGround.u32PhyAddr, pu8BackGroundVir);
+FB_PROCESS_ERROR1:
+    munmap(pu8Screen, u32Size);
+FB_PROCESS_ERROR0:
+    close(s32Fd);
+FB_OPEN_ERROR:
+    HI_TDE2_Close();
+
+    return s32Ret;
+}
+
+/*****************************************************************************
+description: 	this sample shows how to use TDE interface to draw graphic.
+                
+note	   :    for showing graphic layer, VO device should be enabled first.
+				This sample draws graphic on layer G0 which belongs to HD VO device.
+				(here we insmod HiFB.ko like 'insmod hifb.ko video="hifb:vram0_size=XXX" '
+				 so opening hifb sub-device '/dev/fb0' means to opening G0,
+				 and G0 was fixed binded to HD VO device in Hi3520)
+*****************************************************************************/
+int main()
+{
+	HI_S32 s32Ret = 0;
+	VO_PUB_ATTR_S stPubAttr;
+	VB_CONF_S stVbConf;
+
+	stPubAttr.u32BgColor = 0x000000ff;
+#ifdef HI_FPGA 
+    stPubAttr.enIntfType = VO_INTF_BT1120|VO_INTF_VGA;
+#else
+    stPubAttr.enIntfType = VO_INTF_VGA;
+#endif
+    stPubAttr.enIntfSync = VO_OUTPUT_720P50;
+	stPubAttr.bDoubleFrame = HI_FALSE;
+
+	memset(&stVbConf, 0, sizeof(VB_CONF_S));
+    stVbConf.u32MaxPoolCnt             = 16;
+	/*no need common video buffer!*/	
+	
+    /*1 enable Vo device HD first*/
+	if(HI_SUCCESS != SAMPLE_COMM_SYS_Init(&stVbConf))
+	{
+		return -1;
+	}
+	if(HI_SUCCESS != SAMPLE_COMM_VO_StartDevLayer(VoDev, &stPubAttr,25))
+	{
+		SAMPLE_COMM_SYS_Exit();
+		return -1;
+	}
+
+    /* if it's displayed on HDMI, we should start HDMI */
+    if (stPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stPubAttr.enIntfSync))
+        {
+            goto err;
+        }
+    }
+	
+	/*2 run tde sample which draw grahpic on HiFB memory*/
+	s32Ret = TDE_DrawGraphicSample();
+	if(s32Ret != HI_SUCCESS)
+	{
+		goto err;
+	}
+
+err:
+    if (stPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+         SAMPLE_COMM_VO_HdmiStop();
+    }
+	SAMPLE_COMM_VO_StopDevLayer(VoDev);
+	SAMPLE_COMM_SYS_Exit();
+
+	return 0;
+}		
+
+

--- a/libraries/mpp_sample/hi3520dv200/tde/sample_tde_colorkey.c
+++ b/libraries/mpp_sample/hi3520dv200/tde/sample_tde_colorkey.c
@@ -1,0 +1,328 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#include <sys/ioctl.h>
+#include <linux/fb.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "hi_tde_api.h"
+#include "hi_tde_type.h"
+#include "hi_tde_errcode.h"
+#include "hifb.h"
+
+#include "hi_comm_vo.h"
+#include "mpi_sys.h"
+
+#include "mpi_vo.h"
+#include "sample_comm.h"
+
+
+#define TDE_PRINT printf
+
+#define VoDev 0
+#define VoChn 0
+
+
+#define MIN(x,y) ((x) > (y) ? (y) : (x))
+#define MAX(x,y) ((x) > (y) ? (x) : (y))
+
+static const HI_CHAR *pszImageNames =
+{
+    "res1/ARGB1555_r+b.bits", 
+};
+
+#define BACKGROUND_NAME  "res1/background.bits"
+
+#define PIXFMT  TDE2_COLOR_FMT_ARGB1555
+#define BPP     2
+#define SCREEN_WIDTH    720
+#define SCREEN_HEIGHT   576
+
+static TDE2_SURFACE_S g_stScreen;
+static TDE2_SURFACE_S g_stBackGround;
+static TDE2_SURFACE_S g_stImgSur;
+
+static HI_S32 TDE_CreateSurfaceByFile(const HI_CHAR *pszFileName, TDE2_SURFACE_S *pstSurface, HI_U8 *pu8Virt)
+{
+    FILE *fp;
+    HI_U32 colorfmt, w, h, stride;
+
+    if((NULL == pszFileName) || (NULL == pstSurface))
+    {
+        printf("%s, LINE %d, NULL ptr!\n", __FUNCTION__, __LINE__);
+        return -1;
+    }
+
+    fp = fopen(pszFileName, "rb");
+    if(NULL == fp)
+    {
+        printf("error when open pszFileName %s, line:%d\n", pszFileName, __LINE__);
+        return -1;
+    }
+
+    fread(&colorfmt, 1, 4, fp);
+    fread(&w, 1, 4, fp);
+    fread(&h, 1, 4, fp);
+    fread(&stride, 1, 4, fp);
+
+    pstSurface->enColorFmt = colorfmt;
+    pstSurface->u32Width = w;
+    pstSurface->u32Height = h;
+    pstSurface->u32Stride = stride;
+    pstSurface->u8Alpha0 = 0x0;
+    pstSurface->u8Alpha1 = 0xff;
+    pstSurface->bAlphaMax255 = HI_TRUE;
+    pstSurface->bAlphaExt1555 = HI_TRUE;
+
+    fread(pu8Virt, 1, stride*h, fp);
+
+    fclose(fp);
+
+    return 0;
+}
+
+
+HI_S32 TDE_DrawGraphicSample()
+{
+    HI_U32 u32Size;
+    HI_S32 s32Fd;
+    HI_U8* pu8BackGroundVir;
+    HI_U32 u32PhyAddr;
+    HI_S32 s32Ret = -1;
+    HI_BOOL bShow,bCompress;
+    HIFB_ALPHA_S stAlpha = {0};
+    struct fb_fix_screeninfo stFixInfo;
+    struct fb_var_screeninfo stVarInfo;
+    struct fb_bitfield stR32 = {10, 5, 0};
+    struct fb_bitfield stG32 = {5, 5, 0};
+    struct fb_bitfield stB32 = {0, 5, 0};
+    struct fb_bitfield stA32 = {15, 1, 0};
+	TDE_HANDLE s32Handle;
+	TDE2_OPT_S stOpt = {0};
+	TDE2_RECT_S stSrcRect;
+	TDE2_RECT_S stDstRect;
+
+    /* 1. open tde device */
+    HI_TDE2_Open();
+
+    /* 2. framebuffer operation */
+    s32Fd = open("/dev/fb0", O_RDWR);
+    if (s32Fd == -1)
+    {
+        printf("open frame buffer device error\n");
+        goto FB_OPEN_ERROR;
+    }  
+
+	bCompress = HI_FALSE ;
+	if (ioctl(s32Fd, FBIOPUT_COMPRESSION_HIFB, &bCompress) < 0)
+	{
+		printf(" FBIOPUT_COMPRESSION_HIFB failed!\n");
+		close(s32Fd);
+		goto FB_PROCESS_ERROR0;
+	}
+    stAlpha.bAlphaChannel = HI_FALSE;
+    stAlpha.bAlphaEnable = HI_FALSE;
+    if (ioctl(s32Fd, FBIOPUT_ALPHA_HIFB, &stAlpha) < 0)
+    {
+   	    printf("Put alpha info failed!\n");
+        goto FB_PROCESS_ERROR0;
+    }
+    
+	/* get the variable screen info */
+    if (ioctl(s32Fd, FBIOGET_VSCREENINFO, &stVarInfo) < 0)
+    {
+   	    printf("Get variable screen info failed!\n");
+        goto FB_PROCESS_ERROR0;
+    }
+    stVarInfo.xres_virtual	 	= SCREEN_WIDTH;
+    stVarInfo.yres_virtual		= SCREEN_HEIGHT*2;
+    stVarInfo.xres      		= SCREEN_WIDTH;
+    stVarInfo.yres      		= SCREEN_HEIGHT;
+    stVarInfo.activate  		= FB_ACTIVATE_NOW;
+    stVarInfo.bits_per_pixel	= 16;
+    stVarInfo.xoffset = 0;
+    stVarInfo.yoffset = 0;
+    stVarInfo.red   = stR32;
+    stVarInfo.green = stG32;
+    stVarInfo.blue  = stB32;
+    stVarInfo.transp = stA32;
+
+    if (ioctl(s32Fd, FBIOPUT_VSCREENINFO, &stVarInfo) < 0)
+    {
+        printf("process frame buffer device error\n");
+        goto FB_PROCESS_ERROR0;
+    }
+
+    if (ioctl(s32Fd, FBIOGET_FSCREENINFO, &stFixInfo) < 0)
+    {
+        printf("process frame buffer device error\n");
+        goto FB_PROCESS_ERROR0;
+    }
+    u32Size 	= stFixInfo.smem_len;
+    u32PhyAddr  = stFixInfo.smem_start;
+ 
+    /* 3. create surface */
+    g_stScreen.enColorFmt = PIXFMT;
+    g_stScreen.u32PhyAddr = u32PhyAddr;
+    g_stScreen.u32Width = SCREEN_WIDTH;
+    g_stScreen.u32Height = SCREEN_HEIGHT;
+    g_stScreen.u32Stride = stFixInfo.line_length;
+    g_stScreen.bAlphaMax255 = HI_TRUE;
+
+    /* allocate memory (720*576*2*N_IMAGES bytes) to save Images' infornation */
+    if (HI_FAILURE == HI_MPI_SYS_MmzAlloc(&(g_stBackGround.u32PhyAddr), ((void**)&pu8BackGroundVir), 
+            NULL, NULL, 720*576*4))
+    {
+        TDE_PRINT("allocate memory (720*576*2*N_IMAGES bytes) failed\n");
+        goto FB_PROCESS_ERROR0;
+    }
+    
+   TDE_CreateSurfaceByFile(BACKGROUND_NAME, &g_stBackGround, pu8BackGroundVir);
+   g_stImgSur.u32PhyAddr = g_stBackGround.u32PhyAddr + g_stBackGround.u32Stride * g_stBackGround.u32Height;
+   TDE_CreateSurfaceByFile(pszImageNames, &g_stImgSur, 
+							pu8BackGroundVir + ((HI_U32)g_stImgSur.u32PhyAddr - g_stBackGround.u32PhyAddr));    
+	bShow = HI_TRUE;
+	if (ioctl(s32Fd, FBIOPUT_SHOW_HIFB, &bShow) < 0)
+	{
+		fprintf (stderr, "Couldn't show fb\n");
+		goto FB_PROCESS_ERROR1;
+	} 
+
+	stSrcRect.s32Xpos = 0;
+	stSrcRect.s32Ypos = 0;
+	stSrcRect.u32Width = g_stBackGround.u32Width;
+	stSrcRect.u32Height = g_stBackGround.u32Height;
+
+	/* 1. start job */
+	s32Handle = HI_TDE2_BeginJob();
+	if(HI_ERR_TDE_INVALID_HANDLE == s32Handle)
+	{
+		TDE_PRINT("start job failed!\n");
+		goto FB_PROCESS_ERROR1;
+	}
+
+    /* 2.qiuckcopy background to screen */
+    s32Ret = HI_TDE2_QuickCopy(s32Handle, &g_stBackGround, &stSrcRect, 
+        &g_stScreen, &stSrcRect);
+    if(s32Ret < 0)
+	{
+        TDE_PRINT("Line:%d failed,ret=0x%x!\n", __LINE__, s32Ret);
+		HI_TDE2_CancelJob(s32Handle);
+        goto FB_PROCESS_ERROR1;
+	}
+	stOpt.enColorKeyMode = TDE2_COLORKEY_MODE_FOREGROUND;
+	stOpt.enOutAlphaFrom = TDE2_OUTALPHA_FROM_FOREGROUND;
+    stOpt.unColorKeyValue.struCkARGB.stBlue.bCompIgnore = HI_FALSE;
+    stOpt.unColorKeyValue.struCkARGB.stBlue.bCompOut = HI_FALSE;
+    stOpt.unColorKeyValue.struCkARGB.stBlue.u8CompMin = 0xff;
+    stOpt.unColorKeyValue.struCkARGB.stBlue.u8CompMax = 0xff;
+    stOpt.unColorKeyValue.struCkARGB.stBlue.u8CompMask = 0xff;
+
+    stOpt.unColorKeyValue.struCkARGB.stGreen.bCompIgnore = HI_TRUE;
+    stOpt.unColorKeyValue.struCkARGB.stRed.bCompIgnore = HI_TRUE;    
+    stOpt.unColorKeyValue.struCkARGB.stAlpha.bCompIgnore = HI_TRUE;
+	
+    stSrcRect.s32Xpos = 0;
+    stSrcRect.s32Ypos = 0;
+    stSrcRect.u32Width = g_stImgSur.u32Width;
+    stSrcRect.u32Height = g_stImgSur.u32Height;
+
+    stDstRect.s32Xpos = 100;
+    stDstRect.s32Ypos = 100;
+    stDstRect.u32Width = g_stImgSur.u32Width;
+    stDstRect.u32Height = g_stImgSur.u32Height;
+
+    /* 4. bitblt image to screen */
+    s32Ret = HI_TDE2_Bitblit(s32Handle, &g_stScreen, &stDstRect, 
+        &g_stImgSur, &stSrcRect, &g_stScreen, &stDstRect, &stOpt);
+	if(s32Ret < 0)
+	{
+		TDE_PRINT("Line:%d,HI_TDE2_Bitblit failed,ret=0x%x!\n", __LINE__, s32Ret);
+		HI_TDE2_CancelJob(s32Handle);
+		goto FB_PROCESS_ERROR1;
+	}
+    /* 5. submit job */
+    s32Ret = HI_TDE2_EndJob(s32Handle, HI_FALSE, HI_TRUE, 10);
+	if(s32Ret < 0)
+	{
+		TDE_PRINT("Line:%d,HI_TDE2_EndJob failed,ret=0x%x!\n", __LINE__, s32Ret);
+		HI_TDE2_CancelJob(s32Handle);
+		goto FB_PROCESS_ERROR1;
+	}
+   /*set frame buffer start position*/
+	if (ioctl(s32Fd, FBIOPAN_DISPLAY, &stVarInfo) < 0)
+	{
+		TDE_PRINT("process frame buffer device error\n");
+		goto FB_PROCESS_ERROR1;
+	}
+	sleep(10);
+	s32Ret = 0;
+FB_PROCESS_ERROR1:    
+    HI_MPI_SYS_MmzFree(g_stBackGround.u32PhyAddr, pu8BackGroundVir);
+FB_PROCESS_ERROR0:
+    close(s32Fd);
+FB_OPEN_ERROR:
+    HI_TDE2_Close();
+
+    return s32Ret;
+}
+
+/*****************************************************************************
+description: 	this sample shows how to use TDE interface to draw graphic.
+                
+note	   :    for showing graphic layer, VO device should be enabled first.
+				This sample draws graphic on layer G0 which belongs to HD VO device.
+				(here we insmod HiFB.ko like 'insmod hifb.ko video="hifb:vram0_size=XXX" '
+				 so opening hifb sub-device '/dev/fb0' means to opening G0,
+				 and G0 was fixed binded to HD VO device in Hi3531)
+*****************************************************************************/
+int main()
+{
+	HI_S32 s32Ret = 0;
+	VO_PUB_ATTR_S stPubAttr;
+	VB_CONF_S stVbConf;
+
+	stPubAttr.u32BgColor = 0x000000ff;
+#ifdef HI_FPGA 
+	stPubAttr.enIntfType = VO_INTF_BT1120|VO_INTF_VGA;
+#else
+    stPubAttr.enIntfType = VO_INTF_VGA;
+#endif
+    stPubAttr.enIntfSync = VO_OUTPUT_720P50;
+	stPubAttr.bDoubleFrame = HI_FALSE;
+
+	memset(&stVbConf, 0, sizeof(VB_CONF_S));
+    stVbConf.u32MaxPoolCnt             = 16;
+	stVbConf.astCommPool[0].u32BlkSize = 1280*720*2;
+	stVbConf.astCommPool[0].u32BlkCnt  = 16;	
+	
+    /*1 enable Vo device HD first*/
+	if(HI_SUCCESS != SAMPLE_COMM_SYS_Init(&stVbConf))
+	{
+		return -1;
+	}
+	if(HI_SUCCESS != SAMPLE_COMM_VO_StartDevLayer(VoDev, &stPubAttr, 25))
+	{
+		SAMPLE_COMM_SYS_Exit();
+		return -1;
+	}
+	
+	/*2 run tde sample which draw grahpic on HiFB memory*/
+	s32Ret = TDE_DrawGraphicSample();
+	if(s32Ret != HI_SUCCESS)
+	{
+		goto err;
+	}
+
+	err:
+	SAMPLE_COMM_VO_StopDevLayer(VoDev);
+	SAMPLE_COMM_SYS_Exit();
+
+	return 0;
+}		
+
+

--- a/libraries/mpp_sample/hi3520dv200/tde/sample_tde_colorkey1.c
+++ b/libraries/mpp_sample/hi3520dv200/tde/sample_tde_colorkey1.c
@@ -1,0 +1,334 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#include <sys/ioctl.h>
+#include <linux/fb.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "hi_tde_api.h"
+#include "hi_tde_type.h"
+#include "hi_tde_errcode.h"
+#include "hifb.h"
+
+#include "hi_comm_vo.h"
+#include "mpi_sys.h"
+
+#include "mpi_vo.h"
+#include "sample_comm.h"
+
+
+#define TDE_PRINT printf
+
+#define VoDev 0
+#define VoChn 0
+
+
+#define MIN(x,y) ((x) > (y) ? (y) : (x))
+#define MAX(x,y) ((x) > (y) ? (x) : (y))
+
+static const HI_CHAR *pszImageNames =
+{
+    "res1/ARGB1555_r+b.bits", 
+};
+
+#define BACKGROUND_NAME  "res1/background.bits"
+
+#define PIXFMT  TDE2_COLOR_FMT_ARGB1555
+#define BPP     2
+#define SCREEN_WIDTH    720
+#define SCREEN_HEIGHT   576
+
+static TDE2_SURFACE_S g_stScreen[2];
+static TDE2_SURFACE_S g_stImgSur;
+
+static HI_S32 TDE_CreateSurfaceByFile(const HI_CHAR *pszFileName, TDE2_SURFACE_S *pstSurface, HI_U8 *pu8Virt)
+{
+    FILE *fp;
+    HI_U32 colorfmt, w, h, stride;
+
+    if((NULL == pszFileName) || (NULL == pstSurface))
+    {
+        printf("%s, LINE %d, NULL ptr!\n", __FUNCTION__, __LINE__);
+        return -1;
+    }
+
+    fp = fopen(pszFileName, "rb");
+    if(NULL == fp)
+    {
+        printf("error when open pszFileName %s, line:%d\n", pszFileName, __LINE__);
+        return -1;
+    }
+
+    fread(&colorfmt, 1, 4, fp);
+    fread(&w, 1, 4, fp);
+    fread(&h, 1, 4, fp);
+    fread(&stride, 1, 4, fp);
+
+    pstSurface->enColorFmt = colorfmt;
+    pstSurface->u32Width = w;
+    pstSurface->u32Height = h;
+    pstSurface->u32Stride = stride;
+    pstSurface->u8Alpha0 = 0x0;
+    pstSurface->u8Alpha1 = 0xff;
+    pstSurface->bAlphaMax255 = HI_TRUE;
+    pstSurface->bAlphaExt1555 = HI_TRUE;
+
+    fread(pu8Virt, 1, stride*h, fp);
+
+    fclose(fp);
+
+    return 0;
+}
+
+static HI_VOID circumrotate (HI_U32 u32CurOnShow)
+{
+    TDE_HANDLE s32Handle;
+	TDE2_OPT_S stOpt = {0};
+	TDE2_RECT_S stSrcRect;
+	TDE2_RECT_S stDstRect;
+	HI_U32 u32NextOnShow;
+	u32NextOnShow = !u32CurOnShow;
+	HI_U32 s32Ret;
+	HI_U32 u32FillData = 0x8000;
+	TDE2_RECT_S pstScreenRect;
+	/* 1. start job */
+	s32Handle = HI_TDE2_BeginJob();
+	if(HI_ERR_TDE_INVALID_HANDLE == s32Handle)
+	{
+		TDE_PRINT("start job failed!\n");
+		return ;
+	}   
+	pstScreenRect.s32Xpos = 0;
+	pstScreenRect.s32Ypos = 0;
+	pstScreenRect.u32Width = SCREEN_WIDTH;
+	pstScreenRect.u32Height = SCREEN_HEIGHT;
+	
+	s32Ret = HI_TDE2_QuickFill(s32Handle, &g_stScreen[u32NextOnShow], &pstScreenRect, u32FillData);
+	if(s32Ret < 0)
+	{
+		TDE_PRINT("Line:%d,HI_TDE2_QuickFill failed,ret=0x%x!\n", __LINE__, s32Ret);
+		HI_TDE2_CancelJob(s32Handle);
+		return ;
+	}	
+	stOpt.enColorKeyMode = TDE2_COLORKEY_MODE_FOREGROUND;
+    stOpt.unColorKeyValue.struCkARGB.stBlue.bCompIgnore = HI_FALSE;
+    stOpt.unColorKeyValue.struCkARGB.stBlue.bCompOut = HI_FALSE;
+    stOpt.unColorKeyValue.struCkARGB.stBlue.u8CompMin = 0xff;
+    stOpt.unColorKeyValue.struCkARGB.stBlue.u8CompMax = 0xff;
+    stOpt.unColorKeyValue.struCkARGB.stBlue.u8CompMask = 0xff;
+
+    stOpt.unColorKeyValue.struCkARGB.stGreen.bCompIgnore = HI_TRUE;
+    stOpt.unColorKeyValue.struCkARGB.stRed.bCompIgnore = HI_TRUE;    
+    stOpt.unColorKeyValue.struCkARGB.stAlpha.bCompIgnore = HI_TRUE;
+	
+    stSrcRect.s32Xpos = 0;
+    stSrcRect.s32Ypos = 0;
+    stSrcRect.u32Width = g_stImgSur.u32Width;
+    stSrcRect.u32Height = g_stImgSur.u32Height;
+
+    stDstRect.s32Xpos = 100;
+    stDstRect.s32Ypos = 100;
+    stDstRect.u32Width = g_stImgSur.u32Width;
+    stDstRect.u32Height = g_stImgSur.u32Height;
+
+    /* 4. bitblt image to screen */
+    s32Ret = HI_TDE2_Bitblit(s32Handle, &g_stScreen[u32NextOnShow], &stDstRect, 
+        &g_stImgSur, &stSrcRect, &g_stScreen[u32NextOnShow], &stDstRect, &stOpt);
+	if(s32Ret < 0)
+	{
+		TDE_PRINT("Line:%d,HI_TDE2_Bitblit failed,ret=0x%x!\n", __LINE__, s32Ret);
+		HI_TDE2_CancelJob(s32Handle);
+		return ;
+	}
+    /* 5. submit job */
+    s32Ret = HI_TDE2_EndJob(s32Handle, HI_FALSE, HI_TRUE, 10);
+	if(s32Ret < 0)
+	{
+		TDE_PRINT("Line:%d,HI_TDE2_EndJob failed,ret=0x%x!\n", __LINE__, s32Ret);
+		HI_TDE2_CancelJob(s32Handle);
+		return ;
+	}
+
+    return;
+}
+
+HI_S32 TDE_DrawGraphicSample()
+{
+    HI_U32 u32Size;
+    HI_S32 s32Fd;
+    HI_U8* pu8BackGroundVir;
+    HI_U32 u32PhyAddr;
+    HI_S32 s32Ret = -1;
+    HI_BOOL bShow;
+	HI_U32 u32Times;
+    HIFB_ALPHA_S stAlpha = {0};
+    struct fb_fix_screeninfo stFixInfo;
+    struct fb_var_screeninfo stVarInfo;
+    struct fb_bitfield stR32 = {10, 5, 0};
+    struct fb_bitfield stG32 = {5, 5, 0};
+    struct fb_bitfield stB32 = {0, 5, 0};
+    struct fb_bitfield stA32 = {15, 1, 0};
+
+    /* 1. open tde device */
+    HI_TDE2_Open();
+
+    /* 2. framebuffer operation */
+    s32Fd = open("/dev/fb0", O_RDWR);
+    if (s32Fd == -1)
+    {
+        printf("open frame buffer device error\n");
+        goto FB_OPEN_ERROR;
+    }  
+	
+    stAlpha.bAlphaChannel = HI_FALSE;
+    stAlpha.bAlphaEnable = HI_TRUE;
+	stAlpha.u8Alpha0 = 0xFF;
+	stAlpha.u8Alpha1 = 0x0;
+    if (ioctl(s32Fd, FBIOPUT_ALPHA_HIFB, &stAlpha) < 0)
+    {
+    	 printf("Put alpha info failed!\n");
+         goto FB_PROCESS_ERROR1;
+    }
+    
+	/* get the variable screen info */
+    if (ioctl(s32Fd, FBIOGET_VSCREENINFO, &stVarInfo) < 0)
+    {
+   	    printf("Get variable screen info failed!\n");
+        goto FB_PROCESS_ERROR1;
+    }
+    stVarInfo.xres_virtual	 	= SCREEN_WIDTH;
+    stVarInfo.yres_virtual		= SCREEN_HEIGHT*2;
+    stVarInfo.xres      		= SCREEN_WIDTH;
+    stVarInfo.yres      		= SCREEN_HEIGHT;
+    stVarInfo.activate  		= FB_ACTIVATE_NOW;
+    stVarInfo.bits_per_pixel	= 16;
+    stVarInfo.red   = stR32;
+    stVarInfo.green = stG32;
+    stVarInfo.blue  = stB32;
+    stVarInfo.transp = stA32;
+
+    if (ioctl(s32Fd, FBIOPUT_VSCREENINFO, &stVarInfo) < 0)
+    {
+        printf("process frame buffer device error\n");
+        goto FB_PROCESS_ERROR1;
+    }
+
+    if (ioctl(s32Fd, FBIOGET_FSCREENINFO, &stFixInfo) < 0)
+    {
+        printf("process frame buffer device error\n");
+        goto FB_PROCESS_ERROR1;
+    }
+    u32Size 	= stFixInfo.smem_len;
+    u32PhyAddr  = stFixInfo.smem_start;
+
+    /* 3. create surface */
+    g_stScreen[0].enColorFmt = PIXFMT;
+    g_stScreen[0].u32PhyAddr = u32PhyAddr;
+    g_stScreen[0].u32Width = SCREEN_WIDTH;
+    g_stScreen[0].u32Height = SCREEN_HEIGHT;
+    g_stScreen[0].u32Stride = stFixInfo.line_length;
+    g_stScreen[0].bAlphaMax255 = HI_TRUE;
+	g_stScreen[0].u8Alpha0 = 0;
+	g_stScreen[0].u8Alpha1 = 0;
+	g_stScreen[1] = g_stScreen[0];
+	g_stScreen[1].u32PhyAddr = g_stScreen[0].u32PhyAddr + g_stScreen[0].u32Stride * g_stScreen[0].u32Height;
+
+    /* allocate memory (720*576*2 bytes) to save Image infornation */
+    if (HI_FAILURE == HI_MPI_SYS_MmzAlloc(&(g_stImgSur.u32PhyAddr), ((void**)&pu8BackGroundVir), 
+            NULL, NULL, 720*576*4))
+    {
+        TDE_PRINT("allocate memory (720*576*2*N_IMAGES bytes) failed\n");
+        goto FB_PROCESS_ERROR1;
+    }
+    
+    TDE_CreateSurfaceByFile(pszImageNames, &g_stImgSur, pu8BackGroundVir);    
+	bShow = HI_TRUE;
+	if (ioctl(s32Fd, FBIOPUT_SHOW_HIFB, &bShow) < 0)
+	{
+		fprintf (stderr, "Couldn't show fb\n");
+		goto FB_PROCESS_ERROR2;
+	} 
+	for (u32Times = 0; u32Times < 10; u32Times++)
+    {         
+        circumrotate(u32Times%2);
+        stVarInfo.yoffset = (u32Times%2)?0:576;
+
+        /*set frame buffer start position*/
+        if (ioctl(s32Fd, FBIOPAN_DISPLAY, &stVarInfo) < 0)
+        {
+            TDE_PRINT("process frame buffer device error\n");
+            goto FB_PROCESS_ERROR2;
+        }
+        sleep(1);
+    }
+	
+	s32Ret = 0;
+FB_PROCESS_ERROR2:    
+    HI_MPI_SYS_MmzFree(g_stImgSur.u32PhyAddr, pu8BackGroundVir);
+FB_PROCESS_ERROR1:
+    close(s32Fd); 
+FB_OPEN_ERROR:
+    HI_TDE2_Close();
+
+    return s32Ret;
+}
+
+/*****************************************************************************
+description: 	this sample shows how to use TDE interface to draw graphic.
+                
+note	   :    for showing graphic layer, VO device should be enabled first.
+				This sample draws graphic on layer G0 which belongs to HD VO device.
+				(here we insmod HiFB.ko like 'insmod hifb.ko video="hifb:vram0_size=XXX" '
+				 so opening hifb sub-device '/dev/fb0' means to opening G0,
+				 and G0 was fixed binded to HD VO device in Hi3531)
+*****************************************************************************/
+int main()
+{
+	HI_S32 s32Ret = 0;
+	VO_PUB_ATTR_S stPubAttr;
+	VB_CONF_S stVbConf;
+
+	stPubAttr.u32BgColor = 0x000000ff;
+#ifdef HI_FPGA
+	stPubAttr.enIntfType = VO_INTF_BT1120|VO_INTF_VGA;
+#else
+    stPubAttr.enIntfType = VO_INTF_VGA;
+#endif
+    stPubAttr.enIntfSync = VO_OUTPUT_720P50;
+	stPubAttr.bDoubleFrame = HI_FALSE;
+
+	memset(&stVbConf, 0, sizeof(VB_CONF_S));
+    stVbConf.u32MaxPoolCnt             = 16;
+	stVbConf.astCommPool[0].u32BlkSize = 1280*720*2;
+	stVbConf.astCommPool[0].u32BlkCnt  = 8;	
+	
+    /*1 enable Vo device HD first*/
+	if(HI_SUCCESS != SAMPLE_COMM_SYS_Init(&stVbConf))
+	{
+		return -1;
+	}
+	if(HI_SUCCESS != SAMPLE_COMM_VO_StartDevLayer(VoDev, &stPubAttr, 25))
+	{
+		SAMPLE_COMM_SYS_Exit();
+		return -1;
+	}
+	
+	/*2 run tde sample which draw grahpic on HiFB memory*/
+	s32Ret = TDE_DrawGraphicSample();
+	if(s32Ret != HI_SUCCESS)
+	{
+		goto err;
+	}
+
+err:
+	SAMPLE_COMM_VO_StopDevLayer(VoDev);
+	SAMPLE_COMM_SYS_Exit();
+
+	return 0;
+}		
+
+

--- a/libraries/mpp_sample/hi3520dv200/vda/Makefile
+++ b/libraries/mpp_sample/hi3520dv200/vda/Makefile
@@ -1,0 +1,33 @@
+# Hisilicon Hi3516 sample Makefile
+
+include ../Makefile.param
+#ifeq ($(SAMPLE_PARAM_FILE), )
+#     SAMPLE_PARAM_FILE:=../Makefile.param
+#     include $(SAMPLE_PARAM_FILE)
+#endif
+
+# target source
+SRC  := $(wildcard *.c) 
+OBJ  := $(SRC:%.c=%.o)
+
+TARGET := $(OBJ:%.o=%)
+.PHONY : clean all
+
+all: $(TARGET)
+
+MPI_LIBS := $(REL_LIB)/libmpi.a
+MPI_LIBS += $(REL_LIB)/libhdmi.a
+
+$(TARGET):%:%.o $(COMM_OBJ)
+	$(CC) $(CFLAGS) -lpthread -lm -o $@ $^ $(MPI_LIBS) $(AUDIO_LIBA) $(JPEGD_LIBA)
+
+clean:
+	@rm -f $(TARGET)
+	@rm -f $(OBJ)
+	@rm -f $(COMM_OBJ)
+
+cleanstream:
+	@rm -f *.h264
+	@rm -f *.jpg
+	@rm -f *.mjp
+	@rm -f *.mp4

--- a/libraries/mpp_sample/hi3520dv200/vda/sample_vda.c
+++ b/libraries/mpp_sample/hi3520dv200/vda/sample_vda.c
@@ -1,0 +1,519 @@
+/******************************************************************************
+  A simple program of Hisilicon HI3516 vda implementation.
+  the flow as follows:
+    1) init mpp system.
+    2) start vi( internal isp, ViDev 0, vichn0) and vo (HD)                  
+    3) vda md & od start & print information
+    4) stop vi vo and system.
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2012-12 Created
+******************************************************************************/
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <signal.h>
+
+#include "sample_comm.h"
+#include "loadbmp.h"
+
+VIDEO_NORM_E gs_enNorm = VIDEO_ENCODING_MODE_PAL;
+HI_U32    gs_u32ViFrmRate = 0;
+/******************************************************************************
+* function : to process abnormal case                                        
+******************************************************************************/
+void SAMPLE_VDA_HandleSig(HI_S32 signo)
+{
+    if (SIGINT == signo || SIGTSTP == signo)
+    {
+        SAMPLE_COMM_SYS_Exit();
+        printf("\033[0;31mprogram exit abnormally!\033[0;39m\n");
+    }
+
+    exit(0);
+}
+/******************************************************************************
+* function : show usage
+******************************************************************************/
+void SAMPLE_VDA_Usage(char *sPrgNm)
+{
+    printf("Usage : %s <index>\n", sPrgNm);
+    printf("index:\n");
+    printf("\t 0) VI:1*Cif MD+OD.\n");
+    printf("\t 1) VI:MixCap MD+OD. .\n");			
+    return;
+}
+
+/******************************************************************************
+* function      : main() 
+* Description : Vi/VO + VDA(MD&OD)
+*               DC -> VI-PortA ViChn0(1080p) -> VO HD
+*                              ViChn1(D1)    -> VdaChn0 MD
+*                                            -> VdaChn1 OD
+******************************************************************************/
+//int main(int argc, char *argv[])
+HI_S32 SAMPLE_Vda_Cif(HI_VOID)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    VI_CHN ViChn, ViChn_Md = 0, ViChn_Od = 0;
+    VDA_CHN VdaChn_Md = 0, VdaChn_Od = 1;
+    VB_CONF_S stVbConf ={0};	/* vb config define */
+    PIC_SIZE_E enSize_Md = PIC_CIF, enSize_Od = PIC_CIF; 	/* vda picture size */
+
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_D1;
+    HI_U32 u32ViChnCnt = 1;
+    
+    VO_DEV VoDev;
+    VO_CHN VoChn;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    SAMPLE_VO_MODE_E enVoMode;
+    
+    HI_S32 i;
+    HI_U32 u32BlkSize;
+    SIZE_S stSize;
+    HI_U32 u32WndNum;
+
+    /******************************************
+     step  1: init global  variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL== gs_enNorm)?25:30;
+    
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 10;
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END0;
+    }
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END0;
+    }
+#if 0    
+    /******************************************
+     step 5: start VO to preview
+    ******************************************/
+
+    VoDev = SAMPLE_VO_DEV_DSD0;
+    u32WndNum = 1;
+    enVoMode = VO_MODE_1MUX;
+    
+    stVoPubAttr.enIntfSync = VO_OUTPUT_PAL;
+    stVoPubAttr.enIntfType = VO_INTF_CVBS;
+    stVoPubAttr.u32BgColor = 0x000000ff;
+    stVoPubAttr.bDoubleFrame = HI_FALSE;
+#endif
+    /******************************************
+         step 4: start VO to preview
+    ******************************************/
+    VoDev = SAMPLE_VO_DEV_DHD0;
+    u32WndNum = 1;
+    enVoMode = VO_MODE_1MUX;
+
+    stVoPubAttr.enIntfSync = VO_OUTPUT_720P50;
+    stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA;
+    stVoPubAttr.u32BgColor = 0x000000ff;
+    stVoPubAttr.bDoubleFrame = HI_FALSE;
+
+    s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+        goto END0;
+    }
+    
+    s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+        goto END0;
+    }
+
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        ViChn = i;
+        s32Ret = SAMPLE_COMM_VO_BindVi(VoDev,VoChn,ViChn);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SAMPLE_COMM_VO_BindVi failed!\n");
+            goto END0;
+        }
+    }
+
+    /******************************************
+     step  5: VDA process
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, enSize_Md, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END0;
+    }
+    s32Ret = SAMPLE_COMM_VDA_MdStart(VdaChn_Md, ViChn_Md, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("VDA Md Start failed!\n");
+        goto END0;
+    }
+    
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, enSize_Od, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END0;
+    }
+    s32Ret = SAMPLE_COMM_VDA_OdStart(VdaChn_Od, ViChn_Od, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("VDA OD Start failed!\n");
+        goto END0;
+    }
+
+    printf("Press any key to stop!");
+    getchar();
+
+    SAMPLE_COMM_VDA_OdStop(VdaChn_Od, ViChn_Od);
+    SAMPLE_COMM_VDA_MdStop(VdaChn_Md, ViChn_Md);
+    /******************************************
+     step  6: stop vi vo & sys
+    ******************************************/
+    /******************************************
+     step 7: exit process
+    ******************************************/
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        SAMPLE_COMM_VO_UnBindVi(VoDev,VoChn);
+    }
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+    SAMPLE_COMM_VI_Stop(enViMode);
+END0:
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+
+/******************************************************************************
+* function      : main() 
+* Description : Vi/VO + VDA(MD&OD)
+*               DC -> VI-PortA ViChn0(1080p) -> VO HD
+*                              ViChn1(D1)    -> VdaChn0 MD
+*                                            -> VdaChn1 OD
+******************************************************************************/
+//int main(int argc, char *argv[])
+HI_S32 SAMPLE_Vda_MixCap(HI_VOID)
+{
+    HI_S32 s32Ret = HI_SUCCESS;
+    VI_CHN ViChn_Md = 0, ViChn_Od = 0;
+    VDA_CHN VdaChn_Md = 0, VdaChn_Od = 1;
+    VB_CONF_S stVbConf ={0};	/* vb config define */
+    PIC_SIZE_E enSize_Md = PIC_CIF, enSize_Od = PIC_CIF; 	/* vda picture size */
+
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_D1Cif;
+    HI_U32 u32ViChnCnt = 1;
+	
+    HI_S32 s32VpssGrpCnt = 16;
+    VPSS_GRP VpssGrp;
+    VPSS_GRP_ATTR_S stGrpAttr;
+	
+    VO_DEV VoDev;
+    VO_CHN VoChn;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    SAMPLE_VO_MODE_E enVoMode;
+    
+    HI_S32 i;
+    HI_U32 u32BlkSize;
+    SIZE_S stSize;
+    HI_U32 u32WndNum;
+
+    /******************************************
+     step  1: init global  variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL== gs_enNorm)?25:30;
+    
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 4;
+	
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_2CIF, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+    stVbConf.astCommPool[1].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 6;
+
+    /* hist buf*/
+    stVbConf.astCommPool[2].u32BlkSize = (196*4);
+    stVbConf.astCommPool[2].u32BlkCnt =  32;
+    memset(stVbConf.astCommPool[2].acMmzName,0,
+    sizeof(stVbConf.astCommPool[2].acMmzName));
+	
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_0;
+    }
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_MixCap_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_0;
+    }
+
+	/******************************************
+	step 4: start vpss and vi bind vpss
+	******************************************/
+	s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+	if (HI_SUCCESS != s32Ret)
+	{
+	   SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+	   goto END_1;
+	}
+
+	stGrpAttr.u32MaxW = 720;
+	stGrpAttr.u32MaxH = (VIDEO_ENCODING_MODE_PAL==gs_enNorm)?576:480;
+	stGrpAttr.bDrEn = HI_FALSE;
+	stGrpAttr.bDbEn = HI_FALSE;
+	stGrpAttr.bIeEn = HI_TRUE;
+	stGrpAttr.bNrEn = HI_TRUE;
+	stGrpAttr.bHistEn = HI_TRUE;
+	stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+	stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+	s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+	if (HI_SUCCESS != s32Ret)
+	{
+	   SAMPLE_PRT("Start Vpss failed!\n");
+	   goto END_1;
+	}
+	/*open pre-scale*/
+	s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_2CIF, &stSize);
+	if (HI_SUCCESS != s32Ret)
+	{
+	   SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+	   goto END_2;
+	}
+	for(i=0;i<s32VpssGrpCnt;i++)
+	{   
+	   s32Ret = SAMPLE_COMM_EnableVpssPreScale(i,stSize);
+	   if(HI_SUCCESS != s32Ret)
+	   {
+	   SAMPLE_PRT("HI_MPI_VPSS_SetPreScale failed!\n");
+	   goto END_2;
+	   }
+	}
+	   
+	s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+	   SAMPLE_PRT("Vi bind Vpss failed!\n");
+	   goto END_2;
+	}
+
+	/******************************************
+	step 5: start vo HD0(HDMI) 
+	******************************************/
+	printf("start vo HD0.\n");
+	VoDev = SAMPLE_VO_DEV_DHD0;
+	u32WndNum = 1;
+	enVoMode = VO_MODE_1MUX;
+
+	if(VIDEO_ENCODING_MODE_PAL == gs_enNorm)
+	{
+	   stVoPubAttr.enIntfSync = VO_OUTPUT_720P50;
+	}
+	else
+	{
+	   stVoPubAttr.enIntfSync = VO_OUTPUT_720P60;
+	}
+
+	stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA;
+
+	stVoPubAttr.u32BgColor = 0x000000ff;
+	stVoPubAttr.bDoubleFrame = HI_TRUE;
+
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+	   SAMPLE_PRT("Start SAMPLE_COMM_VO_StartDevLayer failed!\n");
+	   goto END_3;
+	}
+
+	s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+	   SAMPLE_PRT("Start SAMPLE_COMM_VO_StartChn failed!\n");
+	   goto END_3;
+	}
+
+	/* if it's displayed on HDMI, we should start HDMI */
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+	{
+	   if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+	   {
+		   SAMPLE_PRT("Start SAMPLE_COMM_VO_HdmiStart failed!\n");
+		   goto END_4;
+	   }
+	}
+
+	/*Only show the chn which vda bind*/
+	VoChn = 0;
+	VpssGrp = 0;
+
+	s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+	if (HI_SUCCESS != s32Ret)
+	{
+	   SAMPLE_PRT("Start VO failed!\n");
+	   goto END_4;
+	}
+
+    /******************************************
+     step  6: VDA process
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, enSize_Md, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_4;
+    }
+    s32Ret = SAMPLE_COMM_VDA_MdStart(VdaChn_Md, ViChn_Md, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("VDA Md Start failed!\n");
+        goto END_4;
+    }
+    
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, enSize_Od, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_4;
+    }
+    s32Ret = SAMPLE_COMM_VDA_OdStart(VdaChn_Od, ViChn_Od, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("VDA OD Start failed!\n");
+        goto END_4;
+    }
+
+    printf("Press any key to stop!");
+    getchar();
+
+    SAMPLE_COMM_VDA_OdStop(VdaChn_Od, ViChn_Od);
+    SAMPLE_COMM_VDA_MdStop(VdaChn_Md, ViChn_Md);
+    /******************************************
+     step  7: stop vi vo & sys
+    ******************************************/
+    /******************************************
+     step 8: exit process
+    ******************************************/
+END_4:
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        SAMPLE_COMM_VO_HdmiStop();
+    }
+    VoDev = SAMPLE_VO_DEV_DHD0;
+    u32WndNum = 16;
+    enVoMode = VO_MODE_16MUX;
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        VpssGrp = i;
+        SAMPLE_COMM_VO_UnBindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+    }
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);	
+END_3:
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_2:
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_1:
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_0:
+    SAMPLE_COMM_SYS_Exit();
+    return s32Ret;
+}
+
+/******************************************************************************
+* function    : main()
+* Description : video preview sample
+******************************************************************************/
+int main(int argc, char *argv[])
+{
+    HI_S32 s32Ret;
+
+    if ( (argc < 2) || (1 != strlen(argv[1])))
+    {
+        SAMPLE_VDA_Usage(argv[0]);
+        return HI_FAILURE;
+    }
+
+    signal(SIGINT, SAMPLE_VDA_HandleSig);
+    signal(SIGTERM, SAMPLE_VDA_HandleSig);
+
+    switch (*argv[1])
+    {
+        case '0':/* Cif MD + OD. */
+            s32Ret = SAMPLE_Vda_Cif();
+            break;
+        case '1':/* Mix Cap MD + OD */
+            s32Ret = SAMPLE_Vda_MixCap();
+            break;
+
+        default:
+            SAMPLE_VDA_Usage(argv[0]);
+            return HI_FAILURE;
+    }
+
+    if (HI_SUCCESS == s32Ret)
+        printf("program exit normally!\n");
+    else
+        printf("program exit abnormally!\n");
+    exit(s32Ret);
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */

--- a/libraries/mpp_sample/hi3520dv200/vdec/Makefile
+++ b/libraries/mpp_sample/hi3520dv200/vdec/Makefile
@@ -1,0 +1,33 @@
+# Hisilicon Hi3516 sample Makefile
+
+include ../Makefile.param
+#ifeq ($(SAMPLE_PARAM_FILE), )
+#     SAMPLE_PARAM_FILE:=../Makefile.param
+#     include $(SAMPLE_PARAM_FILE)
+#endif
+
+# target source
+SRC  := $(wildcard *.c) 
+OBJ  := $(SRC:%.c=%.o)
+
+TARGET := $(OBJ:%.o=%)
+.PHONY : clean all
+
+all: $(TARGET)
+
+MPI_LIBS := $(REL_LIB)/libmpi.a
+MPI_LIBS += $(REL_LIB)/libhdmi.a
+
+$(TARGET):%:%.o $(COMM_OBJ)
+	$(CC) $(CFLAGS) -lpthread -lm -o $@ $^ $(MPI_LIBS) $(AUDIO_LIBA) $(JPEGD_LIBA)
+
+clean:
+	@rm -f $(TARGET)
+	@rm -f $(OBJ)
+	@rm -f $(COMM_OBJ)
+
+cleanstream:
+#	@rm -f *.h264
+#	@rm -f *.jpg
+#	@rm -f *.mjp
+#	@rm -f *.mp4

--- a/libraries/mpp_sample/hi3520dv200/vdec/sample_vdec.c
+++ b/libraries/mpp_sample/hi3520dv200/vdec/sample_vdec.c
@@ -1,0 +1,1330 @@
+/******************************************************************************
+  A simple program of Hisilicon HI3531 video decode implementation.
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-12 Created
+******************************************************************************/
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+#include <assert.h>
+#include <time.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+#include <sys/mman.h>
+
+#include "sample_comm.h"
+
+#define SAMPLE_MAX_VDEC_CHN_CNT 8
+
+typedef struct sample_vdec_sendparam
+{
+    pthread_t Pid;
+    HI_BOOL bRun;
+    VDEC_CHN VdChn;    
+    PAYLOAD_TYPE_E enPayload;
+	HI_S32 s32MinBufSize;
+    VIDEO_MODE_E enVideoMode;
+}SAMPLE_VDEC_SENDPARAM_S;
+
+//HI_S32 gs_VoDevCnt = 4;
+VIDEO_NORM_E gs_enNorm = VIDEO_ENCODING_MODE_PAL;
+HI_U32 gs_u32ViFrmRate = 0;
+SAMPLE_VDEC_SENDPARAM_S gs_SendParam[SAMPLE_MAX_VDEC_CHN_CNT];
+HI_S32 gs_s32Cnt;
+
+    
+/******************************************************************************
+* function : send stream to vdec
+******************************************************************************/
+void* SAMPLE_VDEC_SendStream(void* p)
+{
+    VDEC_STREAM_S stStream;
+    SAMPLE_VDEC_SENDPARAM_S *pstSendParam;
+    char sFileName[50], sFilePostfix[20];
+    FILE* fp = NULL;
+    HI_S32 s32BlockMode = HI_IO_BLOCK;
+    HI_U8 *pu8Buf;
+    HI_U64 u64pts;
+    HI_S32 s32IntervalTime = 40000;
+    HI_S32 i, s32Ret, len, start;
+    HI_S32 s32UsedBytes, s32ReadLen;
+    HI_BOOL bFindStart, bFindEnd;    
+
+    start = 0;
+    u64pts= 0;
+    s32UsedBytes = 0;
+    pstSendParam = (SAMPLE_VDEC_SENDPARAM_S *)p;
+
+    /******************* open the stream file *****************/
+    SAMPLE_COMM_SYS_Payload2FilePostfix(pstSendParam->enPayload, sFilePostfix);
+    sprintf(sFileName, "stream_chn0%s", sFilePostfix);
+    fp = fopen(sFileName, "r");
+    if (HI_NULL == fp)
+    {
+        SAMPLE_PRT("can't open file %s in send stream thread:%d\n", sFileName,pstSendParam->VdChn);
+        return (HI_VOID *)(HI_FAILURE);
+    }
+    printf("open file [%s] ok in send stream thread:%d!\n", sFileName,pstSendParam->VdChn);
+
+
+    /******************* malloc the  stream buffer in user space *****************/
+    if(pstSendParam->s32MinBufSize!=0)
+    {
+        pu8Buf=malloc(pstSendParam->s32MinBufSize);
+        if(pu8Buf==NULL)
+        {
+            SAMPLE_PRT("can't alloc %d in send stream thread:%d\n",pstSendParam->s32MinBufSize,pstSendParam->VdChn);
+            fclose(fp);
+            return (HI_VOID *)(HI_FAILURE);
+        }
+    }
+    else
+    {
+        SAMPLE_PRT("none buffer to operate in send stream thread:%d\n",pstSendParam->VdChn);
+        return (HI_VOID *)(HI_FAILURE);
+    }
+
+    while (pstSendParam->bRun)
+    {
+        fseek(fp, s32UsedBytes, SEEK_SET);
+        s32ReadLen = fread(pu8Buf, 1, pstSendParam->s32MinBufSize, fp);
+        if (s32ReadLen<=0)
+        {
+             printf("file end.\n");
+             break;
+        }
+
+        /******************* cutting the stream for frame *****************/
+        if( (pstSendParam->enVideoMode==VIDEO_MODE_FRAME) && (pstSendParam->enPayload== PT_H264) )
+        {
+            bFindStart = HI_FALSE;  
+            bFindEnd   = HI_FALSE;  
+
+            for (i=0; i<s32ReadLen-8; i++)
+            {
+                int tmp = pu8Buf[i+3] & 0x1F;
+                if (  pu8Buf[i] == 0 && pu8Buf[i+1] == 0 && pu8Buf[i+2] == 1 && 
+                       (
+                           ((tmp == 5 || tmp == 1) && ((pu8Buf[i+4]&0x80) == 0x80)) ||
+                           (tmp == 20 && (pu8Buf[i+7]&0x80) == 0x80)
+                        )
+                   )            
+                {
+                    bFindStart = HI_TRUE;
+                    i += 8;
+                    break;
+                }
+            }
+
+            for (; i<s32ReadLen-8; i++)
+            {
+                int tmp = pu8Buf[i+3] & 0x1F;
+                if (  pu8Buf[i  ] == 0 && pu8Buf[i+1] == 0 && pu8Buf[i+2] == 1 && 
+                            (
+                                  tmp == 15 || tmp == 7 || tmp == 8 || tmp == 6 || 
+                                  ((tmp == 5 || tmp == 1) && ((pu8Buf[i+4]&0x80) == 0x80)) ||
+                                  (tmp == 20 && (pu8Buf[i+7]&0x80) == 0x80)
+                              )
+                   )                   
+                {					
+                    bFindEnd = HI_TRUE;
+                    break;
+                }
+            }			
+        
+            s32ReadLen = i;
+            if (bFindStart == HI_FALSE)
+            {
+                SAMPLE_PRT("can not find start code in send stream thread:%d\n",pstSendParam->VdChn);
+            }
+            else if (bFindEnd == HI_FALSE)
+            {
+                s32ReadLen = i+8;
+            }            
+        }
+        else if( (pstSendParam->enPayload== PT_JPEG) || (pstSendParam->enPayload == PT_MJPEG) )
+        {
+            bFindStart = HI_FALSE;  
+            bFindEnd   = HI_FALSE;                            
+            for (i=0; i<s32ReadLen-2; i++)
+            {
+                if (pu8Buf[i] == 0xFF && pu8Buf[i+1] == 0xD8) 
+                {  
+                    start = i;
+                    bFindStart = HI_TRUE;
+                    i = i + 2;
+                    break;
+                }  
+            }
+        
+            for (; i<s32ReadLen-4; i++)
+            {
+                if ((pu8Buf[i] == 0xFF) && (pu8Buf[i+1]& 0xF0) == 0xE0)
+                {   
+                     len = (pu8Buf[i+2]<<8) + pu8Buf[i+3];                    
+                     i += 1 + len;                  
+                }
+                else
+                {
+                    break;
+                }
+            }
+        
+            for (; i<s32ReadLen-2; i++)
+            {
+                if (pu8Buf[i] == 0xFF && pu8Buf[i+1] == 0xD8)
+                {
+                    bFindEnd = HI_TRUE;
+                    break;
+                } 
+            }
+          
+            s32ReadLen = i;
+            if (bFindStart == HI_FALSE)
+            {
+                printf("\033[0;31mALERT!!!,can not find start code in send stream thread:%d!!!\033[0;39m\n",
+                pstSendParam->VdChn);    
+            }
+            else if (bFindEnd == HI_FALSE)
+            {
+                s32ReadLen = i+2;
+            }            
+        }
+          
+         stStream.u64PTS  = u64pts;
+         stStream.pu8Addr = pu8Buf + start;
+         stStream.u32Len  = s32ReadLen;
+        if(pstSendParam->enVideoMode==VIDEO_MODE_FRAME)
+        {
+            u64pts+=40000;
+        }
+
+        /******************* send stream *****************/
+        if (s32BlockMode == HI_IO_BLOCK)
+        {
+            s32Ret=HI_MPI_VDEC_SendStream(pstSendParam->VdChn, &stStream, HI_IO_BLOCK);
+        }
+        else if (s32BlockMode == HI_IO_NOBLOCK)
+        {
+            s32Ret=HI_MPI_VDEC_SendStream(pstSendParam->VdChn, &stStream, HI_IO_NOBLOCK);
+        }
+        else 
+        {
+            s32Ret=HI_MPI_VDEC_SendStream_TimeOut(pstSendParam->VdChn, &stStream, 8000);
+        }
+
+        if (HI_SUCCESS == s32Ret)
+        { 
+            s32UsedBytes = s32UsedBytes +s32ReadLen + start;
+        }
+        else 
+        {
+            if (s32BlockMode != HI_IO_BLOCK)
+            {
+                SAMPLE_PRT("failret:%x\n",s32Ret);
+            }
+            usleep(s32IntervalTime);
+        }
+        usleep(20000);
+
+    }
+
+	printf("send steam thread %d return ...\n", pstSendParam->VdChn);
+	fflush(stdout);
+	if (pu8Buf != HI_NULL) 
+	{
+        free(pu8Buf);
+	}
+	fclose(fp);
+	return (HI_VOID *)HI_SUCCESS;
+}
+
+
+/******************************************************************************
+* function : create vdec chn
+******************************************************************************/
+static HI_S32 SAMPLE_VDEC_CreateVdecChn(HI_S32 s32ChnID, SIZE_S *pstSize, PAYLOAD_TYPE_E enType, VIDEO_MODE_E enVdecMode)
+{
+    VDEC_CHN_ATTR_S stAttr;
+    VDEC_PRTCL_PARAM_S stPrtclParam;
+    HI_S32 s32Ret;
+
+    memset(&stAttr, 0, sizeof(VDEC_CHN_ATTR_S));
+
+    stAttr.enType = enType;
+    stAttr.u32BufSize = pstSize->u32Height * pstSize->u32Width;//This item should larger than u32Width*u32Height*3/4
+    stAttr.u32Priority = 1;//此处必须大于0
+    stAttr.u32PicWidth = pstSize->u32Width;
+    stAttr.u32PicHeight = pstSize->u32Height;
+    
+    switch (enType)
+    {
+        case PT_H264:
+    	    stAttr.stVdecVideoAttr.u32RefFrameNum = 2;
+    	    stAttr.stVdecVideoAttr.enMode = enVdecMode;
+    	    stAttr.stVdecVideoAttr.s32SupportBFrame = 0;
+            break;
+        case PT_JPEG:
+            stAttr.stVdecJpegAttr.enMode = enVdecMode;
+            break;
+        case PT_MJPEG:
+            stAttr.stVdecJpegAttr.enMode = enVdecMode;
+            break;
+        default:
+            SAMPLE_PRT("err type \n");
+            return HI_FAILURE;
+    }
+
+    s32Ret = HI_MPI_VDEC_CreateChn(s32ChnID, &stAttr);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VDEC_CreateChn failed errno 0x%x \n", s32Ret);
+        return s32Ret;
+    }
+
+    s32Ret = HI_MPI_VDEC_GetPrtclParam(s32ChnID, &stPrtclParam);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VDEC_GetPrtclParam failed errno 0x%x \n", s32Ret);
+        return s32Ret;
+    }
+
+    stPrtclParam.s32MaxSpsNum = 21;
+    stPrtclParam.s32MaxPpsNum = 22;
+    stPrtclParam.s32MaxSliceNum = 100;
+    s32Ret = HI_MPI_VDEC_SetPrtclParam(s32ChnID, &stPrtclParam);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VDEC_SetPrtclParam failed errno 0x%x \n", s32Ret);
+        return s32Ret;
+    }
+
+    s32Ret = HI_MPI_VDEC_StartRecvStream(s32ChnID);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VDEC_StartRecvStream failed errno 0x%x \n", s32Ret);
+        return s32Ret;
+    }
+
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function : force to stop decoder and destroy channel.
+*            stream left in decoder will not be decoded.
+******************************************************************************/
+void SAMPLE_VDEC_ForceDestroyVdecChn(HI_S32 s32ChnID)
+{
+    HI_S32 s32Ret;
+
+    s32Ret = HI_MPI_VDEC_StopRecvStream(s32ChnID);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VDEC_StopRecvStream failed errno 0x%x \n", s32Ret);
+    }
+
+    s32Ret = HI_MPI_VDEC_DestroyChn(s32ChnID);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VDEC_DestroyChn failed errno 0x%x \n", s32Ret);
+    }
+}
+
+/******************************************************************************
+* function : wait for decoder finished and destroy channel.
+*            Stream left in decoder will be decoded.
+******************************************************************************/
+void SAMPLE_VDEC_WaitDestroyVdecChn(HI_S32 s32ChnID, VIDEO_MODE_E enVdecMode)
+{
+    HI_S32 s32Ret;
+    VDEC_CHN_STAT_S stStat;
+
+    memset(&stStat, 0, sizeof(VDEC_CHN_STAT_S));
+
+    s32Ret = HI_MPI_VDEC_StopRecvStream(s32ChnID);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_VDEC_StopRecvStream failed errno 0x%x \n", s32Ret);
+        return;
+    }
+
+    /*** wait destory ONLY used at frame mode! ***/
+    if (VIDEO_MODE_FRAME == enVdecMode)
+    {
+        while (1)
+        {
+            //printf("LeftPics:%d, LeftStreamFrames:%d\n", stStat.u32LeftPics,stStat.u32LeftStreamFrames);
+            usleep(40000);
+            s32Ret = HI_MPI_VDEC_Query(s32ChnID, &stStat);
+            if (s32Ret != HI_SUCCESS)
+            {
+                SAMPLE_PRT("HI_MPI_VDEC_Query failed errno 0x%x \n", s32Ret);
+                return;
+            }
+            if ((stStat.u32LeftPics == 0) && (stStat.u32LeftStreamFrames == 0))
+            {
+                printf("had no stream and pic left\n");
+                break;
+            }
+        }
+    }
+    s32Ret = HI_MPI_VDEC_DestroyChn(s32ChnID);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("HI_MPI_VDEC_DestroyChn failed errno 0x%x \n", s32Ret);
+        return;
+    }
+}
+
+/******************************************************************************
+* function : show usage
+******************************************************************************/
+void SAMPLE_VDEC_Usage(char *sPrgNm)
+{
+    printf("Usage : %s <index>\n", sPrgNm);
+    printf("index:\n");
+    printf("\t0) H264 -> VPSS -> VO(HD).\n");
+    printf("\t1) JPEG ->VPSS -> VO(HD).\n");
+    printf("\t2) MJPEG -> VO(SD).\n");
+    printf("\t3) H264 -> VPSS -> VO(HD PIP PAUSE STEP).\n");
+    return;
+}
+
+/******************************************************************************
+* function : to process abnormal case
+******************************************************************************/
+void SAMPLE_VDEC_HandleSig(HI_S32 signo)
+{
+    HI_S32 i;
+
+    if (SIGINT == signo || SIGTSTP == signo)
+    {
+        printf("SAMPLE_VDEC_HandleSig\n");
+        for (i=0; i<gs_s32Cnt; i++)
+        {
+            if (HI_FALSE != gs_SendParam[i].bRun)
+            {
+                gs_SendParam[i].bRun = HI_FALSE;
+                pthread_join(gs_SendParam[i].Pid, 0);
+            }
+            printf("join thread %d.\n", i);
+        }
+
+        SAMPLE_COMM_SYS_Exit();
+
+        printf("program exit abnormally!\n");    
+    }
+
+    exit(-1);
+}
+
+/******************************************************************************
+* function : vdec process
+*            vo is sd : vdec -> vo
+*            vo is hd : vdec -> vpss -> vo
+******************************************************************************/
+HI_S32 SAMPLE_VDEC_Process(PIC_SIZE_E enPicSize, PAYLOAD_TYPE_E enType, HI_S32 s32Cnt, VO_DEV VoDev)
+{
+    VDEC_CHN VdChn;
+    HI_S32 s32Ret;
+    SIZE_S stSize;
+    VB_CONF_S stVbConf;
+    HI_S32 i;
+    VPSS_GRP VpssGrp;
+    VIDEO_MODE_E enVdecMode;
+    HI_CHAR ch;
+
+    VO_CHN VoChn;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    SAMPLE_VO_MODE_E enVoMode;
+    HI_U32 u32WndNum, u32BlkSize;
+
+    HI_BOOL bVoHd; // through Vpss or not. if vo is SD, needn't through vpss
+ 
+    /******************************************
+     step 1: init varaible.
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL == gs_enNorm)?25:30;
+    
+    if (s32Cnt > SAMPLE_MAX_VDEC_CHN_CNT || s32Cnt <= 0)
+    {
+        SAMPLE_PRT("Vdec count %d err, should be in [%d,%d]. \n", s32Cnt, 1, SAMPLE_MAX_VDEC_CHN_CNT);
+        
+        return HI_FAILURE;
+    }
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, enPicSize, &stSize);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("get picture size failed!\n");
+        return HI_FAILURE;
+    }
+    if (704 == stSize.u32Width)
+    {
+        stSize.u32Width = 720;
+    }
+    else if (352 == stSize.u32Width)
+    {
+        stSize.u32Width = 360;
+    }
+    else if (176 == stSize.u32Width)
+    {
+        stSize.u32Width = 180;
+    }
+    
+    // through Vpss or not. if vo is SD, needn't through vpss
+    if (SAMPLE_VO_DEV_DHD0 != VoDev ) 
+    {
+        bVoHd = HI_FALSE;
+    }
+    else
+    {
+        bVoHd = HI_TRUE;
+    }
+    /******************************************
+     step 2: mpp system init.
+    ******************************************/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /* hist buf*/
+    stVbConf.astCommPool[0].u32BlkSize = (196*4);
+    stVbConf.astCommPool[0].u32BlkCnt = s32Cnt * 6;
+    memset(stVbConf.astCommPool[0].acMmzName,0,
+        sizeof(stVbConf.astCommPool[0].acMmzName));
+	
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("mpp init failed!\n");
+        return HI_FAILURE;
+    }
+  
+    /******************************************
+     step 3: start vpss, if ov is hd.
+    ******************************************/    
+    if (HI_TRUE == bVoHd)
+    {
+        s32Ret = SAMPLE_COMM_VPSS_Start(s32Cnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+        if (HI_SUCCESS !=s32Ret)
+        {
+            SAMPLE_PRT("vpss start failed!\n");
+            goto END_0;
+        }
+    }
+ 
+    /******************************************
+     step 4: start vo
+    ******************************************/
+    u32WndNum = 1;
+    enVoMode = VO_MODE_1MUX;
+
+    if (HI_TRUE == bVoHd)
+    {
+        if(VIDEO_ENCODING_MODE_PAL== gs_enNorm)
+        {
+            stVoPubAttr.enIntfSync = VO_OUTPUT_720P50;
+        }
+        else
+        {
+            stVoPubAttr.enIntfSync = VO_OUTPUT_720P60;
+        }
+        
+        stVoPubAttr.enIntfType = VO_INTF_VGA;
+        stVoPubAttr.u32BgColor = 0x000000ff;
+        stVoPubAttr.bDoubleFrame = HI_FALSE;
+    }
+    else
+    {
+        if(VIDEO_ENCODING_MODE_PAL== gs_enNorm)
+        {
+            stVoPubAttr.enIntfSync = VO_OUTPUT_PAL;
+        }
+        else
+        {
+            stVoPubAttr.enIntfSync = VO_OUTPUT_NTSC;
+        }
+        
+        stVoPubAttr.enIntfType = VO_INTF_CVBS;
+        stVoPubAttr.u32BgColor = 0x000000ff;
+        stVoPubAttr.bDoubleFrame = HI_FALSE;
+    }
+    
+    s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start SAMPLE_COMM_VO_StartDevLayer failed!\n");
+        goto END_1;
+    }
+    
+    s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start SAMPLE_COMM_VO_StartChn failed!\n");
+        goto END_2;
+    }
+
+    if (HI_TRUE == bVoHd)
+    {
+        /* if it's displayed on HDMI, we should start HDMI */
+        if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+        {
+            if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+            {
+                SAMPLE_PRT("Start SAMPLE_COMM_VO_HdmiStart failed!\n");
+                goto END_1;
+            }
+        }
+    }
+
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+
+        if (HI_TRUE == bVoHd)
+        {
+            VpssGrp = i;
+            s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+            if (HI_SUCCESS != s32Ret)
+            {
+                SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+                goto END_2;
+            }
+        }
+    }
+
+    /******************************************
+     step 5: start vdec & bind it to vpss or vo
+    ******************************************/ 
+    if (PT_H264 == enType)
+    { 
+        while(1)
+        {
+            printf("please choose vdec mode:\n");
+            printf("\t0) frame mode.\n");
+            printf("\t1) stream mode.\n");
+            ch = getchar();
+            getchar();
+            if ('0' == ch)
+            {
+                enVdecMode = VIDEO_MODE_FRAME;
+                break;
+            }
+            else if ('1' == ch)
+            {
+                enVdecMode = VIDEO_MODE_STREAM;
+                break;
+            }
+            else
+            {
+                printf("input invaild! please try again.\n");
+                continue;
+            }
+        }
+    }
+    else if (PT_JPEG == enType || PT_MJPEG ==enType)	
+    {
+        /* JPEG, MJPEG must be Frame mode! */
+        enVdecMode = VIDEO_MODE_FRAME;
+    }
+    
+    for (i=0; i<s32Cnt; i++)
+    {
+        /***** create vdec chn *****/
+        VdChn = i;        
+        s32Ret = SAMPLE_VDEC_CreateVdecChn(VdChn, &stSize, enType, enVdecMode);
+        if (HI_SUCCESS !=s32Ret)
+        {
+            SAMPLE_PRT("create vdec chn failed!\n");
+            goto END_3;
+        }
+        
+        /***** bind vdec to vpss *****/
+        if (HI_TRUE == bVoHd)
+        {
+            VpssGrp = i;
+            s32Ret = SAMLE_COMM_VDEC_BindVpss(VdChn, VpssGrp);
+            if (HI_SUCCESS !=s32Ret)
+            {
+                SAMPLE_PRT("vdec(vdch=%d) bind vpss(vpssg=%d) failed!\n", VdChn, VpssGrp);
+                goto END_3;
+            }
+        }
+        else
+    	{
+            VoChn =  i;
+            s32Ret = SAMLE_COMM_VDEC_BindVo(VdChn, VoDev, VoChn);
+            if (HI_SUCCESS !=s32Ret)
+            {
+                SAMPLE_PRT("vdec(vdch=%d) bind vpss(vpssg=%d) failed!\n", VdChn, VpssGrp);
+                goto END_3;
+            }
+        }
+    }
+
+    /******************************************
+     step 6: open file & video decoder
+    ******************************************/
+    for (i=0; i<s32Cnt; i++)
+    {
+        gs_SendParam[i].bRun = HI_TRUE;
+        gs_SendParam[i].VdChn = i;
+        gs_SendParam[i].enPayload = enType;
+        gs_SendParam[i].enVideoMode = enVdecMode;
+        gs_SendParam[i].s32MinBufSize = stSize.u32Height * stSize.u32Width * 3/ 4;
+        pthread_create(&gs_SendParam[i].Pid, NULL, SAMPLE_VDEC_SendStream, &gs_SendParam[i]);
+    }
+
+    if (PT_JPEG != enType)
+    {
+        printf("you can press ctrl+c to terminate program before normal exit.\n");
+    }
+    /******************************************
+     step 7: join thread
+    ******************************************/
+    for (i=0; i<s32Cnt; i++)
+    {      
+        pthread_join(gs_SendParam[i].Pid, 0);
+        printf("join thread %d.\n", i);
+    }
+
+    printf("press two enter to quit!\n");
+    getchar();
+    getchar();
+    /******************************************
+     step 8: Unbind vdec to vpss & destroy vdec-chn
+    ******************************************/
+END_3:
+    for (i=0; i<s32Cnt; i++)
+    {
+        VdChn = i;
+        SAMPLE_VDEC_WaitDestroyVdecChn(VdChn, enVdecMode);
+        if (HI_TRUE == bVoHd)
+        {
+            VpssGrp = i;
+            SAMLE_COMM_VDEC_UnBindVpss(VdChn, VpssGrp);
+        }
+        else
+        {
+            VoChn = i;
+            SAMLE_COMM_VDEC_UnBindVo(VdChn, VoDev, VoChn);
+        }
+    }
+    /******************************************
+     step 9: stop vo
+    ******************************************/
+END_2:
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        if (HI_TRUE == bVoHd)
+        {
+            VpssGrp = i;
+            SAMPLE_COMM_VO_UnBindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+        }
+    }
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+END_1:
+    if (HI_TRUE == bVoHd)
+    {
+        if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+        {
+            SAMPLE_COMM_VO_HdmiStop();
+        }
+        SAMPLE_COMM_VPSS_Stop(s32Cnt, VPSS_MAX_CHN_NUM);
+    }
+    /******************************************
+     step 10: exit mpp system
+    ******************************************/
+END_0:
+    SAMPLE_COMM_SYS_Exit();
+
+    return HI_SUCCESS;
+}
+
+HI_S32 SAMPLE_VDEC_ProcessForPip(PIC_SIZE_E enPicSize, PAYLOAD_TYPE_E enType, HI_S32 s32Cnt, VO_DEV VoDev)
+{
+    VDEC_CHN VdChn;
+    HI_S32 s32Ret;
+    SIZE_S stSize;
+    VB_CONF_S stVbConf;
+    HI_S32 i;
+    VPSS_GRP VpssGrp, VpssGrpForPip = 1;
+    VIDEO_MODE_E enVdecMode;
+
+    VO_CHN VoChn;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    SAMPLE_VO_MODE_E enVoMode;
+    HI_U32 u32WndNum, u32BlkSize;
+
+    HI_BOOL bVoHd; // through Vpss or not. if vo is SD, needn't through vpss
+    VO_CHN_ATTR_S stVoChnAttr;
+    VO_VIDEO_LAYER_ATTR_S stPipLayerAttr;
+    VPSS_CROP_INFO_S stVpssCropInfo;
+    
+    /******************************************
+     step 1: init varaible.
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL== gs_enNorm)?25:30;
+    
+    if (SAMPLE_MAX_VDEC_CHN_CNT < s32Cnt)
+    {
+        SAMPLE_PRT("Vdec count is bigger than sample define!\n");
+        return HI_FAILURE;
+    }
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, enPicSize, &stSize);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("get picture size failed!\n");
+        return HI_FAILURE;
+    }
+    if (704 == stSize.u32Width)
+    {
+        stSize.u32Width = 720;
+    }
+    else if (352 == stSize.u32Width)
+    {
+        stSize.u32Width = 360;
+    }
+    else if (176 == stSize.u32Width)
+    {
+        stSize.u32Width = 180;
+    }
+
+    /* through Vpss or not. if vo is SD, needn't through vpss */
+    if (SAMPLE_VO_DEV_DHD0 != VoDev) 
+    {
+        bVoHd = HI_FALSE;
+    }
+    else
+    {
+        bVoHd = HI_TRUE;
+    }
+    /******************************************
+     step 2: mpp system init.
+    ******************************************/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+    /*vdec no need common video buffer!*/
+
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("mpp init failed!\n");
+        return HI_FAILURE;
+    }
+    
+    /******************************************
+     step 3: start vpss, if ov is hd.
+    ******************************************/    
+    if (HI_TRUE == bVoHd)
+    {
+        s32Ret = SAMPLE_COMM_VPSS_Start(s32Cnt+1, &stSize, VPSS_MAX_CHN_NUM,NULL);
+        if (HI_SUCCESS !=s32Ret)
+        {
+            SAMPLE_PRT("vpss start failed!\n");
+            goto END_0;
+        }
+    }
+ 
+    /******************************************
+     step 4: start vo
+    ******************************************/
+    u32WndNum = 1;
+    enVoMode = VO_MODE_1MUX;
+
+    if (HI_TRUE == bVoHd)
+    {
+        if(VIDEO_ENCODING_MODE_PAL== gs_enNorm)
+        {
+            stVoPubAttr.enIntfSync = VO_OUTPUT_1080P50;
+        }
+        else
+        {
+            stVoPubAttr.enIntfSync = VO_OUTPUT_1080P60;
+        }
+#ifdef HI_FPGA    
+        stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA|VO_INTF_BT1120;
+#else
+        stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA;
+#endif
+        stVoPubAttr.u32BgColor = 0x000000ff;
+        stVoPubAttr.bDoubleFrame = HI_FALSE;
+    }
+    else
+    {
+        if(VIDEO_ENCODING_MODE_PAL== gs_enNorm)
+        {
+            stVoPubAttr.enIntfSync = VO_OUTPUT_PAL;
+        }
+        else
+        {
+            stVoPubAttr.enIntfSync = VO_OUTPUT_NTSC;
+        }
+        
+        stVoPubAttr.enIntfType = VO_INTF_CVBS;
+        stVoPubAttr.u32BgColor = 0x000000ff;
+        stVoPubAttr.bDoubleFrame = HI_FALSE;
+    }
+    
+    s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start SAMPLE_COMM_VO_StartDevLayer failed!\n");
+        goto END_1;
+    }
+    
+    s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start SAMPLE_COMM_VO_StartChn failed!\n");
+        goto END_2;
+    }
+
+    if (HI_TRUE == bVoHd)
+    {
+        /* if it's displayed on HDMI, we should start HDMI */
+        if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+        {
+            if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+            {
+                SAMPLE_PRT("Start SAMPLE_COMM_VO_HdmiStart failed!\n");
+                goto END_1;
+            }
+        }
+    }
+
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+
+        if (HI_TRUE == bVoHd)
+        {
+            VpssGrp = i;
+            s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+            if (HI_SUCCESS != s32Ret)
+            {
+                SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+                goto END_2;
+            }
+        }
+    }
+
+    /******************************************
+     step 5: start vdec & bind it to vpss or vo
+    ******************************************/ 
+    enVdecMode = VIDEO_MODE_FRAME;
+    
+    for (i=0; i<s32Cnt; i++)
+    {
+        /*** create vdec chn ***/
+        VdChn = i;
+        s32Ret = SAMPLE_VDEC_CreateVdecChn(VdChn, &stSize, enType, enVdecMode);
+        if (HI_SUCCESS !=s32Ret)
+        {
+            SAMPLE_PRT("create vdec chn failed!\n");
+            goto END_3;
+        }
+        /*** bind vdec to vpss ***/
+        if (HI_TRUE == bVoHd)
+        {
+            VpssGrp = i;
+            s32Ret = SAMLE_COMM_VDEC_BindVpss(VdChn, VpssGrp);
+            if (HI_SUCCESS !=s32Ret)
+            {
+                SAMPLE_PRT("vdec(vdch=%d) bind vpss(vpssg=%d) failed!\n", VdChn, VpssGrp);
+                goto END_3;
+            }
+        }
+        else
+    	{
+            VoChn =  i;
+            s32Ret = SAMLE_COMM_VDEC_BindVo(VdChn, VoDev, VoChn);
+            if (HI_SUCCESS !=s32Ret)
+            {
+                SAMPLE_PRT("vdec(vdch=%d) bind vpss(vpssg=%d) failed!\n", VdChn, VpssGrp);
+                goto END_3;
+            }
+        }
+    }
+
+    /******************************************
+     step 6: open file & video decoder
+    ******************************************/
+    for (i=0; i<s32Cnt; i++)
+    {
+        gs_SendParam[i].bRun = HI_TRUE;
+        gs_SendParam[i].VdChn = i;
+        gs_SendParam[i].enPayload = enType;
+        gs_SendParam[i].enVideoMode = enVdecMode;
+        gs_SendParam[i].s32MinBufSize = stSize.u32Height * stSize.u32Width *3 / 4;
+        pthread_create(&gs_SendParam[i].Pid, NULL, SAMPLE_VDEC_SendStream, &gs_SendParam[i]);
+    }
+
+    if (PT_JPEG != enType)
+    {
+        printf("you can press ctrl+c to terminate program before normal exit.\n");
+    }
+    
+    printf("please press any key to show pip:\n");
+    getchar();
+
+    s32Ret = HI_MPI_VO_ChnPause(VoDev, 0);
+    if(s32Ret != HI_SUCCESS)
+    {
+        printf("HI_MPI_VO_ChnPause err 0x%x\n",s32Ret);
+        return s32Ret;
+    }
+
+    s32Ret = HI_MPI_VO_PipLayerBindDev(VoDev);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VO_PipLayerBindDev failed with %#x!\n", s32Ret);
+        return s32Ret;
+    }
+
+    stPipLayerAttr.stDispRect.s32X = 0;
+    stPipLayerAttr.stDispRect.s32Y = 0;
+
+    stPipLayerAttr.stDispRect.u32Height  = 1080;
+    stPipLayerAttr.stDispRect.u32Width   = 1920;
+    
+    stPipLayerAttr.stImageSize.u32Height = 1080;
+    stPipLayerAttr.stImageSize.u32Width = 1920;
+    stPipLayerAttr.enPixFormat = SAMPLE_PIXEL_FORMAT;
+    stPipLayerAttr.u32DispFrmRt = 25;
+
+    s32Ret = HI_MPI_VO_SetPipLayerAttr(&stPipLayerAttr);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VO_SetPipLayerAttr failed with %#x!\n", s32Ret);
+        goto END_3;
+    }
+
+    s32Ret = HI_MPI_VO_EnablePipLayer();
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VO_EnablePipLayer failed with %#x!\n", s32Ret);
+        goto END_3;
+    }
+
+    stVoChnAttr.stRect.s32X       = 0;
+    stVoChnAttr.stRect.s32Y       = 0;
+    stVoChnAttr.stRect.u32Width   = 1920;
+    stVoChnAttr.stRect.u32Height  = 1080;
+    stVoChnAttr.u32Priority       = 0;
+    stVoChnAttr.bDeflicker        = HI_FALSE;
+    s32Ret = HI_MPI_VO_SetChnAttr(VoDev, 0, &stVoChnAttr);
+    if(s32Ret != HI_SUCCESS)
+    {
+        printf("HI_MPI_VO_SetChnAttr err 0x%x\n",s32Ret);
+        goto END_3;
+    }
+
+    stVoChnAttr.stRect.s32X       = 1200;
+    stVoChnAttr.stRect.s32Y       = 504;
+    stVoChnAttr.stRect.u32Width   = 720;
+    stVoChnAttr.stRect.u32Height  = 576;
+    stVoChnAttr.u32Priority       = 1;
+    stVoChnAttr.bDeflicker        = HI_FALSE;
+    s32Ret = HI_MPI_VO_SetChnAttr(VoDev, 1, &stVoChnAttr);
+    if(s32Ret != HI_SUCCESS)
+    {
+        printf("HI_MPI_VO_SetChnAttr err 0x%x\n",s32Ret);
+        goto END_3;
+    }
+    s32Ret = HI_MPI_VO_EnableChn(VoDev, 1);
+    if(s32Ret != HI_SUCCESS)
+    {
+        printf("HI_MPI_VO_EnableChn err 0x%x\n",s32Ret);
+        goto END_3;
+    }
+
+    s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev, 1, VpssGrpForPip, VPSS_PRE0_CHN);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+        goto END_3;
+    }
+    
+#if 0
+    s32Ret = HI_MPI_VPSS_UserGetGrpFrame(VpssGrp, &stVideoFrame, 0);
+    if(s32Ret != HI_SUCCESS)
+    {
+        printf("HI_MPI_VPSS_UserGetGrpFrame err 0x%x\n",s32Ret);
+        goto END_3;
+    }
+
+    s32Ret = HI_MPI_VPSS_UserSendFrame(VpssGrpForPip, &stVideoFrame);
+    if(s32Ret != HI_SUCCESS)
+    {
+        printf("HI_MPI_VPSS_UserSendFrame err 0x%x\n",s32Ret);
+        goto END_3;
+    }
+    s32Ret = HI_MPI_VPSS_UserReleaseGrpFrame(VpssGrp, &stVideoFrame);
+    if(s32Ret != HI_SUCCESS)
+    {
+        printf("HI_MPI_VPSS_UserReleaseGrpFrame err 0x%x\n",s32Ret);
+        goto END_3;
+    }
+#endif
+
+
+    stVpssCropInfo.bEnable = HI_TRUE;
+    stVpssCropInfo.enCropCoordinate = VPSS_CROP_ABS_COOR;
+    stVpssCropInfo.stCropRect.s32X = 0;
+    stVpssCropInfo.stCropRect.s32Y = 0;
+    stVpssCropInfo.stCropRect.u32Height = 288;
+    stVpssCropInfo.stCropRect.u32Width = 352;
+    stVpssCropInfo.enCapSel = VPSS_CAPSEL_BOTH;
+    s32Ret = HI_MPI_VPSS_SetCropCfg(VpssGrp, &stVpssCropInfo);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed with %#x!\n", s32Ret);
+        goto END_3;
+    }
+
+    s32Ret = HI_MPI_VO_ChnRefresh(VoDev, 0);
+    if(s32Ret != HI_SUCCESS)
+    {
+        printf("HI_MPI_VO_ChnRefresh err 0x%x\n",s32Ret);
+        goto END_3;
+    }
+    
+    for (i = 0; i < 10; i++)
+    {
+        printf("press any key to step %d!\n", i);
+        getchar();
+        s32Ret = HI_MPI_VO_ChnStep(VoDev, 0);
+        if(s32Ret != HI_SUCCESS)
+        {
+            printf("HI_MPI_VO_ChnStep err 0x%x\n",s32Ret);
+            goto END_3;
+        }
+        usleep(20000); // Here we should usleep some ms to make sure the step has taken effect, then we can get the same pic from VPSS.
+
+
+#if 0        
+        s32Ret = HI_MPI_VPSS_UserGetGrpFrame(VpssGrp, &stVideoFrame, 0);
+        if(s32Ret != HI_SUCCESS)
+        {
+            printf("HI_MPI_VPSS_UserGetGrpFrame err 0x%x\n",s32Ret);
+            goto END_3;
+        }
+        
+        s32Ret = HI_MPI_VPSS_UserSendFrame(VpssGrpForPip, &stVideoFrame);
+        if(s32Ret != HI_SUCCESS)
+        {
+            printf("HI_MPI_VPSS_UserSendFrame err 0x%x\n",s32Ret);
+            goto END_3;
+        }
+        s32Ret = HI_MPI_VPSS_UserReleaseGrpFrame(VpssGrp, &stVideoFrame);
+        if(s32Ret != HI_SUCCESS)
+        {
+            printf("HI_MPI_VPSS_UserReleaseGrpFrame err 0x%x\n",s32Ret);
+            goto END_3;
+        }
+#endif
+
+
+
+    }
+
+    printf("press any key to resume!\n");
+    getchar();
+
+    s32Ret = HI_MPI_VO_ChnResume(VoDev, 0);
+    if(s32Ret != HI_SUCCESS)
+    {
+        printf("HI_MPI_VO_ChnResume err 0x%x\n",s32Ret);
+        goto END_3;
+    }
+
+    s32Ret = SAMLE_COMM_VDEC_BindVpss(VdChn, VpssGrpForPip);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+        goto END_3;
+        
+    }
+
+    s32Ret = HI_MPI_VPSS_ResetGrp(VpssGrp);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VPSS_ResetGrp failed!\n");
+        goto END_3;
+        
+    }
+    s32Ret = HI_MPI_VPSS_ResetGrp(VpssGrpForPip);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VPSS_ResetGrp failed!\n");
+        goto END_3;
+        
+    }
+    s32Ret = HI_MPI_VO_ClearChnBuffer(VoDev, 0, HI_FALSE);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VO_ClearChnBuffer failed!\n");
+        goto END_3;
+        
+    }
+    s32Ret = HI_MPI_VO_ClearChnBuffer(VoDev, 1, HI_FALSE);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VO_ClearChnBuffer failed!\n");
+        goto END_3;
+        
+    }
+
+    /******************************************
+     step 7: join thread
+    ******************************************/
+    for (i=0; i<s32Cnt; i++)
+    {
+        pthread_join(gs_SendParam[i].Pid, 0);
+        printf("join thread %d.\n", i);
+    }
+
+    printf("press two enter to quit!\n");
+    getchar();
+    getchar();
+
+
+    /******************************************
+     step 8: Unbind vdec to vpss & destroy vdec-chn
+    ******************************************/
+END_3:
+    for (i=0; i<s32Cnt; i++)
+    {
+        VdChn = i;
+        SAMPLE_VDEC_WaitDestroyVdecChn(VdChn, enVdecMode);
+        if (HI_TRUE == bVoHd)
+        {
+            VpssGrp = i;
+            SAMLE_COMM_VDEC_UnBindVpss(VdChn, VpssGrp);
+        }
+        else
+        {
+            VoChn = i;
+            SAMLE_COMM_VDEC_UnBindVo(VdChn, VoDev, VoChn);
+        }
+    }
+    
+    s32Ret = HI_MPI_VO_DisableChn(VoDev, 1);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VO_DisableChn failed with %#x!\n", s32Ret);
+    }
+
+    s32Ret = HI_MPI_VO_DisablePipLayer();
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VO_DisablePipLayer failed with %#x!\n", s32Ret);
+    }
+    /******************************************
+     step 9: stop vo
+    ******************************************/
+END_2:
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        if (HI_TRUE == bVoHd)
+        {
+            VpssGrp = i;
+            SAMPLE_COMM_VO_UnBindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+        }
+    }
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+END_1:
+    if (HI_TRUE == bVoHd)
+    {
+        if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+        {
+            SAMPLE_COMM_VO_HdmiStop();
+        }
+        SAMPLE_COMM_VPSS_Stop(s32Cnt+1, VPSS_MAX_CHN_NUM);
+    }
+    /******************************************
+     step 10: exit mpp system
+    ******************************************/
+END_0:
+    SAMPLE_COMM_SYS_Exit();
+
+    return HI_SUCCESS;
+}
+
+/****************************************************************************
+* function: main
+****************************************************************************/
+int main(int argc, char* argv[])
+{
+    HI_S32 s32Index;
+    if (argc != 2)
+    {
+        SAMPLE_VDEC_Usage(argv[0]);
+        return HI_FAILURE;
+    }
+    
+    signal(SIGINT, SAMPLE_VDEC_HandleSig);
+    signal(SIGTERM, SAMPLE_VDEC_HandleSig);
+
+    s32Index = atoi(argv[1]);
+
+    switch (s32Index)
+    {
+        case 0: /* H264 -> VPSS -> VO(HD) */
+            gs_s32Cnt = 1;
+            SAMPLE_VDEC_Process(PIC_D1, PT_H264, gs_s32Cnt, SAMPLE_VO_DEV_DHD0);
+            break;
+        case 1: /* JPEG ->VPSS -> VO(HD) */
+            gs_s32Cnt = 1;
+            SAMPLE_VDEC_Process(PIC_D1, PT_JPEG, gs_s32Cnt, SAMPLE_VO_DEV_DHD0);
+            break;
+        case 2: /* MJPEG -> VO(SD) */
+            gs_s32Cnt = 1;
+            SAMPLE_VDEC_Process(PIC_D1, PT_MJPEG, gs_s32Cnt, SAMPLE_VO_DEV_DSD0);
+            break;
+        case 3:  /* H264 -> VPSS -> VO(HD PIP PAUSE STEP)*/
+            gs_s32Cnt = 1;
+            if (HI_SUCCESS != SAMPLE_VDEC_ProcessForPip(PIC_D1, PT_H264, gs_s32Cnt, SAMPLE_VO_DEV_DHD0))
+            {
+                break;
+            }
+            break;
+        default:
+            printf("the index is invaild!\n");
+            SAMPLE_VDEC_Usage(argv[0]);
+            return HI_FAILURE;
+        break;
+    }
+
+    return HI_SUCCESS;
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */

--- a/libraries/mpp_sample/hi3520dv200/venc/Makefile
+++ b/libraries/mpp_sample/hi3520dv200/venc/Makefile
@@ -1,0 +1,33 @@
+# Hisilicon Hi3516 sample Makefile
+
+include ../Makefile.param
+#ifeq ($(SAMPLE_PARAM_FILE), )
+#     SAMPLE_PARAM_FILE:=../Makefile.param
+#     include $(SAMPLE_PARAM_FILE)
+#endif
+
+# target source
+SRC  := $(wildcard *.c) 
+OBJ  := $(SRC:%.c=%.o)
+
+TARGET := $(OBJ:%.o=%)
+.PHONY : clean all
+
+all: $(TARGET)
+
+MPI_LIBS := $(REL_LIB)/libmpi.a
+MPI_LIBS += $(REL_LIB)/libhdmi.a
+
+$(TARGET):%:%.o $(COMM_OBJ)
+	$(CC) $(CFLAGS) -lpthread -lm -o $@ $^ $(MPI_LIBS) $(AUDIO_LIBA) $(JPEGD_LIBA)
+
+clean:
+	@rm -f $(TARGET)
+	@rm -f $(OBJ)
+	@rm -f $(COMM_OBJ)
+
+cleanstream:
+	@rm -f *.h264
+	@rm -f *.jpg
+	@rm -f *.mjp
+	@rm -f *.mp4

--- a/libraries/mpp_sample/hi3520dv200/venc/sample_venc.c
+++ b/libraries/mpp_sample/hi3520dv200/venc/sample_venc.c
@@ -1,0 +1,1695 @@
+/******************************************************************************
+  A simple program of Hisilicon HI3531 video encode implementation.
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2011-2 Created
+******************************************************************************/
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <signal.h>
+
+#include "sample_comm.h"
+
+VIDEO_NORM_E gs_enNorm = VIDEO_ENCODING_MODE_PAL;
+#define SAMPLE_YUV_D1_FILEPATH         "SAMPLE_420_D1.yuv"
+
+/******************************************************************************
+* function : show usage
+******************************************************************************/
+void SAMPLE_VENC_Usage(char *sPrgNm)
+{
+    printf("Usage : %s <index>\n", sPrgNm);
+    printf("index:\n");
+    printf("\t 0) 4D1 H264 encode.\n");
+    printf("\t 1) 1*720p H264 encode.\n");
+    printf("\t 2) 1D1 MJPEG encode.\n");
+    printf("\t 3) 4D1 JPEG snap with StartRecvPic.\n");
+    printf("\t 4) 4D1 JPEG snap with StartRecvPicEx.\n");
+	printf("\t 5) 8*Cif JPEG snap.\n");
+    printf("\t 6) 1D1 User send pictures for H264 encode.\n");
+    printf("\t 7) 4D1 H264 encode with color2grey.\n");
+    return;
+}
+
+/******************************************************************************
+* function : to process abnormal case                                         
+******************************************************************************/
+void SAMPLE_VENC_HandleSig(HI_S32 signo)
+{
+    if (SIGINT == signo || SIGTSTP == signo)
+    {
+        SAMPLE_COMM_SYS_Exit();
+        printf("\033[0;31mprogram termination abnormally!\033[0;39m\n");
+    }
+    exit(-1);
+}
+
+/******************************************************************************
+* function : to process abnormal case - the case of stream venc
+******************************************************************************/
+void SAMPLE_VENC_StreamHandleSig(HI_S32 signo)
+{
+
+    if (SIGINT == signo || SIGTSTP == signo)
+    {
+        SAMPLE_COMM_SYS_Exit();
+        printf("\033[0;31mprogram exit abnormally!\033[0;39m\n");
+    }
+
+    exit(0);
+}
+
+/******************************************************************************
+* function :  4D1 H264 encode
+******************************************************************************/
+HI_S32 SAMPLE_VENC_4D1_H264(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_4_D1;
+
+    HI_U32 u32ViChnCnt = 4;
+    HI_S32 s32VpssGrpCnt = 4;
+    PAYLOAD_TYPE_E enPayLoad[2]= {PT_H264, PT_H264};
+    PIC_SIZE_E enSize[2] = {PIC_D1, PIC_CIF};
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_CHN VpssChn;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VENC_GRP VencGrp;
+    VENC_CHN VencChn;
+    SAMPLE_RC_E enRcMode;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_CHAR ch;
+    SIZE_S stSize;
+
+    /******************************************
+     step  1: init variable 
+    ******************************************/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+    
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 6;
+    memset(stVbConf.astCommPool[0].acMmzName,0,
+        sizeof(stVbConf.astCommPool[0].acMmzName));
+
+    /* hist buf*/
+    stVbConf.astCommPool[1].u32BlkSize = (196*4);
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 6;
+    memset(stVbConf.astCommPool[1].acMmzName,0,
+        sizeof(stVbConf.astCommPool[1].acMmzName));
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_VENC_8D1_0;
+    }
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_VENC_8D1_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_VENC_8D1_0;
+    }
+    
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_VENC_8D1_1;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_VENC_8D1_2;
+    }
+
+    /******************************************
+     step 5: select rc mode
+    ******************************************/
+    while(1)
+    {
+        printf("please choose rc mode:\n"); 
+        printf("\t0) CBR\n"); 
+        printf("\t1) VBR\n"); 
+        printf("\t2) FIXQP\n"); 
+        ch = getchar();
+        getchar();
+        if ('0' == ch)
+        {
+            enRcMode = SAMPLE_RC_CBR;
+            break;
+        }
+        else if ('1' == ch)
+        {
+            enRcMode = SAMPLE_RC_VBR;
+            break;
+        }
+        else if ('2' == ch)
+        {
+            enRcMode = SAMPLE_RC_FIXQP;
+            break;
+        }
+        else
+        {
+            printf("rc mode invaild! please try again.\n");
+            continue;
+        }
+    }
+    /******************************************
+     step 5: start stream venc (big + little)
+    ******************************************/
+    for (i=0; i<u32ViChnCnt; i++)
+    {
+        /*** main stream **/
+        VencGrp = i*2;
+        VencChn = i*2;
+        VpssGrp = i;
+        s32Ret = SAMPLE_COMM_VENC_Start(VencGrp, VencChn, enPayLoad[0],\
+                                       gs_enNorm, enSize[0], enRcMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_8D1_2;
+        }
+
+        s32Ret = SAMPLE_COMM_VENC_BindVpss(VencGrp, VpssGrp, VPSS_BSTR_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_8D1_3;
+        }
+
+        /*** Sub stream **/
+        VencGrp ++;
+        VencChn ++;
+        s32Ret = SAMPLE_COMM_VENC_Start(VencGrp, VencChn, enPayLoad[1], \
+                                        gs_enNorm, enSize[1], enRcMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_8D1_3;
+        }
+
+        s32Ret = SAMPLE_COMM_VENC_BindVpss(VencChn, VpssGrp, VPSS_PRE0_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_8D1_3;
+        }
+    }
+
+    /******************************************
+     step 6: stream venc process -- get stream, then save it to file. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VENC_StartGetStream(u32ViChnCnt*2);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Venc failed!\n");
+        goto END_VENC_8D1_3;
+    }
+
+    printf("please press twice ENTER to exit this sample\n");
+    getchar();
+    getchar();
+
+    /******************************************
+     step 7: exit process
+    ******************************************/
+    SAMPLE_COMM_VENC_StopGetStream();
+    
+END_VENC_8D1_3:
+    for (i=0; i<u32ViChnCnt*2; i++)
+    {
+        VencGrp = i;
+        VencChn = i;
+        VpssGrp = i/2;
+        VpssChn = (VpssGrp%2)?VPSS_PRE0_CHN:VPSS_BSTR_CHN;
+        SAMPLE_COMM_VENC_UnBindVpss(VencGrp, VpssGrp, VpssChn);
+        SAMPLE_COMM_VENC_Stop(VencGrp,VencChn);
+    }
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_VENC_8D1_2:	//vpss stop
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_VENC_8D1_1:	//vi stop
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_VENC_8D1_0:	//system exit
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+/******************************************************************************
+* function :  1HD H264 encode
+******************************************************************************/
+HI_S32 SAMPLE_VENC_1HD_H264(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_720P;
+
+    HI_U32 u32ViChnCnt = 1;
+    HI_S32 s32VpssGrpCnt = 1;
+    PAYLOAD_TYPE_E enPayLoad[2]= {PT_H264, PT_H264};
+    PIC_SIZE_E enSize[2] = {PIC_HD720, PIC_D1};
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_CHN VpssChn;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VENC_GRP VencGrp;
+    VENC_CHN VencChn;
+    SAMPLE_RC_E enRcMode;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_CHAR ch;
+    SIZE_S stSize;
+
+    /******************************************
+     step  1: init variable 
+    ******************************************/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_HD720, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /* video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 6;
+    memset(stVbConf.astCommPool[0].acMmzName,0,
+        sizeof(stVbConf.astCommPool[0].acMmzName));
+
+    /* hist buf*/
+    stVbConf.astCommPool[1].u32BlkSize = (196*4);
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 4;
+    memset(stVbConf.astCommPool[1].acMmzName,0,
+        sizeof(stVbConf.astCommPool[1].acMmzName));
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_VENC_1HD_0;
+    }
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_VENC_1HD_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_HD720, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_VENC_1HD_0;
+    }
+    
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_NODIE;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM, &stGrpAttr);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_VENC_1HD_1;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_VENC_1HD_2;
+    }
+
+    /******************************************
+     step 5: select rc mode
+    ******************************************/
+    while(1)
+    {
+        printf("please choose rc mode:\n"); 
+        printf("\t0) CBR\n"); 
+        printf("\t1) VBR\n"); 
+        printf("\t2) FIXQP\n"); 
+        ch = getchar();
+        getchar();
+        if ('0' == ch)
+        {
+            enRcMode = SAMPLE_RC_CBR;
+            break;
+        }
+        else if ('1' == ch)
+        {
+            enRcMode = SAMPLE_RC_VBR;
+            break;
+        }
+        else if ('2' == ch)
+        {
+            enRcMode = SAMPLE_RC_FIXQP;
+            break;
+        }
+        else
+        {
+            printf("rc mode invaild! please try again.\n");
+            continue;
+        }
+    }
+    /******************************************
+     step 6: start stream venc (big + little)
+    ******************************************/
+    for (i=0; i<u32ViChnCnt; i++)
+    {
+        /*** main frame **/
+        VencGrp = i*2;
+        VencChn = i*2;
+        VpssGrp = i;
+        s32Ret = SAMPLE_COMM_VENC_Start(VencGrp, VencChn, enPayLoad[0],\
+                                        gs_enNorm, enSize[0], enRcMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_1HD_3;
+        }
+
+        s32Ret = SAMPLE_COMM_VENC_BindVpss(VencGrp, VpssGrp, VPSS_BSTR_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_1HD_3;
+        }
+
+        /*** Sub frame **/
+        VencGrp ++;
+        VencChn ++;
+        s32Ret = SAMPLE_COMM_VENC_Start(VencGrp, VencChn, enPayLoad[1], \
+                                     gs_enNorm, enSize[1], enRcMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_1HD_3;
+        }
+
+        s32Ret = SAMPLE_COMM_VENC_BindVpss(VencChn, VpssGrp, VPSS_PRE0_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_1HD_3;
+        }
+    }
+
+    /******************************************
+     step 7: stream venc process -- get stream, then save it to file. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VENC_StartGetStream(u32ViChnCnt*2);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Venc failed!\n");
+        goto END_VENC_1HD_3;
+    }
+
+    printf("please press twice ENTER to exit this sample\n");
+    getchar();
+    getchar();
+
+    /******************************************
+     step 8: exit process
+    ******************************************/
+    SAMPLE_COMM_VENC_StopGetStream();
+    
+END_VENC_1HD_3:
+    for (i=0; i<u32ViChnCnt*2; i++)
+    {
+        VencGrp = i;
+        VencChn = i;
+        VpssGrp = i/2;
+        VpssChn = (VpssGrp%2)?VPSS_PRE0_CHN:VPSS_BSTR_CHN;
+        SAMPLE_COMM_VENC_UnBindVpss(VencGrp, VpssGrp, VpssChn);
+        SAMPLE_COMM_VENC_Stop(VencGrp,VencChn);
+    }
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_VENC_1HD_2:	//vpss stop
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_VENC_1HD_1:	//vi stop
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_VENC_1HD_0:	//system exit
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+/******************************************************************************
+* function :  1D1 MJPEG encode
+******************************************************************************/
+HI_S32 SAMPLE_VENC_1D1_MJPEG(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_D1;
+
+    HI_U32 u32ViChnCnt = 1;
+    HI_S32 s32VpssGrpCnt = 1;
+    PAYLOAD_TYPE_E enPayLoad = PT_MJPEG;
+    PIC_SIZE_E enSize = PIC_D1;
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_CHN VpssChn;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VENC_GRP VencGrp;
+    VENC_CHN VencChn;
+    SAMPLE_RC_E enRcMode;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_CHAR ch;
+    SIZE_S stSize;
+
+    /******************************************
+     step  1: init variable 
+    ******************************************/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /*video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 6;
+    memset(stVbConf.astCommPool[0].acMmzName,0,
+        sizeof(stVbConf.astCommPool[0].acMmzName));
+
+    /* hist buf*/
+    stVbConf.astCommPool[1].u32BlkSize = (196*4);
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 6;
+    memset(stVbConf.astCommPool[1].acMmzName,0,
+        sizeof(stVbConf.astCommPool[1].acMmzName));
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_VENC_MJPEG_0;
+    }
+ 
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_VENC_MJPEG_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_VENC_MJPEG_0;
+    }
+    
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_VENC_MJPEG_1;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_VENC_MJPEG_2;
+    }
+
+    /******************************************
+     step 5: select rc mode
+    ******************************************/
+    while(1)
+    {
+        printf("please choose rc mode:\n"); 
+        printf("\t0) CBR\n"); 
+        printf("\t1) VBR\n"); 
+        printf("\t2) FIXQP\n");
+        ch = getchar();
+        getchar();
+        if ('0' == ch)
+        {
+            enRcMode = SAMPLE_RC_CBR;
+            break;
+        }
+        else if ('1' == ch)
+        {
+            enRcMode = SAMPLE_RC_VBR;
+            break;
+        }
+        else if ('2' == ch)
+        {
+            enRcMode = SAMPLE_RC_FIXQP;
+            break;
+        }
+        else
+        {
+            printf("rc mode invaild! please try again.\n");
+            continue;
+        }
+    }
+    /******************************************
+     step 5: start stream venc
+    ******************************************/
+    for (i=0; i<u32ViChnCnt; i++)
+    {
+        /*** main frame **/
+        VencGrp = i;
+        VencChn = i;
+        VpssGrp = i;
+        s32Ret = SAMPLE_COMM_VENC_Start(VencGrp, VencChn, enPayLoad,\
+                                        gs_enNorm, enSize, enRcMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_MJPEG_3;
+        }
+
+        s32Ret = SAMPLE_COMM_VENC_BindVpss(VencGrp, VpssGrp, VPSS_PRE0_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_MJPEG_3;
+        }
+    }
+
+    /******************************************
+     step 6: stream venc process -- get stream, then save it to file. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VENC_StartGetStream(u32ViChnCnt);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Venc failed!\n");
+        goto END_VENC_MJPEG_3;
+    }
+
+    printf("please press twice ENTER to exit this sample\n");
+    getchar();
+    getchar();
+
+    /******************************************
+     step 8: exit process
+    ******************************************/
+    SAMPLE_COMM_VENC_StopGetStream();
+    
+END_VENC_MJPEG_3:
+    for (i=0; i<u32ViChnCnt; i++)
+    {
+        VencGrp = i;
+        VencChn = i;
+        VpssGrp = i;
+        VpssChn =VPSS_BSTR_CHN;
+        SAMPLE_COMM_VENC_UnBindVpss(VencGrp, VpssGrp, VpssChn);
+        SAMPLE_COMM_VENC_Stop(VencGrp,VencChn);
+    }
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_VENC_MJPEG_2:	//vpss stop
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_VENC_MJPEG_1:	//vi stop
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_VENC_MJPEG_0:	//system exit
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+/******************************************************************************
+* function :  4D1 SNAP
+******************************************************************************/
+HI_S32 SAMPLE_VENC_4D1_Snap(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_4_D1;
+
+    HI_U32 u32ViChnCnt = 4;
+    HI_S32 s32VpssGrpCnt = 4;
+    PIC_SIZE_E enSize = PIC_D1;
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VENC_GRP VencGrp;
+    VENC_CHN VencChn;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    SIZE_S stSize;
+
+    /******************************************
+     step  1: init variable 
+    ******************************************/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                enSize, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /* video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 15;
+    memset(stVbConf.astCommPool[0].acMmzName,0,
+        sizeof(stVbConf.astCommPool[0].acMmzName));
+
+    /* hist buf*/
+    stVbConf.astCommPool[1].u32BlkSize = (196*4);
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 15;
+    memset(stVbConf.astCommPool[1].acMmzName,0,
+        sizeof(stVbConf.astCommPool[1].acMmzName));
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_VENC_SNAP_0;
+    }
+	
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_VENC_SNAP_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, enSize, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_VENC_SNAP_0;
+    }
+    
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_VENC_SNAP_1;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_VENC_SNAP_2;
+    }
+
+    /******************************************
+     step 5: snap process
+    ******************************************/
+    VencGrp = 0;
+    VencChn = 0;
+    s32Ret = SAMPLE_COMM_VENC_SnapStart(VencGrp, VencChn, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start snap failed!\n");
+        goto END_VENC_SNAP_3;
+    }
+    for (i=0; i<u32ViChnCnt; i++)
+    {
+        /*** main frame **/
+        VpssGrp = i;
+
+        s32Ret = SAMPLE_COMM_VENC_SnapProcess(VencGrp, VencChn, VpssGrp, VPSS_PRE0_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("snap process failed!\n");
+            goto END_VENC_SNAP_4;
+        }
+        printf("snap chn %d ok!\n", i);
+
+        sleep(1);
+    }
+
+    /******************************************
+     step 8: exit process
+    ******************************************/
+    printf("snap over!\n");
+    
+END_VENC_SNAP_4:
+    s32Ret = SAMPLE_COMM_VENC_SnapStop(VencGrp, VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Stop snap failed!\n");
+        goto END_VENC_SNAP_3;
+    }
+END_VENC_SNAP_3:
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_VENC_SNAP_2:	//vpss stop
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_VENC_SNAP_1:	//vi stop
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_VENC_SNAP_0:	//system exit
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+/******************************************************************************
+* function :  16*Cif SNAP
+******************************************************************************/
+HI_S32 SAMPLE_VENC_8_Cif_Snap(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_8_2Cif;
+
+    HI_U32 u32ViChnCnt = 8;
+    HI_S32 s32VpssGrpCnt = 8;
+    PIC_SIZE_E enSize = PIC_2CIF;
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VENC_GRP VencGrp;
+    VENC_CHN VencChn;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    SIZE_S stSize;
+
+    /******************************************
+     step  1: init variable 
+    ******************************************/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                enSize, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /* video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 6;
+    memset(stVbConf.astCommPool[0].acMmzName,0,
+        sizeof(stVbConf.astCommPool[0].acMmzName));
+
+    /* hist buf*/
+    stVbConf.astCommPool[1].u32BlkSize = (196*4);
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 6;
+    memset(stVbConf.astCommPool[1].acMmzName,0,
+        sizeof(stVbConf.astCommPool[1].acMmzName));
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_VENC_SNAP_0;
+    }
+	
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_VENC_SNAP_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, enSize, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_VENC_SNAP_0;
+    }
+    
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_VENC_SNAP_1;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_VENC_SNAP_2;
+    }
+
+    /******************************************
+     step 5: snap process
+    ******************************************/
+    VencGrp = 0;
+    VencChn = 0;
+	/*snap Cif pic*/
+	s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_CIF, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_VENC_SNAP_0;
+    }
+    s32Ret = SAMPLE_COMM_VENC_SnapStart(VencGrp, VencChn, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start snap failed!\n");
+        goto END_VENC_SNAP_3;
+    }
+    
+    for (i=0; i<u32ViChnCnt; i++)
+    {
+        /*** main frame **/
+        VpssGrp = i;
+
+        s32Ret = SAMPLE_COMM_VENC_SnapProcess(VencGrp, VencChn, VpssGrp, VPSS_PRE0_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("snap process failed!\n");
+            goto END_VENC_SNAP_4;
+        }
+        printf("snap chn %d ok!\n", i);
+
+    }
+
+    /******************************************
+     step 8: exit process
+    ******************************************/
+    printf("snap over!\n");
+    
+END_VENC_SNAP_4:
+    s32Ret = SAMPLE_COMM_VENC_SnapStop(VencGrp, VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Stop snap failed!\n");
+        goto END_VENC_SNAP_3;
+    }
+END_VENC_SNAP_3:
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_VENC_SNAP_2:	//vpss stop
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_VENC_SNAP_1:	//vi stop
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_VENC_SNAP_0:	//system exit
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+
+/******************************************************************************
+* function :  1D1 User send pictures for H264 encode
+******************************************************************************/
+HI_S32 SAMPLE_VENC_1D1_USER_SEND_PICTURES(HI_VOID)
+{  
+    VB_CONF_S stVbConf;
+    VENC_GRP VencGrp = 0;
+    VENC_CHN VencChn = 0;
+    PIC_SIZE_E enSize = PIC_D1;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    SIZE_S stSize;
+    VB_POOL hPool  = VB_INVALID_POOLID;
+    FILE *pfp_img = HI_NULL;  
+    HI_U32 u32PicLStride            = 0;
+    HI_U32 u32PicCStride            = 0;
+    HI_U32 u32LumaSize              = 0;
+    HI_U32 u32ChrmSize              = 0;
+    HI_U32 u32Cnt                   = 0;
+    HI_U32 u32ChnCnt                = 1;
+
+    /******************************************
+     step  1: init variable 
+    ******************************************/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                enSize, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /*ddr0 video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = 10;
+    memset(stVbConf.astCommPool[0].acMmzName,0,
+        sizeof(stVbConf.astCommPool[0].acMmzName));
+
+    
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_VENC_USER_0;
+    }
+
+   
+    /******************************************
+     step 3: open yuv file
+    ******************************************/
+    if (pfp_img != HI_NULL)
+    {
+        fclose(pfp_img);
+        pfp_img = HI_NULL;
+    }
+    
+
+    pfp_img = fopen(SAMPLE_YUV_D1_FILEPATH, "rb" ); 
+    if (pfp_img == HI_NULL)
+    {
+        SAMPLE_PRT("Open yuv file failed!Check if the file %s exit\n",SAMPLE_YUV_D1_FILEPATH);
+        goto END_VENC_USER_0;
+    }
+    
+    /******************************************
+     step 4: create private pool on ddr0
+    ******************************************/
+    hPool   = HI_MPI_VB_CreatePool( u32BlkSize, 10,NULL );
+    if (hPool == VB_INVALID_POOLID)
+    {
+        SAMPLE_PRT("HI_MPI_VB_CreatePool failed! \n");
+        goto END_VENC_USER_1;
+    }
+    
+    /******************************************
+     step 5: encode process
+    ******************************************/
+    
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, enSize, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_VENC_USER_2;
+    }
+    
+    s32Ret = SAMPLE_COMM_VENC_Start(VencGrp, VencChn, PT_H264, gs_enNorm, enSize, SAMPLE_RC_CBR);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start snap failed!\n");
+        goto END_VENC_USER_2;
+    }
+
+
+   /******************************************
+     step 6: stream venc process -- get stream, then save it to file. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VENC_StartGetStream(u32ChnCnt);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("StartGetStream failed!\n");
+        goto END_VENC_USER_3;
+    }
+
+    u32PicLStride = CEILING_2_POWER(stSize.u32Width, SAMPLE_SYS_ALIGN_WIDTH);
+    u32PicCStride = CEILING_2_POWER(stSize.u32Width, SAMPLE_SYS_ALIGN_WIDTH);
+    u32LumaSize = (u32PicLStride * stSize.u32Height);
+    u32ChrmSize = (u32PicCStride * stSize.u32Height) >> 2;
+
+
+    while(0 == feof(pfp_img))
+    { 
+        SAMPLE_MEMBUF_S stMem = {0};
+        VIDEO_FRAME_INFO_S stFrmInfo;
+
+        stMem.hPool = hPool;
+        u32Cnt ++;
+        while((stMem.hBlock = HI_MPI_VB_GetBlock(stMem.hPool, u32BlkSize,NULL)) == VB_INVALID_HANDLE)
+        {
+             ;
+        }
+  
+        stMem.u32PhyAddr = HI_MPI_VB_Handle2PhysAddr(stMem.hBlock);
+
+
+        stMem.pVirAddr = (HI_U8 *) HI_MPI_SYS_Mmap( stMem.u32PhyAddr, u32BlkSize );
+        if(stMem.pVirAddr == NULL)
+        {
+            SAMPLE_PRT("Mem dev may not open\n");
+            goto END_VENC_USER_4;
+        }
+    
+        memset(&stFrmInfo.stVFrame, 0, sizeof(VIDEO_FRAME_S));
+        stFrmInfo.stVFrame.u32PhyAddr[0] = stMem.u32PhyAddr;
+        stFrmInfo.stVFrame.u32PhyAddr[1] = stFrmInfo.stVFrame.u32PhyAddr[0] + u32LumaSize;
+        stFrmInfo.stVFrame.u32PhyAddr[2] = stFrmInfo.stVFrame.u32PhyAddr[1] + u32ChrmSize;
+        
+        stFrmInfo.stVFrame.pVirAddr[0] = stMem.pVirAddr;
+        stFrmInfo.stVFrame.pVirAddr[1] = (HI_U8 *) stFrmInfo.stVFrame.pVirAddr[0] + u32LumaSize;
+        stFrmInfo.stVFrame.pVirAddr[2] = (HI_U8 *) stFrmInfo.stVFrame.pVirAddr[1] + u32ChrmSize;
+
+        stFrmInfo.stVFrame.u32Width     = stSize.u32Width;
+        stFrmInfo.stVFrame.u32Height    = stSize.u32Height;
+        stFrmInfo.stVFrame.u32Stride[0] = u32PicLStride;
+        stFrmInfo.stVFrame.u32Stride[1] = u32PicLStride;
+        stFrmInfo.stVFrame.u32Stride[2] = u32PicLStride;
+
+        stFrmInfo.stVFrame.u64pts     = (u32Cnt * 40);
+        stFrmInfo.stVFrame.u32TimeRef = (u32Cnt * 2);
+
+        /*  Different channsel with different picture sequence  */
+        SAMPLE_COMM_VENC_ReadOneFrame( pfp_img, stFrmInfo.stVFrame.pVirAddr[0], 
+            stFrmInfo.stVFrame.pVirAddr[1], stFrmInfo.stVFrame.pVirAddr[2],
+            stFrmInfo.stVFrame.u32Width, stFrmInfo.stVFrame.u32Height, 
+            stFrmInfo.stVFrame.u32Stride[0], stFrmInfo.stVFrame.u32Stride[1] >> 1 );
+
+        if(0 != feof(pfp_img))
+        {
+            break;
+        }
+         
+        SAMPLE_COMM_VENC_PlanToSemi( stFrmInfo.stVFrame.pVirAddr[0], stFrmInfo.stVFrame.u32Stride[0],
+        stFrmInfo.stVFrame.pVirAddr[1], stFrmInfo.stVFrame.u32Stride[1],
+        stFrmInfo.stVFrame.pVirAddr[2], stFrmInfo.stVFrame.u32Stride[1],
+        stFrmInfo.stVFrame.u32Width,    stFrmInfo.stVFrame.u32Height );
+
+        stFrmInfo.stVFrame.enPixelFormat = SAMPLE_PIXEL_FORMAT;
+        stFrmInfo.stVFrame.u32Field = VIDEO_FIELD_FRAME;
+    
+        stMem.u32PoolId = HI_MPI_VB_Handle2PoolId( stMem.hBlock );
+        stFrmInfo.u32PoolId = stMem.u32PoolId;
+        
+        s32Ret = HI_MPI_VENC_SendFrame(VencGrp, &stFrmInfo);
+
+        HI_MPI_SYS_Munmap( stMem.pVirAddr, u32BlkSize );
+        HI_MPI_VB_ReleaseBlock(stMem.hBlock);
+
+    }
+
+    /******************************************
+     step 7: exit process
+    ******************************************/
+END_VENC_USER_4:
+    SAMPLE_COMM_VENC_StopGetStream();
+END_VENC_USER_3:
+    
+    s32Ret = SAMPLE_COMM_VENC_Stop(VencGrp,VencChn);;
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Stop encode failed!\n");
+        goto END_VENC_USER_2;
+    }
+END_VENC_USER_2:    
+    //before destroy private pool,must stop venc
+    HI_MPI_VB_DestroyPool( hPool );
+
+END_VENC_USER_1:	
+    //close the yuv file
+    fclose( pfp_img );
+    pfp_img = HI_NULL;
+END_VENC_USER_0:	
+    //system exit
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+/******************************************************************************
+* function : 4D1 H264 encode with color2grey
+******************************************************************************/
+HI_S32 SAMPLE_VENC_4D1_H264_COLOR2GREY(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_4_D1;
+
+    HI_U32 u32ViChnCnt = 4;
+    HI_S32 s32VpssGrpCnt = 4;
+    PAYLOAD_TYPE_E enPayLoad[2]= {PT_H264, PT_H264};
+    PIC_SIZE_E enSize[2] = {PIC_D1, PIC_CIF};
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_CHN VpssChn;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VENC_GRP VencGrp;
+    VENC_CHN VencChn;
+    SAMPLE_RC_E enRcMode;
+    GROUP_COLOR2GREY_CONF_S stGrpColor2GreyConf;
+    GROUP_COLOR2GREY_S stGrpColor2Grey;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_CHAR ch;
+    SIZE_S stSize;
+
+    /******************************************
+     step  1: init variable 
+    ******************************************/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+    
+    /*ddr0 video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 6;
+    memset(stVbConf.astCommPool[0].acMmzName,0,
+        sizeof(stVbConf.astCommPool[0].acMmzName));
+
+    /*ddr0 hist buf*/
+    stVbConf.astCommPool[1].u32BlkSize = (196*4);
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 3;
+    memset(stVbConf.astCommPool[1].acMmzName,0,
+        sizeof(stVbConf.astCommPool[1].acMmzName));
+
+ 
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_VENC_16D1_0;
+    }
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_VENC_16D1_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_VENC_16D1_0;
+    }
+    
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_VENC_16D1_1;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_VENC_16D1_2;
+    }
+
+
+    /******************************************
+     step 5: Set color2grey conf
+     ******************************************/
+    stGrpColor2GreyConf.bEnable = HI_TRUE;
+    stGrpColor2GreyConf.u32MaxWidth = 720;
+    stGrpColor2GreyConf.u32MaxHeight = 576;
+    s32Ret = HI_MPI_VENC_SetColor2GreyConf(&stGrpColor2GreyConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SetColor2GreyConf failed!\n");
+        goto END_VENC_16D1_2;
+    }
+    /******************************************
+     step 6: select rc mode
+    ******************************************/
+    while(1)
+    {
+        printf("please choose rc mode:\n"); 
+        printf("\t0) CBR\n"); 
+        printf("\t1) VBR\n"); 
+        printf("\t2) FIXQP\n"); 
+        ch = getchar();
+        getchar();
+        if ('0' == ch)
+        {
+            enRcMode = SAMPLE_RC_CBR;
+            break;
+        }
+        else if ('1' == ch)
+        {
+            enRcMode = SAMPLE_RC_VBR;
+            break;
+        }
+        else if ('2' == ch)
+        {
+            enRcMode = SAMPLE_RC_FIXQP;
+            break;
+        }
+        else
+        {
+            printf("rc mode invaild! please try again.\n");
+            continue;
+        }
+    }
+    /******************************************
+     step 7: start stream venc (big + little)
+    ******************************************/
+    for (i=0; i<u32ViChnCnt; i++)
+    {
+        /*** main frame **/
+        VencGrp = i*2;
+        VencChn = i*2;
+        VpssGrp = i;
+        s32Ret = SAMPLE_COMM_VENC_Start(VencGrp, VencChn, enPayLoad[0],\
+                                       gs_enNorm, enSize[0], enRcMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_16D1_3;
+        }
+
+        s32Ret = SAMPLE_COMM_VENC_BindVpss(VencGrp, VpssGrp, VPSS_BSTR_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_16D1_3;
+        }
+        
+        /*** Enable a grp with color2grey **/
+        stGrpColor2Grey.bColor2Grey = HI_TRUE;
+        s32Ret = HI_MPI_VENC_SetGrpColor2Grey(VencGrp, &stGrpColor2Grey);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SetGrpColor2Grey failed!\n");
+            goto END_VENC_16D1_3;
+        }
+
+        /*** Sub frame **/
+        VencGrp ++;
+        VencChn ++;
+        s32Ret = SAMPLE_COMM_VENC_Start(VencGrp, VencChn, enPayLoad[1], \
+                                        gs_enNorm, enSize[1], enRcMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_16D1_3;
+        }
+
+        s32Ret = SAMPLE_COMM_VENC_BindVpss(VencChn, VpssGrp, VPSS_PRE0_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start Venc failed!\n");
+            goto END_VENC_16D1_3;
+        }
+
+        /*** Enable a grp with color2grey **/
+        stGrpColor2Grey.bColor2Grey = HI_TRUE;
+        s32Ret = HI_MPI_VENC_SetGrpColor2Grey(VencGrp, &stGrpColor2Grey);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SetGrpColor2Grey failed!\n");
+            goto END_VENC_16D1_3;
+        }
+    }
+
+    /******************************************
+     step 8: stream venc process -- get stream, then save it to file. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VENC_StartGetStream(u32ViChnCnt*2);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Venc failed!\n");
+        goto END_VENC_16D1_3;
+    }
+
+    printf("please press twice ENTER to exit this sample\n");
+    getchar();
+    getchar();
+
+    /******************************************
+     step 9: exit process
+    ******************************************/
+    for (i=0; i<u32ViChnCnt; i++)
+    {
+        VencGrp = i*2;
+        /*** Enable a grp with color2grey **/
+        stGrpColor2Grey.bColor2Grey = HI_FALSE;
+        s32Ret = HI_MPI_VENC_SetGrpColor2Grey(VencGrp, &stGrpColor2Grey);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SetGrpColor2Grey failed!\n");
+            goto END_VENC_16D1_3;
+        }
+
+        VencGrp = i*2 + 1;
+        /*** Enable a grp with color2grey **/
+        stGrpColor2Grey.bColor2Grey = HI_FALSE;
+        s32Ret = HI_MPI_VENC_SetGrpColor2Grey(VencGrp, &stGrpColor2Grey);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SetGrpColor2Grey failed!\n");
+            goto END_VENC_16D1_3;
+        }
+    }
+
+    
+    SAMPLE_COMM_VENC_StopGetStream();
+    
+END_VENC_16D1_3:
+    for (i=0; i<u32ViChnCnt*2; i++)
+    {
+        VencGrp = i;
+        VencChn = i;
+        VpssGrp = i/2;
+        VpssChn = (VpssGrp%2)?VPSS_PRE0_CHN:VPSS_BSTR_CHN;
+        SAMPLE_COMM_VENC_UnBindVpss(VencGrp, VpssGrp, VpssChn);
+        stGrpColor2Grey.bColor2Grey = HI_FALSE;
+        HI_MPI_VENC_SetGrpColor2Grey(VencGrp, &stGrpColor2Grey);
+        SAMPLE_COMM_VENC_Stop(VencGrp,VencChn);
+    }
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_VENC_16D1_2:	//vpss stop
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_VENC_16D1_1:	//vi stop
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_VENC_16D1_0:	//system exit
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+/******************************************************************************
+* function :  4D1 SNAP with StartRecvPicEx
+******************************************************************************/
+HI_S32 SAMPLE_VENC_4D1_SnapEx(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_4_D1;
+
+    HI_U32 u32ViChnCnt = 4;
+    HI_S32 s32VpssGrpCnt = 4;
+    PIC_SIZE_E enSize = PIC_D1;
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VENC_GRP VencGrp;
+    VENC_CHN VencChn;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    SIZE_S stSize;
+
+    /******************************************
+     step  1: init variable 
+    ******************************************/
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                enSize, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /* video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 15;
+    memset(stVbConf.astCommPool[0].acMmzName,0,
+        sizeof(stVbConf.astCommPool[0].acMmzName));
+
+    /* hist buf*/
+    stVbConf.astCommPool[1].u32BlkSize = (196*4);
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 15;
+    memset(stVbConf.astCommPool[1].acMmzName,0,
+        sizeof(stVbConf.astCommPool[1].acMmzName));
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_VENC_SNAP_0;
+    }
+	
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_VENC_SNAP_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, enSize, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_VENC_SNAP_0;
+    }
+    
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_VENC_SNAP_1;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_VENC_SNAP_2;
+    }
+
+    /******************************************
+     step 5: snap process
+    ******************************************/
+    VencGrp = 0;
+    VencChn = 0;
+    s32Ret = SAMPLE_COMM_VENC_SnapStart(VencGrp, VencChn, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start snap failed!\n");
+        goto END_VENC_SNAP_3;
+    }
+    for (i=0; i<u32ViChnCnt; i++)
+    {
+        /*** main frame **/
+        VpssGrp = i;
+
+        s32Ret = SAMPLE_COMM_VENC_SnapProcessEx(VencGrp, VencChn, VpssGrp, VPSS_PRE0_CHN);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("snap process failed!\n");
+            goto END_VENC_SNAP_4;
+        }
+        printf("snap chn %d ok!\n", i);
+
+        sleep(1);
+    }
+
+    /******************************************
+     step 8: exit process
+    ******************************************/
+    printf("snap over!\n");
+    
+END_VENC_SNAP_4:
+    s32Ret = SAMPLE_COMM_VENC_SnapStop(VencGrp, VencChn);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Stop snap failed!\n");
+        goto END_VENC_SNAP_3;
+    }
+END_VENC_SNAP_3:
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_VENC_SNAP_2:	//vpss stop
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_VENC_SNAP_1:	//vi stop
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_VENC_SNAP_0:	//system exit
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+
+/******************************************************************************
+* function    : main()
+* Description : video venc sample
+******************************************************************************/
+int main(int argc, char *argv[])
+{
+    HI_S32 s32Ret;
+    if ( (argc < 2) || (1 != strlen(argv[1])))
+    {
+        SAMPLE_VENC_Usage(argv[0]);
+        return HI_FAILURE;
+    }
+
+    signal(SIGINT, SAMPLE_VENC_HandleSig);
+    signal(SIGTERM, SAMPLE_VENC_HandleSig);
+    
+    switch (*argv[1])
+    {
+        case '0':/* 4D1 H264 encode */
+            s32Ret = SAMPLE_VENC_4D1_H264();
+            break;
+        case '1':/* 1*720p H264 encode */
+            s32Ret = SAMPLE_VENC_1HD_H264();
+            break;
+        case '2':/* 1D1 MJPEG encode */
+            s32Ret = SAMPLE_VENC_1D1_MJPEG();
+            break;
+        case '3':/* 4D1 JPEG snap */
+            s32Ret = SAMPLE_VENC_4D1_Snap();
+            break;
+        case '4':/* 4D1 JPEG snap */
+            s32Ret = SAMPLE_VENC_4D1_SnapEx();
+            break;            
+        case '5':/* 8*Cif JPEG snap */
+            s32Ret = SAMPLE_VENC_8_Cif_Snap();
+            break;
+        case '6':/* 1D1 User send pictures for H264 encode */
+            s32Ret = SAMPLE_VENC_1D1_USER_SEND_PICTURES();
+            break;
+        case '7':/* 4D1 H264 encode with color2grey */
+            s32Ret = SAMPLE_VENC_4D1_H264_COLOR2GREY();
+            break;
+        default:
+            printf("the index is invaild!\n");
+            SAMPLE_VENC_Usage(argv[0]);
+            return HI_FAILURE;
+    }
+    
+    if (HI_SUCCESS == s32Ret)
+        printf("program exit normally!\n");
+    else
+        printf("program exit abnormally!\n");
+    exit(s32Ret);
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */

--- a/libraries/mpp_sample/hi3520dv200/vio/Makefile
+++ b/libraries/mpp_sample/hi3520dv200/vio/Makefile
@@ -1,0 +1,33 @@
+# Hisilicon Hi3516 sample Makefile
+
+include ../Makefile.param
+#ifeq ($(SAMPLE_PARAM_FILE), )
+#     SAMPLE_PARAM_FILE:=../Makefile.param
+#     include $(SAMPLE_PARAM_FILE)
+#endif
+
+# target source
+SRC  := $(wildcard *.c) 
+OBJ  := $(SRC:%.c=%.o)
+
+TARGET := $(OBJ:%.o=%)
+.PHONY : clean all
+
+all: $(TARGET)
+
+MPI_LIBS := $(REL_LIB)/libmpi.a
+MPI_LIBS += $(REL_LIB)/libhdmi.a
+
+$(TARGET):%:%.o $(COMM_OBJ)
+	$(CC) $(CFLAGS) -lpthread -lm -o $@ $^ $(MPI_LIBS) $(AUDIO_LIBA) $(JPEGD_LIBA)
+
+clean:
+	@rm -f $(TARGET)
+	@rm -f $(OBJ)
+	@rm -f $(COMM_OBJ)
+
+cleanstream:
+	@rm -f *.h264
+	@rm -f *.jpg
+	@rm -f *.mjp
+	@rm -f *.mp4

--- a/libraries/mpp_sample/hi3520dv200/vio/sample_vio.c
+++ b/libraries/mpp_sample/hi3520dv200/vio/sample_vio.c
@@ -1,0 +1,2782 @@
+/******************************************************************************
+  A simple program of Hisilicon HI3520D video input and output implementation.
+  Copyright (C), 2010-2011, Hisilicon Tech. Co., Ltd.
+ ******************************************************************************
+    Modification:  2012-12 Created
+******************************************************************************/
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* End of #ifdef __cplusplus */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+#include "sample_comm.h"
+
+VIDEO_NORM_E gs_enNorm = VIDEO_ENCODING_MODE_PAL;
+SAMPLE_VIDEO_LOSS_S gs_stVideoLoss;
+HI_U32 gs_u32ViFrmRate = 0; 
+
+/******************************************************************************
+* function : show usage
+******************************************************************************/
+void SAMPLE_VIO_Usage(char *sPrgNm)
+{
+    printf("Usage : %s <index>\n", sPrgNm);
+    printf("index:\n");
+    printf("\t 0) VI:8*D1; VO:HD0(HDMI,VGA)+SD0(CVBS)+SD1 video preview.\n");
+    printf("\t 1) VI:1*1080p; VO:SD0(CVBS), HD0(HDMI,1080p@60 + VGA).\n");
+    printf("\t 2) VI:VI:8*2cif; VO:HD0(HDMI  720P50), WBC to SD0(CVBS) video preview.\n");
+    printf("\t 3) VI:VI:8*D1(6fps)/2cif(19fps); VO:HD0(HDMI  720P50)video preview\n");	
+    printf("\t 4) VI: 1*D1, user picture; VO: SD0(CVBS) video preview.\n");
+    printf("\t 5) VI: 1*D1; VO:HD0(VGA) HD Zoom preview.\n");
+    printf("\t 6) VI: 1*D1; VO:SD0(CVBS) SD Zoom preview.\n");
+    printf("\t 7) VI: 4*720p; HD0(HDMI,1080p@50 + VGA). Only for Hi3520DV200\n");
+
+    return;
+}
+
+/******************************************************************************
+* function : to process abnormal case                                         
+******************************************************************************/
+void SAMPLE_VIO_HandleSig(HI_S32 signo)
+{
+    if (SIGINT == signo || SIGTSTP == signo)
+    {
+        SAMPLE_COMM_SYS_Exit();
+        printf("\033[0;31mprogram termination abnormally!\033[0;39m\n");
+    }
+    exit(-1);
+}
+
+/******************************************************************************
+* function : video loss detect process                                         
+* NOTE: If your ADC stop output signal when NoVideo, you can open VDET_USE_VI macro.
+******************************************************************************/
+
+void *SAMPLE_VI_AD26828_VLossDetProc(void *parg)
+{  
+    int fd;
+    HI_S32 s32Ret, i, s32ChnPerDev;
+    VI_DEV ViDev;
+    VI_CHN ViChn;
+    tw2865_video_loss video_loss;
+    SAMPLE_VI_PARAM_S stViParam;
+    SAMPLE_VIDEO_LOSS_S *ctl = (SAMPLE_VIDEO_LOSS_S*)parg;
+    
+    fd = open(CX26828_FILE, O_RDWR);//TW2865_FILE
+    if (fd < 0)
+    {
+        printf("open %s fail\n", CX26828_FILE);
+        ctl->bStart = HI_FALSE;
+        return NULL;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_Mode2Param(ctl->enViMode, &stViParam);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("vi get param failed!\n");
+        return NULL;
+    }
+    s32ChnPerDev = stViParam.s32ViChnCnt / stViParam.s32ViDevCnt;
+    
+    while (ctl->bStart)
+    {
+        for (i = 0; i < stViParam.s32ViChnCnt; i++)
+        {
+            ViChn = i * stViParam.s32ViChnInterval;
+            ViDev = SAMPLE_COMM_VI_GetDev(ctl->enViMode, ViChn);
+            if (ViDev < 0)
+            {
+                SAMPLE_PRT("get vi dev failed !\n");
+                return NULL;
+            }
+            
+            //video_loss.chip = stViParam.s32ViDevCnt;
+            video_loss.chip = 0;
+            video_loss.ch   = ViChn % s32ChnPerDev;
+			//printf("video_loss.chip %d, video_loss.ch %d\n",video_loss.chip,video_loss.ch );
+            ioctl(fd, CX26828_GET_VIDEO_LOSS, &video_loss);
+
+            if (video_loss.is_lost)
+            {   
+                printf("pic loss\n");
+                HI_MPI_VI_EnableUserPic(ViChn);
+            }
+            else
+            {
+                HI_MPI_VI_DisableUserPic(ViChn);
+            }                
+        }
+        usleep(500000);
+    }
+    
+    close(fd);
+    ctl->bStart = HI_FALSE;
+    
+    return NULL;
+}
+
+void *SAMPLE_VI_AD2865_VLossDetProc(void *parg)
+{  
+    int fd;
+    HI_S32 s32Ret, i, s32ChnPerDev;
+    VI_DEV ViDev;
+    VI_CHN ViChn;
+    tw2865_video_loss video_loss;
+    SAMPLE_VI_PARAM_S stViParam;
+    SAMPLE_VIDEO_LOSS_S *ctl = (SAMPLE_VIDEO_LOSS_S*)parg;
+    
+    fd = open(TW2865_FILE, O_RDWR);//TW2865_FILE
+    if (fd < 0)
+    {
+        printf("open %s fail\n", TW2865_FILE);
+        ctl->bStart = HI_FALSE;
+        return NULL;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_Mode2Param(ctl->enViMode, &stViParam);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("vi get param failed!\n");
+        return NULL;
+    }
+    s32ChnPerDev = stViParam.s32ViChnCnt / stViParam.s32ViDevCnt;
+    
+    while (ctl->bStart)
+    {
+        for (i = 0; i < stViParam.s32ViChnCnt; i++)
+        {
+            ViChn = i * stViParam.s32ViChnInterval;
+            ViDev = SAMPLE_COMM_VI_GetDev(ctl->enViMode, ViChn);
+            if (ViDev < 0)
+            {
+                SAMPLE_PRT("get vi dev failed !\n");
+                return NULL;
+            }
+            
+            //video_loss.chip = stViParam.s32ViDevCnt;
+            video_loss.chip = 0;
+            video_loss.ch   = ViChn % s32ChnPerDev;
+			//printf("video_loss.chip %d, video_loss.ch %d\n",video_loss.chip,video_loss.ch );
+            ioctl(fd, TW2865_GET_VIDEO_LOSS, &video_loss);
+
+            if (video_loss.is_lost)
+            {   
+                printf("pic loss\n");
+                HI_MPI_VI_EnableUserPic(ViChn);
+            }
+            else
+            {
+                HI_MPI_VI_DisableUserPic(ViChn);
+            }                
+        }
+        usleep(500000);
+    }
+    
+    close(fd);
+    ctl->bStart = HI_FALSE;
+    
+    return NULL;
+}
+
+
+//#define VDET_USE_VI   
+#ifdef VDET_USE_VI
+static HI_S32 s_astViLastIntCnt[VIU_MAX_CHN_NUM] = {0};
+void *SAMPLE_VI_VLossDetProc(void *parg)
+{ 
+    VI_CHN ViChn;
+    SAMPLE_VI_PARAM_S stViParam;
+    HI_S32 s32Ret, i, s32ChnPerDev;
+    VI_CHN_STAT_S stStat;
+    SAMPLE_VIDEO_LOSS_S *ctl = (SAMPLE_VIDEO_LOSS_S*)parg;
+    
+    s32Ret = SAMPLE_COMM_VI_Mode2Param(ctl->enViMode, &stViParam);
+    if (HI_SUCCESS !=s32Ret)
+    {
+        SAMPLE_PRT("vi get param failed!\n");
+        return NULL;
+    }
+    s32ChnPerDev = stViParam.s32ViChnCnt / stViParam.s32ViDevCnt;
+    
+    while (ctl->bStart)
+    {
+        for (i = 0; i < stViParam.s32ViChnCnt; i++)
+        {
+            ViChn = i * stViParam.s32ViChnInterval;
+
+            s32Ret = HI_MPI_VI_Query(ViChn, &stStat);
+            if (HI_SUCCESS !=s32Ret)
+            {
+                SAMPLE_PRT("HI_MPI_VI_Query failed with %#x!\n", s32Ret);
+                return NULL;
+            }            
+
+            if (stStat.u32IntCnt == s_astViLastIntCnt[i])
+            
+            {
+                printf("VI Chn (%d) int lost , int_cnt:%d \n", ViChn, stStat.u32IntCnt);
+                HI_MPI_VI_EnableUserPic(ViChn);
+            }
+            
+            else
+            {
+                HI_MPI_VI_DisableUserPic(ViChn);
+            }
+            s_astViLastIntCnt[i] = stStat.u32IntCnt;
+        }
+        usleep(500000);
+    }
+    
+    ctl->bStart = HI_FALSE;
+    
+    return NULL;
+}
+
+#endif
+
+HI_S32 SAMPLE_VI_StartVLossDet(SAMPLE_VI_MODE_E enViMode)
+{
+    HI_S32 s32Ret;
+    
+    gs_stVideoLoss.bStart= HI_TRUE;
+    gs_stVideoLoss.enViMode = enViMode;
+#ifdef VDET_USE_VI  
+    s32Ret = pthread_create(&gs_stVideoLoss.Pid, 0, SAMPLE_VI_VLossDetProc, &gs_stVideoLoss);
+#else
+    #ifdef DEMO
+    s32Ret = pthread_create(&gs_stVideoLoss.Pid, 0, SAMPLE_VI_AD26828_VLossDetProc, &gs_stVideoLoss);
+    #else
+    s32Ret = pthread_create(&gs_stVideoLoss.Pid, 0, SAMPLE_VI_AD2865_VLossDetProc, &gs_stVideoLoss);
+    #endif
+#endif
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("pthread_create failed with %#x!\n", s32Ret);
+        return HI_FAILURE;
+    }
+    
+    return HI_SUCCESS;
+}
+
+
+
+HI_VOID SAMPLE_VI_StopVLossDet()
+{
+    if (gs_stVideoLoss.bStart)
+    {
+        gs_stVideoLoss.bStart = HI_FALSE;
+        pthread_join(gs_stVideoLoss.Pid, 0);
+    }
+    return;
+}
+
+HI_S32 SAMPLE_VI_SetUserPic(HI_CHAR *pszYuvFile, HI_U32 u32Width, HI_U32 u32Height,
+        HI_U32 u32Stride, VIDEO_FRAME_INFO_S *pstFrame)
+{
+    FILE *pfd;
+    VI_USERPIC_ATTR_S stUserPicAttr;
+
+    /* open YUV file */
+    pfd = fopen(pszYuvFile, "rb");
+    if (!pfd)
+    {
+        printf("open file -> %s fail \n", pszYuvFile);
+        return -1;
+    }
+
+    /* read YUV file. WARNING: we only support planar 420) */
+    if (SAMPLE_COMM_VI_GetVFrameFromYUV(pfd, u32Width, u32Height, u32Stride, pstFrame))
+    {
+        return -1;
+    }
+    fclose(pfd);
+
+    stUserPicAttr.bPub= HI_TRUE;
+    stUserPicAttr.enUsrPicMode = VI_USERPIC_MODE_PIC;
+    memcpy(&stUserPicAttr.unUsrPic.stUsrPicFrm, pstFrame, sizeof(VIDEO_FRAME_INFO_S));
+    if (HI_MPI_VI_SetUserPic(0, &stUserPicAttr))
+    {
+        return -1;
+    }
+
+    printf("set vi user pic ok, yuvfile:%s\n", pszYuvFile);
+    return HI_SUCCESS;
+}
+
+/******************************************************************************
+* function :  VI:8*D1; VO:HD0(HDMI,VGA)+SD0(CVBS)+SD1 video preview
+******************************************************************************/
+HI_S32 SAMPLE_VIO_8_D1(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_8_D1;
+
+    HI_U32 u32ViChnCnt = 8;
+    HI_S32 s32VpssGrpCnt = 8;
+    
+    VB_CONF_S stVbConf;
+    VI_CHN ViChn;
+    VPSS_GRP VpssGrp;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VPSS_CHN VpssChn_VoHD0 = VPSS_PRE0_CHN;
+    VO_DEV VoDev;
+    VO_CHN VoChn;
+    VO_PUB_ATTR_S stVoPubAttr,stVoPubAttrSD; 
+    SAMPLE_VO_MODE_E enVoMode, enPreVoMode;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_CHAR ch;
+    SIZE_S stSize;
+    HI_U32 u32WndNum;
+	
+	VO_WBC_ATTR_S stWbcAttr;
+
+    /******************************************
+     step  1: init variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL== gs_enNorm)?25:30;
+    
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /* video buffer*/
+    //todo: vb=15
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 8;
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_8D1_0;
+    }
+
+    /******************************************
+     step 3: start vi dev & chn
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_8D1_0;
+    }
+
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_8D1_0;
+    }
+    
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_FALSE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_8D1_1;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_8D1_2;
+    }
+	/******************************************
+	step 5: start vo SD1(CVBS)
+	******************************************/
+
+	printf("start vo SD1.\n");
+	VoDev = SAMPLE_VO_DEV_DSD1;
+	u32WndNum = 1;
+	enVoMode = VO_MODE_1MUX;
+
+	stVoPubAttr.enIntfSync = VO_OUTPUT_PAL;
+	stVoPubAttr.enIntfType = VO_INTF_CVBS;
+	stVoPubAttr.u32BgColor = 0x000000ff;
+	stVoPubAttr.bDoubleFrame = HI_FALSE;
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+		 SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+		 goto END_8D1_3;
+	}
+
+	s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+		 SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+		 goto END_8D1_4;
+	}
+
+	VoChn = 0;
+	ViChn = 0;
+	s32Ret = SAMPLE_COMM_VO_BindVi(VoDev,VoChn, ViChn);
+	if (HI_SUCCESS != s32Ret)
+	{
+		 SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+		 goto END_8D1_4;
+	}
+	
+    /******************************************
+     step 6: start vo HD0 (HDMI+VGA), multi-screen, you can switch mode
+    ******************************************/
+    printf("start vo HD0.\n");
+    VoDev = SAMPLE_VO_DEV_DHD0;
+    u32WndNum = 16;
+    enVoMode = VO_MODE_1MUX;
+    
+    if(VIDEO_ENCODING_MODE_PAL == gs_enNorm)
+    {
+        stVoPubAttr.enIntfSync = VO_OUTPUT_1080P50;
+    }
+    else
+    {
+        stVoPubAttr.enIntfSync = VO_OUTPUT_1080P60;
+    }
+#ifdef HI_FPGA
+	stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA|VO_INTF_BT1120;
+#else 
+	stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA;
+#endif
+
+    stVoPubAttr.u32BgColor = 0x000000ff;
+    stVoPubAttr.bDoubleFrame = HI_TRUE;
+    
+    s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start SAMPLE_COMM_VO_StartDevLayer failed!\n");
+        goto END_8D1_4;
+    }
+    
+    s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start SAMPLE_COMM_VO_StartChn failed!\n");
+        goto END_8D1_5;
+    }
+
+    /* if it's displayed on HDMI, we should start HDMI */
+    if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+        {
+            SAMPLE_PRT("Start SAMPLE_COMM_VO_HdmiStart failed!\n");
+            goto END_8D1_5;
+        }
+    }
+    
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        VpssGrp = i;
+        
+        s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,VpssChn_VoHD0);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8D1_5;
+        }
+    }
+
+	/******************************************
+	step 7: start vo SD0 (CVBS) (WBC target) 
+	******************************************/
+	printf("start vo SD0: wbc from hd0\n");
+	VoDev = SAMPLE_VO_DEV_DSD0;
+	u32WndNum = 16;
+	enVoMode = VO_MODE_1MUX;
+
+	stVoPubAttrSD.enIntfSync = VO_OUTPUT_PAL;
+	stVoPubAttrSD.enIntfType = VO_INTF_CVBS;
+	stVoPubAttrSD.u32BgColor = 0x000000ff;
+	stVoPubAttrSD.bDoubleFrame = HI_FALSE;
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttrSD, gs_u32ViFrmRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+		  SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+		  goto END_8D1_5;
+	}
+
+	s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttrSD, enVoMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+		  SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+		  goto END_8D1_6;
+	}
+	  
+	s32Ret = SAMPLE_COMM_VO_GetWH(VO_OUTPUT_PAL, \
+					  &stWbcAttr.stTargetSize.u32Width, \
+					  &stWbcAttr.stTargetSize.u32Height, \
+					  &stWbcAttr.u32FrameRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("SAMPLE_COMM_VO_GetWH failed!\n");
+		goto END_8D1_6;
+	}
+	stWbcAttr.enPixelFormat = SAMPLE_PIXEL_FORMAT;
+    stWbcAttr.enDataSource = VO_WBC_DATASOURCE_MIXER;
+
+	s32Ret = HI_MPI_VO_SetWbcAttr(SAMPLE_VO_DEV_DHD0, &stWbcAttr);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("HI_MPI_VO_SetWbcAttr failed!\n");
+		goto END_8D1_6;
+	}
+
+	s32Ret = HI_MPI_VO_EnableWbc(SAMPLE_VO_DEV_DHD0);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("HI_MPI_VO_SetWbcAttr failed!\n");
+		goto END_8D1_7;
+	}
+
+	s32Ret = SAMPLE_COMM_VO_BindVoWbc(SAMPLE_VO_DEV_DHD0, SAMPLE_VO_DEV_DSD0, 0);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("HI_MPI_VO_SetWbcAttr failed!\n");
+		goto END_8D1_7;
+	}
+	
+	/******************************************
+	step 8: HD0 switch mode 
+	******************************************/
+	VoDev = SAMPLE_VO_DEV_DHD0;
+	enVoMode = VO_MODE_1MUX;
+    while(1)
+    {
+        enPreVoMode = enVoMode;
+    
+        printf("please choose preview mode, press 'q' to exit this sample.\n"); 
+        printf("\t0) 1 preview\n");
+        printf("\t1) 4 preview\n");
+        printf("\t2) 8 preview\n");
+        printf("\tq) quit\n");
+ 
+        ch = getchar();
+        getchar();
+        if ('0' == ch)
+        {
+            u32WndNum = 1;
+            enVoMode = VO_MODE_1MUX;
+        }
+        else if ('1' == ch)
+        {
+            u32WndNum = 4;
+            enVoMode = VO_MODE_4MUX;
+        }
+		/*Indeed only 8 chns show*/
+        else if ('2' == ch)
+        {
+            u32WndNum = 9;
+            enVoMode = VO_MODE_9MUX;
+        }
+        else if ('q' == ch)
+        {
+            break;
+        }
+        else
+        {
+            SAMPLE_PRT("preview mode invaild! please try again.\n");
+            continue;
+        }
+        SAMPLE_PRT("vo(%d) switch to %d mode\n", VoDev, u32WndNum);
+
+        s32Ret= HI_MPI_VO_SetAttrBegin(VoDev);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8D1_7;
+        }
+        
+        s32Ret = SAMPLE_COMM_VO_StopChn(VoDev, enPreVoMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8D1_7;
+        }
+
+        s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8D1_7;
+        }
+        s32Ret= HI_MPI_VO_SetAttrEnd(VoDev);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8D1_7;
+        }
+    }
+
+    /******************************************
+     step 8: exit process
+    ******************************************/
+
+END_8D1_7:
+	SAMPLE_COMM_VO_UnBindVoWbc(SAMPLE_VO_DEV_DSD0, 0);
+	HI_MPI_VO_DisableWbc(SAMPLE_VO_DEV_DHD0);
+
+END_8D1_6:
+	VoDev = SAMPLE_VO_DEV_DSD0;
+	VoChn = 0;
+	enVoMode = VO_MODE_1MUX;
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+
+END_8D1_5:
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        SAMPLE_COMM_VO_HdmiStop();
+    }
+    VoDev = SAMPLE_VO_DEV_DHD0;
+    u32WndNum = 16;
+    enVoMode = VO_MODE_16MUX;
+    /*先disableChn ,再解除绑定*/
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        VpssGrp = i;
+        SAMPLE_COMM_VO_UnBindVpss(VoDev,VoChn,VpssGrp,VpssChn_VoHD0);
+    }
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+
+END_8D1_4:
+#if HICHIP == HI3521_V100
+	VoDev = SAMPLE_VO_DEV_DSD1;
+	VoChn = 0;
+	enVoMode = VO_MODE_1MUX;
+    SAMPLE_COMM_VO_UnBindVi(VoDev,VoChn); 
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+#endif
+END_8D1_3:	//vi unbind vpss
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_8D1_2:	//vpss stop
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_8D1_1:	//vi stop
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_8D1_0:	//system exit
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+
+/******************************************************************************
+* function :  VI:8*2cif; VO:HD0(HDMI  720P50), WBC to SD0(CVBS) video preview. 
+******************************************************************************/
+HI_S32 SAMPLE_VIO_8_2cif(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_8_2Cif;
+    HI_U32 u32ViChnCnt = 8;
+    HI_S32 s32VpssGrpCnt = 8;
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_GRP_ATTR_S stGrpAttr;
+
+	VPSS_CHN VpssChn_VoHD0 = VPSS_PRE0_CHN;
+	 
+    VO_DEV VoDev;
+    VO_CHN VoChn;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    VO_PUB_ATTR_S stVoPubAttr_SD; 
+    SAMPLE_VO_MODE_E enVoMode, enPreVoMode;
+    VO_WBC_ATTR_S stWbcAttr;
+	 
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_CHAR ch;
+    SIZE_S stSize,stSizeTmp;
+    HI_U32 u32WndNum;
+
+    /******************************************
+     step  1: init global  variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL== gs_enNorm)?25:30;
+    
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                    PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /*video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 12;
+
+	u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_2CIF, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    /* video buffer*/
+    stVbConf.astCommPool[1].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 6;
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_8_2Cif_0;
+    }
+
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_8_2Cif_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_8_2Cif_1;
+    }
+    
+    stGrpAttr.u32MaxW = 720;
+    stGrpAttr.u32MaxH = (VIDEO_ENCODING_MODE_PAL==gs_enNorm)?576:480;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_8_2Cif_1;
+    }
+    /*open pre-scale*/
+	s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_2CIF, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_8_2Cif_1;
+    }
+    for(i=0;i<s32VpssGrpCnt;i++)
+    {   
+		s32Ret = SAMPLE_COMM_EnableVpssPreScale(i,stSize);
+		if(HI_SUCCESS != s32Ret)
+		{
+        SAMPLE_PRT("HI_MPI_VPSS_SetPreScale failed!\n");
+        goto END_8_2Cif_1;
+        }
+    }
+
+		
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_8_2Cif_2;
+    }
+
+    /******************************************
+     step 5: start vo HD1 (VGA+HDMI) (DoubleFrame) (WBC source) 
+    ******************************************/
+	printf("start vo HD0.\n");
+	VoDev = SAMPLE_VO_DEV_DHD0;
+	u32WndNum = 8;
+	enVoMode = VO_MODE_9MUX;
+
+	if(VIDEO_ENCODING_MODE_PAL == gs_enNorm)
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_720P50;
+	}
+	else
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_720P60;
+	}
+#ifdef HI_FPGA
+	stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA|VO_INTF_BT1120;
+#else
+    stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA;
+#endif
+	stVoPubAttr.u32BgColor = 0x000000ff;
+	stVoPubAttr.bDoubleFrame = HI_TRUE;
+
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Start SAMPLE_COMM_VO_StartDevLayer failed!\n");
+		goto END_8_2Cif_3;
+	}
+
+	s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Start SAMPLE_COMM_VO_StartChn failed!\n");
+		goto END_8_2Cif_4;
+	}
+
+	/* if it's displayed on HDMI, we should start HDMI */
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+	{
+		if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+		{
+			SAMPLE_PRT("Start SAMPLE_COMM_VO_HdmiStart failed!\n");
+			goto END_8_2Cif_4;
+		}
+	}
+
+	for(i=0;i<u32WndNum;i++)
+	{
+		VoChn = i;
+		VpssGrp = i;
+		
+		s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,VpssChn_VoHD0);
+		if (HI_SUCCESS != s32Ret)
+		{
+			SAMPLE_PRT("Start VO failed!\n");
+			goto END_8_2Cif_4;
+		}
+	}
+
+	/******************************************
+	step 7: start vo SD0 (CVBS) (WBC target) 
+	******************************************/
+	printf("start vo SD0: wbc from hd0\n");
+	VoDev = SAMPLE_VO_DEV_DSD0;
+	u32WndNum = 1;
+	enVoMode = VO_MODE_1MUX;
+
+	stVoPubAttr_SD.enIntfSync = VO_OUTPUT_PAL;
+	stVoPubAttr_SD.enIntfType = VO_INTF_CVBS;
+	stVoPubAttr_SD.u32BgColor = 0x000000ff;
+	stVoPubAttr_SD.bDoubleFrame = HI_FALSE;
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr_SD, gs_u32ViFrmRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+		  SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+		  goto END_8_2Cif_4;
+	}
+
+	s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr_SD, enVoMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+		  SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+		  goto END_8_2Cif_5;
+	}
+	  
+	s32Ret = SAMPLE_COMM_VO_GetWH(VO_OUTPUT_PAL, \
+					  &stWbcAttr.stTargetSize.u32Width, \
+					  &stWbcAttr.stTargetSize.u32Height, \
+					  &stWbcAttr.u32FrameRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("SAMPLE_COMM_VO_GetWH failed!\n");
+		goto END_8_2Cif_5;
+	}
+	stWbcAttr.enPixelFormat = SAMPLE_PIXEL_FORMAT;
+    stWbcAttr.enDataSource = VO_WBC_DATASOURCE_MIXER;
+
+	s32Ret = HI_MPI_VO_SetWbcAttr(SAMPLE_VO_DEV_DHD0, &stWbcAttr);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("HI_MPI_VO_SetWbcAttr failed!\n");
+		goto END_8_2Cif_5;
+	}
+
+	s32Ret = HI_MPI_VO_EnableWbc(SAMPLE_VO_DEV_DHD0);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("HI_MPI_VO_SetWbcAttr failed!\n");
+		goto END_8_2Cif_6;
+	}
+
+	s32Ret = SAMPLE_COMM_VO_BindVoWbc(SAMPLE_VO_DEV_DHD0, SAMPLE_VO_DEV_DSD0, 0);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("HI_MPI_VO_SetWbcAttr failed!\n");
+		goto END_8_2Cif_6;
+	}
+   
+    /******************************************
+         step 9: HD0 switch mode 
+    ******************************************/
+    VoDev = SAMPLE_VO_DEV_DHD0;
+    enVoMode = VO_MODE_9MUX;
+    while(1)
+    {
+  		enPreVoMode = enVoMode;
+        printf("please choose preview mode, press 'q' to exit this sample.\n"); 
+        printf("\t0) 1 preview\n");
+        printf("\t1) 4 preview\n");
+        printf("\t2) 8 preview\n");        
+        printf("\tq) quit\n");
+ 
+        ch = getchar();
+        getchar();
+        if ('0' == ch)
+        {
+            u32WndNum = 1;
+            enVoMode = VO_MODE_1MUX;
+        }
+        else if ('1' == ch)
+        {
+            u32WndNum = 4;
+            enVoMode = VO_MODE_4MUX;
+        }
+        else if ('2' == ch)
+        {
+            u32WndNum = 8;
+            enVoMode = VO_MODE_9MUX;
+        }       
+        else if ('q' == ch)
+        {
+            break;
+        }
+        else
+        {
+            SAMPLE_PRT("preview mode invaild! please try again.\n");
+            continue;
+        }
+		/* VI Input size should change from 2cif to D1 */
+		if(( VO_MODE_1MUX== enVoMode ||VO_MODE_4MUX== enVoMode)&&( VO_MODE_9MUX== enPreVoMode))
+		{
+		 	stSizeTmp.u32Width = 720;
+			stSizeTmp.u32Height = ((VIDEO_ENCODING_MODE_PAL==gs_enNorm)?576:480);
+            if(VO_MODE_1MUX == enVoMode)
+        	{                
+				s32Ret = SAMPLE_COMM_DisableVpssPreScale(0,stSizeTmp);
+				if (HI_SUCCESS != s32Ret)
+				{
+					SAMPLE_PRT("SAMPLE_COMM_DisableVpssPreScale VO failed!\n");
+					goto END_8_2Cif_6;
+				}
+        	}
+			else
+			{
+				for(i=0;i<u32WndNum;i++)
+			 	{
+					s32Ret = SAMPLE_COMM_DisableVpssPreScale(i,stSizeTmp);
+					if (HI_SUCCESS != s32Ret)
+					{
+						SAMPLE_PRT("SAMPLE_COMM_DisableVpssPreScale VO failed!\n");
+						goto END_8_2Cif_6;
+					}
+			 	}
+			}
+		}
+		/* VI Input size should change from  D1 to 2cif */
+        else if(( VO_MODE_1MUX== enPreVoMode ||VO_MODE_4MUX== enPreVoMode)&&( VO_MODE_9MUX== enVoMode))
+        {
+        	stSizeTmp.u32Width= D1_WIDTH / 2;
+			stSizeTmp.u32Height = ((VIDEO_ENCODING_MODE_PAL==gs_enNorm)?576:480);
+	        if(VO_MODE_9MUX == enVoMode)
+        	{
+        		for(i=0;i<u32WndNum;i++)
+			 	{
+					s32Ret = SAMPLE_COMM_EnableVpssPreScale(i,stSizeTmp);
+					if (HI_SUCCESS != s32Ret)
+					{
+						SAMPLE_PRT("SAMPLE_COMM_DisableVpssPreScale VO failed!\n");
+						goto END_8_2Cif_6;
+					}
+        		}
+        	}
+			else
+			{
+				for(i=0;i<u32WndNum;i++)
+			 	{
+					s32Ret = SAMPLE_COMM_EnableVpssPreScale(i,stSizeTmp);
+					if (HI_SUCCESS != s32Ret)
+					{
+						SAMPLE_PRT("SAMPLE_COMM_DisableVpssPreScale VO failed!\n");
+						goto END_8_2Cif_6;
+					}
+			 	}
+			}
+        }
+		else if (enVoMode== enPreVoMode)
+		{
+			continue;
+		}        
+		
+        SAMPLE_PRT("vo(%d) switch to %d mode\n", VoDev, u32WndNum);
+
+        s32Ret= HI_MPI_VO_SetAttrBegin(VoDev);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8_2Cif_6;
+        }
+        
+        s32Ret = SAMPLE_COMM_VO_StopChn(VoDev, enPreVoMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8_2Cif_6;
+        }
+
+        s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8_2Cif_6;
+        }
+        s32Ret= HI_MPI_VO_SetAttrEnd(VoDev);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8_2Cif_6;
+        }
+    }
+
+    /******************************************
+     step 10: exit process
+    ******************************************/
+
+END_8_2Cif_6:
+	SAMPLE_COMM_VO_UnBindVoWbc(SAMPLE_VO_DEV_DSD0, 0);
+	HI_MPI_VO_DisableWbc(SAMPLE_VO_DEV_DHD0);
+
+END_8_2Cif_5:
+	VoDev = SAMPLE_VO_DEV_DSD0;
+	VoChn = 0;
+	enVoMode = VO_MODE_1MUX;
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+
+END_8_2Cif_4:
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        SAMPLE_COMM_VO_HdmiStop();
+    }
+    VoDev = SAMPLE_VO_DEV_DHD0;
+    u32WndNum = 8;
+    enVoMode = VO_MODE_9MUX;
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        VpssGrp = i;
+        SAMPLE_COMM_VO_UnBindVpss(VoDev,VoChn,VpssGrp,VpssChn_VoHD0);
+    }    
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+
+	
+END_8_2Cif_3:
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_8_2Cif_2:
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_8_2Cif_1:
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_8_2Cif_0:
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+
+
+/******************************************************************************
+* function :  VI:1*1080p; VO:SD0(CVBS), HD0(HDMI,1080p@60 + VGA) 
+******************************************************************************/
+HI_S32 SAMPLE_VIO_1_1080P(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_1080P;
+    HI_U32 u32ViChnCnt = 1;
+    HI_S32 s32VpssGrpCnt = 1;
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VO_DEV VoDev;
+    VO_CHN VoChn;
+	VI_CHN ViChn;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    SAMPLE_VO_MODE_E enVoMode, enPreVoMode;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_CHAR ch;
+    SIZE_S stSize;
+    HI_U32 u32WndNum;
+
+    /******************************************
+     step  1: init global  variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL == gs_enNorm)?25:30;
+    
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_HD1080, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /*ddr0 video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 8;
+
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_1080P_0;
+    }
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_1080P_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss (subchn needn't bind vpss in this mode)
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_HD1080, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_1080P_1;
+    }
+
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_NODIE;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,&stGrpAttr);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_1080P_1;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_1080P_2;
+    }
+
+	/******************************************
+	step 5: start VO SD0 (bind * vi )
+	******************************************/
+	printf("start vo sd0 bind vi chn0 \n");
+	VoDev = SAMPLE_VO_DEV_DSD0;
+	enVoMode = VO_MODE_1MUX;
+
+	stVoPubAttr.enIntfSync = VO_OUTPUT_PAL;
+	stVoPubAttr.enIntfType = VO_INTF_CVBS;
+	stVoPubAttr.u32BgColor = 0x000000ff;
+	stVoPubAttr.bDoubleFrame = HI_FALSE;//In HD, this item should be set to HI_FALSE
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+	   SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+	   goto END_1080P_3;
+	}
+
+	s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+	   SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+	   goto END_1080P_4;
+	}
+
+
+	VoChn = 0;
+	ViChn = 0; //? is vi chn 0?
+	s32Ret = SAMPLE_COMM_VO_BindVi(VoDev, VoChn, ViChn);
+	if (HI_SUCCESS != s32Ret)
+	{
+	   SAMPLE_PRT("SAMPLE_COMM_VO_BindVi(vo:%d)-(vichn:%d) failed with %#x!\n", VoDev, VoChn, s32Ret);
+	   goto END_1080P_4;
+	}
+
+	/******************************************
+	 step 6: start vo HD0 (HDMI), muti-screen, you can switch mode
+	******************************************/
+	printf("start vo HD0.\n");
+	VoDev = SAMPLE_VO_DEV_DHD0;
+	u32WndNum = 4;
+	enVoMode = VO_MODE_1MUX;
+
+	if(VIDEO_ENCODING_MODE_PAL == gs_enNorm)
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_1080P50;
+	}
+	else
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_1080P60;
+	}
+#ifdef HI_FPGA
+	stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA|VO_INTF_BT1120;
+#else
+	stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA;
+#endif
+	stVoPubAttr.u32BgColor = 0x000000ff;
+	stVoPubAttr.bDoubleFrame = HI_FALSE;
+	
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Start SAMPLE_COMM_VO_StartDevLayer failed!\n");
+		goto END_1080P_4;
+	}
+	
+	s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Start SAMPLE_COMM_VO_StartChn failed!\n");
+		goto END_1080P_5;
+	}
+
+	/* if it's displayed on HDMI, we should start HDMI */
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+	{
+		if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+		{
+			SAMPLE_PRT("Start SAMPLE_COMM_VO_HdmiStart failed!\n");
+			goto END_1080P_5;
+		}
+	}
+	
+	for(i=0;i<u32WndNum;i++)
+	{
+		VoChn = i;
+		VpssGrp = 0;
+		
+		s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,i);
+		if (HI_SUCCESS != s32Ret)
+		{
+			SAMPLE_PRT("Start VO failed!\n");
+			goto END_1080P_5;
+		}
+	}
+
+    /******************************************
+     step 7: HD0 switch mode 
+    ******************************************/
+	VoDev = SAMPLE_VO_DEV_DHD0;
+    u32WndNum = 4;
+    enVoMode = VO_MODE_1MUX;
+    while(1)
+    {
+        enPreVoMode = enVoMode;
+    
+        printf("please choose preview mode, press 'q' to exit this sample.\n"); 
+        printf("\t0) 1 preview\n");
+        printf("\t1) 4 preview\n");
+        printf("\tq) quit\n");
+ 
+        ch = getchar();
+        getchar();
+        if ('0' == ch)
+        {
+            u32WndNum = 1;
+            enVoMode = VO_MODE_1MUX;
+        }
+        else if ('1' == ch)
+        {
+            u32WndNum = 4;
+            enVoMode = VO_MODE_4MUX;
+        }
+
+        else if ('q' == ch)
+        {
+            break;
+        }
+        else
+        {
+            SAMPLE_PRT("preview mode invaild! please try again.\n");
+            continue;
+        }
+        SAMPLE_PRT("vo(%d) switch to %d mode\n", VoDev, u32WndNum);
+
+        s32Ret= HI_MPI_VO_SetAttrBegin(VoDev);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_1080P_5;
+        }
+        
+        s32Ret = SAMPLE_COMM_VO_StopChn(VoDev, enPreVoMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_1080P_5;
+        }
+
+        s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_1080P_5;
+        }
+        s32Ret= HI_MPI_VO_SetAttrEnd(VoDev);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_1080P_5;
+        }
+    }
+
+    /******************************************
+     step 8: exit process
+    ******************************************/
+   
+END_1080P_5:	//stop vo hd0
+
+    VoDev = SAMPLE_VO_DEV_DHD0;
+    u32WndNum = 4;
+    enVoMode = VO_MODE_4MUX;   
+    if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        SAMPLE_COMM_VO_HdmiStop();
+    }
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        VpssGrp = i;
+        SAMPLE_COMM_VO_UnBindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+    }
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+ 
+END_1080P_4:	//stop vo sd0
+    VoDev = SAMPLE_VO_DEV_DSD0;  
+    enVoMode = VO_MODE_1MUX;
+    VoChn = 0;
+    SAMPLE_COMM_VO_UnBindVi(VoDev,VoChn);
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+
+END_1080P_3:
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_1080P_2:
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_1080P_1:
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_1080P_0:
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+
+/******************************************************************************
+* function :  VI:8*D1(6fps)/2cif(19fps); VO:HD0(HDMI  720P50)video preview. 
+******************************************************************************/
+HI_S32 SAMPLE_VIO_8_D1Cif(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_8_D1Cif;
+    HI_U32 u32ViChnCnt = 8;
+    HI_S32 s32VpssGrpCnt = 8;
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_GRP_ATTR_S stGrpAttr;
+	VPSS_CHN VpssChn_VoHD0 = VPSS_PRE0_CHN;
+	 
+    VO_DEV VoDev;
+    VO_CHN VoChn;
+    VO_PUB_ATTR_S stVoPubAttr; 
+
+    SAMPLE_VO_MODE_E enVoMode, enPreVoMode;
+	 
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_CHAR ch;
+    SIZE_S stSize,stSizeTmp;
+    HI_U32 u32WndNum;
+
+    /******************************************
+     step  1: init global  variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL== gs_enNorm)?25:30;
+    
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 5;
+	
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_2CIF, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.astCommPool[1].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[1].u32BlkCnt = u32ViChnCnt * 10;
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_8_MixCap_0;
+    }
+
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_MixCap_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_8_MixCap_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_8_MixCap_1;
+    }
+    
+    stGrpAttr.u32MaxW = 720;
+    stGrpAttr.u32MaxH = (VIDEO_ENCODING_MODE_PAL==gs_enNorm)?576:480;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_8_MixCap_1;
+    }
+    /*open pre-scale*/
+	s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_2CIF, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_8_MixCap_1;
+    }
+    for(i=0;i<s32VpssGrpCnt;i++)
+    {   
+		s32Ret = SAMPLE_COMM_EnableVpssPreScale(i,stSize);
+		if(HI_SUCCESS != s32Ret)
+		{
+        SAMPLE_PRT("HI_MPI_VPSS_SetPreScale failed!\n");
+        goto END_8_MixCap_1;
+        }
+    }
+		
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_8_MixCap_2;
+    }
+
+    /******************************************
+     step 5: start vo HD0(HDMI) 
+    ******************************************/
+	printf("start vo HD0.\n");
+	VoDev = SAMPLE_VO_DEV_DHD0;
+	u32WndNum = 8;
+	enVoMode = VO_MODE_9MUX;
+
+	if(VIDEO_ENCODING_MODE_PAL == gs_enNorm)
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_1080P50;
+	}
+	else
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_1080P60;
+	}
+#ifdef HI_FPGA
+	stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA|VO_INTF_BT1120;
+#else
+	stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA;
+#endif
+	stVoPubAttr.u32BgColor = 0x000000ff;
+	stVoPubAttr.bDoubleFrame = HI_TRUE;
+
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Start SAMPLE_COMM_VO_StartDevLayer failed!\n");
+		goto END_8_MixCap_3;
+	}
+
+	s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Start SAMPLE_COMM_VO_StartChn failed!\n");
+		goto END_8_MixCap_4;
+	}
+
+	/* if it's displayed on HDMI, we should start HDMI */
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+	{
+		if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+		{
+			SAMPLE_PRT("Start SAMPLE_COMM_VO_HdmiStart failed!\n");
+			goto END_8_MixCap_4;
+		}
+	}
+
+	for(i=0;i<u32WndNum;i++)
+	{
+		VoChn = i;
+		VpssGrp = i;
+		
+		s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,VpssChn_VoHD0);
+		if (HI_SUCCESS != s32Ret)
+		{
+			SAMPLE_PRT("Start VO failed!\n");
+			goto END_8_MixCap_4;
+		}
+	}
+ 
+    /******************************************
+         step 9: HD0 switch mode 
+    ******************************************/
+    VoDev = SAMPLE_VO_DEV_DHD0;
+    enVoMode = VO_MODE_9MUX;
+    while(1)
+    {
+  		enPreVoMode = enVoMode;
+        printf("please choose preview mode, press 'q' to exit this sample.\n"); 
+        printf("\t0) 1 preview\n");
+        printf("\t1) 4 preview\n");
+        printf("\t2) 9 preview\n");       
+        printf("\tq) quit\n");
+ 
+        ch = getchar();
+        getchar();
+        if ('0' == ch)
+        {
+            u32WndNum = 1;
+            enVoMode = VO_MODE_1MUX;
+        }
+        else if ('1' == ch)
+        {
+            u32WndNum = 4;
+            enVoMode = VO_MODE_4MUX;
+        }
+        else if ('2' == ch)
+        {
+            u32WndNum = 8;
+            enVoMode = VO_MODE_9MUX;
+        }       
+        else if ('q' == ch)
+        {
+            break;
+        }
+        else
+        {
+            SAMPLE_PRT("preview mode invaild! please try again.\n");
+            continue;
+        }
+		/* VI Chn size should change from D1/2cif to D1 */
+		if((VO_MODE_1MUX== enVoMode) || (VO_MODE_4MUX== enVoMode))
+		{
+		 	stSizeTmp.u32Width = 720;
+			stSizeTmp.u32Height = ((VIDEO_ENCODING_MODE_PAL==gs_enNorm)?576:480);
+            if(VO_MODE_1MUX == enVoMode)
+        	{
+				s32Ret = SAMPLE_COMM_VI_ChangeMixCap(0,HI_FALSE,gs_u32ViFrmRate);
+				if (HI_SUCCESS != s32Ret)
+				{
+					SAMPLE_PRT("SAMPLE_COMM_VI_ChangeCapSize VO failed!\n");
+					goto END_8_MixCap_4;
+				}
+
+				s32Ret = SAMPLE_COMM_DisableVpssPreScale(0,stSizeTmp);
+				if (HI_SUCCESS != s32Ret)
+				{
+					SAMPLE_PRT("SAMPLE_COMM_DisableVpssPreScale VO failed!\n");
+					goto END_8_MixCap_4;
+				}
+        	}
+			else
+			{
+				for(i=0;i<u32WndNum;i++)
+			 	{
+					s32Ret = SAMPLE_COMM_VI_ChangeMixCap(i,HI_FALSE,gs_u32ViFrmRate);
+					if (HI_SUCCESS != s32Ret)
+					{
+						SAMPLE_PRT("SAMPLE_COMM_VI_ChangeCapSize VO failed!\n");
+						goto END_8_MixCap_4;
+					}
+
+					s32Ret = SAMPLE_COMM_DisableVpssPreScale(i,stSizeTmp);
+					if (HI_SUCCESS != s32Ret)
+					{
+						SAMPLE_PRT("SAMPLE_COMM_DisableVpssPreScale VO failed!\n");
+						goto END_8_MixCap_4;
+					}
+			 	}
+			}
+		}
+		/* VI Chn size should change from  D1 to D1/2cif */
+        else if((VO_MODE_9MUX== enVoMode) || (VO_MODE_16MUX== enVoMode))
+        {
+        	stSizeTmp.u32Width= D1_WIDTH / 2;
+			stSizeTmp.u32Height = ((VIDEO_ENCODING_MODE_PAL==gs_enNorm)?576:480);
+	        if(VO_MODE_9MUX == enVoMode)
+        	{
+        		for(i=0;i<u32WndNum;i++)
+			 	{
+					s32Ret = SAMPLE_COMM_VI_ChangeMixCap(i,HI_TRUE,6);
+					if (HI_SUCCESS != s32Ret)
+					{
+						SAMPLE_PRT("SAMPLE_COMM_VI_ChangeCapSize VO failed!\n");
+						goto END_8_MixCap_4;
+					}
+
+					s32Ret = SAMPLE_COMM_EnableVpssPreScale(i,stSizeTmp);
+					if (HI_SUCCESS != s32Ret)
+					{
+						SAMPLE_PRT("SAMPLE_COMM_DisableVpssPreScale VO failed!\n");
+						goto END_8_MixCap_4;
+					}
+        		}
+        	}
+			else
+			{
+				for(i=0;i<u32WndNum;i++)
+			 	{
+					s32Ret = SAMPLE_COMM_VI_ChangeMixCap(i,HI_TRUE,6);
+					if (HI_SUCCESS != s32Ret)
+					{
+						SAMPLE_PRT("SAMPLE_COMM_VI_ChangeCapSize VO failed!\n");
+						goto END_8_MixCap_4;
+					}
+
+					s32Ret = SAMPLE_COMM_EnableVpssPreScale(i,stSizeTmp);
+					if (HI_SUCCESS != s32Ret)
+					{
+						SAMPLE_PRT("SAMPLE_COMM_DisableVpssPreScale VO failed!\n");
+						goto END_8_MixCap_4;
+					}
+			 	}
+			}
+        }
+		else if (enVoMode== enPreVoMode)
+		{
+			continue;
+		}
+		
+        SAMPLE_PRT("vo(%d) switch to %d mode\n", VoDev, u32WndNum);
+
+        s32Ret= HI_MPI_VO_SetAttrBegin(VoDev);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8_MixCap_4;
+        }
+        
+        s32Ret = SAMPLE_COMM_VO_StopChn(VoDev, enPreVoMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8_MixCap_4;
+        }
+
+        s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8_MixCap_4;
+        }
+        s32Ret= HI_MPI_VO_SetAttrEnd(VoDev);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_8_MixCap_4;
+        }
+    }
+
+    /******************************************
+     step 10: exit process
+    ******************************************/
+
+END_8_MixCap_4:
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        SAMPLE_COMM_VO_HdmiStop();
+    }
+    VoDev = SAMPLE_VO_DEV_DHD0;
+    u32WndNum = 8;
+    enVoMode = VO_MODE_9MUX;    
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        VpssGrp = i;
+        SAMPLE_COMM_VO_UnBindVpss(VoDev,VoChn,VpssGrp,VpssChn_VoHD0);
+    }
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+
+	
+END_8_MixCap_3:
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_8_MixCap_2:
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_8_MixCap_1:
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_8_MixCap_0:
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+/******************************************************************************
+* function :  VI: 1*D1, user picture; VO: SD0(CVBS) video preview
+******************************************************************************/
+HI_S32 SAMPLE_VIO_1D1_LossDet(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_D1;
+    HI_U32 u32ViChnCnt = 8;
+    
+    VB_CONF_S stVbConf;
+    VI_CHN ViChn;
+    VO_DEV VoDev;
+    VO_CHN VoChn;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    SAMPLE_VO_MODE_E enVoMode;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_U32 u32WndNum;
+
+    VIDEO_FRAME_INFO_S stUserFrame;
+
+    /******************************************
+     step  1: init global  variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL== gs_enNorm)?25:30;
+    
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 6;
+
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_1D1_LOSS_0;
+    }
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_1D1_LOSS_0;
+    }
+    
+    /******************************************
+     step 4: start VO to preview
+    ******************************************/
+    VoDev = SAMPLE_VO_DEV_DSD0;
+    u32WndNum = 1;
+    enVoMode = VO_MODE_1MUX;
+    
+    stVoPubAttr.enIntfSync = VO_OUTPUT_PAL;
+    stVoPubAttr.enIntfType = VO_INTF_CVBS;
+    stVoPubAttr.u32BgColor = 0x000000ff;
+    stVoPubAttr.bDoubleFrame = HI_FALSE;
+
+    s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+        goto END_1D1_LOSS_1;
+    }
+    
+    s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+        goto END_1D1_LOSS_2;
+    }
+
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        ViChn = i;
+        s32Ret = SAMPLE_COMM_VO_BindVi(VoDev,VoChn, ViChn);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+            goto END_1D1_LOSS_2;
+        }
+    }
+
+    /******************************************
+     step 5: set novideo pic
+    ******************************************/
+    /* set novideo pic */
+    s32Ret = SAMPLE_VI_SetUserPic("pic_704_576_p420_novideo01.yuv", 704, 576, 704, &stUserFrame);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VI_SetUserPic failed!\n");
+        goto END_1D1_LOSS_2;
+    }
+    
+    /******************************************
+     step 6: start video loss detect, if loss, then use user-pic
+    ******************************************/
+    s32Ret = SAMPLE_VI_StartVLossDet(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_VI_StartVLossDet failed!\n");
+        goto END_1D1_LOSS_2;
+    }
+
+    printf("\npress twice Enter to stop sample ... ... \n");
+    getchar();
+    getchar();
+    
+    /******************************************
+     step 8: exit process
+    ******************************************/
+    SAMPLE_VI_StopVLossDet();
+    
+END_1D1_LOSS_2:
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        SAMPLE_COMM_VO_UnBindVi(VoDev,VoChn);
+    }
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+END_1D1_LOSS_1:
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_1D1_LOSS_0:
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+/******************************************************************************
+* function :  VI: 1*D1; VO:HD0(HDMI,1080p@60) HD Zoom preview. 
+*                vi ---> vpss grp 0       ---> vo HD0, chn0 (D1, PIP, HIDE)
+*                   ---> vpss grp 1(clip) ---> vo HD0, chn1 (1080p)
+******************************************************************************/
+HI_S32 SAMPLE_VIO_1D1_HDZoom()
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_D1;
+    HI_U32 u32ViChnCnt = 1;
+    HI_S32 s32VpssGrpCnt = 1;
+    VPSS_GRP VpssGrp = 0;
+    VPSS_GRP VpssGrp_Clip = 1;
+    VO_DEV VoDev = SAMPLE_VO_DEV_DHD0;
+    VO_CHN VoChn = 0;
+    VO_CHN VoChn_Clip = 1;
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    SAMPLE_VO_MODE_E enVoMode;
+    MPP_CHN_S stSrcChn;
+    MPP_CHN_S stDestChn;
+    VPSS_CROP_INFO_S stVpssCropInfo;
+    VO_VIDEO_LAYER_ATTR_S stPipLayerAttr;
+    VO_CHN_ATTR_S stChnAttr;
+    SIZE_S stSize;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_CHAR ch;
+    HI_U32 u32WndNum;
+
+
+    /******************************************
+     step  1: init global  variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL == gs_enNorm)?25:30;
+    
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+    /*ddr0 video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 6;
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_1D1_CLIP_0;
+    }
+
+   
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_1D1_CLIP_0;
+    }
+
+    /******************************************
+     step 4: start vpss and vi bind vpss
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_1D1_CLIP_0;
+    }
+
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_AUTO;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    // start 2 vpss group. group-1 for clip use.
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt+1, &stSize, VPSS_MAX_CHN_NUM,NULL);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_1D1_CLIP_1;
+    }
+
+    // bind vi to vpss group 0
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_1D1_CLIP_2;
+    }
+
+    // bind vi(0,0) to vpss group 1, for clip use.
+    stSrcChn.enModId = HI_ID_VIU;
+    stSrcChn.s32DevId = 0;
+    stSrcChn.s32ChnId = 0;
+
+    stDestChn.enModId = HI_ID_VPSS;
+    stDestChn.s32DevId = VpssGrp_Clip; // vpss group for clip
+    stDestChn.s32ChnId = 0;
+
+    s32Ret = HI_MPI_SYS_Bind(&stSrcChn, &stDestChn);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("bind vi(0,0) to vpss group 1 failed with %#x!\n", s32Ret);
+        goto END_1D1_CLIP_2;
+    }
+    
+    /******************************************
+     step 5: start VO to preview
+    ******************************************/
+    printf("start vo hd0\n");
+    u32WndNum = 1;
+    enVoMode = VO_MODE_1MUX;
+    
+    if(VIDEO_ENCODING_MODE_PAL == gs_enNorm)
+    {
+        stVoPubAttr.enIntfSync = VO_OUTPUT_1080P50;
+    }
+    else
+    {
+        stVoPubAttr.enIntfSync = VO_OUTPUT_1080P60;
+    }
+    
+    stVoPubAttr.enIntfType = VO_INTF_VGA|VO_INTF_HDMI;
+    stVoPubAttr.u32BgColor = 0x000000ff;
+    stVoPubAttr.bDoubleFrame = HI_TRUE;
+
+    s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+        goto END_1D1_CLIP_3;
+    }
+    
+    s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+        goto END_1D1_CLIP_4;
+    }
+    /* if it's displayed on HDMI, we should start HDMI */
+    if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+        {
+            SAMPLE_PRT("Start SAMPLE_COMM_VO_HdmiStart failed!\n");
+            goto END_1D1_CLIP_4;
+        }
+    }
+    s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+        goto END_1D1_CLIP_4;
+    }
+    
+    /******************************************
+     step 6: Clip process
+    ******************************************/
+    printf("press any key to show hd zoom.\n");
+    getchar();
+
+    /*** enable vpss group clip ***/
+    stVpssCropInfo.bEnable = HI_TRUE;
+    stVpssCropInfo.enCropCoordinate = VPSS_CROP_ABS_COOR;
+    stVpssCropInfo.stCropRect.s32X = 0;
+    stVpssCropInfo.stCropRect.s32Y = 0;
+    stVpssCropInfo.stCropRect.u32Height = 400;
+    stVpssCropInfo.stCropRect.u32Width = 400; 
+    stVpssCropInfo.enCapSel = VPSS_CAPSEL_BOTH;
+
+    s32Ret = HI_MPI_VPSS_SetCropCfg(VpssGrp_Clip, &stVpssCropInfo);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed with %#x!\n", s32Ret);
+        goto END_1D1_CLIP_4;
+    }
+    
+    /*** enable vo pip layer ***/
+    s32Ret = HI_MPI_VO_PipLayerBindDev(VoDev);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VO_PipLayerBindDev failed with %#x!\n", s32Ret);
+        goto END_1D1_CLIP_4;
+    }
+
+    s32Ret = SAMPLE_COMM_VO_GetWH(stVoPubAttr.enIntfSync, \
+    	               &stPipLayerAttr.stDispRect.u32Width, \
+    	               &stPipLayerAttr.stDispRect.u32Height, \
+    	               &stPipLayerAttr.u32DispFrmRt);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        goto END_1D1_CLIP_5;
+    }
+    
+    stPipLayerAttr.stDispRect.s32X = 0;
+    stPipLayerAttr.stDispRect.s32Y = 0;
+    stPipLayerAttr.stImageSize.u32Height = stPipLayerAttr.stDispRect.u32Height;
+    stPipLayerAttr.stImageSize.u32Width = stPipLayerAttr.stDispRect.u32Width;
+    stPipLayerAttr.enPixFormat = SAMPLE_PIXEL_FORMAT;
+    s32Ret = HI_MPI_VO_SetPipLayerAttr(&stPipLayerAttr);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VO_SetPipLayerAttr failed with %#x!\n", s32Ret);
+        goto END_1D1_CLIP_6;
+    }
+    
+    s32Ret = HI_MPI_VO_EnablePipLayer();
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VO_EnablePipLayer failed with %#x!\n", s32Ret);
+        goto END_1D1_CLIP_6;
+    }   
+   
+    /*** vo chn 0: normal ->pip & 1080p -> D1 ***/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_D1, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_1D1_CLIP_4;
+    }
+    stChnAttr.stRect.u32Width = ALIGN_BACK(stSize.u32Width, 4);
+    stChnAttr.stRect.u32Height= ALIGN_BACK(stSize.u32Height, 4);
+    stChnAttr.stRect.s32X       = ALIGN_BACK(1920-stSize.u32Width, 4);//
+    stChnAttr.stRect.s32Y       = ALIGN_BACK(1080-stSize.u32Height, 4);//
+    stChnAttr.u32Priority        = 1;
+    stChnAttr.bDeflicker         = HI_FALSE;
+
+    s32Ret = HI_MPI_VO_SetChnAttr(VoDev, VoChn, &stChnAttr);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("HI_MPI_VO_SetChnAttr failed with %#x!\n", s32Ret);
+        goto END_1D1_CLIP_4;
+    }
+    
+    /***start new vo Chn(0) for clip.  ***/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_HD1080, &stSize);//
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_1D1_CLIP_4;
+    }
+    
+    stChnAttr.stRect.u32Width = ALIGN_BACK(stSize.u32Width, 4);
+    stChnAttr.stRect.u32Height= ALIGN_BACK(stSize.u32Height, 4);
+    stChnAttr.stRect.s32X       = ALIGN_BACK(0, 4);
+    stChnAttr.stRect.s32Y       = ALIGN_BACK(0, 4);
+    stChnAttr.u32Priority        = 0;
+    stChnAttr.bDeflicker         = HI_FALSE;
+    s32Ret = HI_MPI_VO_SetChnAttr(VoDev, VoChn_Clip, &stChnAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n",  s32Ret);
+        goto END_1D1_CLIP_4;
+    }
+    s32Ret = HI_MPI_VO_EnableChn(VoDev, VoChn_Clip);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        goto END_1D1_CLIP_4;
+    }
+    s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev, VoChn_Clip, VpssGrp_Clip, VPSS_PRE0_CHN);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+        goto END_1D1_CLIP_4;
+    }
+    
+    printf("\npress 'q' to stop sample ... ... \n");
+    while('q' != (ch = getchar()) )  {}
+    
+    /******************************************
+     step 7: exit process
+    ******************************************/
+END_1D1_CLIP_6:
+    HI_MPI_VO_DisableChn(VoDev, VoChn);
+    HI_MPI_VO_DisablePipLayer();
+END_1D1_CLIP_5:
+    HI_MPI_VO_PipLayerUnBindDev(VoDev);
+END_1D1_CLIP_4:    
+    if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        SAMPLE_COMM_VO_HdmiStop();
+    }
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    HI_MPI_VO_DisableChn(VoDev, VoChn_Clip);
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        VpssGrp = i;
+        SAMPLE_COMM_VO_UnBindVpss(VoDev, VoChn, VpssGrp, VPSS_PRE0_CHN);
+    }
+    SAMPLE_COMM_VO_UnBindVpss(VoDev, VoChn_Clip, VpssGrp_Clip, VPSS_PRE0_CHN);
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+END_1D1_CLIP_3:
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+    
+    stSrcChn.enModId = HI_ID_VIU;
+    stSrcChn.s32DevId = 0;
+    stSrcChn.s32ChnId = 0;
+    stDestChn.enModId = HI_ID_VPSS;
+    stDestChn.s32DevId = VpssGrp_Clip; // vpss group 1
+    stDestChn.s32ChnId = 0;
+    HI_MPI_SYS_UnBind(&stSrcChn, &stDestChn);
+END_1D1_CLIP_2:
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt+1, VPSS_MAX_CHN_NUM);
+END_1D1_CLIP_1:
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_1D1_CLIP_0:
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+/******************************************************************************
+* function :  VI: 1*D1; VO:SD0(CVBS) SD Zoom preview.
+******************************************************************************/
+HI_S32 SAMPLE_VIO_1D1_SDZoom(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_1_D1;
+    HI_U32 u32ViChnCnt = 1;
+ 
+    VB_CONF_S stVbConf;
+    VI_CHN ViChn;
+    VO_DEV VoDev;
+    VO_CHN VoChn, VoChn_Clip = 1;
+    VO_CHN_ATTR_S stChnAttr;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    SAMPLE_VO_MODE_E enVoMode;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    SIZE_S stSize;
+    HI_U32 u32WndNum;
+
+    VO_ZOOM_ATTR_S stZoomWindow, stZoomWindowGet;
+
+
+    /******************************************
+     step  1: init global  variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL== gs_enNorm)?25:30;
+    
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_D1, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+    /*ddr0 video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 6;
+
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_1D1_ZOOM_0;
+    }
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_1D1_ZOOM_0;
+    }
+
+    /******************************************
+     step 4: start VO to preview
+    ******************************************/
+    VoDev = SAMPLE_VO_DEV_DSD0;
+    u32WndNum = 1;
+    enVoMode = VO_MODE_1MUX;
+    
+    stVoPubAttr.enIntfSync = VO_OUTPUT_PAL;
+    stVoPubAttr.enIntfType = VO_INTF_CVBS;
+    stVoPubAttr.u32BgColor = 0x000000ff;
+    stVoPubAttr.bDoubleFrame = HI_FALSE;
+    s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartDevLayer failed!\n");
+        goto END_1D1_ZOOM_1;
+    }
+    
+    s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_StartChn failed!\n");
+        goto END_1D1_ZOOM_2;
+    }
+
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        ViChn = i;
+        s32Ret = SAMPLE_COMM_VO_BindVi(VoDev, VoChn, ViChn);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+            goto END_1D1_ZOOM_2;
+        }
+    }
+
+    /******************************************
+     step 5: start new vo Chn for zoom
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_CIF, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_1D1_ZOOM_2;
+    }
+    stChnAttr.stRect.u32Width = ALIGN_BACK(stSize.u32Width, 4);
+    stChnAttr.stRect.u32Height= ALIGN_BACK(stSize.u32Height, 4);
+    stChnAttr.stRect.s32X       = ALIGN_BACK(0, 4);
+    stChnAttr.stRect.s32Y       = ALIGN_BACK(0, 4);
+    stChnAttr.u32Priority        = 1;
+    stChnAttr.bDeflicker         = HI_FALSE;
+
+    s32Ret = HI_MPI_VO_SetChnAttr(VoDev, VoChn_Clip, &stChnAttr);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n",  s32Ret);
+        goto END_1D1_ZOOM_2;
+    }
+    s32Ret = HI_MPI_VO_EnableChn(VoDev, VoChn_Clip);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("failed with %#x!\n", s32Ret);
+        goto END_1D1_ZOOM_2;
+    }
+
+    s32Ret = SAMPLE_COMM_VO_BindVi(VoDev,VoChn_Clip,0);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_VO_BindVpss failed!\n");
+        goto END_1D1_ZOOM_2;
+    }
+
+    /******************************************
+     step 6: ZOOM process
+    ******************************************/
+    printf("print any key to zoom mode.\n");
+    getchar();
+
+    VoChn = 0;
+    stZoomWindow.enZoomType = VOU_ZOOM_IN_RECT;
+    stZoomWindow.stZoomRect.s32X = 128;
+    stZoomWindow.stZoomRect.s32Y = 128;
+    stZoomWindow.stZoomRect.u32Width = 200;
+    stZoomWindow.stZoomRect.u32Height = 200;
+    
+    
+    /* set zoom window */
+    s32Ret = HI_MPI_VO_SetZoomInWindow(VoDev, VoChn, &stZoomWindow);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("Set zoom attribute failed with %#x!\n", s32Ret);
+        goto END_1D1_ZOOM_2;
+    }
+    
+    /* get current zoom window parameter */
+    s32Ret = HI_MPI_VO_GetZoomInWindow(VoDev, VoChn, &stZoomWindowGet);
+    if (s32Ret != HI_SUCCESS)
+    {
+        SAMPLE_PRT("Get zoom attribute failed with %#x!\n", s32Ret);
+        goto END_1D1_ZOOM_2;
+    }
+    printf("Current zoom window is (%d,%d,%d,%d)!\n",
+                stZoomWindowGet.stZoomRect.s32X,
+                stZoomWindowGet.stZoomRect.s32Y, 
+                stZoomWindowGet.stZoomRect.u32Width,
+                stZoomWindowGet.stZoomRect.u32Height);
+
+    printf("\npress 'q' to stop sample ... ... \n");
+    while('q' != getchar())  {}
+    
+    /******************************************
+     step 7: exit process
+    ******************************************/
+END_1D1_ZOOM_2:
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        ViChn= i;
+        SAMPLE_COMM_VO_UnBindVi(VoDev, VoChn);
+    }
+    SAMPLE_COMM_VO_UnBindVi(VoDev, VoChn_Clip);
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    HI_MPI_VO_DisableChn(VoDev, VoChn_Clip);
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+END_1D1_ZOOM_1:
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_1D1_ZOOM_0:
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+
+
+/******************************************************************************
+* function :  VI:4*720P;  HD0(HDMI,1080p@50 + VGA) 
+******************************************************************************/
+HI_S32 SAMPLE_VIO_4_720P(HI_VOID)
+{
+    SAMPLE_VI_MODE_E enViMode = SAMPLE_VI_MODE_4_720P;
+    HI_U32 u32ViChnCnt = 4;
+    HI_S32 s32VpssGrpCnt = 4;
+    
+    VB_CONF_S stVbConf;
+    VPSS_GRP VpssGrp;
+    VPSS_GRP_ATTR_S stGrpAttr;
+    VO_DEV VoDev;
+    VO_CHN VoChn;
+	VI_CHN ViChn;
+    VO_PUB_ATTR_S stVoPubAttr; 
+    SAMPLE_VO_MODE_E enVoMode, enPreVoMode;
+    
+    HI_S32 i;
+    HI_S32 s32Ret = HI_SUCCESS;
+    HI_U32 u32BlkSize;
+    HI_CHAR ch;
+    SIZE_S stSize;
+    HI_U32 u32WndNum;
+
+    /******************************************
+     step  1: init global  variable 
+    ******************************************/
+    gs_u32ViFrmRate = (VIDEO_ENCODING_MODE_PAL == gs_enNorm)?25:30;
+    
+    memset(&stVbConf,0,sizeof(VB_CONF_S));
+
+    u32BlkSize = SAMPLE_COMM_SYS_CalcPicVbBlkSize(gs_enNorm,\
+                PIC_HD720, SAMPLE_PIXEL_FORMAT, SAMPLE_SYS_ALIGN_WIDTH);
+    stVbConf.u32MaxPoolCnt = 128;
+
+    /*ddr0 video buffer*/
+    stVbConf.astCommPool[0].u32BlkSize = u32BlkSize;
+    stVbConf.astCommPool[0].u32BlkCnt = u32ViChnCnt * 8;
+
+
+    /******************************************
+     step 2: mpp system init. 
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_Init(&stVbConf);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("system init failed with %d!\n", s32Ret);
+        goto END_720P_0;
+    }
+
+    /******************************************
+     step 3: start vi dev & chn to capture
+    ******************************************/
+    s32Ret = SAMPLE_COMM_VI_Start(enViMode, gs_enNorm);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("start vi failed!\n");
+        goto END_720P_0;
+    }
+    
+    /******************************************
+     step 4: start vpss and vi bind vpss (subchn needn't bind vpss in this mode)
+    ******************************************/
+    s32Ret = SAMPLE_COMM_SYS_GetPicSize(gs_enNorm, PIC_HD720, &stSize);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("SAMPLE_COMM_SYS_GetPicSize failed!\n");
+        goto END_720P_1;
+    }
+
+    stGrpAttr.u32MaxW = stSize.u32Width;
+    stGrpAttr.u32MaxH = stSize.u32Height;
+    stGrpAttr.bDrEn = HI_FALSE;
+    stGrpAttr.bDbEn = HI_FALSE;
+    stGrpAttr.bIeEn = HI_TRUE;
+    stGrpAttr.bNrEn = HI_TRUE;
+    stGrpAttr.bHistEn = HI_TRUE;
+    stGrpAttr.enDieMode = VPSS_DIE_MODE_NODIE;
+    stGrpAttr.enPixFmt = SAMPLE_PIXEL_FORMAT;
+
+    s32Ret = SAMPLE_COMM_VPSS_Start(s32VpssGrpCnt, &stSize, VPSS_MAX_CHN_NUM,&stGrpAttr);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Start Vpss failed!\n");
+        goto END_720P_1;
+    }
+
+    s32Ret = SAMPLE_COMM_VI_BindVpss(enViMode);
+    if (HI_SUCCESS != s32Ret)
+    {
+        SAMPLE_PRT("Vi bind Vpss failed!\n");
+        goto END_720P_2;
+    }
+
+	/******************************************
+	 step 5: start vo HD0 (HDMI), muti-screen, you can switch mode
+	******************************************/
+	printf("start vo HD0.\n");
+	VoDev = SAMPLE_VO_DEV_DHD0;
+	u32WndNum = 4;
+	enVoMode = VO_MODE_1MUX;
+
+	if(VIDEO_ENCODING_MODE_PAL == gs_enNorm)
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_1080P50;
+	}
+	else
+	{
+		stVoPubAttr.enIntfSync = VO_OUTPUT_1080P60;
+	}
+#ifdef HI_FPGA
+	stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA|VO_INTF_BT1120;
+#else
+	stVoPubAttr.enIntfType = VO_INTF_HDMI|VO_INTF_VGA;
+#endif
+	stVoPubAttr.u32BgColor = 0x000000ff;
+	stVoPubAttr.bDoubleFrame = HI_FALSE;
+	
+	s32Ret = SAMPLE_COMM_VO_StartDevLayer(VoDev, &stVoPubAttr, gs_u32ViFrmRate);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Start SAMPLE_COMM_VO_StartDevLayer failed!\n");
+		goto END_720P_3;
+	}
+	
+	s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+	if (HI_SUCCESS != s32Ret)
+	{
+		SAMPLE_PRT("Start SAMPLE_COMM_VO_StartChn failed!\n");
+		goto END_720P_4;
+	}
+
+	/* if it's displayed on HDMI, we should start HDMI */
+	if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+	{
+		if (HI_SUCCESS != SAMPLE_COMM_VO_HdmiStart(stVoPubAttr.enIntfSync))
+		{
+			SAMPLE_PRT("Start SAMPLE_COMM_VO_HdmiStart failed!\n");
+			goto END_720P_4;
+		}
+	}
+	
+	for(i=0;i<u32WndNum;i++)
+	{
+		VoChn = i;
+		VpssGrp = i;
+		
+		s32Ret = SAMPLE_COMM_VO_BindVpss(VoDev,VoChn,VpssGrp,i);
+		if (HI_SUCCESS != s32Ret)
+		{
+			SAMPLE_PRT("Start VO failed!\n");
+			goto END_720P_4;
+		}
+	}
+
+    /******************************************
+     step 6: HD0 switch mode 
+    ******************************************/
+	VoDev = SAMPLE_VO_DEV_DHD0;
+    u32WndNum = 4;
+    enVoMode = VO_MODE_1MUX;
+    while(1)
+    {
+        enPreVoMode = enVoMode;
+    
+        printf("please choose preview mode, press 'q' to exit this sample.\n"); 
+        printf("\t0) 1 preview\n");
+        printf("\t1) 4 preview\n");
+        printf("\tq) quit\n");
+ 
+        ch = getchar();
+        getchar();
+        if ('0' == ch)
+        {
+            u32WndNum = 1;
+            enVoMode = VO_MODE_1MUX;
+        }
+        else if ('1' == ch)
+        {
+            u32WndNum = 4;
+            enVoMode = VO_MODE_4MUX;
+        }
+
+        else if ('q' == ch)
+        {
+            break;
+        }
+        else
+        {
+            SAMPLE_PRT("preview mode invaild! please try again.\n");
+            continue;
+        }
+        SAMPLE_PRT("vo(%d) switch to %d mode\n", VoDev, u32WndNum);
+
+        s32Ret= HI_MPI_VO_SetAttrBegin(VoDev);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_720P_4;
+        }
+        
+        s32Ret = SAMPLE_COMM_VO_StopChn(VoDev, enPreVoMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_720P_4;
+        }
+
+        s32Ret = SAMPLE_COMM_VO_StartChn(VoDev, &stVoPubAttr, enVoMode);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_720P_4;
+        }
+        s32Ret= HI_MPI_VO_SetAttrEnd(VoDev);
+        if (HI_SUCCESS != s32Ret)
+        {
+            SAMPLE_PRT("Start VO failed!\n");
+            goto END_720P_4;
+        }
+    }
+
+    /******************************************
+     step 7: exit process
+    ******************************************/
+   
+END_720P_4:	//stop vo hd0
+
+    VoDev = SAMPLE_VO_DEV_DHD0;
+    u32WndNum = 4;
+    enVoMode = VO_MODE_4MUX;   
+    if (stVoPubAttr.enIntfType & VO_INTF_HDMI)
+    {
+        SAMPLE_COMM_VO_HdmiStop();
+    }
+    SAMPLE_COMM_VO_StopChn(VoDev, enVoMode);
+    for(i=0;i<u32WndNum;i++)
+    {
+        VoChn = i;
+        VpssGrp = i;
+        SAMPLE_COMM_VO_UnBindVpss(VoDev,VoChn,VpssGrp,VPSS_PRE0_CHN);
+    }
+    SAMPLE_COMM_VO_StopDevLayer(VoDev);
+END_720P_3:
+    SAMPLE_COMM_VI_UnBindVpss(enViMode);
+END_720P_2:
+    SAMPLE_COMM_VPSS_Stop(s32VpssGrpCnt, VPSS_MAX_CHN_NUM);
+END_720P_1:
+    SAMPLE_COMM_VI_Stop(enViMode);
+END_720P_0:
+    SAMPLE_COMM_SYS_Exit();
+    
+    return s32Ret;
+}
+
+
+
+
+
+/******************************************************************************
+* function    : main()
+* Description : video preview sample
+******************************************************************************/
+int main(int argc, char *argv[])
+{
+    HI_S32 s32Ret;
+
+    if ( (argc < 2) || (1 != strlen(argv[1])))
+    {
+        SAMPLE_VIO_Usage(argv[0]);
+        return HI_FAILURE;
+    }
+
+    signal(SIGINT, SAMPLE_VIO_HandleSig);
+    signal(SIGTERM, SAMPLE_VIO_HandleSig);
+
+    switch (*argv[1])
+    {
+        case '0':/* VI:8*D1; VO:HD0(HDMI,VGA)+SD0(CVBS)+SD1 video preview. */
+            s32Ret = SAMPLE_VIO_8_D1();
+            break;
+        case '1':/* VI:1*1080P; VO:HD0(HDMI ),  video preview */
+            s32Ret = SAMPLE_VIO_1_1080P();
+            break;
+        case '2':/* VI:8*2cif; VO: HD0(HDMI,1080p@60 ), WBC to SD0(CVBS) video preview. */
+            s32Ret = SAMPLE_VIO_8_2cif();
+            break;
+	    case '3':/* VI:8*D1/2Cif MixCap;  HD0(HDMI,1080p@60 ) video preview. */
+            s32Ret = SAMPLE_VIO_8_D1Cif();
+            break;
+        case '4':/* VI: 1*D1, user picture; VO: SD0(CVBS) video preview. */
+            s32Ret = SAMPLE_VIO_1D1_LossDet();
+            break;
+        case '5':/* VI: 1*D1; VO:HD0(HDMI) HD Zoom preview.  */
+            s32Ret = SAMPLE_VIO_1D1_HDZoom();
+            break;
+        case '6':/* VI: 1*D1; VO:SD0(CVBS) SD Zoom preview. */
+            s32Ret = SAMPLE_VIO_1D1_SDZoom();
+            break;
+		case '7':/* VI:4*720P; VO:HD0(HDMI ),  video preview . Only for Hi3520DV200 */
+			s32Ret = SAMPLE_VIO_4_720P();
+			break;
+			
+        default:
+            printf("the index is invaild!\n");
+            SAMPLE_VIO_Usage(argv[0]);
+            return HI_FAILURE;
+    }
+
+    if (HI_SUCCESS == s32Ret)
+        printf("program exit normally!\n");
+    else
+        printf("program exit abnormally!\n");
+    exit(s32Ret);
+}
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* End of #ifdef __cplusplus */
+


### PR DESCRIPTION
## Summary

Mirror of \`\$(SDK_ROOT)/package/mpp/sample/\` from Hi3520D_SDK_V2.0.5.1 (Apr 2015):

| Subdir | Files | Purpose |
|---|---|---|
| \`common/\` | sample_comm_{sys,vi,vpss,vo,venc,vdec,vda,audio}.c, sample_comm.h, loadbmp.{c,h} | shared helpers (the canonical V2 VENC pipeline lives here) |
| \`venc/\` | sample_venc.c | 4ch DVR VENC pipeline reference |
| \`vio/\` | sample_vio.c | VI → VPSS → VO tile composition |
| \`vdec/\`, \`vda/\`, \`ive/\`, \`audio/\`, \`region/\`, \`tde/\`, \`hifb/\` | one .c + Makefile each | rest of the vendor sample set |
| top-level | \`Makefile\`, \`Makefile.param\` | vendor build glue (kept as reference) |

35 files / 19.5k lines / 692 KiB.

## Why mirror these now

These were explicitly **skipped** from the kernel-side hi3520dv200 mirror in #163 per the 'skip Vendor MPP sample C code' direction. Including them in a follow-up turns out to be useful because the V2-era MPP pipeline topology isn't documented anywhere public, and the only canonical reference is in these samples:

VENC channels on hi3520dv200 live inside an intermediate \`HI_ID_GROUP\` dispatcher module, and the SYS_Bind sequence is:

\`\`\`
VENC_CreateGroup -> CreateChn -> RegisterChn(grp,chn) ->
SYS_Bind(VPSS, HI_ID_GROUP[grp]) -> StartRecvPic
\`\`\`

Direct \`SYS_Bind(VPSS, HI_ID_VENC[chn])\` returns SYS \`ILLEGAL_PARAM\` (0xa0028003) — observed while bringing up the dvr_home demo against the source-built mmz / hi_user / gpioi2c / nvp6134_ex modules from #163 + #164. The fix pattern is laid out in \`common/sample_comm_venc.c\`:

- \`SAMPLE_COMM_VENC_BindVpss\` — shows the \`HI_ID_GROUP\` destination
- \`SAMPLE_COMM_VENC_MemConfig\` — the 64-grp x 64-chn \`SYS_SetMemConf\` loop the vendor blob expects before chn-create
- \`SAMPLE_COMM_VENC_Start\` — the canonical Create/Register/Start order

## Out of scope (deliberate)

- **No build wiring** — \`libraries/Makefile\` still has no \`SUBDIRS\` entry for \`hi3520dv200\` (the kernel-side opensdk wiring sidesteps the libraries build via a no-op \`BUILD_CMDS\` override in firmware's \`hisilicon-opensdk.mk\`). These are reference / documentation source for future opensdk userspace work, not a buildable target yet.
- **No porting** — the sample sources still use the vendor's 32-bit \`off_t\` glibc ABI and reference the vendor \`Makefile.param\` toolchain settings. Bringing them up against the OpenIPC musl rootfs needs the glibc-compat-static.a mmap shim (already landed via openipc/firmware#2110).
- **No binary res/** — Windows VC2008 project files (\`ive/windows(VC2008)/\`) and binary BMP image dirs (\`hifb/res/\`, \`tde/res/\`) are not mirrored.