### PR TITLE
openipc_frame_ts: disable cv200/V2A hook pending hardware validation

### DIFF
--- a/kernel/isp/arch/hi3516cv200/firmware/drv/isp.c
+++ b/kernel/isp/arch/hi3516cv200/firmware/drv/isp.c
@@ -2627,13 +2627,26 @@ static inline irqreturn_t ISP_ISR(int irq, void *id)
     }
     if (u32PortIntStatus)
     {
-        /* cv200's MIPI RX hardware doesn't expose a usable vsync bit,
-         * so we report this ISP-port FSTART IRQ as MIPI_FS-equivalent.
-         * It fires at the same pipeline point (frame start) as the
-         * MIPI_FS path on V4 SoCs. cv200 doesn't have an FEND IRQ
-         * source we can hook today — see kernel/isp/arch/hi3516cv200
-         * for the ISP register map. */
-        openipc_frame_ts_push(IspDev, OPENIPC_FT_EVT_MIPI_FS);
+        /*
+         * openipc_frame_ts hook disabled on hi3516cv200 family pending
+         * a hardware-validation bench. The family includes hi3516cv200
+         * AND hi3518ev200 (same CHIPARCH=hi3516cv200, same open_isp.ko
+         * renamed to hi3518e_isp.ko at firmware install time). The hook
+         * adds a few µs to the ISR hot path which, on a real
+         * hi3518ev200 board, tips a latent i2c-from-hardirq race
+         * (rt_mutex_trylock WARN at rtmutex.c:1545 via
+         * hi_sensor_i2c_write → i2c_transfer); majestic can no longer
+         * read the sensor and /image.jpg returns HTTP 000.
+         *
+         * Re-enable here only after the i2c-in-IRQ path is fixed
+         * upstream OR after we've confirmed on real hi3518ev200 and
+         * hi3516cv200 hardware that the hook doesn't perturb the
+         * sensor i2c timing budget.
+         *
+         * Tracked: openipc/firmware#2128 (revert of opensdk bump),
+         * openhisilicon#178 follow-up.
+         */
+        /* openipc_frame_ts_push(IspDev, OPENIPC_FT_EVT_MIPI_FS); */
         HW_REG(IO_ADDRESS_PORT(VI_PT0_INT)) = VI_PT0_INT_FSTART;
     }
     /*When detect vi port's width&height changed,then reset isp*/

--- a/kernel/openipc_frame_ts/README.md
+++ b/kernel/openipc_frame_ts/README.md
@@ -9,14 +9,38 @@ timecode, evidence chains. See [issue #144][issue].
 
 ## Attach point per SoC
 
-| SoC family                  | Hook                                     | Build status   |
-| --------------------------- | ---------------------------------------- | -------------- |
-| hi3516ev200 / ev300         | MIPI RX (shared `mipi_rx_hal.c`)         | active         |
-| gk7205v200                  | MIPI RX (shared `mipi_rx_hal.c`)         | active         |
-| hi3516cv500 / hi3516av300   | MIPI RX (`hi3516cv500/mipi_rx_hal.c`)    | active         |
-| hi3516cv200                 | ISP `ISP_ISR` (`VI_PT0_INT_FSTART`)      | active         |
-| hi3516cv300, av100, v101    | n/a — ISP ships as prebuilt blob today   | blocked by #58 |
-| hi3516cv100                 | n/a — no MIPI, no sensor frame-start IRQ | not supported  |
+| SoC family                  | Hook                                     | Build status     |
+| --------------------------- | ---------------------------------------- | ---------------- |
+| hi3516ev200 / ev300         | MIPI RX (shared `mipi_rx_hal.c`)         | active           |
+| gk7205v200                  | MIPI RX (shared `mipi_rx_hal.c`)         | active           |
+| hi3516cv500 / hi3516av300   | MIPI RX (`hi3516cv500/mipi_rx_hal.c`)    | active           |
+| hi3516cv200 / hi3518ev200   | ISP `ISP_ISR` (`VI_PT0_INT_FSTART`)      | **not validated**, hook disabled (see below) |
+| hi3516cv300, av100, v101    | n/a — ISP ships as prebuilt blob today   | blocked by #58   |
+| hi3516cv100                 | n/a — no MIPI, no sensor frame-start IRQ | not supported    |
+
+### hi3516cv200 / hi3518ev200 family — hook disabled
+
+These two SoCs share `BR2_OPENIPC_SOC_FAMILY=hi3516cv200` in the firmware build,
+which means our `open_isp.ko` is renamed to `hi3518e_isp.ko` and used as the
+ISP driver on **both** hi3516cv200 cameras AND hi3518ev200 cameras. The single
+`openipc_frame_ts_push(...)` call inside the cv200 `ISP_ISR` adds a few µs to
+the ISR hot path which, on a real hi3518ev200 board, tips a latent
+i2c-from-hardirq race (`rt_mutex_trylock` WARN at `rtmutex.c:1545` via
+`hi_sensor_i2c_write → i2c_transfer`); majestic can no longer read the sensor
+and `/image.jpg` returns HTTP 000 / 10 s timeout. The bug isn't strictly new —
+backtrace matches a pre-existing issue — but our code is what tipped it over
+the threshold.
+
+The push call is therefore commented out in
+`kernel/isp/arch/hi3516cv200/firmware/drv/isp.c`. The chrdev `/dev/openipc-frame-ts`
+still exists on these cameras (the module loads cleanly), it just never
+receives events. Consumers that probe for it will see an empty stream and fall
+back to `clock_gettime()`.
+
+Re-enable here only after the i2c-in-IRQ path is fixed upstream **or** after
+the hook has been hardware-validated on both hi3516cv200 and hi3518ev200
+boards under a real majestic stream. The wider re-scope is tracked alongside
+the openipc/firmware revert of the opensdk bump.
 
 MIPI RX is the preferred attach point where the IP exposes a positive
 frame-start interrupt (`MIPI_CTRL_INT.int_vsync` bit 4 or


### PR DESCRIPTION
## Why

PR #178 hardware-validated the FEND extension on hi3516ev300 (V4 / IMX335) and hi3516av300 (cv500 / IMX415). For the hi3516cv200 family I checked QEMU boot only — which passes, because QEMU doesn't run a real sensor over i2c.

The hi3516cv200 family build also produces the firmware-shipped `hi3518e_isp.ko` for **hi3518ev200** boards: same `BR2_OPENIPC_SOC_FAMILY=hi3516cv200`, same `open_isp.ko` renamed at install time. So this single hook ran on V2A hardware in last night's nightly via openipc/firmware#2126 — and bricked majestic: kernel WARN at `rtmutex.c:1545` (`rt_mutex_trylock` from inside `ISP_ISR` via `hi_sensor_i2c_write → i2c_transfer`), `curl http://localhost/image.jpg` → HTTP 000 / 10 s timeout.

Backtrace is identical to a pre-existing issue, so the i2c-in-hardirq race isn't strictly new, but the few µs my push call adds to the ISR hot path is what tips it over the threshold on real V2A boards.

openipc/firmware#2128 reverted the opensdk bump that shipped the regression. This PR re-scopes #178 in openhisilicon so the next bump is safe on V2A.

## Change

- `kernel/isp/arch/hi3516cv200/firmware/drv/isp.c`: comment out the single `openipc_frame_ts_push(IspDev, OPENIPC_FT_EVT_MIPI_FS)` call inside `ISP_ISR`, with a comment explaining the i2c-in-IRQ race, the SOC family sharing, and the re-enable criteria.
- `kernel/openipc_frame_ts/README.md`: list hi3516cv200 / hi3518ev200 as **not validated** with the full explanation.

## What still works

- V4 (hi3516ev200 / ev300 / gk7205v200) — MIPI RX hook, hardware-validated, unchanged.
- cv500 / av300 — MIPI RX hook, hardware-validated, unchanged.
- cv200 / V2A — `/dev/openipc-frame-ts` chrdev still loads cleanly, just emits no events. Consumers fall back to `clock_gettime()` (same as on a kernel without the modules).

## Re-enable criteria

- The i2c-from-hardirq path fixed upstream, OR
- The hook hardware-validated on **both** hi3516cv200 and hi3518ev200 cameras under a real majestic stream (no `rt_mutex_trylock` WARN, `/image.jpg` reachable, no regression in sensor reads).

## Test plan

- [x] cv200 / hi3518ev200 build: `open_isp.ko` no longer references `openipc_frame_ts_push` (symbol table verified; `depends=` no longer includes `open_openipc_frame_ts`).
- [x] V4 (ev200) build: `open_mipi_rx.ko` still references `openipc_frame_ts_push` — V4 hook intact, no collateral damage.
- [ ] CI matrix pass.
- [ ] Once green, fast-track merge → openipc/firmware re-bump (separate PR).