### PR TITLE
ci: add cv200_neo + av100_neo qemu-boot matrix rows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -822,7 +822,7 @@ jobs:
   # Each platform uses its own QEMU machine model from qemu-hisilicon.
   #
   qemu-boot:
-    name: QEMU boot (${{ matrix.machine }})
+    name: QEMU boot (${{ matrix.machine }}${{ matrix.variant && format('_{0}', matrix.variant) || '' }})
     runs-on: ubuntu-latest
     # Per-row continue-on-error so we can keep platforms in the matrix that
     # currently surface pre-existing firmware-side bugs (av100 module-name
@@ -900,6 +900,32 @@ jobs:
             mem: 128M
             min_modules: 5
             append: "console=ttyAMA0,115200 panic=20 mem=128M root=/dev/ram0 rootfstype=squashfs mmz_allocator=cma mmz=anonymous,0,0x42000000,96M"
+          # cv200_neo (V2 / ARM926EJ-S, Linux 7.0). Builds from
+          # openhisilicon main carrying the open_v2_shim re-exports
+          # (do_gettimeofday, init_timer_key, register_sysctl_table,
+          # printk, etc.) for the 4.9-compiled blobs. Tarball
+          # `openipc.hi3516cv200-nor-neo.tgz` is published by the
+          # firmware nightly (OpenIPC/firmware#2124). Boots to login,
+          # eth0 gets DHCP from SLIRP, no Oops/panic. load_hisilicon
+          # doesn't load HiSi blobs on neo (kernel-version path
+          # mismatch — separate firmware-side follow-up), so we don't
+          # set min_modules here.
+          - machine: hi3516cv200
+            firmware: hi3516cv200
+            variant: neo
+            mem: 64M
+            append: "console=ttyAMA0,115200 mem=32M root=/dev/ram0 rootfstype=squashfs"
+          # av100_neo (V2A / Cortex-A7, Linux 7.0). Same shape as
+          # cv200_neo but using mainline hi3516av100 SoC support +
+          # hisi_higmac ethernet driver from openipc/linux#44.
+          # Tarball `openipc.hi3516av100-nor-neo.tgz` from firmware
+          # nightly. Same login + DHCP + ping coverage; no module
+          # count assertion (same reason as cv200_neo).
+          - machine: hi3516av100
+            firmware: hi3516av100
+            variant: neo
+            mem: 256M
+            append: "console=ttyAMA0,115200 mem=32M root=/dev/ram0 rootfstype=squashfs"
 
     steps:
       - uses: actions/checkout@v4
@@ -936,7 +962,7 @@ jobs:
           mkdir -p /tmp/openipc
           cd /tmp/openipc
           curl -sSLf -o fw.tgz \
-            https://github.com/OpenIPC/firmware/releases/download/latest/openipc.${{ matrix.firmware }}-nor-lite.tgz
+            https://github.com/OpenIPC/firmware/releases/download/latest/openipc.${{ matrix.firmware }}-nor-${{ matrix.variant || 'lite' }}.tgz
           tar xzf fw.tgz
           ls uImage.${{ matrix.firmware }}
 
@@ -1081,7 +1107,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: qemu-boot-${{ matrix.machine }}
+          name: qemu-boot-${{ matrix.machine }}${{ matrix.variant && format('_{0}', matrix.variant) || '' }}
           path: qemu-output.txt
           retention-days: 7
 


### PR DESCRIPTION
## Summary

Closes [OpenIPC/firmware#2123](https://github.com/OpenIPC/firmware/issues/2123). Now that the firmware nightly publishes `openipc.hi3516cv200-nor-neo.tgz` and `openipc.hi3516av100-nor-neo.tgz` (after OpenIPC/firmware#2124 added both boards to the firmware build matrix), wire two new rows into the qemu-boot job.

## Local pre-merge validation

Both nightly tarballs were downloaded and exercised against the same smoke harness this PR's CI will use:

```
hi3516cv200_neo (nightly tarball):
  [PASS] login (openipc-hi3516cv200 login:)
  [PASS] IP (10.0.2.15 via SLIRP DHCP)
  [PASS] ping 10.0.2.2
  [PASS] no Oops/panic/BUG/Call Trace patterns

hi3516av100_neo (nightly tarball):
  [PASS] login (openipc-hi3516av100 login:)
  [PASS] IP (10.0.2.15 via SLIRP DHCP)
  [PASS] ping 10.0.2.2
  [PASS] no Oops/panic/BUG/Call Trace patterns
```

## Row mechanics

New optional `variant:` field on a row:
- Defaults to `lite`. Rows that don't set it stay byte-equivalent (download URL `openipc.X-nor-lite.tgz`, row name unchanged).
- When `variant: neo`:
  - row name becomes `QEMU boot (<machine>_neo)`
  - download URL becomes `openipc.<machine>-nor-neo.tgz`
  - upload-artifact name becomes `qemu-boot-<machine>_neo`

## Real gate, not allow-failure

Both new rows are **real gates** — no `allow-failure: true`. `load_hisilicon` on neo doesn't load HiSi blobs (kernel-version path mismatch — separate firmware follow-up to teach it the `/lib/modules/7.0` path), so neither row sets `min_modules:`; the assertion is "login reached + no error patterns". That's what the local DoD test exercises and what the CI will exercise.

## Test plan

- [x] YAML parses cleanly
- [x] Existing lite rows unchanged (variant defaults to lite)
- [x] Local QEMU smoke against published nightly tarballs (cv200_neo, av100_neo): login + DHCP + ping + clean dmesg
- [ ] CI exercises both new rows on this PR — must reach `SUCCESS` before merge (branch protection enforces all 27 required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)