### PR TITLE
ci: add cv200_neo + av100_neo qemu-boot matrix rows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -822,7 +822,7 @@ jobs:
   # Each platform uses its own QEMU machine model from qemu-hisilicon.
   #
   qemu-boot:
-    name: QEMU boot (${{ matrix.machine }})
+    name: QEMU boot (${{ matrix.machine }}${{ matrix.variant && format('_{0}', matrix.variant) || '' }})
     runs-on: ubuntu-latest
     # Per-row continue-on-error so we can keep platforms in the matrix that
     # currently surface pre-existing firmware-side bugs (av100 module-name
@@ -900,6 +900,34 @@ jobs:
             mem: 128M
             min_modules: 5
             append: "console=ttyAMA0,115200 panic=20 mem=128M root=/dev/ram0 rootfstype=squashfs mmz_allocator=cma mmz=anonymous,0,0x42000000,96M"
+          # cv200_neo (V2 / ARM926EJ-S, Linux 7.0). Built from
+          # OpenIPC/firmware#2122 against the openhisilicon main tip that
+          # carries the open_v2_shim re-exporting do_gettimeofday,
+          # init_timer_key, register_sysctl_table, printk, etc. for the
+          # 4.9-compiled blobs. Boots to login + DHCP + ping in QEMU
+          # locally; allow-failure stays on until the firmware-side
+          # load_hisilicon learns the kernel 7.0 module path. Video
+          # pipeline blocked on openhisilicon#172 (struct timer_list.data
+          # drift on chnl/viu/vpss blobs).
+          - machine: hi3516cv200
+            firmware: hi3516cv200
+            variant: neo
+            mem: 64M
+            allow-failure: true
+            append: "console=ttyAMA0,115200 mem=32M root=/dev/ram0 rootfstype=squashfs"
+          # av100_neo (V2A / Cortex-A7, Linux 7.0). Built from
+          # OpenIPC/firmware#2122 against the openhisilicon main tip
+          # carrying open_v2a_shim, plus openipc/linux#44 with the
+          # mainline hi3516av100 SoC support (DT + CRG + hisi_higmac
+          # ethernet driver). Boots to login + DHCP + ping in QEMU
+          # locally via hisi_higmac. Same allow-failure rationale +
+          # struct timer_list.data caveat as cv200_neo.
+          - machine: hi3516av100
+            firmware: hi3516av100
+            variant: neo
+            mem: 256M
+            allow-failure: true
+            append: "console=ttyAMA0,115200 mem=32M root=/dev/ram0 rootfstype=squashfs"
 
     steps:
       - uses: actions/checkout@v4
@@ -936,7 +964,7 @@ jobs:
           mkdir -p /tmp/openipc
           cd /tmp/openipc
           curl -sSLf -o fw.tgz \
-            https://github.com/OpenIPC/firmware/releases/download/latest/openipc.${{ matrix.firmware }}-nor-lite.tgz
+            https://github.com/OpenIPC/firmware/releases/download/latest/openipc.${{ matrix.firmware }}-nor-${{ matrix.variant || 'lite' }}.tgz
           tar xzf fw.tgz
           ls uImage.${{ matrix.firmware }}
 
@@ -1081,7 +1109,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: qemu-boot-${{ matrix.machine }}
+          name: qemu-boot-${{ matrix.machine }}${{ matrix.variant && format('_{0}', matrix.variant) || '' }}
           path: qemu-output.txt
           retention-days: 7
 


### PR DESCRIPTION
## Summary

Closes [OpenIPC/firmware#2123](https://github.com/OpenIPC/firmware/issues/2123). Adds two new rows to the `qemu-boot:` matrix so the V2/V2A neo targets that landed in [OpenIPC/firmware#2122](https://github.com/OpenIPC/firmware/pull/2122) get smoke-tested every PR / merge to main.

## Mechanics

- New optional `variant:` field per matrix row. Defaults to `lite` (download URL becomes `openipc.X-nor-lite.tgz`, behavior byte-equivalent to today). When set to `neo`:
  - row name becomes `QEMU boot (<machine>_neo)`
  - download URL becomes `openipc.<machine>-nor-neo.tgz`
  - artifact upload name becomes `qemu-boot-<machine>_neo`
- Two new rows added: `hi3516cv200_neo` (mem 64M) and `hi3516av100_neo` (mem 256M). Both `allow-failure: true` until two upstream conditions land.

## Why allow-failure for now

1. **Nightly catch-up**: the firmware-side artifact loop already iterates defconfigs, so the next nightly after #2122 will publish `openipc.hi3516cv200-nor-neo.tgz` + `openipc.hi3516av100-nor-neo.tgz`. Until then, the rows 404 on the download step.
2. **`load_hisilicon` not yet 7.0-aware**: the firmware-side script hardcodes `/lib/modules/4.9.37/hisilicon` — on a 7.0 kernel that path doesn't exist, so `lsmod` stays empty and the `min_modules` check (if we set one) would fail. Boot still reaches `login:` cleanly. Separate firmware-side fix.

Drop allow-failure once both land. Same pattern as cv300_neo's row went through.

## Verification

Local QEMU smoke matches what CI will run, against the *_neo tarballs produced by PR #2122:

```
hi3516cv200_neo  → login + DHCP + ping (4.218 ms)
hi3516av100_neo  → login + DHCP + ping (2.728 ms, via hisi_higmac)
```

Existing lite rows unchanged (variant field defaults to lite).

## Test plan

- [x] YAML parses cleanly (`python3 -c yaml.safe_load`)
- [x] Existing lite rows still produce `qemu-boot-<machine>` artifact names (no breaking change)
- [ ] New neo rows 404 on first run (nightly hasn't published yet) — expected; resolves on next nightly
- [ ] After nightly: rows produce `qemu-boot-<machine>_neo` artifacts, hit login prompt, allow-failure passes

## Related

- OpenIPC/firmware#2122 (cv200_neo + av100_neo bring-up)
- OpenIPC/firmware#2123 (this issue)
- OpenIPC/openhisilicon#170, #171 (V2/V2A OSAL shim)
- openipc/linux#44 (av100 mainline SoC + higmac driver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)