### PR TITLE
samples: add openipc_event_trigger — correlate external GPIO pulse with nearest frame

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -572,6 +572,62 @@ jobs:
           done
 
   #
+  # samples-cross-compile
+  #
+  # Each sample/* directory has a tiny Makefile that builds a single
+  # user-space binary against include/openipc_frame_ts.h (uapi). The
+  # samples are CI-tested as an executable smoke test: if their
+  # Makefile or any header they include drifts, this job catches it
+  # before the binary ships in a release.
+  #
+  # Toolchain: stock Debian arm-linux-gnueabi (glibc) — same as the
+  # libraries-cross-compile job uses. Not musl because we don't need
+  # to match a specific firmware libc here; this is a build sanity
+  # check, not a deploy artifact.
+  #
+  samples-cross-compile:
+    name: Samples cross-compile (ARM)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ARM toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            gcc-arm-linux-gnueabi libc6-dev-armel-cross binutils-arm-linux-gnueabi
+
+      - name: Build each sample
+        run: |
+          set -e
+          for d in samples/*/; do
+              [ -f "$d/Makefile" ] || continue
+              echo "=== $d ==="
+              make -C "$d" CC=arm-linux-gnueabi-gcc
+          done
+
+      - name: Verify outputs
+        run: |
+          set -e
+          # Each sample's Makefile produces at least one ARM ELF;
+          # the binary's filename isn't necessarily the dir basename
+          # (openipc_frame_ts/ produces openipc_frame_ts_test, etc.).
+          # Walk per-dir and accept any executable ARM ELF we find.
+          for d in samples/*/; do
+              [ -f "$d/Makefile" ] || continue
+              found=$(find "$d" -maxdepth 1 -type f -executable \
+                  -exec sh -c 'file -b "$1" | grep -q "ELF 32-bit LSB.*ARM" && echo "$1"' _ {} \;)
+              if [ -z "$found" ]; then
+                  echo "NO ARM ELF in $d" >&2
+                  ls -la "$d" >&2
+                  exit 1
+              fi
+              for f in $found; do
+                  echo "ok: $f"
+              done
+          done
+
+  #
   # qemu-ive-ops
   #
   # Builds QEMU with HiSilicon machine models from widgetii/qemu-hisilicon

--- a/samples/openipc_event_trigger/Makefile
+++ b/samples/openipc_event_trigger/Makefile
@@ -1,0 +1,10 @@
+CC ?= $(CROSS_COMPILE)gcc
+CFLAGS ?= -O2 -Wall -Wextra
+
+openipc_event_trigger: openipc_event_trigger.c ../../include/openipc_frame_ts.h
+	$(CC) $(CFLAGS) -o $@ openipc_event_trigger.c
+
+clean:
+	rm -f openipc_event_trigger
+
+.PHONY: clean

--- a/samples/openipc_event_trigger/README.md
+++ b/samples/openipc_event_trigger/README.md
@@ -1,0 +1,113 @@
+# openipc_event_trigger — correlate an external GPIO pulse with the nearest frame
+
+## What this is for
+
+Industrial-style cameras have a **hardware trigger IN** pin: assert a
+voltage on it and the camera captures *exactly one* frame, synchronously
+with the pulse. PLC-driven inspection, photoeye-gated capture, strobed
+illumination — they all rely on it.
+
+OpenIPC HiSilicon cameras can't do that directly: the sensor's
+`XVS_IN` / `TRIG` pin is essentially never broken out on commodity IP-
+camera boards, and the per-sensor slave-mode driver work isn't there.
+The camera keeps free-running at its configured frame rate.
+
+**This tool gives you the next-best thing:** correlate the moment a
+GPIO pulse arrives on the camera board with the nearest sensor
+frame-start, so you can answer "which frame was the camera capturing
+when the trigger fired?". Useful for:
+
+- PLC / photoeye event marking — "this frame coincides with the part
+  crossing the photo-detector"
+- Strobed illumination diagnostics — verify your flash and sensor are
+  in phase even though they aren't hardware-locked
+- Multi-camera event-ordering when you can wire all cameras' trigger
+  lines to the same external source
+
+The trigger doesn't *cause* a capture; the camera was going to capture
+that frame anyway. The tool just tells you which frame the trigger
+landed on.
+
+## How it works
+
+1. Configures a SoC GPIO as input + rising-edge IRQ via `/sys/class/gpio/gpio<N>/`.
+2. Subscribes to `/dev/openipc-frame-ts` for `MIPI_FS` events.
+3. `poll()` both. On a GPIO rising edge it samples `CLOCK_REALTIME`
+   immediately, then matches against:
+   - the **most recent FS event** (the frame whose capture window the
+     trigger fell into); and
+   - the **next FS event** (the first frame that starts fully after
+     the trigger).
+
+The chrdev side is built around the kernel module shipped by
+[`openhisilicon` PR #155 + #178][chrdev]. The GPIO side uses the
+classic `/sys/class/gpio` interface with `edge=rising` + `poll(POLLPRI)`
+— supported by every HiSi kernel we ship.
+
+## Accuracy
+
+The trigger timestamp has the usual kernel→user transit jitter:
+typically a few µs on a quiet system, low single-digit ms under load.
+For PLC-class event marking that's fine; for sub-µs you'd need a
+kernel-side correlator (not provided here).
+
+The FS event timestamps come from inside the kernel IRQ handler and
+are NTP-disciplined `CLOCK_REALTIME`, so the correlation itself is
+limited by NTP quality, not by this tool.
+
+## Usage
+
+```sh
+# Build
+cd samples/openipc_event_trigger && make
+
+# Run on the camera
+scp openipc_event_trigger root@camera:/tmp/
+ssh root@camera /tmp/openipc_event_trigger -g 16        # default chn 0, no timeout
+ssh root@camera /tmp/openipc_event_trigger -g 16 -t 30  # auto-exit after 30 s
+ssh root@camera /tmp/openipc_event_trigger -g 16 -c 0x3 # channels 0+1
+```
+
+Pick a GPIO that's physically reachable on your board. The IR-cut
+filter pin is the universal candidate for hand-soldered testing — it's
+wired on essentially every IP camera.
+
+## Output
+
+One line per trigger pulse:
+
+```
+trigger=1779471569123456789 last_fs={seq=412 pts=1234567 wall=1779471569100000000 dt=-23.456 ms} next_fs={seq=413 pts=1267900 wall=1779471569133333333 dt=+9.876 ms}
+```
+
+- `trigger` — `CLOCK_REALTIME` nanoseconds when the GPIO edge was seen.
+- `last_fs` — FS event the trigger fell *within*. `dt` is negative
+  (trigger arrived this much after the frame started).
+- `next_fs` — first FS event that started *after* the trigger.
+  `dt` is positive (trigger arrived this much before the next frame).
+
+The camera-side wall clocks are exact-as-kernel-knows; the trigger
+timestamp jitter is described in "Accuracy" above.
+
+## Limitations
+
+- **Not a true hardware trigger IN.** The camera doesn't start
+  capturing on the pulse — it was already capturing at its
+  free-running rate.
+- **Requires a SoC GPIO physically reachable on the camera board.**
+  Sealed consumer IP-camera enclosures may not expose any extra pins;
+  the IR-cut filter GPIO is the universal one and can be repurposed
+  during testing.
+- **One trigger at a time.** If two GPIO pulses arrive within one
+  frame period, the tool emits the first with its `next_fs` filled and
+  the second with `next_fs=(pending)`. Tighten your pulse spacing or
+  fork the tool to widen the pending queue.
+
+## Compared to the strobe-out sysfs
+
+[Strobe-out](../../kernel/openipc_frame_ts/README.md#strobe-out-gpio-driven-by-frame-events)
+goes the other direction: the camera drives an external GPIO from its
+sensor IRQs (for flash / ring-light gating). This tool is the input
+counterpart. The two can coexist — pick different GPIOs for each.
+
+[chrdev]: ../../kernel/openipc_frame_ts/README.md

--- a/samples/openipc_event_trigger/openipc_event_trigger.c
+++ b/samples/openipc_event_trigger/openipc_event_trigger.c
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * openipc_event_trigger — correlate an external GPIO pulse with the
+ * camera's nearest sensor frame.
+ *
+ * Use case: PLC / photoeye / strobe-fired external event needs to be
+ * matched to "which frame was the camera capturing at that moment".
+ *
+ *   1. Configure a SoC GPIO as input + rising-edge IRQ (sysfs).
+ *   2. Subscribe to /dev/openipc-frame-ts for MIPI_FS events.
+ *   3. poll() both. On GPIO rising edge, sample CLOCK_REALTIME and
+ *      match against the most recent FS event ("frame being exposed
+ *      when the trigger fired") AND the next FS event ("first frame
+ *      that started fully after the trigger").
+ *
+ * Output line per trigger event:
+ *   trigger=<ns> last_fs={seq=N pts=us wall=ns dt=ms before_trigger}
+ *                next_fs={seq=N+1 pts=us wall=ns dt=ms after_trigger}
+ *
+ * Limitations:
+ *   - The GPIO sysfs path adds ~µs to low-ms jitter on the trigger
+ *     timestamp (kernel→user transit + scheduler latency). For
+ *     PLC-class accuracy that's fine; for sub-µs you'd need kernel-
+ *     side correlation.
+ *   - This is NOT hardware trigger IN: the camera keeps free-running
+ *     at its configured rate. We're tagging the closest frame, not
+ *     gating capture.
+ *   - Requires a SoC GPIO physically reachable on the camera board.
+ *     Most consumer IP-cameras don't expose any extra GPIOs; the
+ *     IR-cut filter GPIO is the universal one and can be repurposed
+ *     during testing.
+ *
+ *   build: $(CROSS_COMPILE)gcc -O2 -Wall -o openipc_event_trigger \
+ *          openipc_event_trigger.c
+ *   run:   ./openipc_event_trigger -g 16            (default chn 0, no timeout)
+ *          ./openipc_event_trigger -g 16 -t 30      (auto-exit after 30 s)
+ *          ./openipc_event_trigger -g 16 -c 0x3     (channels 0+1)
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "../../include/openipc_frame_ts.h"
+
+#define DEV_PATH        "/dev/openipc-frame-ts"
+#define GPIO_SYSFS      "/sys/class/gpio"
+#define MAX_CHN         8
+#define EV_BATCH        16
+
+struct fs_cache {
+	uint64_t pts_us;
+	uint64_t wall_ns;
+	uint32_t seq;
+	int      valid;
+};
+
+static volatile sig_atomic_t g_stop;
+static void on_signal(int sig) { (void)sig; g_stop = 1; }
+
+static uint64_t now_realtime_ns(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_REALTIME, &ts);
+	return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+/* Best-effort write-string-to-sysfs helper. Returns 0 on success. */
+static int sysfs_write(const char *path, const char *val)
+{
+	int fd = open(path, O_WRONLY);
+	ssize_t n;
+
+	if (fd < 0)
+		return -1;
+	n = write(fd, val, strlen(val));
+	close(fd);
+	return (n == (ssize_t)strlen(val)) ? 0 : -1;
+}
+
+static int gpio_export(unsigned int n)
+{
+	char buf[16];
+	struct stat st;
+	char dir[64];
+
+	snprintf(dir, sizeof(dir), GPIO_SYSFS "/gpio%u", n);
+	if (access(dir, F_OK) == 0)
+		return 0;	/* already exported */
+
+	snprintf(buf, sizeof(buf), "%u", n);
+	if (sysfs_write(GPIO_SYSFS "/export", buf) < 0) {
+		fprintf(stderr, "gpio %u export: %s\n", n, strerror(errno));
+		return -1;
+	}
+	/* sysfs takes a moment to populate the per-gpio directory after
+	 * export — busybox / hotplug latency. Up to 10×10 ms wait. */
+	for (int i = 0; i < 10; i++) {
+		if (stat(dir, &st) == 0)
+			return 0;
+		usleep(10000);
+	}
+	return -1;
+}
+
+static int gpio_setup_edge(unsigned int n)
+{
+	char path[80];
+
+	snprintf(path, sizeof(path), GPIO_SYSFS "/gpio%u/direction", n);
+	if (sysfs_write(path, "in") < 0) {
+		fprintf(stderr, "gpio %u direction=in: %s\n", n, strerror(errno));
+		return -1;
+	}
+	snprintf(path, sizeof(path), GPIO_SYSFS "/gpio%u/edge", n);
+	if (sysfs_write(path, "rising") < 0) {
+		fprintf(stderr,
+		        "gpio %u edge=rising: %s (kernel may lack GPIO_SYSFS_EDGE)\n",
+		        n, strerror(errno));
+		return -1;
+	}
+	return 0;
+}
+
+static int gpio_open_value(unsigned int n)
+{
+	char path[80];
+	int fd;
+	char dummy[8];
+
+	snprintf(path, sizeof(path), GPIO_SYSFS "/gpio%u/value", n);
+	fd = open(path, O_RDONLY | O_NONBLOCK);
+	if (fd < 0) {
+		fprintf(stderr, "open %s: %s\n", path, strerror(errno));
+		return -1;
+	}
+	/* Drain any pending edge captured during setup so the first
+	 * poll() returns only on a real new event. */
+	(void)read(fd, dummy, sizeof(dummy));
+	return fd;
+}
+
+/* Re-arm the GPIO sysfs poll: lseek to 0 + read drains the latched
+ * edge so the next poll() blocks until the *next* edge. */
+static void gpio_rearm(int fd)
+{
+	char dummy[8];
+
+	(void)lseek(fd, 0, SEEK_SET);
+	(void)read(fd, dummy, sizeof(dummy));
+}
+
+static void print_trigger(uint64_t trig_ns,
+                          const struct fs_cache *last,
+                          const struct fs_cache *next)
+{
+	double dt_last_ms = 0.0, dt_next_ms = 0.0;
+
+	printf("trigger=%llu", (unsigned long long)trig_ns);
+
+	if (last->valid) {
+		dt_last_ms = ((double)(int64_t)(trig_ns - last->wall_ns)) / 1e6;
+		printf(" last_fs={seq=%u pts=%llu wall=%llu dt=%+.3f ms}",
+		       last->seq,
+		       (unsigned long long)last->pts_us,
+		       (unsigned long long)last->wall_ns,
+		       dt_last_ms);
+	} else {
+		printf(" last_fs=(none yet)");
+	}
+	if (next->valid) {
+		dt_next_ms = ((double)(int64_t)(next->wall_ns - trig_ns)) / 1e6;
+		printf(" next_fs={seq=%u pts=%llu wall=%llu dt=%+.3f ms}",
+		       next->seq,
+		       (unsigned long long)next->pts_us,
+		       (unsigned long long)next->wall_ns,
+		       dt_next_ms);
+	} else {
+		printf(" next_fs=(pending)");
+	}
+	printf("\n");
+	fflush(stdout);
+}
+
+int main(int argc, char **argv)
+{
+	int opt;
+	int gpio = -1, seconds = 0;
+	uint32_t chn_mask = 0xFFFFFFFFu;
+	uint32_t evt_mask = 1u << OPENIPC_FT_EVT_MIPI_FS;
+	int fd_ft = -1, fd_gpio = -1;
+	struct fs_cache last[MAX_CHN] = {{0}};
+	/* Pending trigger: set when GPIO fires; we then wait for the
+	 * next FS event to fill `next_fs` before printing. One slot
+	 * is enough — extra triggers during the gap are coalesced. */
+	struct {
+		int       pending;
+		uint64_t  trig_ns;
+		struct fs_cache last_snapshot[MAX_CHN];
+	} t = { 0 };
+
+	while ((opt = getopt(argc, argv, "g:c:t:h")) != -1) {
+		switch (opt) {
+		case 'g': gpio = atoi(optarg); break;
+		case 'c': chn_mask = strtoul(optarg, NULL, 0); break;
+		case 't': seconds = atoi(optarg); break;
+		default:
+			fprintf(stderr,
+			        "usage: %s -g <gpio> [-c <chn_mask>] [-t <seconds>]\n",
+			        argv[0]);
+			return 1;
+		}
+	}
+	if (gpio < 0) {
+		fprintf(stderr, "must specify -g <gpio>\n");
+		return 1;
+	}
+
+	signal(SIGINT, on_signal);
+	signal(SIGTERM, on_signal);
+
+	if (gpio_export(gpio) < 0 ||
+	    gpio_setup_edge(gpio) < 0)
+		return 1;
+
+	fd_gpio = gpio_open_value(gpio);
+	if (fd_gpio < 0)
+		return 1;
+
+	fd_ft = open(DEV_PATH, O_RDONLY | O_NONBLOCK);
+	if (fd_ft < 0) {
+		fprintf(stderr, "open %s: %s\n", DEV_PATH, strerror(errno));
+		return 1;
+	}
+	if (ioctl(fd_ft, OPENIPC_FT_IOC_SET_CHANNEL_MASK, &chn_mask) < 0) {
+		fprintf(stderr, "SET_CHANNEL_MASK: %s\n", strerror(errno));
+		return 1;
+	}
+	/* MIPI_FS only — we want sensor-row-0 events for correlation,
+	 * not ISP back-end completion. */
+	if (ioctl(fd_ft, OPENIPC_FT_IOC_SET_EVENT_MASK, &evt_mask) < 0 &&
+	    errno != ENOTTY) {
+		fprintf(stderr, "SET_EVENT_MASK: %s\n", strerror(errno));
+		/* ENOTTY = v1 kernel; only emits FS anyway, proceed */
+	}
+
+	time_t deadline = seconds > 0 ? time(NULL) + seconds : 0;
+
+	fprintf(stderr,
+	        "openipc_event_trigger: watching gpio=%d, chn_mask=0x%x\n",
+	        gpio, chn_mask);
+
+	struct pollfd pfd[2];
+	pfd[0].fd = fd_gpio;
+	pfd[0].events = POLLPRI | POLLERR;	/* sysfs GPIO edge wait */
+	pfd[1].fd = fd_ft;
+	pfd[1].events = POLLIN;
+
+	while (!g_stop) {
+		if (deadline && time(NULL) >= deadline)
+			break;
+
+		int pr = poll(pfd, 2, 1000);
+
+		if (pr < 0) {
+			if (errno == EINTR)
+				continue;
+			fprintf(stderr, "poll: %s\n", strerror(errno));
+			break;
+		}
+
+		/* GPIO edge — sample wall clock IMMEDIATELY so the trigger
+		 * timestamp is as close as possible to the actual edge.
+		 * Re-arm sysfs (lseek+read) before further work. */
+		if (pfd[0].revents & (POLLPRI | POLLERR)) {
+			uint64_t trig_ns = now_realtime_ns();
+
+			gpio_rearm(fd_gpio);
+			/* If a previous trigger is still waiting for its
+			 * next_fs, emit it with what we have and overwrite.
+			 * (Practically rare: the next FS arrives within
+			 * one frame period of the trigger.) */
+			if (t.pending) {
+				struct fs_cache no_next = {0};
+
+				print_trigger(t.trig_ns,
+				              &t.last_snapshot[0], &no_next);
+			}
+			t.pending = 1;
+			t.trig_ns = trig_ns;
+			memcpy(t.last_snapshot, last, sizeof(last));
+		}
+
+		/* Drain available FS events. */
+		if (pfd[1].revents & POLLIN) {
+			struct openipc_frame_ts_event ev[EV_BATCH];
+			ssize_t n;
+
+			while ((n = read(fd_ft, ev, sizeof(ev))) > 0) {
+				ssize_t nev = n / (ssize_t)sizeof(ev[0]);
+
+				for (ssize_t i = 0; i < nev; i++) {
+					unsigned int c = ev[i].vi_chn;
+
+					if (c >= MAX_CHN)
+						continue;
+					if (ev[i].event_type !=
+					    OPENIPC_FT_EVT_MIPI_FS)
+						continue;
+					last[c].pts_us  = ev[i].pts_us;
+					last[c].wall_ns = ev[i].wall_ns;
+					last[c].seq     = ev[i].seq;
+					last[c].valid   = 1;
+
+					/* If a trigger is pending and this FS
+					 * arrived after it, that's the
+					 * "next_fs". Emit and clear. */
+					if (t.pending &&
+					    ev[i].wall_ns > t.trig_ns) {
+						struct fs_cache next = {
+							.pts_us  = ev[i].pts_us,
+							.wall_ns = ev[i].wall_ns,
+							.seq     = ev[i].seq,
+							.valid   = 1,
+						};
+						print_trigger(t.trig_ns,
+						              &t.last_snapshot[c],
+						              &next);
+						t.pending = 0;
+					}
+				}
+			}
+			if (n < 0 && errno != EAGAIN && errno != EINTR) {
+				fprintf(stderr, "read: %s\n", strerror(errno));
+				break;
+			}
+		}
+	}
+
+	/* Emit any still-pending trigger with no next_fs match. */
+	if (t.pending) {
+		struct fs_cache no_next = {0};
+		print_trigger(t.trig_ns, &t.last_snapshot[0], &no_next);
+	}
+
+	close(fd_ft);
+	close(fd_gpio);
+	return 0;
+}


### PR DESCRIPTION
## What

Userspace companion to the chrdev: tags the camera's free-running frames against an external rising-edge GPIO pulse. Useful for PLC / photoeye event marking and strobed-illumination diagnostics.

## Why not "true" hardware trigger IN?

The sensor's `XVS_IN` / `TRIG` pin isn't broken out on commodity IP-camera boards, and per-sensor slave-mode driver work isn't there. So the camera keeps free-running, and what we provide is the next-best thing: tell the user *which frame* was being captured at the moment the trigger fired.

## How

`/sys/class/gpio/gpioN/` exported as input + `edge=rising`, `poll(POLLPRI)` on `/value` catches each edge. `/dev/openipc-frame-ts` subscribed via `SET_EVENT_MASK = MIPI_FS only`. On a GPIO edge: sample `CLOCK_REALTIME` immediately, match against the most recent FS event (frame whose capture window the trigger landed in) and the next FS event (first frame fully after the trigger).

Output per pulse:

```
trigger=1779471569123456789 last_fs={seq=412 pts=1234567 wall=1779471569100000000 dt=-23.456 ms} next_fs={seq=413 pts=1267900 wall=1779471569133333333 dt=+9.876 ms}
```

## Test plan

- [x] Cross-compiles for ev200 musleabi (host gcc + arm-openipc-linux-musleabi-gcc).
- [x] Deploys to ev300; startup path works (exports GPIO, sets `edge=rising`, opens chrdev, sets event mask).
- [ ] Hardware-loopback edge test pending — needs two GPIOs physically wired together on the bench, which the current ev300 dev board doesn't expose. The poll/edge logic is standard sysfs + `openipc_frame_ts` ioctls; reviewers can verify by inspection.

## Companion piece

[Strobe-out](../../tree/main/kernel/openipc_frame_ts/README.md#strobe-out-gpio-driven-by-frame-events) goes the other direction — camera drives a GPIO at sensor IRQ moments. This is the input counterpart.