### PR TITLE
kernel/mipi_rx: reboot_notifier to quiesce MIPI bus before machine_restart (partial #159)

### DIFF
--- a/kernel/mipi_rx/mipi_rx_init.c
+++ b/kernel/mipi_rx/mipi_rx_init.c
@@ -14,6 +14,10 @@ Function List :
 #include <linux/printk.h>
 #include <linux/version.h>
 #include <linux/of_platform.h>
+#include <linux/reboot.h>
+#include <linux/notifier.h>
+#include <linux/io.h>
+#include <linux/delay.h>
 
 #include "../compat/compat.h"
 
@@ -23,9 +27,60 @@ extern void *mipi_rx_regs_va;
 extern int mipi_rx_mod_init(void);
 extern void mipi_rx_mod_exit(void);
 
+/*
+ * Issue #159: when machine_restart fires with active video streaming on
+ * hi3516ev300, the MIPI RX / VI_CAP DMA path can still be live, and the
+ * SoC reset triggered by hisi_restart_handler races against in-flight
+ * transactions. The result is a hang in the next kernel's pre-init phase.
+ *
+ * Assert the MIPI RX bus soft-reset (MIPI_RX_CRG_ADDR=0x120100F8, bit 6
+ * = mipi_bus_srst_req; see kernel/mipi_rx/mipi_rx_hal.c) from a reboot
+ * notifier that runs in kernel_restart_prepare(), BEFORE device_shutdown.
+ *
+ * Empirical: this stops the source of the video pipeline; downstream
+ * blocks (VI_CAP, VPSS, VEDU) drain naturally. Stress on hi3516ev300
+ * dlab dropped the hang rate from ~25% baseline to ~10%; combining
+ * with clock-gate clears made it WORSE (50%), so we only assert the
+ * soft-reset and leave clocks alone.
+ *
+ * TODO(issue #159): move this notifier into open_osal once the approach
+ * is validated; osal is the centralised place but cannot be live-replaced
+ * on a running camera (refcount > 60), so we keep it here for iteration
+ * agility.
+ */
+#define HI3516EV300_MIPI_RX_CRG_ADDR 0x120100F8
+#define MIPI_BUS_SRST_BIT            (1U << 6)
+
+static int hi35xx_mipi_rx_reboot_notify(struct notifier_block *nb,
+					unsigned long action, void *data)
+{
+	void __iomem *crg;
+	u32 v;
+
+	if (action != SYS_RESTART && action != SYS_POWER_OFF &&
+	    action != SYS_HALT)
+		return NOTIFY_DONE;
+
+	crg = ioremap(HI3516EV300_MIPI_RX_CRG_ADDR, 4);
+	if (!crg)
+		return NOTIFY_DONE;
+	v = readl(crg);
+	writel(v | MIPI_BUS_SRST_BIT, crg);
+	wmb();
+	/* Let the soft-reset propagate before machine_restart fires. */
+	mdelay(2);
+	iounmap(crg);
+	return NOTIFY_DONE;
+}
+
+static struct notifier_block hi35xx_mipi_rx_reboot_nb = {
+	.notifier_call = hi35xx_mipi_rx_reboot_notify,
+};
+
 static int hi35xx_mipi_rx_probe(struct platform_device *pdev)
 {
 	struct resource *mem;
+	int ret;
 
 	mem = platform_get_resource_byname(pdev, IORESOURCE_MEM, "mipi_rx");
 	mipi_rx_regs_va = devm_ioremap_resource(&pdev->dev, mem);
@@ -39,11 +94,17 @@ static int hi35xx_mipi_rx_probe(struct platform_device *pdev)
 		dev_err(&pdev->dev, "can not find mipi_rx IRQ\n");
 	}
 
-	return mipi_rx_mod_init();
+	ret = mipi_rx_mod_init();
+	if (ret)
+		return ret;
+
+	register_reboot_notifier(&hi35xx_mipi_rx_reboot_nb);
+	return 0;
 }
 
 static compat_platform_remove_ret hi35xx_mipi_rx_remove(struct platform_device *pdev)
 {
+	unregister_reboot_notifier(&hi35xx_mipi_rx_reboot_nb);
 	mipi_rx_mod_exit();
 	mipi_rx_regs_va = NULL;
 


### PR DESCRIPTION
## Summary

Partial fix for #159 (hi3516ev300 / UP 4.9.37 — next kernel hangs at `Starting kernel ...` after rmmod+insmod+stream+reboot stress).

Register a `reboot_notifier` from `hi35xx_mipi_rx_probe` that runs in `kernel_restart_prepare()` BEFORE `device_shutdown`. The notifier asserts bit 6 of `MIPI_RX_CRG_ADDR` (`0x120100F8` — `mipi_bus_srst_req`) and holds for 2 ms, gating the source of the video pipeline so downstream blocks (VI_CAP, VPSS, VEDU) drain in-flight DMA before `hisi_restart_handler` toggles the SoC reset.

## Why it's needed

Empirical Heisenbug. Same kernel + same streaming + same reboot path:
- `printk = 0 0 0 0` (OpenIPC default — silent console): `device_shutdown` completes in < 100 ms → DMA still in flight at `machine_restart` → next kernel hangs (~25% rate per issue body).
- `printk = 8 8 1 7` (verbose, ~2.4 s UART back-pressure during shutdown): same kernel boots cleanly every time.

UART instrumentation of `kernel_restart_prepare` and `device_shutdown` (kernel rebuilt with `pr_emerg` per-device, flashed to `/dev/mtd2` for diagnosis only — **not** part of this PR) showed all 294 bound devices' `.shutdown` callbacks completing, then the kernel printing \`Restarting system\` cleanly. The hang is fundamentally a hardware-timing problem, not a kernel-software hang in `device_shutdown`.

## Stress results

Stress on \`openipc-hi3516ev300.dlab.torturelabs.com\`, default quiet printk, 25 s majestic streaming per cycle:

| Variant | Hangs / cycles | Rate |
|---|---|---|
| Baseline (stock) | — (issue body) | ~25% |
| **This patch (bit 6 + mdelay 2)** | **2 / 21** | **~9.5%** |
| Same patch + mdelay(50) | 1 / 11 | ~9% (no measurable change) |
| Same + clear MIPI clocks + disable_irq + mdelay(100) | 1 / 2 | **~50% (WORSE)** |

2.6x improvement, not a complete fix. The ~10% residual is in some other IP block (VI_CAP, VPSS or VEDU) winning the race independently.

## Why it's a partial fix

Closing the residual requires resetting downstream IP blocks too. Their CRG bit positions are not documented in any source we have access to:
- vendor binaries `hi3516ev200_vi.ko`, `_vpss.ko`, `_vedu.ko`, `_isp.ko` do **not** reference the CRG block (`0x12010000`-`0x120100FF`) — only `hi_mipi_rx.ko` does.
- vendor SDK `Hi3516EV200_SDK_V1.0.1.2` (under \`~/projects/cameras/sdk/\`) ships only headers and prebuilt blobs for these modules; no source.

The aggressiveness curve is non-monotonic (50% rate when also clearing MIPI clock gates) — most likely because killing the MIPI clock while downstream VI_CAP is still reading from the shared buffer hangs the AHB/AXI bus.

## What's NOT in this PR

- The kernel-side `pr_emerg` instrumentation patches that were used for diagnosis only — those live in `drivers/base/core.c::device_shutdown` and `kernel/reboot.c::kernel_restart_prepare`. They're useful for any future #159-class investigation but don't belong in firmware.
- A move to `open_osal` (the centralised place for this kind of thing) — sealed off by a TODO in source. osal can't be live-rmmod-replaced on a running camera (refcount > 60), and the iteration loop needed live testing.
- VI_CAP/VPSS/VEDU resets — see "Why it's a partial fix".
- Cross-validation on av300 (cv500/SMP) or V3 boards — only tested on hi3516ev300.

## Scope

Touches only `kernel/mipi_rx/mipi_rx_init.c`, which is built for the V4 path (\`CHIPARCH=hi3516ev200\` / \`gk7205v200\`). V3 boards (cv500/cv300/cv200/av100/3519v101) use the separate \`kernel/mipi_rx/hi3516cv500/\` tree which is not touched.

## Test plan

- [x] Build for V4 (\`CHIPARCH=hi3516ev200\`) — clean, +108 bytes \`.text\`
- [x] Verify \`register_reboot_notifier\` is referenced via \`nm -u\` on the \`.ko\`
- [x] Stress on dlab hi3516ev300, default \`printk = 0 0 0 0\`, 25 s streaming, \`/sbin/reboot\` — 19/21 cycles clean
- [ ] Stress for 50 consecutive cycles (issue #159 "Definition of done" §4) — not done; tracked as residual work
- [ ] Cross-validate on av300 / cv500 / V3 — not done; need access to those boards
- [ ] Move notifier from \`mipi_rx\` to \`open_osal\` — tracked by TODO in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)