### PR TITLE
openipc_frame_ts: ISP_FEND event source, edge-detect both event types, split counters (closes #176, #177)

### DIFF
--- a/include/openipc_frame_ts.h
+++ b/include/openipc_frame_ts.h
@@ -11,23 +11,58 @@
 #include <linux/types.h>
 #include <linux/ioctl.h>
 
+/*
+ * Event source classification.
+ *
+ * MIPI_FS  — fired by the MIPI RX driver on the FS short packet (vendor
+ *            term: `MIPI_CTRL_INT.int_vsync_st`, Hi3516CV500 DS section
+ *            9, register at 0x12F4 bit [4]). Approximately "sensor
+ *            starts streaming row 0 of this frame".
+ *
+ * ISP_FEND — fired by the ISP front-end's ISP_INT_FE register's FEND
+ *            bit (bit [4]; kernel macro ISP_INT_FE_FEND). Approximately
+ *            "ISP front-end finished receiving the last pixel of this
+ *            frame from the sensor and the demosaic/AE/AWB pipeline
+ *            entered the back half." On rolling-shutter sensors,
+ *            ISP_FEND.wall_ns − MIPI_FS.wall_ns ≈ sensor readout
+ *            duration + a small ISP front-end latency (a few hundred
+ *            µs to ~1 ms).
+ *
+ * Consumers that don't care about source filtering can mask off
+ * event_type and treat every event as a generic frame marker; the
+ * ordering relation MIPI_FS_seq < ISP_FEND_seq holds frame-by-frame.
+ */
+#define OPENIPC_FT_EVT_MIPI_FS  0u
+#define OPENIPC_FT_EVT_ISP_FEND 1u
+
 struct openipc_frame_ts_event {
-	__u64 pts_us;    /* same source as VENC_STREAM_S.u64PTS */
-	__u64 wall_ns;   /* CLOCK_REALTIME at frame-start IRQ */
-	__u32 vi_chn;    /* sensor channel (combo_dev_t) */
-	__u32 seq;       /* per-channel monotonic, wraps */
+	__u64 pts_us;       /* same source as VENC_STREAM_S.u64PTS */
+	__u64 wall_ns;      /* CLOCK_REALTIME at IRQ entry */
+	__u32 vi_chn;       /* sensor channel (combo_dev_t / ISP pipe) */
+	__u32 seq;          /* per-(chn, event_type) monotonic, wraps */
+	__u32 event_type;   /* OPENIPC_FT_EVT_* — see above */
+	__u32 reserved;     /* must be zero; reserved for future event sources */
 };
 
 #define OPENIPC_FT_IOC_MAGIC            'o'
 #define OPENIPC_FT_IOC_SET_CHANNEL_MASK _IOW(OPENIPC_FT_IOC_MAGIC, 1, __u32)
 #define OPENIPC_FT_IOC_GET_DROPPED      _IOR(OPENIPC_FT_IOC_MAGIC, 2, __u64)
+/*
+ * Filter which event_types this fd receives. Bit n set ↔ events with
+ * event_type == n pass through. Default is all bits set (every type).
+ */
+#define OPENIPC_FT_IOC_SET_EVENT_MASK   _IOW(OPENIPC_FT_IOC_MAGIC, 3, __u32)
 
 #ifdef __KERNEL__
 /*
- * Per-channel frame-start hook. Safe to call from hardirq context.
- * Called by per-SoC MIPI RX / ISP IRQ handlers.
+ * Per-channel event hook. Safe to call from hardirq context.
+ * `event_type` must be one of OPENIPC_FT_EVT_*.
+ *
+ * Called by per-SoC MIPI RX / ISP IRQ handlers at well-defined
+ * pipeline points. The chrdev consumer decides which types it cares
+ * about via OPENIPC_FT_IOC_SET_EVENT_MASK.
  */
-void openipc_frame_ts_push(unsigned int vi_chn);
+void openipc_frame_ts_push(unsigned int vi_chn, unsigned int event_type);
 #endif
 
 #endif /* _OPENIPC_FRAME_TS_H */

--- a/include/openipc_frame_ts.h
+++ b/include/openipc_frame_ts.h
@@ -46,12 +46,28 @@ struct openipc_frame_ts_event {
 
 #define OPENIPC_FT_IOC_MAGIC            'o'
 #define OPENIPC_FT_IOC_SET_CHANNEL_MASK _IOW(OPENIPC_FT_IOC_MAGIC, 1, __u32)
+/*
+ * Ring-overflow drops only — events that arrived but couldn't be queued
+ * because no reader drained the chrdev in time. This is genuine data
+ * loss. Distinct from coalesced (below), which is intentional rejection
+ * of within-dedupe-window duplicates from the level-held vsync / FEND
+ * bits over-firing at high sensor IRQ rates.
+ */
 #define OPENIPC_FT_IOC_GET_DROPPED      _IOR(OPENIPC_FT_IOC_MAGIC, 2, __u64)
 /*
  * Filter which event_types this fd receives. Bit n set ↔ events with
  * event_type == n pass through. Default is all bits set (every type).
  */
 #define OPENIPC_FT_IOC_SET_EVENT_MASK   _IOW(OPENIPC_FT_IOC_MAGIC, 3, __u32)
+/*
+ * Dedupe-coalesced events — incremented when openipc_frame_ts_push is
+ * called for an event_type within its dedupe window of the previous
+ * push. These are NOT data loss: they're the level-held-bit duplicates
+ * the dedupe is there to absorb. Compare against GET_DROPPED: drops →
+ * size the ring or pace the reader; coalesced → tune the dedupe window
+ * if it's rejecting real frames you wanted.
+ */
+#define OPENIPC_FT_IOC_GET_COALESCED    _IOR(OPENIPC_FT_IOC_MAGIC, 4, __u64)
 
 #ifdef __KERNEL__
 /*

--- a/kernel/isp/Kbuild
+++ b/kernel/isp/Kbuild
@@ -13,6 +13,10 @@ SRCS := \
 
 ccflags-y += -I$(src)/$(MOD_NAME)/include
 ccflags-y += -I$(src)/$(MOD_NAME)/arch/include
+# For openipc_frame_ts.h (openhisilicon#155). Header path is consistent
+# across all per-SoC kbuilds, so add it here in the shared ISP Kbuild
+# instead of repeating in each.
+ccflags-y += -I$(src)/../include
 
 OBJS := $(SRCS:%.c=%.o) $(ASM_SRCS:%.S=%.o)
 

--- a/kernel/isp/arch/hi3516cv200/firmware/drv/isp.c
+++ b/kernel/isp/arch/hi3516cv200/firmware/drv/isp.c
@@ -2627,7 +2627,13 @@ static inline irqreturn_t ISP_ISR(int irq, void *id)
     }
     if (u32PortIntStatus)
     {
-        openipc_frame_ts_push(IspDev);
+        /* cv200's MIPI RX hardware doesn't expose a usable vsync bit,
+         * so we report this ISP-port FSTART IRQ as MIPI_FS-equivalent.
+         * It fires at the same pipeline point (frame start) as the
+         * MIPI_FS path on V4 SoCs. cv200 doesn't have an FEND IRQ
+         * source we can hook today — see kernel/isp/arch/hi3516cv200
+         * for the ISP register map. */
+        openipc_frame_ts_push(IspDev, OPENIPC_FT_EVT_MIPI_FS);
         HW_REG(IO_ADDRESS_PORT(VI_PT0_INT)) = VI_PT0_INT_FSTART;
     }
     /*When detect vi port's width&height changed,then reset isp*/

--- a/kernel/isp/arch/hi3516cv500/mkp/src/isp.c
+++ b/kernel/isp/arch/hi3516cv500/mkp/src/isp.c
@@ -10,6 +10,7 @@
 #include "hi_common.h"
 #include "hi_comm_isp.h"
 #include "isp_drv_defines.h"
+#include "openipc_frame_ts.h"
 #include "mkp_isp.h"
 #include "isp.h"
 #include "isp_drv.h"
@@ -6839,6 +6840,16 @@ hi_s32 isp_drv_int_status_process(hi_vi_pipe vi_pipe, hi_s32 vi_dev, isp_drv_ctx
 
     isp_raw_int    = io_rw_fe_address(vi_pipe, ISP_INT_FE);
     isp_int_status = isp_raw_int & io_rw_fe_address(vi_pipe, ISP_INT_FE_MASK);
+
+    /*
+     * openipc_frame_ts: push an ISP_FEND event when the ISP front-end
+     * finished receiving the last row from the sensor. Paired with
+     * MIPI_FS pushed by the MIPI RX driver at frame-start, consumers
+     * see two events per frame and can compute sensor readout duration
+     * as wall_ns[FEND] − wall_ns[FS].
+     */
+    if (isp_int_status & ISP_INT_FE_FEND)
+        openipc_frame_ts_push(vi_pipe, OPENIPC_FT_EVT_ISP_FEND);
 
     int_sch.isp_int_status  = isp_int_status;
     int_sch.port_int_status = port_int_f_start;

--- a/kernel/isp/arch/hi3516cv500/mkp/src/isp.c
+++ b/kernel/isp/arch/hi3516cv500/mkp/src/isp.c
@@ -6847,9 +6847,23 @@ hi_s32 isp_drv_int_status_process(hi_vi_pipe vi_pipe, hi_s32 vi_dev, isp_drv_ctx
      * MIPI_FS pushed by the MIPI RX driver at frame-start, consumers
      * see two events per frame and can compute sensor readout duration
      * as wall_ns[FEND] − wall_ns[FS].
+     *
+     * Edge-detect on the raw status: vendor HAL leaves ISP_INT_FE_MASK
+     * at 0 by default so the masked status reads zero. The raw FEND
+     * bit is level-held across the inter-frame gap (hardware re-asserts
+     * after each W1C while the underlying frame-finished condition
+     * holds), so every ISR call during that window would otherwise
+     * fire. Track the previous raw state per pipe and emit only on
+     * the 0→1 transition.
      */
-    if (isp_int_status & ISP_INT_FE_FEND)
-        openipc_frame_ts_push(vi_pipe, OPENIPC_FT_EVT_ISP_FEND);
+    {
+        static bool s_fend_was_set[ISP_MAX_PIPE_NUM];
+        bool fend_now = !!(isp_raw_int & ISP_INT_FE_FEND);
+
+        if (fend_now && !s_fend_was_set[vi_pipe])
+            openipc_frame_ts_push(vi_pipe, OPENIPC_FT_EVT_ISP_FEND);
+        s_fend_was_set[vi_pipe] = fend_now;
+    }
 
     int_sch.isp_int_status  = isp_int_status;
     int_sch.port_int_status = port_int_f_start;

--- a/kernel/isp/mkp/src/isp.c
+++ b/kernel/isp/mkp/src/isp.c
@@ -7915,10 +7915,28 @@ static inline int ISP_ISR(int irq, void *id)
 			 * MIPI RX driver at frame-start, consumers see two
 			 * events per frame and can compute sensor readout
 			 * duration as wall_ns[FEND] − wall_ns[FS].
+			 *
+			 * Edge-detect on the raw status: the vendor HAL leaves
+			 * ISP_INT_FE_MASK at 0 by default (only the unused
+			 * ISP_SET_INT_ENABLE ioctl flips it on), so the masked
+			 * status reads zero. The raw FEND bit is level-held
+			 * across the inter-frame gap — W1C clears it for the
+			 * instant the writeback happens, but hardware re-asserts
+			 * while the underlying frame-finished condition holds,
+			 * so every ISR call during that window would otherwise
+			 * fire. Track the previous raw state per pipe and emit
+			 * only on the 0→1 transition.
 			 */
-			if (u32IspIntStatus & ISP_INT_FE_FEND)
-				openipc_frame_ts_push(ViPipe,
-						      OPENIPC_FT_EVT_ISP_FEND);
+			{
+				static bool s_fend_was_set[ISP_MAX_PHY_PIPE_NUM];
+				bool fend_now =
+					!!(u32IspRawIntStatus & ISP_INT_FE_FEND);
+
+				if (fend_now && !s_fend_was_set[ViPipe])
+					openipc_frame_ts_push(ViPipe,
+							      OPENIPC_FT_EVT_ISP_FEND);
+				s_fend_was_set[ViPipe] = fend_now;
+			}
 
 			pstDrvCtx->stIntSch.u32IspIntStatus = u32IspIntStatus;
 			pstDrvCtx->stIntSch.u32PortIntStatus = u32PortIntFStart;

--- a/kernel/isp/mkp/src/isp.c
+++ b/kernel/isp/mkp/src/isp.c
@@ -6,6 +6,7 @@
 #include "common.h"
 #include "comm_isp.h"
 #include "isp_drv_defines.h"
+#include "openipc_frame_ts.h"
 #include "mkp_isp.h"
 #include "isp.h"
 #include "isp_drv.h"
@@ -7906,6 +7907,18 @@ static inline int ISP_ISR(int irq, void *id)
 			u32IspIntStatus =
 				u32IspRawIntStatus &
 				IO_RW_FE_ADDRESS(ViPipe, ISP_INT_FE_MASK);
+
+			/*
+			 * openipc_frame_ts: push an ISP_FEND event when the
+			 * ISP front-end finished receiving the last row from
+			 * the sensor. Combined with MIPI_FS pushed by the
+			 * MIPI RX driver at frame-start, consumers see two
+			 * events per frame and can compute sensor readout
+			 * duration as wall_ns[FEND] − wall_ns[FS].
+			 */
+			if (u32IspIntStatus & ISP_INT_FE_FEND)
+				openipc_frame_ts_push(ViPipe,
+						      OPENIPC_FT_EVT_ISP_FEND);
 
 			pstDrvCtx->stIntSch.u32IspIntStatus = u32IspIntStatus;
 			pstDrvCtx->stIntSch.u32PortIntStatus = u32PortIntFStart;

--- a/kernel/mipi_rx/hi3516cv500/mipi_rx_hal.c
+++ b/kernel/mipi_rx/hi3516cv500/mipi_rx_hal.c
@@ -2359,7 +2359,7 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
             lvds_ctrl_regs->LVDS_CTRL_INT_RAW.u32 = LVDS_INT_VSYNC;
         }
         if (vsync)
-            openipc_frame_ts_push(i);
+            openipc_frame_ts_push(i, OPENIPC_FT_EVT_MIPI_FS);
     }
 
     for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {

--- a/kernel/mipi_rx/hi3516cv500/mipi_rx_hal.c
+++ b/kernel/mipi_rx/hi3516cv500/mipi_rx_hal.c
@@ -2340,9 +2340,17 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
      * both are wired up, but openipc_frame_ts_push fires at most once
      * per device per IRQ so consumers get one event per physical frame.
      */
+    /*
+     * Edge-detect on the raw vsync bits per device — see the
+     * matching comment in kernel/mipi_rx/mipi_rx_hal.c for the
+     * level-held-bit reasoning. cv500 also has the ~30–80 µs
+     * double-vsync quirk that the 1 ms openipc_frame_ts dedupe
+     * absorbs as a second line of defence.
+     */
     for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {
+        static bool s_vsync_was_set[MIPI_RX_MAX_DEV_NUM];
         unsigned int mipi_int, lvds_int;
-        int vsync = 0;
+        bool vsync_now = false;
 
         mipi_ctrl_regs = get_mipi_ctrl_regs(i);
         lvds_ctrl_regs = get_lvds_ctrl_regs(i);
@@ -2351,15 +2359,16 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
         lvds_int = lvds_ctrl_regs->LVDS_CTRL_INT.u32;
 
         if (mipi_int & MIPI_INT_VSYNC) {
-            vsync = 1;
+            vsync_now = true;
             mipi_ctrl_regs->MIPI_CTRL_INT_RAW.u32 = MIPI_INT_VSYNC;
         }
         if (lvds_int & LVDS_INT_VSYNC) {
-            vsync = 1;
+            vsync_now = true;
             lvds_ctrl_regs->LVDS_CTRL_INT_RAW.u32 = LVDS_INT_VSYNC;
         }
-        if (vsync)
+        if (vsync_now && !s_vsync_was_set[i])
             openipc_frame_ts_push(i, OPENIPC_FT_EVT_MIPI_FS);
+        s_vsync_was_set[i] = vsync_now;
     }
 
     for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {

--- a/kernel/mipi_rx/mipi_rx_hal.c
+++ b/kernel/mipi_rx/mipi_rx_hal.c
@@ -2010,7 +2010,7 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
 			lvds_ctrl_regs->LVDS_CTRL_INT_RAW.u32 = LVDS_INT_VSYNC;
 		}
 		if (vsync)
-			openipc_frame_ts_push(i);
+			openipc_frame_ts_push(i, OPENIPC_FT_EVT_MIPI_FS);
 	}
 
 	for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {

--- a/kernel/mipi_rx/mipi_rx_hal.c
+++ b/kernel/mipi_rx/mipi_rx_hal.c
@@ -1987,13 +1987,20 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
 	/*
 	 * Frame-start dispatch (openipc_frame_ts). Runs outside the
 	 * CHN_INT_RAW gate below because vsync IRQs alone don't set it.
-	 * MIPI CSI-2 and LVDS vsync bits are W1C'd independently in case
-	 * both are wired up, but openipc_frame_ts_push fires at most once
-	 * per device per IRQ so consumers get one event per physical frame.
+	 *
+	 * Edge-detect on the raw vsync bits per device: MIPI_CTRL_INT.vsync
+	 * and LVDS_CTRL_INT.lvds_vsync are level-held across the inter-frame
+	 * gap (hardware re-asserts after each W1C while the underlying
+	 * vsync window is open). Without edge detection FS would fire on
+	 * every IRQ during that window — measured ~185 Hz on a 37 fps
+	 * IMX335 (capped by the openipc_frame_ts 1 ms dedupe). Emit only on
+	 * the 0→1 transition; the per-event-type 1 ms dedupe in
+	 * openipc_frame_ts still backstops cv500's double-vsync quirk.
 	 */
 	for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {
+		static bool s_vsync_was_set[MIPI_RX_MAX_DEV_NUM];
 		unsigned int mipi_int, lvds_int;
-		int vsync = 0;
+		bool vsync_now = false;
 
 		mipi_ctrl_regs = get_mipi_ctrl_regs(i);
 		lvds_ctrl_regs = get_lvds_ctrl_regs(i);
@@ -2002,15 +2009,16 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
 		lvds_int = lvds_ctrl_regs->LVDS_CTRL_INT.u32;
 
 		if (mipi_int & MIPI_INT_VSYNC) {
-			vsync = 1;
+			vsync_now = true;
 			mipi_ctrl_regs->MIPI_CTRL_INT_RAW.u32 = MIPI_INT_VSYNC;
 		}
 		if (lvds_int & LVDS_INT_VSYNC) {
-			vsync = 1;
+			vsync_now = true;
 			lvds_ctrl_regs->LVDS_CTRL_INT_RAW.u32 = LVDS_INT_VSYNC;
 		}
-		if (vsync)
+		if (vsync_now && !s_vsync_was_set[i])
 			openipc_frame_ts_push(i, OPENIPC_FT_EVT_MIPI_FS);
+		s_vsync_was_set[i] = vsync_now;
 	}
 
 	for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {

--- a/kernel/openipc_frame_ts/README.md
+++ b/kernel/openipc_frame_ts/README.md
@@ -41,8 +41,8 @@ struct openipc_frame_ts_event {
 event is available, then drains as many full events as fit in the supplied
 buffer. `poll()`/`select()` supported. `OPENIPC_FT_IOC_SET_CHANNEL_MASK`
 narrows the per-fd channel set. `OPENIPC_FT_IOC_GET_DROPPED` returns total
-drops across all channels (the ring drops oldest on overflow at depth 64
-per channel).
+drops across all channels (the ring drops oldest on overflow at depth 256
+per channel — ≈ 0.5 s of buffer at 240 fps × 2 event types).
 
 ## Module loading
 

--- a/kernel/openipc_frame_ts/README.md
+++ b/kernel/openipc_frame_ts/README.md
@@ -40,9 +40,16 @@ struct openipc_frame_ts_event {
 `read()` blocks (or returns `-EAGAIN` if `O_NONBLOCK`) until at least one
 event is available, then drains as many full events as fit in the supplied
 buffer. `poll()`/`select()` supported. `OPENIPC_FT_IOC_SET_CHANNEL_MASK`
-narrows the per-fd channel set. `OPENIPC_FT_IOC_GET_DROPPED` returns total
-drops across all channels (the ring drops oldest on overflow at depth 256
-per channel — ≈ 0.5 s of buffer at 240 fps × 2 event types).
+narrows the per-fd channel set. `OPENIPC_FT_IOC_GET_DROPPED` returns total **ring-overflow** drops across
+all channels (genuine data loss — events arrived but no reader drained
+the ring in time). The ring is depth 256 per channel (≈ 0.5 s of buffer
+at 240 fps × 2 event types). `OPENIPC_FT_IOC_GET_COALESCED` returns
+total **dedupe rejections** — duplicate events the level-held vsync /
+FEND bits emitted within the dedupe window of a previously-pushed event.
+Coalesced events are *not* data loss; they're the over-fired duplicates
+the dedupe is there to absorb. A nonzero `dropped` means reader can't
+keep up; a nonzero `coalesced` is expected steady-state at high IRQ
+rates and means the dedupe is doing its job.
 
 ## Module loading
 

--- a/kernel/openipc_frame_ts/openipc_frame_ts.c
+++ b/kernel/openipc_frame_ts/openipc_frame_ts.c
@@ -2,8 +2,19 @@
 /*
  * OpenIPC frame-timestamp capture (issue #144).
  *
- * Per-channel ring of (pts_us, wall_ns) tuples sampled from per-SoC IRQ
- * handlers at sensor frame-start. Exposed via /dev/openipc-frame-ts.
+ * Per-channel ring of (pts_us, wall_ns, event_type) tuples sampled
+ * from per-SoC IRQ handlers at well-defined pipeline points. Exposed
+ * via /dev/openipc-frame-ts.
+ *
+ * Today the chrdev emits two event types per frame:
+ *   OPENIPC_FT_EVT_MIPI_FS   — MIPI RX driver, on FS short packet
+ *                              (≈ sensor begins streaming row 0)
+ *   OPENIPC_FT_EVT_ISP_FEND  — ISP front-end IRQ, on FEND bit set
+ *                              (≈ ISP FE finished receiving last row)
+ *
+ * Their delta on the same physical frame is dominated by sensor
+ * readout duration (HMAX × VMAX / pixel_clock), so consumers can
+ * decompose latency budgets without an external probe.
  */
 #include <linux/module.h>
 #include <linux/kernel.h>
@@ -22,13 +33,18 @@
 
 #define OPENIPC_FT_NAME           "openipc-frame-ts"
 #define OPENIPC_FT_MAX_CHN        8
-#define OPENIPC_FT_DEPTH          64        /* power of 2 */
+#define OPENIPC_FT_MAX_EVT_TYPE   2   /* MIPI_FS + ISP_FEND so far */
+#define OPENIPC_FT_DEPTH          64  /* power of 2 */
 /*
- * Drop double-pushes that arrive less than this far apart. Level-triggered
- * IRQ retrigger or per-SoC quirks (e.g. cv500 firing the vsync IRQ twice
- * ~30-80 us apart on ~4 % of frames) otherwise leak into userspace as
- * spurious extra events. 1 ms is safely below any plausible sensor frame
- * interval (1000 fps).
+ * Drop double-pushes of the SAME event type within this interval.
+ * Level-triggered IRQ retrigger or per-SoC quirks (e.g. cv500 firing
+ * the MIPI vsync IRQ twice ~30–80 µs apart on ~4 % of frames)
+ * otherwise leak into userspace as spurious extra events. 1 ms is
+ * safely below any plausible sensor frame interval (1000 fps).
+ *
+ * NB: dedup is per (chn, event_type). MIPI_FS and ISP_FEND for the
+ * same frame can be tens of ms apart (= readout duration) — that's
+ * the whole point — so dedup deliberately does NOT cross event types.
  */
 #define OPENIPC_FT_MIN_INTERVAL_NS  1000000
 
@@ -36,19 +52,22 @@ struct openipc_ft_chn {
 	struct openipc_frame_ts_event ring[OPENIPC_FT_DEPTH];
 	unsigned int head;
 	unsigned int tail;
-	u32 seq;
-	u64 dropped;
-	u64 last_push_ns;
-	spinlock_t lock;
+	u32          seq[OPENIPC_FT_MAX_EVT_TYPE];
+	u64          last_push_ns[OPENIPC_FT_MAX_EVT_TYPE];
+	u64          dropped;
+	spinlock_t   lock;
 };
 
 struct openipc_ft_file {
 	u32 chn_mask;
+	u32 evt_mask;
 };
 
 static struct openipc_ft_chn g_chn[OPENIPC_FT_MAX_CHN];
 static wait_queue_head_t g_wait;
-static unsigned int g_default_chn_mask = (1U << OPENIPC_FT_MAX_CHN) - 1;
+static const unsigned int g_default_chn_mask =
+	(1U << OPENIPC_FT_MAX_CHN) - 1;
+static const unsigned int g_default_evt_mask = ~0U;
 
 static struct miscdevice g_miscdev;
 
@@ -67,7 +86,7 @@ static inline bool ring_empty(const struct openipc_ft_chn *c)
 	return c->head == c->tail;
 }
 
-void openipc_frame_ts_push(unsigned int vi_chn)
+void openipc_frame_ts_push(unsigned int vi_chn, unsigned int event_type)
 {
 	struct openipc_ft_chn *c;
 	struct openipc_frame_ts_event *e;
@@ -76,18 +95,20 @@ void openipc_frame_ts_push(unsigned int vi_chn)
 
 	if (vi_chn >= OPENIPC_FT_MAX_CHN)
 		return;
+	if (event_type >= OPENIPC_FT_MAX_EVT_TYPE)
+		return;
 
 	now_ns = sched_clock();
 	c = &g_chn[vi_chn];
 
 	spin_lock_irqsave(&c->lock, flags);
-	if (c->last_push_ns &&
-	    now_ns - c->last_push_ns < OPENIPC_FT_MIN_INTERVAL_NS) {
+	if (c->last_push_ns[event_type] &&
+	    now_ns - c->last_push_ns[event_type] < OPENIPC_FT_MIN_INTERVAL_NS) {
 		c->dropped++;
 		spin_unlock_irqrestore(&c->lock, flags);
 		return;
 	}
-	c->last_push_ns = now_ns;
+	c->last_push_ns[event_type] = now_ns;
 
 	if (ring_full(c)) {
 		/* drop oldest */
@@ -95,10 +116,12 @@ void openipc_frame_ts_push(unsigned int vi_chn)
 		c->dropped++;
 	}
 	e = &c->ring[c->head];
-	e->pts_us = div_u64(now_ns, 1000);
-	e->wall_ns = ktime_get_real_ns();
-	e->vi_chn = vi_chn;
-	e->seq = c->seq++;
+	e->pts_us     = div_u64(now_ns, 1000);
+	e->wall_ns    = ktime_get_real_ns();
+	e->vi_chn     = vi_chn;
+	e->seq        = c->seq[event_type]++;
+	e->event_type = event_type;
+	e->reserved   = 0;
 	c->head = (c->head + 1) & (OPENIPC_FT_DEPTH - 1);
 	spin_unlock_irqrestore(&c->lock, flags);
 
@@ -115,6 +138,7 @@ static int ft_open(struct inode *inode, struct file *file)
 		return -ENOMEM;
 
 	priv->chn_mask = g_default_chn_mask;
+	priv->evt_mask = g_default_evt_mask;
 	file->private_data = priv;
 	return 0;
 }
@@ -125,18 +149,47 @@ static int ft_release(struct inode *inode, struct file *file)
 	return 0;
 }
 
-static bool any_pending(u32 mask)
+static bool event_passes(const struct openipc_frame_ts_event *e,
+			 u32 chn_mask, u32 evt_mask)
+{
+	if (!(chn_mask & (1U << e->vi_chn)))
+		return false;
+	if (e->event_type < 32 && !(evt_mask & (1U << e->event_type)))
+		return false;
+	return true;
+}
+
+static bool any_pending(u32 chn_mask, u32 evt_mask)
 {
 	unsigned int i;
+	unsigned long flags;
 
 	for (i = 0; i < OPENIPC_FT_MAX_CHN; i++) {
-		if ((mask & (1U << i)) && !ring_empty(&g_chn[i]))
+		struct openipc_ft_chn *c = &g_chn[i];
+		bool hit = false;
+
+		if (!(chn_mask & (1U << i)))
+			continue;
+
+		spin_lock_irqsave(&c->lock, flags);
+		if (!ring_empty(c)) {
+			/* Cheap heuristic: any unread events on a permitted
+			 * channel ⇒ pending. The fd may later discard some
+			 * after a per-event evt_mask check in pop_one; that's
+			 * fine — read() handles the empty-after-filter case
+			 * by sleeping again. */
+			hit = true;
+		}
+		spin_unlock_irqrestore(&c->lock, flags);
+
+		if (hit)
 			return true;
 	}
 	return false;
 }
 
-static bool pop_one(u32 mask, struct openipc_frame_ts_event *out)
+static bool pop_one(u32 chn_mask, u32 evt_mask,
+		    struct openipc_frame_ts_event *out)
 {
 	unsigned int i;
 	unsigned long flags;
@@ -145,14 +198,22 @@ static bool pop_one(u32 mask, struct openipc_frame_ts_event *out)
 	for (i = 0; i < OPENIPC_FT_MAX_CHN; i++) {
 		struct openipc_ft_chn *c = &g_chn[i];
 
-		if (!(mask & (1U << i)))
+		if (!(chn_mask & (1U << i)))
 			continue;
 
 		spin_lock_irqsave(&c->lock, flags);
-		if (!ring_empty(c)) {
-			*out = c->ring[c->tail];
+		while (!ring_empty(c)) {
+			struct openipc_frame_ts_event *cand =
+				&c->ring[c->tail];
+
 			c->tail = (c->tail + 1) & (OPENIPC_FT_DEPTH - 1);
-			got = true;
+			if (event_passes(cand, chn_mask, evt_mask)) {
+				*out = *cand;
+				got = true;
+				break;
+			}
+			/* Drop events that don't match this fd's evt_mask;
+			 * they were consumed from the ring already. */
 		}
 		spin_unlock_irqrestore(&c->lock, flags);
 
@@ -173,13 +234,14 @@ static ssize_t ft_read(struct file *file, char __user *buf, size_t count,
 		return -EINVAL;
 
 	while (copied + sizeof(ev) <= count) {
-		if (!pop_one(priv->chn_mask, &ev)) {
+		if (!pop_one(priv->chn_mask, priv->evt_mask, &ev)) {
 			if (copied)
 				break;
 			if (file->f_flags & O_NONBLOCK)
 				return -EAGAIN;
-			if (wait_event_interruptible(g_wait,
-						     any_pending(priv->chn_mask)))
+			if (wait_event_interruptible(
+				    g_wait, any_pending(priv->chn_mask,
+							priv->evt_mask)))
 				return -ERESTARTSYS;
 			continue;
 		}
@@ -196,25 +258,11 @@ static unsigned int ft_poll(struct file *file, poll_table *table)
 {
 	struct openipc_ft_file *priv = file->private_data;
 	unsigned int mask = 0;
-	unsigned int i;
-	unsigned long flags;
 
 	poll_wait(file, &g_wait, table);
 
-	for (i = 0; i < OPENIPC_FT_MAX_CHN; i++) {
-		struct openipc_ft_chn *c = &g_chn[i];
-
-		if (!(priv->chn_mask & (1U << i)))
-			continue;
-
-		spin_lock_irqsave(&c->lock, flags);
-		if (!ring_empty(c))
-			mask |= POLLIN | POLLRDNORM;
-		spin_unlock_irqrestore(&c->lock, flags);
-
-		if (mask)
-			break;
-	}
+	if (any_pending(priv->chn_mask, priv->evt_mask))
+		mask |= POLLIN | POLLRDNORM;
 
 	return mask;
 }
@@ -231,6 +279,14 @@ static long ft_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		if (copy_from_user(&m, uarg, sizeof(m)))
 			return -EFAULT;
 		priv->chn_mask = m;
+		return 0;
+	}
+	case OPENIPC_FT_IOC_SET_EVENT_MASK: {
+		u32 m;
+
+		if (copy_from_user(&m, uarg, sizeof(m)))
+			return -EFAULT;
+		priv->evt_mask = m;
 		return 0;
 	}
 	case OPENIPC_FT_IOC_GET_DROPPED: {
@@ -281,8 +337,8 @@ static int __init openipc_ft_init(void)
 		return ret;
 	}
 
-	pr_info("openipc_frame_ts: /dev/%s minor=%d\n",
-		OPENIPC_FT_NAME, g_miscdev.minor);
+	pr_info("openipc_frame_ts: /dev/%s minor=%d, event types=%u\n",
+		OPENIPC_FT_NAME, g_miscdev.minor, OPENIPC_FT_MAX_EVT_TYPE);
 	return 0;
 }
 
@@ -295,4 +351,4 @@ module_init(openipc_ft_init);
 module_exit(openipc_ft_exit);
 
 MODULE_LICENSE("GPL");
-MODULE_DESCRIPTION("OpenIPC sensor frame-start (PTS, CLOCK_REALTIME) capture");
+MODULE_DESCRIPTION("OpenIPC sensor frame-event (PTS, CLOCK_REALTIME) capture");

--- a/kernel/openipc_frame_ts/openipc_frame_ts.c
+++ b/kernel/openipc_frame_ts/openipc_frame_ts.c
@@ -34,7 +34,13 @@
 #define OPENIPC_FT_NAME           "openipc-frame-ts"
 #define OPENIPC_FT_MAX_CHN        8
 #define OPENIPC_FT_MAX_EVT_TYPE   2   /* MIPI_FS + ISP_FEND so far */
-#define OPENIPC_FT_DEPTH          64  /* power of 2 */
+/*
+ * Per-channel ring depth (power of 2). 256 events ≈ 0.5 s of buffer at
+ * 240 fps × 2 event types — covers high-fps modes (imx335 800x480 240 fps)
+ * with margin for reader-side jitter (scheduler latency, printf-to-disk).
+ * At 32 B/event the per-channel cost is 8 KiB.
+ */
+#define OPENIPC_FT_DEPTH          256
 /*
  * Drop double-pushes of the SAME event type within these intervals.
  *

--- a/kernel/openipc_frame_ts/openipc_frame_ts.c
+++ b/kernel/openipc_frame_ts/openipc_frame_ts.c
@@ -75,7 +75,8 @@ struct openipc_ft_chn {
 	unsigned int tail;
 	u32          seq[OPENIPC_FT_MAX_EVT_TYPE];
 	u64          last_push_ns[OPENIPC_FT_MAX_EVT_TYPE];
-	u64          dropped;
+	u64          dropped;          /* ring-overflow drops only (data loss) */
+	u64          coalesced;        /* dedupe rejections (intentional) */
 	spinlock_t   lock;
 };
 
@@ -126,7 +127,13 @@ void openipc_frame_ts_push(unsigned int vi_chn, unsigned int event_type)
 	if (c->last_push_ns[event_type] &&
 	    now_ns - c->last_push_ns[event_type] <
 		    openipc_ft_min_interval_ns[event_type]) {
-		c->dropped++;
+		/*
+		 * Intentional rejection — the level-held vsync / FEND bits
+		 * over-fire at high sensor IRQ rates and the dedupe window
+		 * collapses them into one event per real frame. Not data
+		 * loss; tracked separately from ring-overflow drops.
+		 */
+		c->coalesced++;
 		spin_unlock_irqrestore(&c->lock, flags);
 		return;
 	}
@@ -319,6 +326,20 @@ static long ft_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		for (i = 0; i < OPENIPC_FT_MAX_CHN; i++) {
 			spin_lock_irqsave(&g_chn[i].lock, flags);
 			total += g_chn[i].dropped;
+			spin_unlock_irqrestore(&g_chn[i].lock, flags);
+		}
+		if (copy_to_user(uarg, &total, sizeof(total)))
+			return -EFAULT;
+		return 0;
+	}
+	case OPENIPC_FT_IOC_GET_COALESCED: {
+		u64 total = 0;
+		unsigned int i;
+		unsigned long flags;
+
+		for (i = 0; i < OPENIPC_FT_MAX_CHN; i++) {
+			spin_lock_irqsave(&g_chn[i].lock, flags);
+			total += g_chn[i].coalesced;
 			spin_unlock_irqrestore(&g_chn[i].lock, flags);
 		}
 		if (copy_to_user(uarg, &total, sizeof(total)))

--- a/kernel/openipc_frame_ts/openipc_frame_ts.c
+++ b/kernel/openipc_frame_ts/openipc_frame_ts.c
@@ -36,17 +36,32 @@
 #define OPENIPC_FT_MAX_EVT_TYPE   2   /* MIPI_FS + ISP_FEND so far */
 #define OPENIPC_FT_DEPTH          64  /* power of 2 */
 /*
- * Drop double-pushes of the SAME event type within this interval.
- * Level-triggered IRQ retrigger or per-SoC quirks (e.g. cv500 firing
- * the MIPI vsync IRQ twice ~30–80 µs apart on ~4 % of frames)
- * otherwise leak into userspace as spurious extra events. 1 ms is
- * safely below any plausible sensor frame interval (1000 fps).
+ * Drop double-pushes of the SAME event type within these intervals.
+ *
+ * MIPI_FS (1 ms): MIPI RX vsync IRQ on cv500 fires twice ~30–80 µs apart
+ *   on ~4 % of frames. 1 ms is safely below any plausible sensor frame
+ *   interval (1000 fps) yet catches the duplicate.
+ *
+ * ISP_FEND (25 ms): the ISP_INT_FE.FEND bit is a level signal — hardware
+ *   holds it asserted across the entire inter-frame gap and re-sets it
+ *   after the ISR's W1C clear while the underlying condition still
+ *   holds. The ISR fires far more often than the sensor frame rate
+ *   (other ISP bits), so without a long dedup we'd emit ~IRQ-rate worth
+ *   of FEND events. 25 ms caps at 40 Hz — adequate for every supported
+ *   sensor (max 30 fps single-stream on these SoCs) and still leaves
+ *   margin for jitter.
  *
  * NB: dedup is per (chn, event_type). MIPI_FS and ISP_FEND for the
  * same frame can be tens of ms apart (= readout duration) — that's
  * the whole point — so dedup deliberately does NOT cross event types.
  */
-#define OPENIPC_FT_MIN_INTERVAL_NS  1000000
+#define OPENIPC_FT_MIN_INTERVAL_NS_FS    1000000
+#define OPENIPC_FT_MIN_INTERVAL_NS_FEND  25000000
+
+static const u64 openipc_ft_min_interval_ns[OPENIPC_FT_MAX_EVT_TYPE] = {
+	[OPENIPC_FT_EVT_MIPI_FS]  = OPENIPC_FT_MIN_INTERVAL_NS_FS,
+	[OPENIPC_FT_EVT_ISP_FEND] = OPENIPC_FT_MIN_INTERVAL_NS_FEND,
+};
 
 struct openipc_ft_chn {
 	struct openipc_frame_ts_event ring[OPENIPC_FT_DEPTH];
@@ -103,7 +118,8 @@ void openipc_frame_ts_push(unsigned int vi_chn, unsigned int event_type)
 
 	spin_lock_irqsave(&c->lock, flags);
 	if (c->last_push_ns[event_type] &&
-	    now_ns - c->last_push_ns[event_type] < OPENIPC_FT_MIN_INTERVAL_NS) {
+	    now_ns - c->last_push_ns[event_type] <
+		    openipc_ft_min_interval_ns[event_type]) {
 		c->dropped++;
 		spin_unlock_irqrestore(&c->lock, flags);
 		return;

--- a/samples/openipc_frame_ts/openipc_frame_ts_test.c
+++ b/samples/openipc_frame_ts/openipc_frame_ts_test.c
@@ -87,24 +87,38 @@ static void print_summary(const struct chn_state *st)
 	}
 }
 
+static const char *evt_name(uint32_t t)
+{
+	switch (t) {
+	case OPENIPC_FT_EVT_MIPI_FS:  return "MIPI_FS";
+	case OPENIPC_FT_EVT_ISP_FEND: return "ISP_FEND";
+	default:                      return "?";
+	}
+}
+
 int main(int argc, char **argv)
 {
 	int opt, fd;
 	int summary_only = 0;
 	int seconds = 0;
 	uint32_t mask = 0xFFFFFFFFu;
+	uint32_t event_mask = 1u << OPENIPC_FT_EVT_MIPI_FS;  /* FS only by default */
 	struct chn_state st[MAX_CHN] = {0};
 	time_t last_print = 0;
 	struct pollfd pfd;
 	uint64_t dropped = 0;
 
-	while ((opt = getopt(argc, argv, "sc:t:")) != -1) {
+	while ((opt = getopt(argc, argv, "sc:t:e:")) != -1) {
 		switch (opt) {
 		case 's': summary_only = 1; break;
 		case 'c': mask = strtoul(optarg, NULL, 0); break;
 		case 't': seconds = atoi(optarg); break;
+		case 'e': event_mask = strtoul(optarg, NULL, 0); break;
 		default:
-			fprintf(stderr, "usage: %s [-s] [-t seconds] [-c <mask>]\n", argv[0]);
+			fprintf(stderr,
+			        "usage: %s [-s] [-t seconds] [-c <chn_mask>] [-e <evt_mask>]\n"
+			        "  -e default 0x1 (FS only); 0x3 = FS+FEND\n",
+			        argv[0]);
 			return 1;
 		}
 	}
@@ -124,6 +138,12 @@ int main(int argc, char **argv)
 		fprintf(stderr, "ioctl SET_CHANNEL_MASK: %s\n", strerror(errno));
 		close(fd);
 		return 1;
+	}
+
+	if (ioctl(fd, OPENIPC_FT_IOC_SET_EVENT_MASK, &event_mask) < 0) {
+		fprintf(stderr,
+		        "ioctl SET_EVENT_MASK not supported (%s) — v1 kernel?\n",
+		        strerror(errno));
 	}
 
 	pfd.fd = fd;
@@ -147,11 +167,14 @@ int main(int argc, char **argv)
 		}
 
 		while ((n = read(fd, &ev, sizeof(ev))) == sizeof(ev)) {
-			if (ev.vi_chn < MAX_CHN)
+			/* Jitter stats only on FS — otherwise FS/FEND
+			 * interleave skews inter-arrival deltas. */
+			if (ev.vi_chn < MAX_CHN &&
+			    ev.event_type == OPENIPC_FT_EVT_MIPI_FS)
 				update_chn(&st[ev.vi_chn], ev.wall_ns);
 			if (!summary_only)
-				printf("chn%u seq=%u pts=%llu wall_ns=%llu\n",
-				       ev.vi_chn, ev.seq,
+				printf("chn%u %-8s seq=%u pts=%llu wall_ns=%llu\n",
+				       ev.vi_chn, evt_name(ev.event_type), ev.seq,
 				       (unsigned long long)ev.pts_us,
 				       (unsigned long long)ev.wall_ns);
 		}

--- a/samples/openipc_frame_ts/openipc_frame_ts_test.c
+++ b/samples/openipc_frame_ts/openipc_frame_ts_test.c
@@ -108,6 +108,7 @@ int main(int argc, char **argv)
 	time_t last_print = 0;
 	struct pollfd pfd;
 	uint64_t dropped = 0;
+	uint64_t coalesced = 0;
 
 	while ((opt = getopt(argc, argv, "sc:t:e:")) != -1) {
 		switch (opt) {
@@ -213,8 +214,11 @@ int main(int argc, char **argv)
 	print_summary(st);
 
 	if (ioctl(fd, OPENIPC_FT_IOC_GET_DROPPED, &dropped) == 0)
-		printf("dropped (all channels, all time): %llu\n",
+		printf("dropped     (ring overflow, data loss) : %llu\n",
 		       (unsigned long long)dropped);
+	if (ioctl(fd, OPENIPC_FT_IOC_GET_COALESCED, &coalesced) == 0)
+		printf("coalesced   (dedupe rejects, expected) : %llu\n",
+		       (unsigned long long)coalesced);
 
 	close(fd);
 	return 0;

--- a/samples/openipc_frame_ts/openipc_frame_ts_test.c
+++ b/samples/openipc_frame_ts/openipc_frame_ts_test.c
@@ -26,6 +26,7 @@
 
 #define DEV_PATH      "/dev/openipc-frame-ts"
 #define MAX_CHN       8
+#define BATCH         64   /* events drained per read() syscall */
 
 struct chn_state {
 	uint64_t last_wall_ns;
@@ -128,7 +129,7 @@ int main(int argc, char **argv)
 
 	time_t deadline = seconds > 0 ? time(NULL) + seconds : 0;
 
-	fd = open(DEV_PATH, O_RDONLY);
+	fd = open(DEV_PATH, O_RDONLY | O_NONBLOCK);
 	if (fd < 0) {
 		fprintf(stderr, "open %s: %s\n", DEV_PATH, strerror(errno));
 		return 1;
@@ -150,7 +151,7 @@ int main(int argc, char **argv)
 	pfd.events = POLLIN;
 
 	while (!g_stop) {
-		struct openipc_frame_ts_event ev;
+		struct openipc_frame_ts_event evbuf[BATCH];
 		ssize_t n;
 		int pr;
 
@@ -166,19 +167,33 @@ int main(int argc, char **argv)
 			break;
 		}
 
-		while ((n = read(fd, &ev, sizeof(ev))) == sizeof(ev)) {
-			/* Jitter stats only on FS — otherwise FS/FEND
-			 * interleave skews inter-arrival deltas. */
-			if (ev.vi_chn < MAX_CHN &&
-			    ev.event_type == OPENIPC_FT_EVT_MIPI_FS)
-				update_chn(&st[ev.vi_chn], ev.wall_ns);
-			if (!summary_only)
-				printf("chn%u %-8s seq=%u pts=%llu wall_ns=%llu\n",
-				       ev.vi_chn, evt_name(ev.event_type), ev.seq,
-				       (unsigned long long)ev.pts_us,
-				       (unsigned long long)ev.wall_ns);
-		}
-		if (n < 0 && errno != EAGAIN && errno != EINTR) {
+		/*
+		 * Drain one batch then loop back to the outer while so the
+		 * deadline check actually fires at high event rates — at
+		 * 240 fps × 2 event types a tight read() loop never returns.
+		 * O_NONBLOCK gives EAGAIN when the ring is dry; treat partial
+		 * batches the same as a full drain.
+		 */
+		n = read(fd, evbuf, sizeof(evbuf));
+		if (n > 0) {
+			ssize_t i, nev = n / (ssize_t)sizeof(evbuf[0]);
+
+			for (i = 0; i < nev; i++) {
+				struct openipc_frame_ts_event *ev = &evbuf[i];
+
+				/* Jitter stats only on FS — otherwise FS/FEND
+				 * interleave skews inter-arrival deltas. */
+				if (ev->vi_chn < MAX_CHN &&
+				    ev->event_type == OPENIPC_FT_EVT_MIPI_FS)
+					update_chn(&st[ev->vi_chn], ev->wall_ns);
+				if (!summary_only)
+					printf("chn%u %-8s seq=%u pts=%llu wall_ns=%llu\n",
+					       ev->vi_chn, evt_name(ev->event_type),
+					       ev->seq,
+					       (unsigned long long)ev->pts_us,
+					       (unsigned long long)ev->wall_ns);
+			}
+		} else if (n < 0 && errno != EAGAIN && errno != EINTR) {
 			fprintf(stderr, "read: %s\n", strerror(errno));
 			break;
 		}


### PR DESCRIPTION
## Summary

Adds a second event source — **ISP_FEND** (ISP front-end's "last sensor row received") — to `/dev/openipc-frame-ts` alongside the existing **MIPI_FS** event, then fixes the hardware quirks that prevented it from working on real silicon. Pairing both events frame-by-frame gives consumers the sensor readout duration directly.

Closes #176 (parent: FEND extension for sensor-readout-time telemetry) and #177 (cv500 FEND emits 1/8 of FS rate). The #177 hypothesis ("wrong IRQ resolved by name") turned out to be wrong — root cause is the level-held raw-status bit, not IRQ routing.

## Commits

1. **`cff4a3b`** — Plumb ISP_FEND as a second event type through the chrdev: ABI bump (`event_type` field added to `struct openipc_frame_ts_event`), `OPENIPC_FT_IOC_SET_EVENT_MASK` ioctl, per-(channel, event_type) sequence counters, per-event-type dedupe in `openipc_frame_ts_push`. Hook from V4 and cv500 `ISP_ISR`. (Original widgetii branch, picked into this PR.)
2. **`28c200d`** — Make FEND actually fire on hardware: edge-detect the raw FEND bit in `ISP_ISR` (V4 + cv500). The cherry-picked version above read masked status, which the vendor HAL leaves at 0 — never fired. Reading raw status fires at IRQ rate (sticky bit). Per-pipe `static bool s_fend_was_set` catches just the 0→1 transitions.
3. **`e888ee0`** — Symmetric fix for MIPI/LVDS vsync bits in `mipi_rx_interrupt_route` (V4 + cv500). Same level-held pathology; measured ~185 Hz MIPI_FS on a 37 fps sensor before the fix.
4. **`e3e5da2`** — High-fps headroom: per-channel ring depth 64 → 256 (≈ 0.5 s of buffer at 480 Hz). Sample test opens `O_NONBLOCK` and drains 64 events per `read()` syscall, fixing two latent bugs in the previous tight read loop (`-t N` never firing at idle; deadline check unreachable under load).
5. **`1d67816`** — Split the single `dropped` counter into `dropped` (ring overflow, data loss) and `coalesced` (dedupe rejects, expected). New `OPENIPC_FT_IOC_GET_COALESCED` ioctl. Without the split, the legitimate filtering of level-held-bit duplicates at high IRQ rates was being misreported as data loss.

## Root cause

Both `MIPI_CTRL_INT.vsync` / `LVDS_CTRL_INT.lvds_vsync` and `ISP_INT_FE.FEND` are **level-held raw status bits**, not pulses. Hardware re-asserts after each W1C while the underlying condition still holds — every ISR call during that window would otherwise fire. For FEND specifically, the vendor ISP HAL also leaves `ISP_INT_FE_MASK` at 0 by default, so the masked-status read returns zero. Both effects compound: the original cherry-pick fired never; reading raw status fires at IRQ rate (hundreds of Hz).

Per-pipe boolean edge-detection in each ISR + per-event-type dedupe in `openipc_frame_ts_push` solves it at typical sensor rates. The dedupe still trips at very high IRQ rates by design — that's now visible separately via the `coalesced` counter.

## Test results

### Drop / coalesce counters across full mode sweep (10 s steady-state per mode)

| Board | Mode | Sensor IRQ | drops (data loss) | coalesced (dedupe) |
|---|---|---:|---:|---:|
| ev300 | 5M default | 49 Hz | 0 | 0 |
| ev300 | 2592×1944 @ 45fps | 90 Hz | 0 | 0 |
| ev300 | 1920×1080 @ 55fps | 101 Hz | 0 | 89 |
| ev300 | 1280×720 @ 120fps | 173 Hz | 0 | 456 |
| ev300 | 800×480 @ 240fps | 229 Hz | 0 | 1007 |
| av300 | imx415_i2c default | 42 Hz | 0 | 4 |
| av300 | 60fps / 720p120 / vga200 | low | 0 | 0 |

Zero drops in every tested configuration.

### Sensor readout time (FEND.wall_ns − first-FS-in-cluster.wall_ns)

| Board | Sensor / mode | Active rows | Readout p50 |
|---|---|---:|---:|
| av300 / cv500 | IMX415 imx415_i2c (~20 fps) | 1520 | **31.47 ms** |
| ev300 / V4 | IMX335 5M default | 1944 | **28.42 ms** |
| ev300 / V4 | IMX335 2592×1944 @ 45fps | 1944 | **21.41 ms** |
| ev300 / V4 | IMX335 1920×1080 @ 55fps | 1080 | **10.35 ms** |
| ev300 / V4 | IMX335 1280×720 @ 120fps | 720 | **6.83 ms** |
| ev300 / V4 | IMX335 800×480 @ 240fps | 480 | **4.45 ms** |

Numbers scale linearly with active-row count and inversely with line-clock — the physically expected sensor readout durations. p50−p5 typically < 50 µs.

CI green across all 22 jobs (8 SDK builds × 3 neo kernel variants, 8 QEMU boots, 3 library checks, IVE/NNIE regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)