### PR TITLE
kernel: ship blob .cmd stubs + gate open_pm + add dev_warn shim (cv200/av100 neo unblock)

### DIFF
--- a/kernel/hi3516av100.kbuild
+++ b/kernel/hi3516av100.kbuild
@@ -98,7 +98,9 @@ obj-m += $(PREFIX)rgn.o
 obj-m += $(PREFIX)vgs.o
 obj-m += $(PREFIX)ive.o
 obj-m += $(PREFIX)vda.o
-obj-m += $(PREFIX)pm.o
+ifndef DISABLE_PM
+    obj-m += $(PREFIX)pm.o
+endif
 ifndef DISABLE_ISP
     obj-m += $(PREFIX)isp.o
 endif

--- a/kernel/obj/hi3516av100/.acodec.o.cmd
+++ b/kernel/obj/hi3516av100/.acodec.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/acodec.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_adec.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_adec.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_adec.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_aenc.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_aenc.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_aenc.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_ai.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_ai.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_ai.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_aio.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_aio.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_aio.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_ao.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_ao.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_ao.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_base.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_base.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_base.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_chnl.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_chnl.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_chnl.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_h264e.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_h264e.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_h264e.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_h265e.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_h265e.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_h265e.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_isp.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_isp.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_isp.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_ive.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_ive.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_ive.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_jpege.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_jpege.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_jpege.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_pm.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_pm.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_pm.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_rc.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_rc.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_rc.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_region.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_region.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_region.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_sys.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_sys.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_sys.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_tde.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_tde.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_tde.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_vda.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_vda.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_vda.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_venc.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_venc.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_venc.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_vgs.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_vgs.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_vgs.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_viu.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_viu.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_viu.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_vou.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_vou.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_vou.o := :

--- a/kernel/obj/hi3516av100/.hi3516a_vpss.o.cmd
+++ b/kernel/obj/hi3516av100/.hi3516a_vpss.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi3516a_vpss.o := :

--- a/kernel/obj/hi3516av100/.hi_rtc.o.cmd
+++ b/kernel/obj/hi3516av100/.hi_rtc.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hi_rtc.o := :

--- a/kernel/obj/hi3516av100/.hifb.o.cmd
+++ b/kernel/obj/hi3516av100/.hifb.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516av100/hifb.o := :

--- a/kernel/obj/hi3516cv200/.acodec.o.cmd
+++ b/kernel/obj/hi3516cv200/.acodec.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/acodec.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_adec.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_adec.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_adec.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_aenc.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_aenc.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_aenc.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_ai.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_ai.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_ai.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_aio.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_aio.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_aio.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_ao.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_ao.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_ao.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_base.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_base.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_base.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_chnl.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_chnl.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_chnl.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_h264e.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_h264e.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_h264e.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_ive.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_ive.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_ive.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_jpege.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_jpege.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_jpege.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_rc.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_rc.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_rc.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_region.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_region.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_region.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_sys.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_sys.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_sys.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_tde.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_tde.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_tde.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_venc.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_venc.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_venc.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_vgs.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_vgs.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_vgs.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_viu.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_viu.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_viu.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_vou.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_vou.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_vou.o := :

--- a/kernel/obj/hi3516cv200/.hi3518e_vpss.o.cmd
+++ b/kernel/obj/hi3516cv200/.hi3518e_vpss.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hi3518e_vpss.o := :

--- a/kernel/obj/hi3516cv200/.hifb.o.cmd
+++ b/kernel/obj/hi3516cv200/.hifb.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3516cv200/hifb.o := :

--- a/kernel/osal_v2_shim/cv200_shim.c
+++ b/kernel/osal_v2_shim/cv200_shim.c
@@ -375,6 +375,19 @@ asmlinkage __printf(2, 3) void dev_err(const struct device *dev,
 }
 EXPORT_SYMBOL(dev_err);
 
+/* dev_warn — KERN_WARNING variant. */
+#undef dev_warn
+asmlinkage __printf(2, 3) void dev_warn(const struct device *dev,
+					const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	dev_vprintk_emit(4 /* KERN_WARNING */, dev, fmt, args);
+	va_end(args);
+}
+EXPORT_SYMBOL(dev_warn);
+
 /* -------------------------------------------------------------------
  * sched_setscheduler() — was EXPORT_SYMBOL_GPL'd in 4.9 but the export
  * was removed in 5.9 (commit 7318d4cc14c8); modules are expected to

--- a/kernel/osal_v2a_shim/av100_shim.c
+++ b/kernel/osal_v2a_shim/av100_shim.c
@@ -276,6 +276,19 @@ asmlinkage __printf(2, 3) void dev_err(const struct device *dev,
 }
 EXPORT_SYMBOL(dev_err);
 
+/* dev_warn (KERN_WARNING; same shape as dev_err). */
+#undef dev_warn
+asmlinkage __printf(2, 3) void dev_warn(const struct device *dev,
+					const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	dev_vprintk_emit(4 /* KERN_WARNING */, dev, fmt, args);
+	va_end(args);
+}
+EXPORT_SYMBOL(dev_warn);
+
 /* sched_setscheduler (export removed 5.9; best-effort dispatch — drops
  * caller priority). See cv200_shim.c for rationale. */
 int sched_setscheduler(struct task_struct *p, int policy,


### PR DESCRIPTION
## Summary

Three small follow-ups to the V2/V2A shim work in #170 that surface only when you actually exercise the firmware-tarball build path (the openhisilicon repo CI uses `actions/checkout` so it never hits these):

1. **Ship stub `.o.cmd` files** for cv200/av100 blobs (47 files). GitHub-archive tarballs strip dotfile siblings; Linux 7.0 modpost calls `read_text_file()` and `exit(1)`s on missing `.cmd`. cv500 already had them committed (31 files); cv200/av100 didn't.

2. **Gate `open_pm.ko` build behind `DISABLE_PM`** in `kernel/hi3516av100.kbuild`. Vendor blob references `dev_pm_opp_init_cpufreq_table` / `cpufreq_table_validate_and_show` / `cpufreq_generic_attr` — all removed in mainline. opensdk already passes `DISABLE_PM=1` by default; matching the gate makes the directive effective. Lite (4.9) unaffected — `DISABLE_PM=1` already applied there and the previous unconditional `obj-m` made it a no-op anyway.

3. **Add `dev_warn` to both shims** (cv200_shim.c, av100_shim.c). Same shape as the `dev_err` shim from #170 — macro in `<linux/dev_printk.h>` that funnels through `_dev_err`; variadic wrapper via `dev_vprintk_emit` at `KERN_WARNING`.

## Verification

End-to-end QEMU smoke on both neo targets (login + DHCP + ping):

| Target | Kernel | DoD |
|---|---|---|
| `hi3516cv200_neo` | 7.0 | ✅ login + IP + ping (4.218 ms) |
| `hi3516av100_neo` | 7.0 | ✅ login + IP + ping (2.728 ms) — via new openipc/linux higmac driver |
| `hi3516cv200_lite` | 4.9 | ✅ byte-equivalent to nightly (331/331 files, 68/68 .ko) |
| `hi3516av100_lite` | 4.9 | ✅ byte-equivalent to nightly (290/290 files, 61/61 .ko) |

## Test plan

- [x] cv200_neo builds + boots + login + ping
- [x] av100_neo builds + boots + login + ping
- [x] cv200_lite byte-equivalence vs nightly
- [x] av100_lite byte-equivalence vs nightly

## Related

Builds on #170 (full V2/V2A blob-symbol set). Companion to a forthcoming `openipc/linux` PR adding hi3516av100 mainline DT + CRG + higmac driver, and an `OpenIPC/firmware` PR with the cv200_neo + av100_neo board files + opensdk hash bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)