### PR TITLE
openipc_frame_ts: strobe-out — drive a GPIO synchronously with frame events

### DIFF
--- a/kernel/compat/kernel_compat.h
+++ b/kernel/compat/kernel_compat.h
@@ -412,5 +412,49 @@ static inline struct spi_controller *compat_spi_busnum_to_controller(u16 bus_num
 #define pte_offset_map(pmd, addr) pte_offset_kernel((pmd), (addr))
 #endif
 
+/*
+ * hrtimer_init() + manual `timer->function = ...` was unified into a
+ * single hrtimer_setup(timer, fn, clock, mode) call in Linux 6.7
+ * (closes the small window where the timer could fire before the
+ * function pointer was assigned). Provide hrtimer_setup() as an
+ * inline shim on older kernels so driver code can be written in the
+ * new style and still compile on the 3.x / 4.x / 5.x trees this
+ * project supports.
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0)
+/*
+ * Macro rather than a static inline so the compat header doesn't have
+ * to force-include <linux/hrtimer.h> into every translation unit (the
+ * compat header is `-include`d by kernel/Kbuild for the whole tree).
+ * Drivers that actually use hrtimer_setup() include <linux/hrtimer.h>
+ * themselves, which provides the type definitions the expanded macro
+ * needs.
+ */
+#define hrtimer_setup(t, fn, clk, mode) do { \
+	hrtimer_init((t), (clk), (mode)); \
+	(t)->function = (fn); \
+} while (0)
+#endif
+
+/*
+ * gpio_cansleep() — the int-based legacy wrapper — was removed in
+ * favour of the descriptor-based gpiod_cansleep() during the gpiolib
+ * cleanups around Linux 6.5+. The legacy gpio_request / gpio_set_value
+ * etc. integer API otherwise still works via CONFIG_GPIOLIB. Provide a
+ * gpio_to_desc() bridge so drivers that hold an integer GPIO number
+ * can still query "can this GPIO sleep?" without restructuring.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#include <linux/gpio.h>
+#include <linux/gpio/consumer.h>
+static inline int gpio_cansleep_compat(unsigned int gpio)
+{
+	struct gpio_desc *d = gpio_to_desc(gpio);
+
+	return d ? gpiod_cansleep(d) : 0;
+}
+#define gpio_cansleep(gpio) gpio_cansleep_compat(gpio)
+#endif
+
 #endif /* KERNEL_COMPAT_H */
 

--- a/kernel/openipc_frame_ts/README.md
+++ b/kernel/openipc_frame_ts/README.md
@@ -75,6 +75,50 @@ the dedupe is there to absorb. A nonzero `dropped` means reader can't
 keep up; a nonzero `coalesced` is expected steady-state at high IRQ
 rates and means the dedupe is doing its job.
 
+## Strobe-out (GPIO driven by frame events)
+
+The module can drive a SoC GPIO synchronously with the sensor frame
+events, for triggering an external flash / LED ring / measurement
+device. Configured at runtime via sysfs:
+
+```
+/sys/class/misc/openipc-frame-ts/
+├── strobe_gpio         (rw int)   GPIO number, -1 = disabled (default)
+├── strobe_mode         (rw str)   off | pulse | hold (default off)
+├── strobe_pulse_us     (rw uint)  pulse width µs, 1..100000 (default 1000)
+├── strobe_active_low   (rw bool)  invert polarity (default 0)
+└── strobe_events       (r  u64)   counter of fires since module load
+```
+
+Modes:
+
+- `pulse`: assert on `MIPI_FS`, deassert via hrtimer `strobe_pulse_us`
+  µs later. For triggering a flash / LED with a fixed-width pulse
+  aligned to sensor row-0 start. Latency from sensor vsync to GPIO
+  assert ≈ a few µs (kernel IRQ entry + register write).
+- `hold`: assert on `MIPI_FS`, deassert on `ISP_FEND`. High window
+  equals the sensor readout duration (~10–30 ms depending on
+  resolution). For driving a ring light that should be on while
+  pixels are being received.
+- `off`: no GPIO activity.
+
+The GPIO must be a SoC-direct (memory-mapped) line — GPIOs that can
+sleep (I2C / SPI expanders) are rejected at configure time because the
+firing path runs in hardirq context. One global strobe slot for now.
+
+Quick smoke test on any IP-camera board (almost all expose an IR-cut
+filter or day/night-sensor GPIO):
+
+```sh
+echo 16 > /sys/class/misc/openipc-frame-ts/strobe_gpio
+echo 500 > /sys/class/misc/openipc-frame-ts/strobe_pulse_us
+echo pulse > /sys/class/misc/openipc-frame-ts/strobe_mode
+sleep 5
+cat /sys/class/misc/openipc-frame-ts/strobe_events  # should ≈ sensor fps × 5
+echo off > /sys/class/misc/openipc-frame-ts/strobe_mode
+echo -1 > /sys/class/misc/openipc-frame-ts/strobe_gpio
+```
+
 ## Module loading
 
 `open_mipi_rx.ko` (and on hi3516cv200, `open_isp.ko`) reference

--- a/kernel/openipc_frame_ts/openipc_frame_ts.c
+++ b/kernel/openipc_frame_ts/openipc_frame_ts.c
@@ -24,10 +24,14 @@
 #include <linux/poll.h>
 #include <linux/wait.h>
 #include <linux/spinlock.h>
+#include <linux/mutex.h>
 #include <linux/uaccess.h>
 #include <linux/slab.h>
 #include <linux/ktime.h>
+#include <linux/hrtimer.h>
+#include <linux/gpio.h>
 #include <linux/sched.h>
+#include <linux/device.h>
 
 #include "openipc_frame_ts.h"
 
@@ -93,6 +97,77 @@ static const unsigned int g_default_evt_mask = ~0U;
 
 static struct miscdevice g_miscdev;
 
+/*
+ * Strobe-out: drive a GPIO synchronously with the sensor frame events,
+ * for triggering external illumination / measurement equipment.
+ *
+ *   pulse — assert on MIPI_FS, deassert via hrtimer `strobe_pulse_us`
+ *           microseconds later. Fixed-width pulse aligned with sensor
+ *           row-0 start; suitable for flash / strobe lights.
+ *   hold  — assert on MIPI_FS, deassert on ISP_FEND. High window equals
+ *           the sensor readout duration (~10–30 ms depending on mode);
+ *           suitable for a ring light that should be on only while
+ *           pixels are being received.
+ *
+ * The GPIO must be SoC-direct (memory-mapped); GPIOs that can sleep
+ * (I2C / SPI expanders) are rejected at configure time because the
+ * firing path runs in hardirq context. One global strobe slot for now.
+ */
+enum strobe_mode {
+	STROBE_OFF,
+	STROBE_PULSE,
+	STROBE_HOLD,
+};
+
+static int g_strobe_gpio = -1;
+static enum strobe_mode g_strobe_mode = STROBE_OFF;
+static unsigned int g_strobe_pulse_us = 1000;
+static bool g_strobe_active_low;
+static u64 g_strobe_events;
+static struct hrtimer g_strobe_timer;
+/* Serializes sysfs writes that re-request the GPIO. The firing path
+ * doesn't take this — it only reads the scalar tunables. */
+static DEFINE_MUTEX(g_strobe_lock);
+
+static inline int strobe_active_level(void)
+{
+	return g_strobe_active_low ? 0 : 1;
+}
+
+static enum hrtimer_restart strobe_timer_cb(struct hrtimer *t)
+{
+	int gpio = READ_ONCE(g_strobe_gpio);
+
+	if (gpio >= 0)
+		gpio_set_value(gpio, !strobe_active_level());
+	return HRTIMER_NORESTART;
+}
+
+/* Called from openipc_frame_ts_push after the ring push. Hardirq
+ * context. */
+static void strobe_on_event(unsigned int event_type)
+{
+	int gpio = READ_ONCE(g_strobe_gpio);
+	enum strobe_mode mode = READ_ONCE(g_strobe_mode);
+
+	if (gpio < 0 || mode == STROBE_OFF)
+		return;
+
+	if (event_type == OPENIPC_FT_EVT_MIPI_FS) {
+		gpio_set_value(gpio, strobe_active_level());
+		g_strobe_events++;
+		if (mode == STROBE_PULSE) {
+			u64 ns = (u64)READ_ONCE(g_strobe_pulse_us) * 1000ULL;
+
+			hrtimer_start(&g_strobe_timer, ns_to_ktime(ns),
+				      HRTIMER_MODE_REL);
+		}
+	} else if (event_type == OPENIPC_FT_EVT_ISP_FEND &&
+		   mode == STROBE_HOLD) {
+		gpio_set_value(gpio, !strobe_active_level());
+	}
+}
+
 static inline unsigned int ring_count(const struct openipc_ft_chn *c)
 {
 	return (c->head - c->tail) & (OPENIPC_FT_DEPTH - 1);
@@ -153,6 +228,8 @@ void openipc_frame_ts_push(unsigned int vi_chn, unsigned int event_type)
 	e->reserved   = 0;
 	c->head = (c->head + 1) & (OPENIPC_FT_DEPTH - 1);
 	spin_unlock_irqrestore(&c->lock, flags);
+
+	strobe_on_event(event_type);
 
 	wake_up_interruptible(&g_wait);
 }
@@ -360,6 +437,176 @@ static const struct file_operations g_fops = {
 	.unlocked_ioctl = ft_ioctl,
 };
 
+/*
+ * Strobe sysfs knobs, attached to the miscdev's underlying device so
+ * they appear at /sys/class/misc/openipc-frame-ts/.
+ */
+static void strobe_release_gpio_locked(void)
+{
+	if (g_strobe_gpio < 0)
+		return;
+	gpio_set_value(g_strobe_gpio, !strobe_active_level());
+	gpio_free(g_strobe_gpio);
+	g_strobe_gpio = -1;
+}
+
+static ssize_t strobe_gpio_show(struct device *dev,
+				struct device_attribute *attr, char *buf)
+{
+	return scnprintf(buf, PAGE_SIZE, "%d\n", g_strobe_gpio);
+}
+
+static ssize_t strobe_gpio_store(struct device *dev,
+				 struct device_attribute *attr,
+				 const char *buf, size_t count)
+{
+	int new_gpio;
+	int ret;
+
+	if (kstrtoint(buf, 0, &new_gpio))
+		return -EINVAL;
+
+	mutex_lock(&g_strobe_lock);
+
+	hrtimer_cancel(&g_strobe_timer);
+	strobe_release_gpio_locked();
+
+	if (new_gpio < 0) {
+		ret = count;
+		goto out;
+	}
+
+	if (!gpio_is_valid(new_gpio)) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	ret = gpio_request(new_gpio, "openipc_frame_ts_strobe");
+	if (ret)
+		goto out;
+
+	if (gpio_cansleep(new_gpio)) {
+		gpio_free(new_gpio);
+		ret = -EINVAL;
+		goto out;
+	}
+
+	gpio_direction_output(new_gpio, g_strobe_active_low ? 1 : 0);
+	g_strobe_gpio = new_gpio;
+	ret = count;
+
+out:
+	mutex_unlock(&g_strobe_lock);
+	return ret;
+}
+static DEVICE_ATTR(strobe_gpio, 0644, strobe_gpio_show, strobe_gpio_store);
+
+static ssize_t strobe_mode_show(struct device *dev,
+				struct device_attribute *attr, char *buf)
+{
+	const char *s;
+
+	switch (g_strobe_mode) {
+	case STROBE_PULSE: s = "pulse"; break;
+	case STROBE_HOLD:  s = "hold";  break;
+	default:           s = "off";   break;
+	}
+	return scnprintf(buf, PAGE_SIZE, "%s\n", s);
+}
+
+static ssize_t strobe_mode_store(struct device *dev,
+				 struct device_attribute *attr,
+				 const char *buf, size_t count)
+{
+	enum strobe_mode new_mode;
+
+	if (sysfs_streq(buf, "off"))
+		new_mode = STROBE_OFF;
+	else if (sysfs_streq(buf, "pulse"))
+		new_mode = STROBE_PULSE;
+	else if (sysfs_streq(buf, "hold"))
+		new_mode = STROBE_HOLD;
+	else
+		return -EINVAL;
+
+	mutex_lock(&g_strobe_lock);
+	if (new_mode == STROBE_OFF) {
+		hrtimer_cancel(&g_strobe_timer);
+		if (g_strobe_gpio >= 0)
+			gpio_set_value(g_strobe_gpio, !strobe_active_level());
+	}
+	g_strobe_mode = new_mode;
+	mutex_unlock(&g_strobe_lock);
+	return count;
+}
+static DEVICE_ATTR(strobe_mode, 0644, strobe_mode_show, strobe_mode_store);
+
+static ssize_t strobe_pulse_us_show(struct device *dev,
+				    struct device_attribute *attr, char *buf)
+{
+	return scnprintf(buf, PAGE_SIZE, "%u\n", g_strobe_pulse_us);
+}
+
+static ssize_t strobe_pulse_us_store(struct device *dev,
+				     struct device_attribute *attr,
+				     const char *buf, size_t count)
+{
+	unsigned int v;
+
+	if (kstrtouint(buf, 0, &v))
+		return -EINVAL;
+	if (v < 1 || v > 100000)
+		return -EINVAL;
+	g_strobe_pulse_us = v;
+	return count;
+}
+static DEVICE_ATTR(strobe_pulse_us, 0644,
+		   strobe_pulse_us_show, strobe_pulse_us_store);
+
+static ssize_t strobe_active_low_show(struct device *dev,
+				      struct device_attribute *attr, char *buf)
+{
+	return scnprintf(buf, PAGE_SIZE, "%u\n", g_strobe_active_low ? 1 : 0);
+}
+
+static ssize_t strobe_active_low_store(struct device *dev,
+				       struct device_attribute *attr,
+				       const char *buf, size_t count)
+{
+	bool v;
+
+	if (kstrtobool(buf, &v))
+		return -EINVAL;
+	mutex_lock(&g_strobe_lock);
+	g_strobe_active_low = v;
+	if (g_strobe_gpio >= 0)
+		gpio_direction_output(g_strobe_gpio, v ? 1 : 0);
+	mutex_unlock(&g_strobe_lock);
+	return count;
+}
+static DEVICE_ATTR(strobe_active_low, 0644,
+		   strobe_active_low_show, strobe_active_low_store);
+
+static ssize_t strobe_events_show(struct device *dev,
+				  struct device_attribute *attr, char *buf)
+{
+	return scnprintf(buf, PAGE_SIZE, "%llu\n",
+			 (unsigned long long)g_strobe_events);
+}
+static DEVICE_ATTR(strobe_events, 0444, strobe_events_show, NULL);
+
+static struct attribute *strobe_attrs[] = {
+	&dev_attr_strobe_gpio.attr,
+	&dev_attr_strobe_mode.attr,
+	&dev_attr_strobe_pulse_us.attr,
+	&dev_attr_strobe_active_low.attr,
+	&dev_attr_strobe_events.attr,
+	NULL,
+};
+static const struct attribute_group strobe_attr_group = {
+	.attrs = strobe_attrs,
+};
+
 static int __init openipc_ft_init(void)
 {
 	unsigned int i;
@@ -369,6 +616,9 @@ static int __init openipc_ft_init(void)
 		spin_lock_init(&g_chn[i].lock);
 
 	init_waitqueue_head(&g_wait);
+
+	hrtimer_setup(&g_strobe_timer, strobe_timer_cb,
+		      CLOCK_MONOTONIC, HRTIMER_MODE_REL);
 
 	g_miscdev.minor = MISC_DYNAMIC_MINOR;
 	g_miscdev.name  = OPENIPC_FT_NAME;
@@ -380,6 +630,12 @@ static int __init openipc_ft_init(void)
 		return ret;
 	}
 
+	ret = sysfs_create_group(&g_miscdev.this_device->kobj,
+				 &strobe_attr_group);
+	if (ret)
+		pr_warn("openipc_frame_ts: strobe sysfs attrs not created: %d\n",
+			ret);
+
 	pr_info("openipc_frame_ts: /dev/%s minor=%d, event types=%u\n",
 		OPENIPC_FT_NAME, g_miscdev.minor, OPENIPC_FT_MAX_EVT_TYPE);
 	return 0;
@@ -387,6 +643,12 @@ static int __init openipc_ft_init(void)
 
 static void __exit openipc_ft_exit(void)
 {
+	sysfs_remove_group(&g_miscdev.this_device->kobj, &strobe_attr_group);
+	hrtimer_cancel(&g_strobe_timer);
+	mutex_lock(&g_strobe_lock);
+	g_strobe_mode = STROBE_OFF;
+	strobe_release_gpio_locked();
+	mutex_unlock(&g_strobe_lock);
 	misc_deregister(&g_miscdev);
 }
 


### PR DESCRIPTION
## Summary

Adds a strobe-out feature to the existing `openipc_frame_ts` module: drive a SoC GPIO at the exact moment the sensor begins streaming row 0 (`MIPI_FS`) and/or finishes the last row (`ISP_FEND`). The expensive part — being inside the kernel at sub-µs precision relative to vsync — already exists from PR #178. This PR adds ~260 lines so that hook can also flip a GPIO without spinning up a userspace daemon.

Two modes:

| Mode | Behaviour | Use case |
|---|---|---|
| `pulse` | Assert on `MIPI_FS`, deassert via `hrtimer` after `strobe_pulse_us` µs | Flash / strobe light aligned to sensor row-0 start |
| `hold`  | Assert on `MIPI_FS`, deassert on `ISP_FEND` | Ring light that should be on only while pixels are being received (high window = sensor readout duration, ~10–30 ms depending on mode) |
| `off`   | No GPIO activity | Default |

Configured via sysfs:

```
/sys/class/misc/openipc-frame-ts/
├── strobe_gpio         (rw int)   GPIO number, -1 = off (default)
├── strobe_mode         (rw str)   off | pulse | hold
├── strobe_pulse_us     (rw uint)  pulse width µs, 1..100000 (default 1000)
├── strobe_active_low   (rw bool)  invert polarity (default 0)
└── strobe_events       (r  u64)   counter of fires since module load
```

## Constraints

- The GPIO must be SoC-direct (memory-mapped). GPIOs that can sleep (I2C / SPI expanders) are rejected at configure time — the firing path is hardirq.
- One global strobe slot for now; per-channel can be added later by indexing the state by `vi_chn` if anyone needs it.
- Latency from sensor vsync to GPIO assert: a few µs. Pulse-width precision: hrtimer-grade.
- Pure software strobe — physical GPIO must be exposed on the camera board (most IP-camera designs have at least one — the IR-cut filter / day-night sensor pin).

## Test plan — validated on hardware

Both lab boards re-flashed with the new module:

**ev300 (V4, IMX335)** — `/tmp/strobe_stress.sh`:
- 10 s of `pulse` mode at `strobe_pulse_us=50`: 276 strobe_events fired
- Invalid inputs rejected: `gpio=9999`, `pulse_us=0`, `mode=bogus` all returned EINVAL
- `dmesg` clean: no relevant kernel messages
- `echo -1 > strobe_gpio` cleanly releases the GPIO

**av300 (cv500, IMX415)**:
- 5 s of `pulse`: 56 events
- Switch to `hold` mode while running: another 75 events in 5 s
- Clean teardown

## Why bother

The robotics-camera audience documented in the new wiki page ([proposed here](https://github.com/OpenIPC/wiki) — not yet merged) lists "hardware trigger / strobe out" as one of the few capabilities that genuinely separate sub-$50 OpenIPC cameras from $500+ industrial gear. With this module the strobe-out half of that gap closes:

- LED ring driven only during exposure (saves power, reduces heat, removes ambient artefacts)
- Camera–IMU calibration: hardware-correlated pulse on every frame
- Triggering downstream measurement equipment at frame rate
- Active-illumination perception (laser line, structured light) gated by the camera's sensor window rather than a free-running timer

Trigger-IN (camera waits for an external pulse before each frame) is a separate, harder problem requiring per-sensor slave-mode driver work; out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)