### PR TITLE
kernel/osal_v2_shim,osal_v2a_shim: cover the full V2/V2A blob-symbol set

### DIFF
--- a/kernel/compat/kernel_compat.h
+++ b/kernel/compat/kernel_compat.h
@@ -399,5 +399,18 @@ static inline struct spi_controller *compat_spi_busnum_to_controller(u16 bus_num
 #define no_llseek NULL
 #endif
 
+/*
+ * pte_offset_map() became an inline that calls __pte_offset_map() which
+ * is NOT EXPORT_SYMBOL'd, so modules can't link it. Source walks of
+ * user page tables (cv200/av100 mmz-userdev usr_virt_to_phys) need to
+ * use an exported equivalent. pte_offset_kernel() is a static inline
+ * over pmd_page_vaddr() + pte_index() — same lookup, no RCU section,
+ * no exported symbol dependency. Matches the (unlocked) semantics of
+ * the legacy code, which already did no locking.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#define pte_offset_map(pmd, addr) pte_offset_kernel((pmd), (addr))
+#endif
+
 #endif /* KERNEL_COMPAT_H */
 

--- a/kernel/hi3516av100.kbuild
+++ b/kernel/hi3516av100.kbuild
@@ -36,6 +36,12 @@ ccflags-y += -I$(src)/isp/arch/hi3516av100/firmware/vreg/arch/hi3516a
 # --- V2A OSAL shim (source) — re-exports removed-since-4.9 kernel APIs
 # so av100 blobs (which were compiled against 4.9) load against modern
 # kernels. Must be inserted BEFORE any blob module by load_hisilicon.
+# Suppress static-inline definitions of _cond_resched and
+# jiffies_to_msecs via macro rename BEFORE kernel headers are
+# processed. See cv200_shim block.
+CFLAGS_osal_v2a_shim/av100_shim.o := \
+	-D_cond_resched=__v2a_shim_cond_resched_unused_inline \
+	-Djiffies_to_msecs=__v2a_shim_jiffies_to_msecs_unused_inline
 $(PREFIX)v2a_shim-objs := osal_v2a_shim/av100_shim.o
 obj-m += $(PREFIX)v2a_shim.o
 

--- a/kernel/hi3516cv200.kbuild
+++ b/kernel/hi3516cv200.kbuild
@@ -38,6 +38,14 @@ ccflags-y += -I$(src)/isp/arch/hi3516cv200/firmware/vreg/arch/hi3518e
 # --- V2 OSAL shim (source) — re-exports removed-since-4.9 kernel APIs
 # so cv200 blobs (which were compiled against 4.9) load against modern
 # kernels. Must be inserted BEFORE any blob module by load_hisilicon.
+# Suppress static-inline definitions of _cond_resched and
+# jiffies_to_msecs via macro rename BEFORE kernel headers are
+# processed. The force-include of kernel_compat.h (which transitively
+# pulls sched.h / jiffies.h) happens earlier than any #define inside
+# cv200_shim.c — must be a compiler flag.
+CFLAGS_osal_v2_shim/cv200_shim.o := \
+	-D_cond_resched=__v2_shim_cond_resched_unused_inline \
+	-Djiffies_to_msecs=__v2_shim_jiffies_to_msecs_unused_inline
 $(PREFIX)v2_shim-objs := osal_v2_shim/cv200_shim.o
 obj-m += $(PREFIX)v2_shim.o
 

--- a/kernel/osal_v2_shim/cv200_shim.c
+++ b/kernel/osal_v2_shim/cv200_shim.c
@@ -9,30 +9,37 @@
  * provides EXPORT_SYMBOL wrappers under the old names so depmod resolves
  * them.
  *
- * Symbols re-exported:
+ * Symbols re-exported (initial four from issue #50 + extended set
+ * discovered at modpost-time during the cv200_neo firmware bring-up):
  *
  *   do_gettimeofday          (removed 5.0)
  *   register_sysctl_table    (removed 6.6 — best-effort flat path)
+ *   register_sysctl_paths    (removed 6.6 — last-component-only)
  *   init_timer_key           (callback signature changed; struct field
  *                             drift — runtime correctness BROKEN for
  *                             blobs that touch timer->data; see caveat
  *                             below)
  *   strlcpy                  (removed 6.8)
+ *   _cond_resched            (export removed 5.10 — wrap __cond_resched)
+ *   __kmalloc                (renamed __kmalloc_noprof 6.5)
+ *   kmem_cache_alloc         (became macro over kmem_cache_alloc_noprof 7.0)
+ *   __memzero                (ARM-specific helper, removed long ago)
+ *   PDE_DATA                 (renamed pde_data 5.17 — alias-style)
+ *   printk                   (renamed _printk 6.0 — varargs wrapper via vprintk)
  *
  * Notably NOT re-exported here (must be handled separately):
- *
- *   printk → _printk         The kernel renamed the export 'printk' to
- *                            '_printk' in 6.0. We can't easily wrap it
- *                            because <linux/printk.h> defines 'printk'
- *                            as a macro globally, fouling any attempt
- *                            to define a function of the same name.
- *                            Use objcopy --redefine-sym on the blob
- *                            .o files at build time (see Kbuild).
  *
  *   unregister_sysctl_table  Still exported natively by the modern
  *                            kernel — no shim needed.
  *
  *   filp_open                Still exported natively — no shim needed.
+ *
+ *   __pte_offset_map         Source-side, NOT a blob symbol. Modern
+ *                            kernel pte_offset_map() inlines to the
+ *                            unexported __pte_offset_map(). cv200
+ *                            mmz-userdev.c usr_virt_to_phys is patched
+ *                            to use pte_offset_kernel() via
+ *                            kernel_compat.h — no shim needed.
  *
  * struct timer_list .data caveat
  * ------------------------------
@@ -47,6 +54,13 @@
  * open_mmz → open_himedia → open_v2_shim → open_base → ...).
  */
 
+/* NB: kernel/hi3516cv200.kbuild passes
+ *   -D_cond_resched=__v2_shim_cond_resched_unused_inline
+ * for this TU. That rename suppresses the static-inline definition of
+ * _cond_resched in <linux/sched.h> (which is pulled in via the force-
+ * included kernel_compat.h before any source-level #define would
+ * take effect), so we can EXPORT_SYMBOL our own version below. The
+ * renamed inline is never emitted because we don't reference it. */
 #include <linux/module.h>
 #include <linux/init.h>
 #include <linux/printk.h>
@@ -57,6 +71,21 @@
 #include <linux/fs.h>
 #include <linux/types.h>
 #include <linux/version.h>
+#include <linux/sched.h>      /* __cond_resched */
+#include <linux/slab.h>       /* __kmalloc_noprof, kmem_cache_alloc_noprof */
+#include <linux/proc_fs.h>    /* pde_data */
+#include <linux/vmalloc.h>    /* vmalloc_noprof */
+#include <linux/device.h>     /* dev_vprintk_emit */
+#include <stdarg.h>           /* va_list, va_start, va_end (vprintk wrapper) */
+
+/* Now that headers are processed, restore the legacy names so our own
+ * function definitions below export under the unrenamed symbols. */
+#undef _cond_resched
+#undef jiffies_to_msecs
+/* kernel_compat.h #defines del_timer → timer_delete on 7.0+ for
+ * source-side rewrite. v2_shim provides del_timer as an exported
+ * function for blob resolution — must use the legacy name verbatim. */
+#undef del_timer
 
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("cv200 V2 OSAL shim — re-exports removed-since-4.9 kernel APIs");
@@ -165,6 +194,212 @@ extern size_t strlcpy(char *dst, const char *src, size_t size)
 	__attribute__((alias("__v2_shim_strlcpy")));
 EXPORT_SYMBOL(strlcpy);
 
+/* -------------------------------------------------------------------
+ * _cond_resched() — EXPORT_SYMBOL removed in 5.10 (commit fe32d3cd5e8e)
+ * when cond_resched() became a static inline calling __cond_resched().
+ * The header's inline definition is suppressed via the macro rename at
+ * the top of this file; we provide the legacy export directly.
+ * ------------------------------------------------------------------- */
+
+int _cond_resched(void)
+{
+	return __cond_resched();
+}
+EXPORT_SYMBOL(_cond_resched);
+
+/* -------------------------------------------------------------------
+ * __kmalloc() — renamed __kmalloc_noprof in 6.5 (commit b0fd33f93330).
+ * <linux/slab.h> still declares __kmalloc (sometimes as macro, sometimes
+ * as static inline depending on config). Alias pattern.
+ * ------------------------------------------------------------------- */
+
+void *__v2_shim_kmalloc(size_t size, gfp_t flags)
+{
+	return __kmalloc_noprof(size, flags);
+}
+#undef __kmalloc
+extern void *__kmalloc(size_t size, gfp_t flags)
+	__attribute__((alias("__v2_shim_kmalloc")));
+EXPORT_SYMBOL(__kmalloc);
+
+/* -------------------------------------------------------------------
+ * kmem_cache_alloc() — became `#define kmem_cache_alloc(...)
+ * alloc_hooks(kmem_cache_alloc_noprof(__VA_ARGS__))` in 7.0. Undef the
+ * macro, then alias.
+ * ------------------------------------------------------------------- */
+
+void *__v2_shim_kmem_cache_alloc(struct kmem_cache *s, gfp_t flags)
+{
+	return kmem_cache_alloc_noprof(s, flags);
+}
+#undef kmem_cache_alloc
+extern void *kmem_cache_alloc(struct kmem_cache *s, gfp_t flags)
+	__attribute__((alias("__v2_shim_kmem_cache_alloc")));
+EXPORT_SYMBOL(kmem_cache_alloc);
+
+/* -------------------------------------------------------------------
+ * __memzero() — ARM-specific lib helper in 4.9 (arch/arm/lib/memzero.S),
+ * gone from modern arch/arm/lib. Not declared in any header on modern
+ * kernels, so a plain function definition is safe.
+ * ------------------------------------------------------------------- */
+
+void __memzero(void *ptr, size_t n)
+{
+	memset(ptr, 0, n);
+}
+EXPORT_SYMBOL(__memzero);
+
+/* -------------------------------------------------------------------
+ * PDE_DATA() — renamed pde_data() in 5.17 (commit 359745d78351).
+ * kernel_compat.h #defines PDE_DATA → pde_data for source-side
+ * compilation. Here we provide the legacy symbol export. Alias pattern
+ * after #undef'ing the compat macro.
+ * ------------------------------------------------------------------- */
+
+void *__v2_shim_PDE_DATA(const struct inode *inode)
+{
+	return pde_data(inode);
+}
+#undef PDE_DATA
+extern void *PDE_DATA(const struct inode *inode)
+	__attribute__((alias("__v2_shim_PDE_DATA")));
+EXPORT_SYMBOL(PDE_DATA);
+
+/* -------------------------------------------------------------------
+ * printk() — EXPORT_SYMBOL renamed printk → _printk in 6.0 (commit
+ * eda9cec4c9a0). <linux/printk.h> globally #defines printk(fmt, ...)
+ * → _printk(fmt, ##__VA_ARGS__) so a function definition under that
+ * name needs the macro undef'd first. Variadic prototype matches the
+ * legacy export. Funnel through vprintk (still exported).
+ * ------------------------------------------------------------------- */
+
+asmlinkage __printf(1, 2) int __v2_shim_printk(const char *fmt, ...)
+{
+	va_list args;
+	int r;
+
+	va_start(args, fmt);
+	r = vprintk(fmt, args);
+	va_end(args);
+	return r;
+}
+#undef printk
+extern __printf(1, 2) int printk(const char *fmt, ...)
+	__attribute__((alias("__v2_shim_printk")));
+EXPORT_SYMBOL(printk);
+
+/* -------------------------------------------------------------------
+ * register_sysctl_paths() — removed in 6.6 alongside register_sysctl_table
+ * (commit c1d967dd49a3). Same best-effort flat handling as the _table
+ * variant.
+ * ------------------------------------------------------------------- */
+
+struct ctl_path {
+	const char *procname;
+};
+
+struct ctl_table_header *register_sysctl_paths(const struct ctl_path *path,
+					       struct ctl_table *table)
+{
+	int count = 0;
+	while (table[count].procname)
+		count++;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+	return register_sysctl_sz("hisi", table, count);
+#else
+	return register_sysctl("hisi", table);
+#endif
+}
+EXPORT_SYMBOL(register_sysctl_paths);
+
+/* -------------------------------------------------------------------
+ * jiffies_to_msecs() — static inline in <linux/jiffies.h> when
+ * HZ divides MSEC_PER_SEC (e.g. HZ=100 — our default). Same trick as
+ * _cond_resched: header inline is renamed away via a Kbuild macro
+ * (-Djiffies_to_msecs=__v2_shim_jiffies_to_msecs_unused_inline) so we
+ * can EXPORT_SYMBOL our own.
+ * ------------------------------------------------------------------- */
+
+unsigned int jiffies_to_msecs(const unsigned long j)
+{
+	return (MSEC_PER_SEC / HZ) * j;
+}
+EXPORT_SYMBOL(jiffies_to_msecs);
+
+/* -------------------------------------------------------------------
+ * del_timer() — renamed timer_delete() in 7.0 (commit 9b13df3fb64e).
+ * No conflicting declaration in modern <linux/timer.h>.
+ * ------------------------------------------------------------------- */
+
+int del_timer(struct timer_list *timer)
+{
+	return timer_delete(timer);
+}
+EXPORT_SYMBOL(del_timer);
+
+/* -------------------------------------------------------------------
+ * vmalloc() — became `#define vmalloc(...) alloc_hooks(vmalloc_noprof
+ * (__VA_ARGS__))` in 7.0. Undef the macro before defining the function
+ * under the same name.
+ * ------------------------------------------------------------------- */
+
+void *__v2_shim_vmalloc(unsigned long size)
+{
+	return vmalloc_noprof(size);
+}
+#undef vmalloc
+extern void *vmalloc(unsigned long size)
+	__attribute__((alias("__v2_shim_vmalloc")));
+EXPORT_SYMBOL(vmalloc);
+
+/* -------------------------------------------------------------------
+ * dev_err() — `#define dev_err(dev, fmt, ...)` macro in modern
+ * <linux/dev_printk.h> that funnels through _dev_err. The blob
+ * references dev_err as a symbol; provide a variadic wrapper using
+ * dev_vprintk_emit (still exported, takes va_list).
+ *
+ * NB: cv200 vendor blobs (compiled against 4.9.37) emit calls to
+ * dev_err with KERN_ERR semantics. The first arg to dev_vprintk_emit
+ * is the loglevel digit (KERN_ERR == "<3>" → 3).
+ * ------------------------------------------------------------------- */
+
+#undef dev_err
+asmlinkage __printf(2, 3) void dev_err(const struct device *dev,
+				       const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	dev_vprintk_emit(3 /* KERN_ERR */, dev, fmt, args);
+	va_end(args);
+}
+EXPORT_SYMBOL(dev_err);
+
+/* -------------------------------------------------------------------
+ * sched_setscheduler() — was EXPORT_SYMBOL_GPL'd in 4.9 but the export
+ * was removed in 5.9 (commit 7318d4cc14c8); modules are expected to
+ * call the named helpers (sched_set_fifo / sched_set_normal). The
+ * cv200 vendor blobs still embed direct sched_setscheduler() calls.
+ *
+ * Best-effort dispatch: SCHED_FIFO / SCHED_RR → sched_set_fifo (MAX_RT_PRIO/2),
+ * everything else → sched_set_normal(nice=0). Caller-supplied priority
+ * is dropped — sched_set_fifo doesn't accept one. Acceptable for the
+ * blobs that just want "raise above SCHED_NORMAL"; truly priority-
+ * sensitive code paths would need a recompile.
+ * ------------------------------------------------------------------- */
+
+int sched_setscheduler(struct task_struct *p, int policy,
+		       const struct sched_param *param)
+{
+	if (policy == SCHED_FIFO || policy == SCHED_RR) {
+		sched_set_fifo(p);
+		return 0;
+	}
+	sched_set_normal(p, 0);
+	return 0;
+}
+EXPORT_SYMBOL(sched_setscheduler);
+
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) */
 
 /* -------------------------------------------------------------------
@@ -177,8 +412,9 @@ static int __init v2_shim_init(void)
 {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
 	pr_info("cv200 V2 OSAL shim: ready "
-		"(do_gettimeofday, register_sysctl_table, "
-		"init_timer_key, strlcpy)\n");
+		"(do_gettimeofday, register_sysctl_table/paths, "
+		"init_timer_key, strlcpy, _cond_resched, __kmalloc, "
+		"kmem_cache_alloc, __memzero, PDE_DATA, printk)\n");
 #else
 	pr_info("cv200 V2 OSAL shim: no-op on this kernel (4.x); legacy "
 		"symbols still natively exported\n");

--- a/kernel/osal_v2a_shim/av100_shim.c
+++ b/kernel/osal_v2a_shim/av100_shim.c
@@ -4,31 +4,30 @@
  *
  * V2A (Cortex-A7) generation has no OSAL abstraction layer — the vendor
  * blobs were compiled against kernel 4.9.37 (Hi3516A_SDK_V1.0.8.0) and
- * embed the call sites verbatim. Per issue #50, the API surface here is
- * even cleaner than V2 (cv200): no strlcpy, no ARMv5-specific cache
- * ops (Cortex-A7 = ARMv7), no create_proc_entry, no __arm_ioremap, no
- * do_mmap_pgoff, no filp_open restrictions. Three legacy symbols are
- * the entire shim surface:
+ * embed the call sites verbatim. Per issue #50, the API surface is
+ * narrower than cv200 (V2, ARM926EJ-S): no strlcpy, no ARMv5-specific
+ * cache ops (Cortex-A7 = ARMv7), no create_proc_entry, no __arm_ioremap,
+ * no do_mmap_pgoff, no filp_open restrictions. Same extended set as
+ * cv200 minus strlcpy:
  *
  *   do_gettimeofday          (removed 5.0)
  *     used by: ai, ao, h264e, isp, ive, rc, sys, vgs, viu, vou, vpss (10)
  *   register_sysctl_table    (removed 6.6 — best-effort flat path)
+ *   register_sysctl_paths    (removed 6.6 — last-component-only)
  *     used by: base (and indirectly sys via unregister_sysctl_table,
  *     which the modern kernel still exports natively)
  *   init_timer_key           (callback signature changed; struct field
  *                             drift — runtime correctness BROKEN for
  *                             blobs that touch timer->data; see caveat)
  *     used by: chnl, viu, vpss
+ *   _cond_resched            (export removed 5.10 — wrap __cond_resched)
+ *   __kmalloc                (renamed __kmalloc_noprof 6.5)
+ *   kmem_cache_alloc         (became macro over kmem_cache_alloc_noprof 7.0)
+ *   __memzero                (ARM helper, removed long ago)
+ *   PDE_DATA                 (renamed pde_data 5.17 — alias-style)
+ *   printk                   (renamed _printk 6.0 — varargs wrapper via vprintk)
  *
- * Notably NOT re-exported here (must be handled separately):
- *
- *   printk → _printk         The kernel renamed the export 'printk' to
- *                            '_printk' in 6.0. We can't easily wrap it
- *                            because <linux/printk.h> defines 'printk'
- *                            as a macro globally, fouling any attempt
- *                            to define a function of the same name.
- *                            Same gap as cv200_shim — surfaces at
- *                            blob insmod time on >= 6.0; works on 4.9.
+ * Notably NOT re-exported here:
  *
  *   unregister_sysctl_table  Still exported natively by the modern
  *                            kernel — no shim needed.
@@ -46,14 +45,29 @@
  * open_mmz → open_himedia → open_v2a_shim → open_base → ...).
  */
 
+/* NB: kernel/hi3516av100.kbuild passes
+ *   -D_cond_resched=__v2a_shim_cond_resched_unused_inline
+ * to this TU to suppress the static-inline definition of
+ * _cond_resched in <linux/sched.h>. See cv200_shim.c for rationale. */
 #include <linux/module.h>
 #include <linux/init.h>
 #include <linux/printk.h>
 #include <linux/timekeeping.h>
 #include <linux/timer.h>
 #include <linux/sysctl.h>
+#include <linux/string.h>     /* memset (for __memzero shim) */
 #include <linux/types.h>
 #include <linux/version.h>
+#include <linux/sched.h>      /* __cond_resched */
+#include <linux/slab.h>       /* __kmalloc_noprof, kmem_cache_alloc_noprof */
+#include <linux/proc_fs.h>    /* pde_data */
+#include <linux/vmalloc.h>    /* vmalloc_noprof */
+#include <linux/device.h>     /* dev_vprintk_emit */
+#include <stdarg.h>           /* va_list, va_start, va_end (vprintk wrapper) */
+
+#undef _cond_resched
+#undef jiffies_to_msecs
+#undef del_timer
 
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("av100 V2A OSAL shim — re-exports removed-since-4.9 kernel APIs");
@@ -141,6 +155,141 @@ extern void init_timer_key(struct timer_list *timer,
 	__attribute__((alias("__v2a_shim_init_timer_key")));
 EXPORT_SYMBOL(init_timer_key);
 
+/* See cv200_shim.c for the full rationale on each of the following;
+ * the alias-attribute pattern lets us name a wrapper internally and
+ * provide the legacy symbol via the linker without colliding with
+ * static-inline declarations or macros in the modern kernel headers. */
+
+/* _cond_resched (export gone 5.10; header has static inline suppressed
+ * via the macro rename at the top of this file). */
+int _cond_resched(void) { return __cond_resched(); }
+EXPORT_SYMBOL(_cond_resched);
+
+/* __kmalloc (renamed __kmalloc_noprof 6.5). */
+void *__v2a_shim_kmalloc(size_t size, gfp_t flags)
+{
+	return __kmalloc_noprof(size, flags);
+}
+#undef __kmalloc
+extern void *__kmalloc(size_t size, gfp_t flags)
+	__attribute__((alias("__v2a_shim_kmalloc")));
+EXPORT_SYMBOL(__kmalloc);
+
+/* kmem_cache_alloc (became macro 7.0). */
+void *__v2a_shim_kmem_cache_alloc(struct kmem_cache *s, gfp_t flags)
+{
+	return kmem_cache_alloc_noprof(s, flags);
+}
+#undef kmem_cache_alloc
+extern void *kmem_cache_alloc(struct kmem_cache *s, gfp_t flags)
+	__attribute__((alias("__v2a_shim_kmem_cache_alloc")));
+EXPORT_SYMBOL(kmem_cache_alloc);
+
+/* __memzero (ARM-specific lib helper, gone). */
+void __memzero(void *ptr, size_t n)
+{
+	memset(ptr, 0, n);
+}
+EXPORT_SYMBOL(__memzero);
+
+/* PDE_DATA (renamed pde_data 5.17). */
+void *__v2a_shim_PDE_DATA(const struct inode *inode)
+{
+	return pde_data(inode);
+}
+#undef PDE_DATA
+extern void *PDE_DATA(const struct inode *inode)
+	__attribute__((alias("__v2a_shim_PDE_DATA")));
+EXPORT_SYMBOL(PDE_DATA);
+
+/* printk (renamed _printk 6.0). */
+asmlinkage __printf(1, 2) int __v2a_shim_printk(const char *fmt, ...)
+{
+	va_list args;
+	int r;
+
+	va_start(args, fmt);
+	r = vprintk(fmt, args);
+	va_end(args);
+	return r;
+}
+#undef printk
+extern __printf(1, 2) int printk(const char *fmt, ...)
+	__attribute__((alias("__v2a_shim_printk")));
+EXPORT_SYMBOL(printk);
+
+/* register_sysctl_paths (removed 6.6 — same flat handling as _table). */
+struct ctl_path {
+	const char *procname;
+};
+
+struct ctl_table_header *register_sysctl_paths(const struct ctl_path *path,
+					       struct ctl_table *table)
+{
+	int count = 0;
+	while (table[count].procname)
+		count++;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+	return register_sysctl_sz("hisi", table, count);
+#else
+	return register_sysctl("hisi", table);
+#endif
+}
+EXPORT_SYMBOL(register_sysctl_paths);
+
+/* jiffies_to_msecs (static inline in jiffies.h when HZ | MSEC_PER_SEC —
+ * suppressed via Kbuild macro rename, same as _cond_resched). */
+unsigned int jiffies_to_msecs(const unsigned long j)
+{
+	return (MSEC_PER_SEC / HZ) * j;
+}
+EXPORT_SYMBOL(jiffies_to_msecs);
+
+/* del_timer (renamed timer_delete 7.0). */
+int del_timer(struct timer_list *timer)
+{
+	return timer_delete(timer);
+}
+EXPORT_SYMBOL(del_timer);
+
+/* vmalloc (became macro 7.0). */
+void *__v2a_shim_vmalloc(unsigned long size)
+{
+	return vmalloc_noprof(size);
+}
+#undef vmalloc
+extern void *vmalloc(unsigned long size)
+	__attribute__((alias("__v2a_shim_vmalloc")));
+EXPORT_SYMBOL(vmalloc);
+
+/* dev_err (macro that funnels through _dev_err — blob references the
+ * macro-name symbol; provide variadic wrapper via dev_vprintk_emit). */
+#undef dev_err
+asmlinkage __printf(2, 3) void dev_err(const struct device *dev,
+				       const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	dev_vprintk_emit(3 /* KERN_ERR */, dev, fmt, args);
+	va_end(args);
+}
+EXPORT_SYMBOL(dev_err);
+
+/* sched_setscheduler (export removed 5.9; best-effort dispatch — drops
+ * caller priority). See cv200_shim.c for rationale. */
+int sched_setscheduler(struct task_struct *p, int policy,
+		       const struct sched_param *param)
+{
+	if (policy == SCHED_FIFO || policy == SCHED_RR) {
+		sched_set_fifo(p);
+		return 0;
+	}
+	sched_set_normal(p, 0);
+	return 0;
+}
+EXPORT_SYMBOL(sched_setscheduler);
+
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) */
 
 /* -------------------------------------------------------------------
@@ -153,7 +302,9 @@ static int __init v2a_shim_init(void)
 {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
 	pr_info("av100 V2A OSAL shim: ready "
-		"(do_gettimeofday, register_sysctl_table, init_timer_key)\n");
+		"(do_gettimeofday, register_sysctl_table/paths, init_timer_key, "
+		"_cond_resched, __kmalloc, kmem_cache_alloc, __memzero, "
+		"PDE_DATA, printk)\n");
 #else
 	pr_info("av100 V2A OSAL shim: no-op on this kernel (4.x); legacy "
 		"symbols still natively exported\n");


### PR DESCRIPTION
## Summary

Extends the V2 (cv200, #162) and V2A (av100, #165) blob-symbol shims to cover the full undefined-symbol set revealed by exercising the real firmware build for the first time. The original PRs based the shim contents on the issue [#50](https://github.com/OpenIPC/openhisilicon/issues/50) audit (4 symbols for cv200, 3 for av100), which only counted explicit blob source-imports. Modpost on the actual `hi3516cv200_neo` firmware build surfaced 8 more undefined symbols pulled in via inline-expansion at blob-build time against 4.9 headers (e.g. `memset → __memzero`, `kmalloc → __kmalloc`).

Plus one source-side compat shim for `pte_offset_map` (its inline now calls the unexported `__pte_offset_map` on 6.5+).

## Verification

Built end-to-end against the merged opensdk-bumped firmware tree:

| Target | Kernel | Result |
|---|---|---|
| **`hi3516cv200_neo`** | **7.0** (openipc/linux upstream-patches) | **Builds clean; boots in QEMU; meets DoD** |
| `hi3516cv200_lite` | 4.9 (production) | 331/331 rootfs files, 68/68 `.ko` set — byte-equivalent to nightly |
| `hi3516av100_lite` | 4.9 (production) | 290/290 rootfs files, 61/61 `.ko` set — byte-equivalent to nightly |

cv200_neo QEMU DoD report:

```
[PASS] login prompt
[PASS] DoD probe fired
[PASS] eth0 has IP (10.0.2.15, SLIRP DHCP)
[PASS] ping reply (10.0.2.2, 4.218 ms, 0% loss)
--- errors ---
(none)
```

## Symbols added to both shims (gated >= 5.0)

| Legacy symbol | Modern target |
|---|---|
| `_cond_resched` | `__cond_resched` |
| `__kmalloc` | `__kmalloc_noprof` (6.5+) |
| `kmem_cache_alloc` | `kmem_cache_alloc_noprof` (7.0 macro) |
| `__memzero` | `memset(ptr, 0, n)` |
| `PDE_DATA` | `pde_data` (5.17 rename) |
| `printk` | `vprintk` via `_printk` (6.0 rename) |
| `register_sysctl_paths` | `register_sysctl_sz` / `register_sysctl` |
| `jiffies_to_msecs` | inline `(MSEC_PER_SEC / HZ) * j` |
| `del_timer` | `timer_delete` (7.0 rename) |
| `vmalloc` | `vmalloc_noprof` (7.0 macro) |
| `dev_err` | `dev_vprintk_emit` at `KERN_ERR` |
| `sched_setscheduler` | `sched_set_fifo` / `sched_set_normal` — best-effort, drops caller priority |

## Source-side compat

`kernel/compat/kernel_compat.h` adds `pte_offset_map(pmd, addr) → pte_offset_kernel(...)` on >= 6.5. Modern `pte_offset_map()` inlines to the unexported `__pte_offset_map()` so modules can't link it; `pte_offset_kernel` is a static inline over `pmd_page_vaddr() + pte_index()` — same lookup, no exported-symbol dep, matches the (unlocked) semantics of the legacy code.

## Header collisions

`_cond_resched` and `jiffies_to_msecs` are `static inline` in modern kernel headers — function definitions under the same name collide. Both Kbuilds (`hi3516cv200.kbuild`, `hi3516av100.kbuild`) pass a per-shim `-D<sym>=...` rename in `CFLAGS_<obj>` so the static-inline definition is suppressed during header processing; the shim source then `#undef`s the rename and provides the legacy export.

Macro-style conflicts (`kmem_cache_alloc`, `vmalloc`, `PDE_DATA`, `printk`, `dev_err`, `del_timer` — last one collides with our own `kernel_compat.h` source-side rename) handled with `#undef` in the shim source.

## Out of scope (still tracked in [#51](https://github.com/OpenIPC/openhisilicon/issues/51))

- **`struct timer_list.data` ABI drift** (chnl/viu/vpss blobs) — the shim resolves `init_timer_key` but timers don't fire with the correct argument until the blob is recompiled. Documented in both shim sources. Surfaces as broken video pipeline on cv200_neo / av100_neo; not a load-time error.
- **hi3516av100 mainline DT / CRG** — av100_neo firmware target is blocked on a separate openipc/linux PR (av100 has no mainline Kconfig / DT / clock-driver support yet, unlike cv200 which landed in openipc/linux#43). **cv200_neo unblocked** by this PR.

## Test plan

- [x] Linux 7.0 compile clean (no modpost errors)
- [x] `hi3516cv200_neo` QEMU smoke meeting DoD (login + ping)
- [x] `hi3516cv200_lite` (4.9) byte-equivalence vs nightly
- [x] `hi3516av100_lite` (4.9) byte-equivalence vs nightly
- [ ] Real-hardware test cv200_neo — deferred to firmware-side PR landing
- [ ] av100_neo — blocked on openipc/linux av100 mainline support

🤖 Generated with [Claude Code](https://claude.com/claude-code)