### PR TITLE
kernel: bring up hi3519v101 (V3A) against Linux 7.0

### DIFF
--- a/kernel/compat/kernel_compat.h
+++ b/kernel/compat/kernel_compat.h
@@ -317,10 +317,22 @@ static inline struct spi_controller *compat_spi_busnum_to_controller(u16 bus_num
 
 /* Inserted before #endif */
 /*
- * i2c_new_device renamed to i2c_new_client_device in 5.x.
+ * i2c_new_device renamed to i2c_new_client_device in 5.2 (and the old name
+ * dropped later). Map legacy source forward, normalising the error return
+ * (ERR_PTR -> NULL) so callers that check `if (client == NULL)` still work.
  */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
 #define i2c_new_client_device i2c_new_device
+#else
+#include <linux/i2c.h>
+#include <linux/err.h>
+static inline struct i2c_client *compat_i2c_new_device(
+	struct i2c_adapter *adap, struct i2c_board_info const *info)
+{
+	struct i2c_client *c = i2c_new_client_device(adap, info);
+	return IS_ERR(c) ? NULL : c;
+}
+#define i2c_new_device(adap, info) compat_i2c_new_device(adap, info)
 #endif
 
 /*
@@ -329,6 +341,20 @@ static inline struct spi_controller *compat_spi_busnum_to_controller(u16 bus_num
  */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
 #define spi_busnum_to_controller spi_busnum_to_master
+#endif
+
+/*
+ * Re-export blob symbols only on kernels where modpost ignores the
+ * legacy 8-byte __ksymtab_ format. Pre-5.0 modpost honours the legacy
+ * blob ksymtab, so a second EXPORT_SYMBOL in our init wrapper would
+ * collide ("multiple definition of __ksymtab_X"). On 5.0+ modpost
+ * skips the legacy format — we must re-publish via EXPORT_SYMBOL to
+ * make the symbol visible to other modules.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+#define COMPAT_REEXPORT_BLOB_SYMBOL(sym) EXPORT_SYMBOL(sym)
+#else
+#define COMPAT_REEXPORT_BLOB_SYMBOL(sym)
 #endif
 
 /*

--- a/kernel/hi3519v101.kbuild
+++ b/kernel/hi3519v101.kbuild
@@ -65,6 +65,22 @@ obj-m += $(PREFIX)osal.o
 $(PREFIX)sys_config-objs := sys_config/hi3519v101/sys_config.o
 obj-m += $(PREFIX)sys_config.o
 
+# --- V3A OSAL shim (source) — re-exports removed-since-3.18 kernel APIs
+# (printk → _printk, vmalloc/kmalloc_noprof, dev_err/warn, sysctl table
+# variants, raw spinlock ops, ARM helpers) AND stubs vendor BSP symbols
+# the blob references (dis_irq_handle[], hios_mcc_*, hil_*, cmpi_*).
+# Must load BEFORE any blob module. The shim body is gated to >= 5.0;
+# on the lite target (3.18) it compiles to a no-op.
+CFLAGS_osal_v3a_shim/v3a_shim.o := \
+	-Ddel_timer_sync=__v3a_shim_del_timer_sync_unused_inline \
+	-Dmsecs_to_jiffies=__v3a_shim_msecs_to_jiffies_unused_inline \
+	-Dof_property_read_u32_array=__v3a_shim_of_prop_unused_inline \
+	-Dmodule_put=__v3a_shim_module_put_unused_inline \
+	-Dtry_module_get=__v3a_shim_try_module_get_unused_inline \
+	-D__mutex_init=__v3a_shim_mutex_init_unused_inline
+$(PREFIX)v3a_shim-objs := osal_v3a_shim/v3a_shim.o
+obj-m += $(PREFIX)v3a_shim.o
+
 # --- Blob modules (pre-built .o + init wrapper) ---
 V101_BLOB_DIR = obj/hi3519v101
 V101_INIT_DIR = init/hi3519v101
@@ -115,7 +131,13 @@ obj-m += $(PREFIX)ao.o
 obj-m += $(PREFIX)aenc.o
 obj-m += $(PREFIX)adec.o
 obj-m += $(PREFIX)acodec.o
+# pm.ko has hard-coded cpufreq/regulator integration referencing vendor
+# BSP symbols (devm_regulator_*, dev_pm_opp_*, cpufreq_*) that aren't
+# in mainline kernel. Hisilicon firmware build passes DISABLE_PM=1, so
+# this gate matches the upstream convention and skips the broken module.
+ifndef DISABLE_PM
 obj-m += $(PREFIX)pm.o
+endif
 obj-m += $(PREFIX)fisheye.o
 obj-m += $(PREFIX)photo.o
 obj-m += $(PREFIX)pciv.o

--- a/kernel/init/hi3519v101/ai_init.c
+++ b/kernel/init/hi3519v101/ai_init.c
@@ -1,8 +1,14 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
+#include <linux/version.h>
+
+/* See base_init.c for the >= 5.0 gate rationale. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+
 
 extern int AI_DRV_IsVqeEnable(int chn);
 COMPAT_REEXPORT_BLOB_SYMBOL(AI_DRV_IsVqeEnable);
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) */
 
 extern int _3519v101_hi3519v101_ai_init(void);
 extern void _3519v101_hi3519v101_ai_exit(void);

--- a/kernel/init/hi3519v101/ai_init.c
+++ b/kernel/init/hi3519v101/ai_init.c
@@ -1,6 +1,9 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
 
+extern int AI_DRV_IsVqeEnable(int chn);
+COMPAT_REEXPORT_BLOB_SYMBOL(AI_DRV_IsVqeEnable);
+
 extern int _3519v101_hi3519v101_ai_init(void);
 extern void _3519v101_hi3519v101_ai_exit(void);
 

--- a/kernel/init/hi3519v101/aio_init.c
+++ b/kernel/init/hi3519v101/aio_init.c
@@ -1,10 +1,16 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
+#include <linux/version.h>
+
+/* See base_init.c for the >= 5.0 gate rationale. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+
 
 extern void *pAcodec;
 COMPAT_REEXPORT_BLOB_SYMBOL(pAcodec);
 extern void *pAioBase;
 COMPAT_REEXPORT_BLOB_SYMBOL(pAioBase);
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) */
 
 extern int _3519v101_hi3519v101_aio_init(void);
 extern void _3519v101_hi3519v101_aio_exit(void);

--- a/kernel/init/hi3519v101/aio_init.c
+++ b/kernel/init/hi3519v101/aio_init.c
@@ -1,6 +1,11 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
 
+extern void *pAcodec;
+COMPAT_REEXPORT_BLOB_SYMBOL(pAcodec);
+extern void *pAioBase;
+COMPAT_REEXPORT_BLOB_SYMBOL(pAioBase);
+
 extern int _3519v101_hi3519v101_aio_init(void);
 extern void _3519v101_hi3519v101_aio_exit(void);
 

--- a/kernel/init/hi3519v101/base_init.c
+++ b/kernel/init/hi3519v101/base_init.c
@@ -14,6 +14,15 @@
 #include <linux/kernel.h>
 #include <linux/printk.h>
 #include <linux/sysctl.h>
+#include <linux/version.h>
+
+/* Pre-5.0 kernels honour the blob's legacy 8-byte __ksymtab_* entries
+ * directly; adding our own extern + EXPORT_SYMBOL declarations on top
+ * regresses lite-target loading on hardware (blob's exports disappear
+ * from /proc/kallsyms when paired with our extern in the same TU).
+ * Gate every re-export to >= 5.0 so the 3.18 lite path stays a simple
+ * forwarder, bit-for-bit equivalent to the pre-V3A-neo upstream. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
 
 extern int HI_LOG(int level, int mod_id, const char *fmt, ...);
 COMPAT_REEXPORT_BLOB_SYMBOL(HI_LOG);
@@ -61,6 +70,8 @@ extern int g_proc_enable;
 COMPAT_REEXPORT_BLOB_SYMBOL(g_proc_enable);
 extern int g_power_save_enable;
 COMPAT_REEXPORT_BLOB_SYMBOL(g_power_save_enable);
+
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) */
 
 extern int _3519v101_hi3519v101_base_init(void);
 extern void _3519v101_hi3519v101_base_exit(void);

--- a/kernel/init/hi3519v101/base_init.c
+++ b/kernel/init/hi3519v101/base_init.c
@@ -1,8 +1,80 @@
+/*
+ * V3A base module init wrapper.
+ *
+ * The hi3519v101_base.o blob defines CMPI_, VB_, HI_LOG and g_ symbols
+ * via legacy __ksymtab_ entries (8-byte struct kernel_symbol). Modern
+ * (Linux 5 and newer) modpost ignores that legacy format, so consumer
+ * modules (open_sys, open_isp, ...) would see them as undefined.
+ *
+ * Re-export the same symbols here via EXPORT_SYMBOL so modpost picks
+ * them up via Module.symvers. Pattern mirrors the cv300 init wrapper.
+ */
+
 #include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/printk.h>
+#include <linux/sysctl.h>
+
+extern int HI_LOG(int level, int mod_id, const char *fmt, ...);
+COMPAT_REEXPORT_BLOB_SYMBOL(HI_LOG);
+
+extern void *CMPI_MmzMalloc(char *mmz_name, char *buf_name, unsigned int size);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_MmzMalloc);
+extern void CMPI_MmzFree(unsigned int phy_addr, void *vir_addr);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_MmzFree);
+extern int CMPI_MmzMallocNocache(char *cpMmzName, char *pBufName,
+				 unsigned int *pu32PhyAddr, void **ppVitAddr,
+				 int s32Len);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_MmzMallocNocache);
+extern int CMPI_MmzMallocCached(char *cpMmzName, char *pBufName,
+				unsigned int *pu32PhyAddr, void **ppVitAddr,
+				int s32Len);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_MmzMallocCached);
+
+extern int CMPI_GetModuleName(int mod_id, char *name);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_GetModuleName);
+extern int CMPI_GetModuleById(int mod_id);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_GetModuleById);
+extern int CMPI_GetModuleFuncById(int mod_id);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_GetModuleFuncById);
+extern int CMPI_StopModules(void);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_StopModules);
+extern int CMPI_QueryModules(void *info);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_QueryModules);
+extern int CMPI_ExitModules(void);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_ExitModules);
+extern int CMPI_InitModules(void);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_InitModules);
+extern int CMPI_RegisterModule(void *mod_info);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_RegisterModule);
+extern int CMPI_UnRegisterModule(int mod_id);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_UnRegisterModule);
+
+extern int CMPI_LogInit(void);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_LogInit);
+extern void CMPI_LogExit(void);
+COMPAT_REEXPORT_BLOB_SYMBOL(CMPI_LogExit);
+
+extern int g_proc_all;
+COMPAT_REEXPORT_BLOB_SYMBOL(g_proc_all);
+extern int g_proc_enable;
+COMPAT_REEXPORT_BLOB_SYMBOL(g_proc_enable);
+extern int g_power_save_enable;
+COMPAT_REEXPORT_BLOB_SYMBOL(g_power_save_enable);
+
 extern int _3519v101_hi3519v101_base_init(void);
 extern void _3519v101_hi3519v101_base_exit(void);
-static int __init base_mod_init(void) { return _3519v101_hi3519v101_base_init(); }
-static void __exit base_mod_exit(void) { _3519v101_hi3519v101_base_exit(); }
+
+static int __init base_mod_init(void)
+{
+	return _3519v101_hi3519v101_base_init();
+}
+
+static void __exit base_mod_exit(void)
+{
+	_3519v101_hi3519v101_base_exit();
+}
+
 module_init(base_mod_init);
 module_exit(base_mod_exit);
 MODULE_LICENSE("GPL");

--- a/kernel/init/hi3519v101/pciv_fmw_init.c
+++ b/kernel/init/hi3519v101/pciv_fmw_init.c
@@ -1,5 +1,10 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
+#include <linux/version.h>
+
+/* See base_init.c for the >= 5.0 gate rationale. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+
 
 extern int PCIV_FirmWareCreate(void *p);
 COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareCreate);
@@ -33,6 +38,7 @@ extern int PCIV_FirmWareWindowVbCreate(int id, void *attr);
 COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareWindowVbCreate);
 extern int PCIV_FirmWareWindowVbDestroy(int id);
 COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareWindowVbDestroy);
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) */
 
 extern int _3519v101_hi3519v101_pciv_fmw_init(void);
 extern void _3519v101_hi3519v101_pciv_fmw_exit(void);

--- a/kernel/init/hi3519v101/pciv_fmw_init.c
+++ b/kernel/init/hi3519v101/pciv_fmw_init.c
@@ -1,6 +1,39 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
 
+extern int PCIV_FirmWareCreate(void *p);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareCreate);
+extern int PCIV_FirmWareDestroy(int id);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareDestroy);
+extern int PCIV_FirmWareFree(int id);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareFree);
+extern int PCIV_FirmWareFreeChnBuffer(int id, int chn);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareFreeChnBuffer);
+extern int PCIV_FirmWareGetPreProcCfg(int id, void *cfg);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareGetPreProcCfg);
+extern int PCIV_FirmWareMalloc(int id, unsigned int size);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareMalloc);
+extern int PCIV_FirmWareMallocChnBuffer(int id, int chn, unsigned int size);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareMallocChnBuffer);
+extern int PCIV_FirmWareRecvPicAndSend(int id, void *pic);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareRecvPicAndSend);
+extern int PCIV_FirmWareRegisterFunc(int id, void *func);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareRegisterFunc);
+extern int PCIV_FirmWareSetAttr(int id, void *attr);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareSetAttr);
+extern int PCIV_FirmWareSetPreProcCfg(int id, void *cfg);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareSetPreProcCfg);
+extern int PCIV_FirmWareSrcPicFree(int id, void *pic);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareSrcPicFree);
+extern int PCIV_FirmWareStart(int id);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareStart);
+extern int PCIV_FirmWareStop(int id);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareStop);
+extern int PCIV_FirmWareWindowVbCreate(int id, void *attr);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareWindowVbCreate);
+extern int PCIV_FirmWareWindowVbDestroy(int id);
+COMPAT_REEXPORT_BLOB_SYMBOL(PCIV_FirmWareWindowVbDestroy);
+
 extern int _3519v101_hi3519v101_pciv_fmw_init(void);
 extern void _3519v101_hi3519v101_pciv_fmw_exit(void);
 

--- a/kernel/init/hi3519v101/sys_init.c
+++ b/kernel/init/hi3519v101/sys_init.c
@@ -11,6 +11,10 @@
 #include <linux/init.h>
 #include <linux/moduleparam.h>
 #include <linux/types.h>
+#include <linux/version.h>
+
+/* See base_init.c for the >= 5.0 gate rationale. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
 
 extern int vi_vpss_online;
 module_param(vi_vpss_online, int, 0444);
@@ -32,6 +36,8 @@ extern void *reg_ddr0_base_va;
 COMPAT_REEXPORT_BLOB_SYMBOL(reg_ddr0_base_va);
 extern void *reg_misc_base_va;
 COMPAT_REEXPORT_BLOB_SYMBOL(reg_misc_base_va);
+
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) */
 
 extern int _3519v101_hi3519v101_sys_init(void);
 extern void _3519v101_hi3519v101_sys_exit(void);

--- a/kernel/init/hi3519v101/sys_init.c
+++ b/kernel/init/hi3519v101/sys_init.c
@@ -1,8 +1,51 @@
+/*
+ * V3A sys module init wrapper.
+ *
+ * Re-exports legacy __ksymtab_ globals defined by hi3519v101_sys.o
+ * (vi_vpss_online, en_online_delayint, mem_total, reg_*_base_va).
+ * Consumer modules (open_vi, open_vpss, ...) reference these directly.
+ */
+
 #include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/moduleparam.h>
+#include <linux/types.h>
+
+extern int vi_vpss_online;
+module_param(vi_vpss_online, int, 0444);
+COMPAT_REEXPORT_BLOB_SYMBOL(vi_vpss_online);
+
+extern int en_online_delayint;
+module_param(en_online_delayint, int, 0444);
+COMPAT_REEXPORT_BLOB_SYMBOL(en_online_delayint);
+
+extern unsigned int mem_total;
+module_param(mem_total, uint, 0444);
+COMPAT_REEXPORT_BLOB_SYMBOL(mem_total);
+
+extern void *reg_crg_base_va;
+COMPAT_REEXPORT_BLOB_SYMBOL(reg_crg_base_va);
+extern void *reg_sys_base_va;
+COMPAT_REEXPORT_BLOB_SYMBOL(reg_sys_base_va);
+extern void *reg_ddr0_base_va;
+COMPAT_REEXPORT_BLOB_SYMBOL(reg_ddr0_base_va);
+extern void *reg_misc_base_va;
+COMPAT_REEXPORT_BLOB_SYMBOL(reg_misc_base_va);
+
 extern int _3519v101_hi3519v101_sys_init(void);
 extern void _3519v101_hi3519v101_sys_exit(void);
-static int __init sys_mod_init(void) { return _3519v101_hi3519v101_sys_init(); }
-static void __exit sys_mod_exit(void) { _3519v101_hi3519v101_sys_exit(); }
+
+static int __init sys_mod_init(void)
+{
+	return _3519v101_hi3519v101_sys_init();
+}
+
+static void __exit sys_mod_exit(void)
+{
+	_3519v101_hi3519v101_sys_exit();
+}
+
 module_init(sys_mod_init);
 module_exit(sys_mod_exit);
 MODULE_LICENSE("GPL");

--- a/kernel/init/hi3519v101/venc_init.c
+++ b/kernel/init/hi3519v101/venc_init.c
@@ -1,5 +1,10 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
+#include <linux/version.h>
+
+/* See base_init.c for the >= 5.0 gate rationale. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+
 
 extern int VencMaxChnNum;
 COMPAT_REEXPORT_BLOB_SYMBOL(VencMaxChnNum);
@@ -13,6 +18,7 @@ extern void *OneBufferForJpegOSD;
 COMPAT_REEXPORT_BLOB_SYMBOL(OneBufferForJpegOSD);
 extern void QuickSchedule(void);
 COMPAT_REEXPORT_BLOB_SYMBOL(QuickSchedule);
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) */
 
 extern int _3519v101_hi3519v101_venc_init(void);
 extern void _3519v101_hi3519v101_venc_exit(void);

--- a/kernel/init/hi3519v101/venc_init.c
+++ b/kernel/init/hi3519v101/venc_init.c
@@ -1,6 +1,19 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
 
+extern int VencMaxChnNum;
+COMPAT_REEXPORT_BLOB_SYMBOL(VencMaxChnNum);
+extern int VencBufferCache;
+COMPAT_REEXPORT_BLOB_SYMBOL(VencBufferCache);
+extern void FrameBufRecycle(void *ctx);
+COMPAT_REEXPORT_BLOB_SYMBOL(FrameBufRecycle);
+extern void JpegClearStreamBuf(int chn);
+COMPAT_REEXPORT_BLOB_SYMBOL(JpegClearStreamBuf);
+extern void *OneBufferForJpegOSD;
+COMPAT_REEXPORT_BLOB_SYMBOL(OneBufferForJpegOSD);
+extern void QuickSchedule(void);
+COMPAT_REEXPORT_BLOB_SYMBOL(QuickSchedule);
+
 extern int _3519v101_hi3519v101_venc_init(void);
 extern void _3519v101_hi3519v101_venc_exit(void);
 

--- a/kernel/init/hi3519v101/viu_init.c
+++ b/kernel/init/hi3519v101/viu_init.c
@@ -1,8 +1,46 @@
+/*
+ * V3A vi/viu module init wrapper.
+ *
+ * Re-exports legacy __ksymtab_ entries from hi3519v101_viu.o that
+ * consumer modules (vpss, isp) reference at link time.
+ */
+
 #include <linux/module.h>
+#include <linux/init.h>
+
+extern int VIU_DRV_GetChnIntStatus(int chn);
+COMPAT_REEXPORT_BLOB_SYMBOL(VIU_DRV_GetChnIntStatus);
+extern void VIU_DRV_ClearChnIntStatus(int chn);
+COMPAT_REEXPORT_BLOB_SYMBOL(VIU_DRV_ClearChnIntStatus);
+extern void VIU_DRV_ClearChnIntMask(int chn);
+COMPAT_REEXPORT_BLOB_SYMBOL(VIU_DRV_ClearChnIntMask);
+extern int VIU_DRV_GetGlobalChnIntMask(void);
+COMPAT_REEXPORT_BLOB_SYMBOL(VIU_DRV_GetGlobalChnIntMask);
+extern int VIU_DRV_GetGlobalIntIndicator(void);
+COMPAT_REEXPORT_BLOB_SYMBOL(VIU_DRV_GetGlobalIntIndicator);
+extern void *VIU_DRV_GetPrivateData(int chn);
+COMPAT_REEXPORT_BLOB_SYMBOL(VIU_DRV_GetPrivateData);
+extern int VIU_DRV_IsFrameFlashed(int chn);
+COMPAT_REEXPORT_BLOB_SYMBOL(VIU_DRV_IsFrameFlashed);
+
+extern void *g_psViuAllReg;
+COMPAT_REEXPORT_BLOB_SYMBOL(g_psViuAllReg);
+extern void *g_stViuExpFunc;
+COMPAT_REEXPORT_BLOB_SYMBOL(g_stViuExpFunc);
+
 extern int _3519v101_hi3519v101_viu_init(void);
 extern void _3519v101_hi3519v101_viu_exit(void);
-static int __init viu_mod_init(void) { return _3519v101_hi3519v101_viu_init(); }
-static void __exit viu_mod_exit(void) { _3519v101_hi3519v101_viu_exit(); }
+
+static int __init viu_mod_init(void)
+{
+	return _3519v101_hi3519v101_viu_init();
+}
+
+static void __exit viu_mod_exit(void)
+{
+	_3519v101_hi3519v101_viu_exit();
+}
+
 module_init(viu_mod_init);
 module_exit(viu_mod_exit);
 MODULE_LICENSE("GPL");

--- a/kernel/init/hi3519v101/viu_init.c
+++ b/kernel/init/hi3519v101/viu_init.c
@@ -7,6 +7,11 @@
 
 #include <linux/module.h>
 #include <linux/init.h>
+#include <linux/version.h>
+
+/* See base_init.c for the >= 5.0 gate rationale. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+
 
 extern int VIU_DRV_GetChnIntStatus(int chn);
 COMPAT_REEXPORT_BLOB_SYMBOL(VIU_DRV_GetChnIntStatus);
@@ -27,6 +32,7 @@ extern void *g_psViuAllReg;
 COMPAT_REEXPORT_BLOB_SYMBOL(g_psViuAllReg);
 extern void *g_stViuExpFunc;
 COMPAT_REEXPORT_BLOB_SYMBOL(g_stViuExpFunc);
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) */
 
 extern int _3519v101_hi3519v101_viu_init(void);
 extern void _3519v101_hi3519v101_viu_exit(void);

--- a/kernel/init/hi3519v101/vou_init.c
+++ b/kernel/init/hi3519v101/vou_init.c
@@ -1,6 +1,9 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
 
+extern void *g_stVouExpFunc;
+COMPAT_REEXPORT_BLOB_SYMBOL(g_stVouExpFunc);
+
 extern int _3519v101_hi3519v101_vou_init(void);
 extern void _3519v101_hi3519v101_vou_exit(void);
 

--- a/kernel/init/hi3519v101/vou_init.c
+++ b/kernel/init/hi3519v101/vou_init.c
@@ -1,8 +1,14 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
+#include <linux/version.h>
+
+/* See base_init.c for the >= 5.0 gate rationale. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+
 
 extern void *g_stVouExpFunc;
 COMPAT_REEXPORT_BLOB_SYMBOL(g_stVouExpFunc);
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) */
 
 extern int _3519v101_hi3519v101_vou_init(void);
 extern void _3519v101_hi3519v101_vou_exit(void);

--- a/kernel/osal/hi3519v101/himedia/base.c
+++ b/kernel/osal/hi3519v101/himedia/base.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Hisilicon Technologies Co., Ltd. 2016-2019.
+ * Description: osal himedia base file.
+ * Author: Hisilicon multimedia software group
+ * Create: 2016-11-11
+ */
+
 #include <linux/module.h>
 #include <linux/init.h>
 #include <linux/dma-mapping.h>
@@ -11,83 +18,87 @@
 #include <linux/stat.h>
 #include <linux/init.h>
 #include <linux/kmod.h>
-
-
 #include "base.h"
 
-/*****************************************************************************/
-/**** himedia bus  ****/
-/*****************************************************************************/
+#include "../../../compat/kernel_compat.h"
 
 static void himedia_bus_release(struct device *dev)
 {
-	//printk("himedia bus release\n");
-	return;
+    return;
 }
 
-struct device himedia_bus = {
-	.init_name	= "himedia",
-	.release    = himedia_bus_release
+struct device g_himedia_bus = {
+    .init_name = "himedia",
+    .release = himedia_bus_release
 };
 
-/*sysfs modalias store/show*/
+/* sysfs modalias store/show */
 static ssize_t modalias_show(struct device *dev, struct device_attribute *a,
-							char *buf)
+                             char *buf)
 {
-	struct himedia_device *pdev = to_himedia_device(dev);
-	int len = snprintf(buf, PAGE_SIZE, "himedia:%s\n", pdev->devfs_name);
+    struct himedia_device *pdev = to_himedia_device(dev);
+    int len = snprintf(buf, PAGE_SIZE, "himedia:%s\n", pdev->devfs_name);
 
-	return (len >= PAGE_SIZE) ? (PAGE_SIZE - 1) : len;
+    return (len >= PAGE_SIZE) ? (PAGE_SIZE - 1) : len;
 }
 
-
-static struct device_attribute himedia_dev_attrs[] = {
-	__ATTR_RO(modalias),
-	__ATTR_NULL,
+static struct device_attribute g_himedia_dev_attrs[] = {
+    __ATTR_RO(modalias),
+    __ATTR_NULL,
 };
 
+static struct attribute *g_himedia_dev_attrs_list_attrs[] = {
+    &g_himedia_dev_attrs[0].attr,
+    NULL,
+};
+ATTRIBUTE_GROUPS(g_himedia_dev_attrs_list);
 
-/*bus match & uevent*/
+/* bus match & uevent */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+static int himedia_match(struct device *dev, const struct device_driver *drv)
+#else
 static int himedia_match(struct device *dev, struct device_driver *drv)
+#endif
 {
-	struct himedia_device *pdev = to_himedia_device(dev);
-	return (strncmp(pdev->devfs_name, drv->name, sizeof(pdev->devfs_name)) == 0);
+    struct himedia_device *pdev = to_himedia_device(dev);
+    return (strncmp(pdev->devfs_name, drv->name, sizeof(pdev->devfs_name)) == 0);
 }
 
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+static int himedia_uevent(const struct device *dev, struct kobj_uevent_env *env)
+{
+    struct himedia_device *pdev = to_himedia_device((struct device *)dev);
+#else
 static int himedia_uevent(struct device *dev, struct kobj_uevent_env *env)
 {
-	struct himedia_device	*pdev = to_himedia_device(dev);
-	add_uevent_var(env, "MODALIAS=himedia:%s", pdev->devfs_name);
-	return 0;
+    struct himedia_device *pdev = to_himedia_device(dev);
+#endif
+    add_uevent_var(env, "MODALIAS=himedia:%s", pdev->devfs_name);
+    return 0;
 }
 
-/*****************************************************************************/
-//pm methods
+/* pm methods */
 static int himedia_pm_prepare(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    if (!pdrv->ops || !pdrv->ops->pm_prepare)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_prepare == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_prepare(pdev);
 }
-
 
 static void himedia_pm_complete(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    if (!pdrv->ops || !pdrv->ops->pm_complete)
-    {
-        return ;
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_complete == NULL)) {
+        return;
     }
-    
+
     pdrv->ops->pm_complete(pdev);
 }
 
@@ -96,107 +107,81 @@ static int himedia_pm_suspend(struct device *dev)
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
 
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__);
-    
-    if (!pdrv->ops || !pdrv->ops->pm_suspend)
-    {
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_suspend == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_suspend(pdev);
 }
-
 
 static int himedia_pm_resume(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__);
-    
-    if (!pdrv->ops || !pdrv->ops->pm_resume)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_resume == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_resume(pdev);
 }
-
 
 static int himedia_pm_freeze(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__); 
-    
-    if (!pdrv->ops || !pdrv->ops->pm_freeze)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_freeze == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_freeze(pdev);
 }
-
 
 static int himedia_pm_thaw(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__); 
-    
-    if (!pdrv->ops || !pdrv->ops->pm_thaw)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_thaw == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_thaw(pdev);
 }
-
 
 static int himedia_pm_poweroff(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__); 
-    
-    if (!pdrv->ops || !pdrv->ops->pm_poweroff)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_poweroff == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_poweroff(pdev);
 }
-
 
 static int himedia_pm_restore(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__); 
-    
-    if (!pdrv->ops || !pdrv->ops->pm_restore)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_restore == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_restore(pdev);
 }
 static int himedia_pm_suspend_noirq(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__);
-    
-    if (!pdrv->ops || !pdrv->ops->pm_suspend_noirq)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_suspend_noirq == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_suspend_noirq(pdev);
 }
 
@@ -204,30 +189,23 @@ static int himedia_pm_resume_noirq(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__); 
-    
-    if (!pdrv->ops || !pdrv->ops->pm_resume_noirq)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_resume_noirq == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_resume_noirq(pdev);
 }
-
 
 static int himedia_pm_freeze_noirq(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__); 
-    
-    if (!pdrv->ops || !pdrv->ops->pm_freeze_noirq)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_freeze_noirq == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_freeze_noirq(pdev);
 }
 
@@ -235,171 +213,163 @@ static int himedia_pm_thaw_noirq(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__); 
-    
-    if (!pdrv->ops || !pdrv->ops->pm_thaw_noirq)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_thaw_noirq == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_thaw_noirq(pdev);
 }
-
 
 static int himedia_pm_poweroff_noirq(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__); 
-    
-    if (!pdrv->ops || !pdrv->ops->pm_poweroff_noirq)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_poweroff_noirq == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_poweroff_noirq(pdev);
 }
-
 
 static int himedia_pm_restore_noirq(struct device *dev)
 {
     struct himedia_device *pdev = to_himedia_device(dev);
     struct himedia_driver *pdrv = to_himedia_driver(dev->driver);
-    
-    //printk(KERN_INFO "%s %d\n", __func__, __LINE__); 
-    
-    if (!pdrv->ops || !pdrv->ops->pm_restore_noirq)
-    {
+
+    if ((pdrv->ops == NULL) || (pdrv->ops->pm_restore_noirq == NULL)) {
         return 0;
     }
-    
+
     return pdrv->ops->pm_restore_noirq(pdev);
 }
 
+static struct dev_pm_ops g_himedia_bus_pm_ops = {
+    .prepare = himedia_pm_prepare,
+    .complete = himedia_pm_complete,
 
-static struct dev_pm_ops himedia_bus_pm_ops = {
-	.prepare        = himedia_pm_prepare,
-	.complete       = himedia_pm_complete,
-	
-	//with irq
-	.suspend        = himedia_pm_suspend,
-	.resume         = himedia_pm_resume,
-	
-	.freeze         = himedia_pm_freeze,
-	.thaw           = himedia_pm_thaw,
-	.poweroff       = himedia_pm_poweroff,
-	.restore        = himedia_pm_restore,
-	
-	//with noirq
-	.suspend_noirq  = himedia_pm_suspend_noirq,
-	.resume_noirq   = himedia_pm_resume_noirq,
-	.freeze_noirq   = himedia_pm_freeze_noirq,
-	.thaw_noirq     = himedia_pm_thaw_noirq,
-	.poweroff_noirq = himedia_pm_poweroff_noirq,
-	.restore_noirq  = himedia_pm_restore_noirq,
+    /* with irq */
+    .suspend = himedia_pm_suspend,
+    .resume = himedia_pm_resume,
+
+    .freeze = himedia_pm_freeze,
+    .thaw = himedia_pm_thaw,
+    .poweroff = himedia_pm_poweroff,
+    .restore = himedia_pm_restore,
+
+    /* with noirq */
+    .suspend_noirq = himedia_pm_suspend_noirq,
+    .resume_noirq = himedia_pm_resume_noirq,
+    .freeze_noirq = himedia_pm_freeze_noirq,
+    .thaw_noirq = himedia_pm_thaw_noirq,
+    .poweroff_noirq = himedia_pm_poweroff_noirq,
+    .restore_noirq = himedia_pm_restore_noirq,
 };
 
-
-struct bus_type himedia_bus_type = {
-	.name		= "himedia",
-	.dev_attrs	= himedia_dev_attrs,
-	.match		= himedia_match,
-	.uevent		= himedia_uevent,
-	.pm		    = &himedia_bus_pm_ops,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 12, 0)
+struct bus_type g_himedia_bus_type = {
+    .name = "himedia",
+    .dev_groups = g_himedia_dev_attrs_list_groups,
+    .match = himedia_match,
+    .uevent = himedia_uevent,
+    .pm = &g_himedia_bus_pm_ops,
 };
-
+#else
+struct bus_type g_himedia_bus_type = {
+    .name = "himedia",
+    .dev_attrs = g_himedia_dev_attrs,
+    .match = himedia_match,
+    .uevent = himedia_uevent,
+    .pm = &g_himedia_bus_pm_ops,
+};
+#endif
 
 int himedia_bus_init(void)
 {
-	int ret;
-	ret = device_register(&himedia_bus);
-	if (ret)
-		return ret;
+    int ret;
 
-	ret = bus_register(&himedia_bus_type);
-	if (ret) 
-		goto error;
+    ret = device_register(&g_himedia_bus);
+    if (ret) {
+        return ret;
+    }
 
-	return 0;
+    ret = bus_register(&g_himedia_bus_type);
+    if (ret) {
+        goto error;
+    }
+
+    return 0;
 error:
-	
-	device_unregister(&himedia_bus);
-	return ret;
+    device_unregister(&g_himedia_bus);
+    return ret;
 }
-
 
 void himedia_bus_exit(void)
 {
-	bus_unregister(&himedia_bus_type);
-	device_unregister(&himedia_bus);
+    bus_unregister(&g_himedia_bus_type);
+    device_unregister(&g_himedia_bus);
 }
 
 static void himedia_device_release(struct device *dev)
 {
-	//struct himedia_device *pdev = to_himedia_device(dev);
-    //printk("dev:%s releasing...\n", pdev->devfs_name);
+    return;
 }
-
 
 int himedia_device_register(struct himedia_device *pdev)
 {
-	dev_set_name(&pdev->device, "%s", pdev->devfs_name);
+    dev_set_name(&pdev->device, "%s", pdev->devfs_name);
 
-    pdev->device.devt    = MKDEV(HIMEDIA_DEVICE_MAJOR, pdev->minor);
-	pdev->device.release = himedia_device_release;
-	pdev->device.bus     = &himedia_bus_type;
-	
-	return device_register(&pdev->device);
+    pdev->device.devt = MKDEV(HIMEDIA_DEVICE_MAJOR, pdev->minor);
+    pdev->device.release = himedia_device_release;
+    pdev->device.bus = &g_himedia_bus_type;
+
+    return device_register(&pdev->device);
 }
-
 
 void himedia_device_unregister(struct himedia_device *pdev)
 {
-	device_unregister(&pdev->device);
+    device_unregister(&pdev->device);
 }
 
-
 struct himedia_driver *himedia_driver_register(const char *name,
-        struct module *owner,  struct himedia_ops *ops)
+                                               struct module *owner, struct himedia_ops *ops)
 {
-	int ret;
-	struct himedia_driver *pdrv;
-    
-	if( (name == NULL)||(owner == NULL) /*||(ops == NULL)*/)
-		return ERR_PTR(-EINVAL);
+    int ret;
+    struct himedia_driver *pdrv = NULL;
 
-	pdrv = kzalloc(sizeof(struct himedia_driver) + strlen(name), GFP_KERNEL);
-	if (!pdrv) 
+    if ((name == NULL) || (owner == NULL)) {
+        return ERR_PTR(-EINVAL);
+    }
+
+    pdrv = kzalloc(sizeof(struct himedia_driver) + strnlen(name, HIMIDIA_MAX_DEV_NAME_LEN), GFP_KERNEL);
+    if (pdrv == NULL) {
         return ERR_PTR(-ENOMEM);
-	
-	/*init driver object*/
-	strlcpy(pdrv->name, name, strlen(name)+1);
-	
-	pdrv->ops  = ops;
+    }
 
-	pdrv->driver.name  = pdrv->name;
-	pdrv->driver.owner = owner;
-	pdrv->driver.bus   = &himedia_bus_type;
+    /* init driver object */
+    strncpy(pdrv->name, name, strnlen(name, HIMIDIA_MAX_DEV_NAME_LEN));
 
-	ret = driver_register(&pdrv->driver);
-	if(ret){
-		kfree(pdrv);
-		return ERR_PTR(ret);
-	}
+    pdrv->ops = ops;
 
-	return pdrv;
+    pdrv->driver.name = pdrv->name;
+    pdrv->driver.owner = owner;
+    pdrv->driver.bus = &g_himedia_bus_type;
+
+    ret = driver_register(&pdrv->driver);
+    if (ret) {
+        kfree(pdrv);
+        pdrv = NULL;
+        return ERR_PTR(ret);
+    }
+
+    return pdrv;
 }
 
 void himedia_driver_unregister(struct himedia_driver *pdrv)
 {
-    if (pdrv) {
-	    driver_unregister(&pdrv->driver);
-	    kfree(pdrv);
-	}
+    if (pdrv != NULL) {
+        driver_unregister(&pdrv->driver);
+        kfree(pdrv);
+    }
 }
-
-//end!
-/*****************************************************************************/
-

--- a/kernel/osal/hi3519v101/himedia/base.h
+++ b/kernel/osal/hi3519v101/himedia/base.h
@@ -1,27 +1,23 @@
+/*
+ * Copyright (c) Hisilicon Technologies Co., Ltd. 2016-2019.
+ * Description: osal himedia base header file.
+ * Author: Hisilicon multimedia software group
+ * Create: 2016-11-11
+ */
 #ifndef _HIMEDIA_BASE_H_
 #define _HIMEDIA_BASE_H_
 
 #include "himedia.h"
 
-int    himedia_bus_init(void);
-void   himedia_bus_exit(void);
-
-#if 0
-struct device *himedia_device_register(struct class *class,
-		dev_t devt, const char *name);
-
-void himedia_device_unregister(struct class *class, dev_t devt);
-
-#else
+int himedia_bus_init(void);
+void himedia_bus_exit(void);
 
 int himedia_device_register(struct himedia_device *pdev);
 
 void himedia_device_unregister(struct himedia_device *pdev);
 
-#endif
-
 struct himedia_driver *himedia_driver_register(const char *name,
-        struct module *owner,  struct himedia_ops *ops);
+                                               struct module *owner, struct himedia_ops *ops);
 
 void himedia_driver_unregister(struct himedia_driver *pdrv);
 

--- a/kernel/osal/hi3519v101/himedia/himedia.c
+++ b/kernel/osal/hi3519v101/himedia/himedia.c
@@ -1,8 +1,8 @@
 /*
- * linux/drivers/char/himedia.c
- *
- * HISILICON driver base frameforwk
- * Changed for hisilicon-media devices by Liu Jiandong 10-Dec-2007
+ * Copyright (c) Hisilicon Technologies Co., Ltd. 2016-2019.
+ * Description: osal himedia source file.
+ * Author: Hisilicon multimedia software group
+ * Create: 2016-11-11
  */
 
 #include <linux/module.h>
@@ -22,241 +22,240 @@
 
 #include "base.h"
 
-static OSAL_LIST_HEAD(himedia_list);
-static DEFINE_MUTEX(himedia_sem);
+static OSAL_LIST_HEAD(g_himedia_list);
+static DEFINE_MUTEX(g_himedia_sem);
 
 /*
  * Assigned numbers, used for dynamic minors
  */
 #define DYNAMIC_MINORS 64 /* like dynamic majors */
-static unsigned char himedia_minors[DYNAMIC_MINORS / 8];
+static unsigned char g_himedia_minors[DYNAMIC_MINORS / 8]; /* 8: bitmap 1Byte has 8 bit */
 
-static int himedia_open(struct inode * inode, struct file * file)
+static int himedia_open(struct inode *inode, struct file *file)
 {
-	int minor = iminor(inode);
-	struct himedia_device *c;
-	int err = -ENODEV;
-	const struct file_operations *old_fops, *new_fops = NULL;
-	
-	mutex_lock(&himedia_sem);
-	
-	osal_list_for_each_entry(c, &himedia_list, list) {
-		if (c->minor == minor) {
-			new_fops = fops_get(c->fops);		
-			break;
-		}
-	}
+    int minor = iminor(inode);
+    struct himedia_device *c = NULL;
+    int err = -ENODEV;
+    const struct file_operations *old_fops = NULL;
+    const struct file_operations *new_fops = NULL;
 
-	if (!new_fops) {
-		mutex_unlock(&himedia_sem);
-		request_module("char-major-%d-%d", HIMEDIA_DEVICE_MAJOR, minor);
-		mutex_lock(&himedia_sem);
+    mutex_lock(&g_himedia_sem);
 
-		osal_list_for_each_entry(c, &himedia_list, list) {
-			if (c->minor == minor) {
-				new_fops = fops_get(c->fops);
-				break;
-			}
-		}
-		
-		if (!new_fops)
-			goto fail;
-	}
-
-	err = 0;
-	
-	old_fops = file->f_op;
-	file->f_op = new_fops;
-	if (file->f_op->open) {
-		file->private_data = c;
-		err=file->f_op->open(inode,file);
-		if (err) {
-			fops_put(file->f_op);
-			file->private_data = NULL;
-			file->f_op = fops_get(old_fops);
-		}
-	}
-	
-	fops_put(old_fops);
-fail:
-	mutex_unlock(&himedia_sem);
-	return err;
-}
-
-
-static struct file_operations himedia_fops = {
-	.owner		= THIS_MODULE,
-	.open		= himedia_open,
-};
-
-/**
- *	himedia_register - register a himedia device
- *	@himedia: device structure
- *	
- *	Register a himedia device with the kernel. If the minor
- *	number is set to %HIMEDIA_DYNAMIC_MINOR a minor number is assigned
- *	and placed in the minor field of the structure. For other cases
- *	the minor number requested is used.
- *
- *	The structure passed is linked into the kernel and may not be
- *	destroyed until it has been unregistered.
- *
- *	A zero is returned on success and a negative errno code for
- *	failure.
- */
-
-int himedia_register(struct himedia_device *himedia)
-{	
-	struct himedia_device  *ptmp;
-    struct himedia_driver  *pdrv;
-
-	int err = 0;
-	
-	mutex_lock(&himedia_sem);
-
-	/*check if registered*/
-	osal_list_for_each_entry(ptmp, &himedia_list, list) {
-		if (ptmp->minor == himedia->minor) {
-			mutex_unlock(&himedia_sem);
-			return -EBUSY;
-		}
-	}
-
-    /*check minor*/
-	if (himedia->minor == HIMEDIA_DYNAMIC_MINOR) {
-		int i = DYNAMIC_MINORS;
-		
-		while (--i >= 0)
-			if ( (himedia_minors[i>>3] & (1 << (i&7))) == 0)
-				break;
-		if (i<0) {
-			mutex_unlock(&himedia_sem);
-			return -EBUSY;
-		}
-		
-		himedia->minor = i;
-	}
-
-	if (himedia->minor < DYNAMIC_MINORS)
-		himedia_minors[himedia->minor >> 3] |= 1 << (himedia->minor & 7);
-
-    /*device register*/
-    err = himedia_device_register(himedia);
-    if (err < 0) {
-        himedia_minors[himedia->minor >> 3] &= ~(1 << (himedia->minor & 7));
-		goto out;
+    osal_list_for_each_entry(c, &g_himedia_list, list) {
+        if (c->minor == minor) {
+            new_fops = fops_get(c->fops);
+            break;
+        }
     }
 
+    if (new_fops == NULL) {
+        mutex_unlock(&g_himedia_sem);
+        request_module("char-major-%d-%d", HIMEDIA_DEVICE_MAJOR, minor);
+        mutex_lock(&g_himedia_sem);
 
-    /*driver register*/
-	pdrv = himedia_driver_register(
-	    himedia->devfs_name, himedia->owner, himedia->drvops);
-	if (IS_ERR(pdrv)) {
+        osal_list_for_each_entry(c, &g_himedia_list, list) {
+            if (c->minor == minor) {
+                new_fops = fops_get(c->fops);
+                break;
+            }
+        }
 
+        if (new_fops == NULL) {
+            goto fail;
+        }
+    }
+
+    err = 0;
+
+    old_fops = file->f_op;
+    file->f_op = new_fops;
+    if (file->f_op->open) {
+        file->private_data = c;
+        err = file->f_op->open(inode, file);
+        if (err) {
+            fops_put(file->f_op);
+            file->private_data = NULL;
+            file->f_op = fops_get(old_fops);
+        }
+    }
+
+    fops_put(old_fops);
+fail:
+    mutex_unlock(&g_himedia_sem);
+    return err;
+}
+
+static struct file_operations g_himedia_fops = {
+    .owner = THIS_MODULE,
+    .open = himedia_open,
+};
+
+/*
+ * himedia_register - register a himedia device
+ * @himedia: device structure
+ *
+ * Register a himedia device with the kernel. If the minor
+ * number is set to %HIMEDIA_DYNAMIC_MINOR a minor number is assigned
+ * and placed in the minor field of the structure. For other cases
+ * the minor number requested is used.
+ *
+ * The structure passed is linked into the kernel and may not be
+ * destroyed until it has been unregistered.
+ *
+ * A zero is returned on success and a negative errno code for
+ * failure.
+ */
+int himedia_register(struct himedia_device *himedia)
+{
+    struct himedia_device *ptmp = NULL;
+    struct himedia_driver *pdrv = NULL;
+    int err;
+
+    mutex_lock(&g_himedia_sem);
+
+    /* check if registered */
+    osal_list_for_each_entry(ptmp, &g_himedia_list, list) {
+        if (ptmp->minor == himedia->minor) {
+            mutex_unlock(&g_himedia_sem);
+            return -EBUSY;
+        }
+    }
+
+    /* check minor */
+    if (himedia->minor == HIMEDIA_DYNAMIC_MINOR) {
+        int i = DYNAMIC_MINORS;
+
+        while (--i >= 0)
+            if ((g_himedia_minors[(unsigned int)i >> 3] &  /* 3: left shift 3bit to locate the index of char array */
+                (1 << ((unsigned int)i & 7))) == 0) { /* 7: locate the bit in bitmap */
+                break;
+            }
+        if (i < 0) {
+            mutex_unlock(&g_himedia_sem);
+            return -EBUSY;
+        }
+
+        himedia->minor = i;
+    }
+
+    if (himedia->minor < DYNAMIC_MINORS) {
+        g_himedia_minors[himedia->minor >> 3] |= 1 << (himedia->minor & 7); /* 3, 7: bitmap write set bit 1 */
+    }
+
+    /* device register */
+    err = himedia_device_register(himedia);
+    if (err < 0) {
+        g_himedia_minors[himedia->minor >> 3] &= ~(1 << (himedia->minor & 7)); /* 3, 7: bitmap write set bit 0 */
+        goto out;
+    }
+
+    /* driver register */
+    pdrv = himedia_driver_register(himedia->devfs_name, himedia->owner, himedia->drvops);
+    if (IS_ERR(pdrv)) {
         himedia_device_unregister(himedia);
 
-		himedia_minors[himedia->minor >> 3] &= ~(1 << (himedia->minor & 7));
+        g_himedia_minors[himedia->minor >> 3] &= ~(1 << (himedia->minor & 7)); /* 3, 7: bitmap write set bit 0 */
 
-		err = PTR_ERR(pdrv);
-		goto out;
-	}
+        err = PTR_ERR(pdrv);
+        goto out;
+    }
 
-	himedia->driver = pdrv;
-	
-	/*
-	 * Add it to the front, so that later devices can "override"
-	 * earlier defaults
-	 */
-	osal_list_add(&himedia->list, &himedia_list);
+    himedia->driver = pdrv;
 
- out:
-	mutex_unlock(&himedia_sem);
-	return err;
+    /*
+     * Add it to the front, so that later devices can "override"
+     * earlier defaults
+     */
+    osal_list_add(&himedia->list, &g_himedia_list);
+
+out:
+    mutex_unlock(&g_himedia_sem);
+    return err;
 }
 EXPORT_SYMBOL(himedia_register);
 
-/**
- *	himedia_unregister - unregister a himedia device
- *	@himedia: device to unregister
+/*
+ * himedia_unregister - unregister a himedia device
+ * @himedia: device to unregister
  *
- *	Unregister a himedia device that was previously
- *	successfully registered with himedia_register(). Success
- *	is indicated by a zero return, a negative errno code
- *	indicates an error.
+ * Unregister a himedia device that was previously
+ * successfully registered with himedia_register(). Success
+ * is indicated by a zero return, a negative errno code
+ * indicates an error.
  */
-
-int himedia_unregister(struct himedia_device * himedia)
+int himedia_unregister(struct himedia_device *himedia)
 {
-	struct himedia_device  *ptmp,*_ptmp;
+    struct himedia_device *ptmp = NULL;
+    struct himedia_device *_ptmp = NULL;
 
-	if (osal_list_empty(&himedia->list))
-		return -EINVAL;
+    if (osal_list_empty(&himedia->list)) {
+        return -EINVAL;
+    }
 
-	mutex_lock(&himedia_sem);
+    mutex_lock(&g_himedia_sem);
 
-	osal_list_for_each_entry_safe(ptmp, _ptmp, &himedia_list, list) {
-	
-	    /*if found, unregister device & driver*/
-		if (ptmp->minor == himedia->minor) {
-
+    osal_list_for_each_entry_safe(ptmp, _ptmp, &g_himedia_list, list) {
+        /* if found, unregister device & driver */
+        if (ptmp->minor == himedia->minor) {
             osal_list_del(&himedia->list);
 
-        	himedia_driver_unregister(himedia->driver);
+            himedia_driver_unregister(himedia->driver);
 
-        	himedia->driver = NULL;
+            himedia->driver = NULL;
 
             himedia_device_unregister(himedia);
 
-        	himedia_minors[himedia->minor>>3] &= ~(1 << (himedia->minor & 7));
+            g_himedia_minors[himedia->minor >> 3] &= ~(1 << (himedia->minor & 7)); /* 3, 7: bitmap write set bit 0 */
 
-        	break;
-		}
-	}
-    
-	mutex_unlock(&himedia_sem);
-	
-	return 0;
+            break;
+        }
+    }
+
+    mutex_unlock(&g_himedia_sem);
+
+    return 0;
 }
 EXPORT_SYMBOL(himedia_unregister);
 
-
-//static int __init himedia_init(void)
 int himedia_init(void)
 {
-	int ret;
-	// 1
-	ret = himedia_bus_init();
-	if(ret)
-		goto err0;
+    int ret;
 
-	// 2
-	ret = -EIO;
+    /* 1 */
+    ret = himedia_bus_init();
+    if (ret) {
+        goto err0;
+    }
 
-	if (register_chrdev(HIMEDIA_DEVICE_MAJOR, "himedia", &himedia_fops))
-		goto err1;
+    /* 2 */
+    ret = -EIO;
 
-	printk("Module himedia: init ok\n");
-	
-	return 0;
-	
-	// 3
+    if (register_chrdev(HIMEDIA_DEVICE_MAJOR, "himedia", &g_himedia_fops)) {
+        goto err1;
+    }
+
+    printk("Module himedia: init ok\n");
+
+    return 0;
+
+    /* 3 */
 err1:
-	himedia_bus_exit();
-err0:	
-	return ret;
+    himedia_bus_exit();
+err0:
+    return ret;
 }
 
 void himedia_exit(void)
 {
-	if (!osal_list_empty(&himedia_list))
-	{
-		printk("!!! Module himedia: sub module in list\n");
-		return;
-	}
+    /* 0 */
+    if (!osal_list_empty(&g_himedia_list)) {
+        printk("!!! Module himedia: sub module in list\n");
+        return;
+    }
 
-	unregister_chrdev(HIMEDIA_DEVICE_MAJOR, "himedia");
-	
-	himedia_bus_exit();
-	
-	printk("!!! Module himedia: exit ok\n");
+    unregister_chrdev(HIMEDIA_DEVICE_MAJOR, "himedia");
+
+    himedia_bus_exit();
+
+    printk("!!! Module himedia: exit ok\n");
 }

--- a/kernel/osal/hi3519v101/himedia/himedia.h
+++ b/kernel/osal/hi3519v101/himedia/himedia.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Hisilicon Technologies Co., Ltd. 2016-2019.
+ * Description: osal himedia header file.
+ * Author: Hisilicon multimedia software group
+ * Create: 2016-11-11
+ */
+
 #ifndef _LINUX_HIMEDIA_DEVICE_H_
 #define _LINUX_HIMEDIA_DEVICE_H_
 
@@ -6,19 +13,19 @@
 #include <linux/device.h>
 #include "osal_list.h"
 
-#define HIMEDIA_DEVICE_MAJOR  218
-#define HIMEDIA_DYNAMIC_MINOR 255
+#define HIMEDIA_DEVICE_MAJOR     218
+#define HIMEDIA_DYNAMIC_MINOR    255
 
 struct himedia_device;
 
 struct himedia_ops {
-    //pm methos
+    /* pm methos */
     int (*pm_prepare)(struct himedia_device *);
     void (*pm_complete)(struct himedia_device *);
-    
+
     int (*pm_suspend)(struct himedia_device *);
     int (*pm_resume)(struct himedia_device *);
-    
+
     int (*pm_freeze)(struct himedia_device *);
     int (*pm_thaw)(struct himedia_device *);
     int (*pm_poweroff)(struct himedia_device *);
@@ -40,35 +47,35 @@ struct himedia_ops {
     int (*pm_restore_noirq)(struct himedia_device *);
 };
 
-struct himedia_driver{
+#define HIMIDIA_MAX_DEV_NAME_LEN 32
+
+struct himedia_driver {
     struct device_driver driver;
     struct himedia_ops *ops;
-	char name[1];
+    char name[1];
 };
 
-#define to_himedia_driver(drv)	\
+#define to_himedia_driver(drv) \
     container_of((drv), struct himedia_driver, driver)
 
-struct himedia_device  {
-	struct osal_list_head list;
+struct himedia_device {
+    struct osal_list_head list;
 
-#define MAX_LEN 32	
-    char devfs_name[MAX_LEN];
-    
-	unsigned int minor;
+    char devfs_name[HIMIDIA_MAX_DEV_NAME_LEN];
+
+    unsigned int minor;
 
     struct device device;
 
-	struct module *owner;
+    struct module *owner;
 
-	const struct file_operations *fops;
-	
-	struct himedia_ops *drvops;
+    const struct file_operations *fops;
 
-    /*for internal use*/
-	struct himedia_driver *driver;
+    struct himedia_ops *drvops;
+
+    /* for internal use */
+    struct himedia_driver *driver;
 };
-
 
 #define to_himedia_device(dev) \
     container_of((dev), struct himedia_device, device)
@@ -78,7 +85,6 @@ int himedia_register(struct himedia_device *pdev);
 int himedia_unregister(struct himedia_device *pdev);
 
 #define MODULE_ALIAS_HIMEDIA(minor) \
-	MODULE_ALIAS("himedia-char-major-" __stringify(HIMEDIA_DEVICE_MAJOR) \
-	"-" __stringify(minor))
+    MODULE_ALIAS("himedia-char-major-" __stringify(HIMEDIA_DEVICE_MAJOR) "-" __stringify(minor))
 
-#endif /*_LINUX_HIMEDIA_DEVICE_H_*/
+#endif /* _LINUX_HIMEDIA_DEVICE_H_ */

--- a/kernel/osal/hi3519v101/mmz/allocator.h
+++ b/kernel/osal/hi3519v101/mmz/allocator.h
@@ -1,51 +1,38 @@
 /*
- * Copyright (c) 2006 Hisilicon Co., Ltd.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
- *
+ * Copyright (c) Hisilicon Technologies Co., Ltd. 2016-2019.
+ * Description: allocator header file.
+ * Author: Hisilicon multimedia software group
+ * Create: 2016-11-11
  */
 
 #ifndef __ALLOCATOR_H__
 #define __ALLOCATOR_H__
 
-
+#include <linux/device.h>
 #include "osal_mmz.h"
 
-#define NAME_LEN_MAX	64
-
+#define NAME_LEN_MAX 64
 
 struct mmz_allocator {
-	int (*init)(char *args);
-	hil_mmb_t *(*mmb_alloc)(const char *name,
-			unsigned long size,
-			unsigned long align,
-			unsigned long gfp,
-			const char *mmz_name,
-			hil_mmz_t *_user_mmz);
-	hil_mmb_t *(*mmb_alloc_v2)(const char *name,
-			unsigned long size,
-			unsigned long align,
-			unsigned long gfp,
-			const char *mmz_name,
-			hil_mmz_t *_user_mmz,
-			unsigned int order);
-	void *(*mmb_map2kern)(hil_mmb_t *mmb, int cached);
-	int (*mmb_unmap)(hil_mmb_t *mmb);
-	void (*mmb_free)(hil_mmb_t *mmb);
-	void *(*mmf_map)(unsigned long phys, int len, int cache);
-	void (*mmf_unmap)(void *virt);
+    int (*init)(char *args);
+    hil_mmb_t *(*mmb_alloc)(const char *name,
+                            unsigned long size,
+                            unsigned long align,
+                            unsigned long gfp,
+                            const char *mmz_name,
+                            hil_mmz_t *_user_mmz);
+    hil_mmb_t *(*mmb_alloc_v2)(const char *name,
+                               unsigned long size,
+                               unsigned long align,
+                               unsigned long gfp,
+                               const char *mmz_name,
+                               hil_mmz_t *_user_mmz,
+                               unsigned int order);
+    void *(*mmb_map2kern)(hil_mmb_t *mmb, int cached);
+    int (*mmb_unmap)(hil_mmb_t *mmb);
+    void (*mmb_free)(hil_mmb_t *mmb);
+    void *(*mmf_map)(phys_addr_t phys, int len, int cache);
+    void (*mmf_unmap)(void *virt);
 };
 
 int cma_allocator_setopt(struct mmz_allocator *allocator);

--- a/kernel/osal/hi3519v101/mmz/cma_allocator.c
+++ b/kernel/osal/hi3519v101/mmz/cma_allocator.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Hisilicon Technologies Co., Ltd. 2016-2019.
+ * Description: cma allocator source file.
+ * Author: Hisilicon multimedia software group
+ * Create: 2016-11-11
+ */
+
 #include <linux/fs.h>
 #include <linux/slab.h>
 #include <linux/init.h>
@@ -8,630 +15,607 @@
 #include <asm/cacheflush.h>
 
 #include <asm/memory.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
+#include <linux/cma.h>
+#endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
 #include <linux/dma-contiguous.h>
+#endif
 #include <linux/dma-mapping.h>
 #include <asm/memory.h>
-#include <asm/highmem.h>
 #include <asm/tlbflush.h>
 #include <asm/pgtable.h>
-#include <linux/device.h>
 #include <linux/vmalloc.h>
 
-//#include "media-mem.h"
-#include "osal_mmz.h"
 #include "allocator.h"
+#include "mmz_arm.h"
 
+#include "../../../compat/kernel_compat.h"
 
-struct cma_zone{
-	struct device pdev;
-	char name[NAME_LEN_MAX];
-	unsigned long gfp;
-	unsigned long phys_start;
-	unsigned long nbytes;
-	unsigned int alloc_type;
-	unsigned long block_align;
+/* Externs from media-mem.c — V3A osal_mmz.h doesn't publish them. */
+extern struct osal_list_head mmz_list;
+extern int anony;
+
+#define __use_vmalloc_space 1
+
+struct cma_zone {
+    struct device pdev;
+    char name[NAME_LEN_MAX];
+    unsigned long gfp;
+    unsigned long phys_start;
+    unsigned long nbytes;
+    unsigned int alloc_type;
+    unsigned long block_align;
 };
 
-extern struct osal_list_head mmz_list;
-
-extern int anony;
-extern int mmb_number; /* for mmb id */
-
-#ifdef CONFIG_CMA
-#if 1
-static int __dma_update_pte(pte_t *pte, pgtable_t token,
-		unsigned long addr, void *data)
-{
-	struct page *page = virt_to_page(addr);
-
-	pgprot_t prot = *(pgprot_t *)data;
-
-	set_pte_ext(pte, mk_pte(page, prot), 0);
-	
-	return 0;
-}
-#endif
-
-extern void __dma_clear_buffer(struct page *page, size_t size);
-#if 0
-static void __dma_clear_buffer(struct page *page, size_t size)
-{
-	void *ptr;
-	/*
-	 * Ensure that the allocated pages are zeroed, and that any data
-	 * lurking in the kernel direct-mapped region is invalidated.
-	 */
-	ptr = page_address(page);
-
-	if (ptr) {
-		/* remove memset for speed
-		memset(ptr, 0, size);
-		*/
-		
-		if (size <= SZ_1M)
-		{
-			dmac_flush_range(ptr, ptr + size);
-			outer_flush_range(__pa(ptr), __pa(ptr) + size);
-		}
-		else
-		{
-			flush_cache_all();
-			outer_flush_all();
-		}
-	}
-}
-#endif
-
-extern void hisi_flush_tlb_kernel_range(unsigned long start, unsigned long end);
-
-#if 1
-static void __dma_remap(struct page *page, size_t size, pgprot_t prot)
-{    
-#ifdef CONFIG_CMA
-	unsigned long start = (unsigned long) page_address(page);
-	unsigned end = start + size;
-
-	apply_to_page_range(&init_mm, start, size, __dma_update_pte, &prot);
-	dsb();
-	hisi_flush_tlb_kernel_range(start, end);
-	//flush_tlb_kernel_range(start, end);
-#endif
-}
-#endif
-#endif
-
+long long g_max_malloc_size = 0x40000000UL;           /* 1GB */
 
 static int do_mmb_alloc(hil_mmb_t *mmb)
 {
-	hil_mmb_t *p = NULL;
-	mmz_trace_func();
+    hil_mmb_t *p = NULL;
 
-	/* add mmb sorted */
-	osal_list_for_each_entry(p,&mmb->zone->mmb_list, list) {
-		if (mmb->phys_addr < p->phys_addr)
-			break;
+    mmz_trace_func();
 
-        //BUG_ON(mmb->phys_addr != p->phys_addr);
-        if (mmb->phys_addr == p->phys_addr)
-        {
-	        printk("ERROR: media-mem allocator bad in %s! (%s, %d)",
-                mmb->zone->name,  __FUNCTION__, __LINE__);
-
-			return -1;
+    /* add mmb into zone, sorted */
+    osal_list_for_each_entry(p, &mmb->zone->mmb_list, list) {
+        if (mmb->phys_addr < p->phys_addr) {
+            break;
         }
-	}
-	osal_list_add(&mmb->list, p->list.prev);
 
-	mmz_trace(1, HIL_MMB_FMT_S, hil_mmb_fmt_arg(mmb));
+        if (mmb->phys_addr == p->phys_addr) {
+            pr_err("ERROR:cma allocator bad in %s(%s, %d)",
+                   mmb->zone->name, __func__, __LINE__);
+            return -EFAULT;
+        }
+    }
 
-	return 0;
+    osal_list_add(&mmb->list, p->list.prev);
+    mmz_trace(1, HIL_MMB_FMT_S, hil_mmb_fmt_arg(mmb));
+
+    return 0;
 }
 
 static hil_mmb_t *__mmb_alloc(const char *name,
-		unsigned long size,
-		unsigned long align, 
-		unsigned long gfp,
-		const char *mmz_name,
-		hil_mmz_t *_user_mmz)
+                              unsigned long size,
+                              unsigned long align,
+                              unsigned long gfp,
+                              const char *mmz_name,
+                              hil_mmz_t *_user_mmz)
 {
-#ifdef CONFIG_CMA
-	hil_mmz_t *mmz;
-	hil_mmb_t *mmb;
+    hil_mmz_t *mmz = NULL;
+    hil_mmb_t *mmb = NULL;
+    unsigned long order;
+    size_t count;
+    struct page *page = NULL;
 
-	unsigned long order;
-	size_t count;
-	struct page *page = NULL;
+    mmz_trace_func();
 
-	unsigned long fixed_start = 0;
+    /*
+     * No zero length memory request, no supper
+     * large memory (4GB and above) request.
+     */
+    if ((size == 0) || (size > g_max_malloc_size)) {
+        return NULL;
+    }
 
-	hil_mmz_t *fixed_mmz = NULL;
+    if (align == 0) {
+        align = MMZ_GRAIN;
+    }
 
-	mmz_trace_func();
+    size = mmz_grain_align(size);
+    order = get_order(size);
+    count = size >> PAGE_SHIFT;
 
-	/*
-	 * no more than 1GB
-	 */
-	if (size == 0 || size > 0x40000000UL)
-		return NULL;
+    mmz_trace(1, "anonymous=%s,size=%luKB,align=%lu", mmz_name, size / SZ_1K, align);
 
-	if (align == 0)
-		align = MMZ_GRAIN;
+    begin_list_for_each_mmz(mmz, gfp, mmz_name)
 
-	size = mmz_grain_align(size);
-	order = get_order(size);
-	count = size>>PAGE_SHIFT;
+    if ((_user_mmz != NULL) && (_user_mmz != mmz)) {
+        continue;
+    }
 
-	mmz_trace(1,"size=%luKB, align=%lu", size/SZ_1K, align);
+    page = compat_dma_alloc_from_contiguous(mmz->cma_dev, count, order);
+    if (page == NULL) {
+        return NULL;
+    }
 
-	begin_list_for_each_mmz(mmz, gfp, mmz_name)
+    /* Get it */
+    break;
+    end_list_for_each_mmz()
 
-		if ((_user_mmz != NULL) && (_user_mmz != mmz))
-			continue;
+    if (page == NULL) {
+        return NULL;
+    }
 
-		page = dma_alloc_from_contiguous(mmz->cma_dev, count, order);
-		if (!page)
-			break;
-		fixed_mmz = mmz;
-		fixed_start = page_to_phys(page);
-		break;
+    /* clear the allocated buffer, if needed! */
+    dma_buffer_clear(page, size);
 
-	end_list_for_each_mmz()
+    mmb = kmalloc(sizeof(hil_mmb_t), GFP_KERNEL);
+    if (mmb == NULL) {
+        pr_err("<%s,%d> mmb struct alloc failed\n", __func__, __LINE__);
+        goto cma_free;
+    }
 
-	if (fixed_mmz == NULL)
-		return NULL;
-	if (page)
-		__dma_clear_buffer(page, size);
+    memset(mmb, 0, sizeof(hil_mmb_t));
+    mmb->zone = mmz;
+    mmb->phys_addr = page_to_phys(page);
+    mmb->length = size;
 
-	mmb = kmalloc(sizeof(hil_mmb_t), GFP_KERNEL);
-	if (mmb == NULL)
-		goto cma_free;
-	memset(mmb, 0, sizeof(hil_mmb_t));
+    if (name != NULL) {
+        compat_strlcpy(mmb->name, name, HIL_MMB_NAME_LEN);
+    } else {
+        strncpy(mmb->name, "<null>", HIL_MMB_NAME_LEN - 1);
+    }
 
-	mmb->zone = fixed_mmz;
-	mmb->phys_addr = fixed_start;
-	mmb->length = size;
-	mmb->id = ++mmb_number;
+    if (do_mmb_alloc(mmb)) {
+        goto mmb_free;
+    }
 
-	if (name)
-		strlcpy(mmb->name, name, HIL_MMB_NAME_LEN);
-	else
-		strncpy(mmb->name, "<null>", HIL_MMB_NAME_LEN - 1);
-
-	if (do_mmb_alloc(mmb))
-		goto mmb_free;
-
-	return mmb;
+    return mmb;
 
 mmb_free:
-	kfree(mmb);
+    kfree(mmb);
+    mmb = NULL;
 cma_free:
-	dma_release_from_contiguous(mmz->cma_dev, page, count);
-#endif
-	return NULL;
+    dma_release_from_contiguous(mmz->cma_dev, page, count);
+    return NULL;
 }
 
 static hil_mmb_t *__mmb_alloc_v2(const char *name,
-		unsigned long size,
-		unsigned long align,
-		unsigned long gfp, 
-		const char *mmz_name,
-		hil_mmz_t *_user_mmz,
-		unsigned int order)
+                                 unsigned long size,
+                                 unsigned long align,
+                                 unsigned long gfp,
+                                 const char *mmz_name,
+                                 hil_mmz_t *_user_mmz,
+                                 unsigned int order)
 {
-	hil_mmz_t *mmz;
-	hil_mmb_t *mmb;
-	unsigned int i;
+    hil_mmz_t *mmz = NULL;
+    hil_mmb_t *mmb = NULL;
+    unsigned int i;
+    unsigned long cma_order;
+    size_t count = size >> PAGE_SHIFT;
+    struct page *page = NULL;
 
-	unsigned long cma_order;
-	size_t count = size >> PAGE_SHIFT;
-	struct page *page = NULL;
+    mmz_trace_func();
 
-	unsigned long fixed_start = 0;
+    /*
+     * No zero length memory request, no supper
+     * large memory (4GB and above) request.
+     */
+    if ((size == 0) || (size > g_max_malloc_size)) {
+        return NULL;
+    }
 
-	hil_mmz_t *fixed_mmz=NULL;
+    if (align == 0) {
+        align = 1;
+    }
 
-	mmz_trace_func();
+    size = mmz_grain_align(size);
 
-	if ((size == 0) || (size > 0x40000000UL))
-		return NULL;
+    mmz_trace(1, "size=%luKB, align=%lu", size / SZ_1K, align);
 
-	if (align == 0)
-		align = 1;
+    begin_list_for_each_mmz(mmz, gfp, mmz_name)
 
-	size = mmz_grain_align(size);
+    if ((_user_mmz != NULL) && (_user_mmz != mmz)) {
+        continue;
+    }
 
-	mmz_trace(1,"size=%luKB, align=%lu", size/SZ_1K, align);
+    if (mmz->alloc_type == SLAB_ALLOC) {
+        if ((size - 1) & size) {
+            for (i = 1; i < 32; i++) { /* 32: the max size is 2^(32-1) */
+                if (!((size >> i) & ~0)) {
+                    size = 1 << i;
+                    break;
+                }
+            }
+        }
+    } else if (mmz->alloc_type == EQ_BLOCK_ALLOC) {
+        size = mmz_align2(size, mmz->block_align);
+    }
 
-	begin_list_for_each_mmz(mmz, gfp, mmz_name)
-		if ((_user_mmz != NULL) && (_user_mmz != mmz))
-			continue;
+    cma_order = get_order(size);
+    page = compat_dma_alloc_from_contiguous(mmz->cma_dev, count, cma_order);
+    if (page == NULL) {
+        return NULL;
+    }
 
-		if (mmz->alloc_type == SLAB_ALLOC) {
-			if ((size-1) & size) {
-				for (i = 1; i <= 32; i++) {
-					if (!((size >> i) & ~0)) {
-						size = 1 << i;	
-						break;
-					}						
-				}	
-			}
-		} else if (mmz->alloc_type == EQ_BLOCK_ALLOC) {
-			size = mmz_align2(size,mmz->block_align);
-		}
+    /* Get it */
+    break;
+    end_list_for_each_mmz()
 
-		cma_order = get_order(size);		     	
+    if (page == NULL) {
+        return NULL;
+    }
 
-		page = dma_alloc_from_contiguous(mmz->cma_dev, count, cma_order);
-		if (!page)
-			return NULL;
+    /* clear the allocated buffer, if needed! */
+    dma_buffer_clear(page, size);
 
-		fixed_mmz = mmz;
-		fixed_start = page_to_phys(page);
-		break;
-	end_list_for_each_mmz()
+    mmb = kmalloc(sizeof(hil_mmb_t), GFP_KERNEL);
+    if (mmb == NULL) {
+        pr_err("<%s,%d> mmb struct alloc failed\n", __func__, __LINE__);
+        goto cma_free;
+    }
 
-	if (fixed_mmz == NULL)
-		return NULL;
+    memset(mmb, 0, sizeof(hil_mmb_t));
+    mmb->zone = mmz;
+    mmb->phys_addr = page_to_phys(page);
+    mmb->length = size;
+    mmb->order = order;
 
-	mmb = kmalloc(sizeof(hil_mmb_t), GFP_KERNEL);
-	
-	//mark by liucan, need fix.
-	if (mmb == NULL)
-		goto cma_free;
+    if (name != NULL) {
+        compat_strlcpy(mmb->name, name, HIL_MMB_NAME_LEN);
+    } else {
+        strncpy(mmb->name, "<null>", HIL_MMB_NAME_LEN - 1);
+    }
 
-	memset(mmb, 0, sizeof(hil_mmb_t));
+    if (do_mmb_alloc(mmb)) {
+        goto mmb_free;
+    }
 
-	mmb->zone = fixed_mmz;
-	mmb->phys_addr = fixed_start;
-	mmb->length = size;
-	mmb->order = order;
-
-	if (name)
-		strlcpy(mmb->name, name, HIL_MMB_NAME_LEN);
-	else
-		strncpy(mmb->name, "<null>", HIL_MMB_NAME_LEN - 1);
-
-	if (do_mmb_alloc(mmb))
-		goto mmb_free;
-
-	return mmb;
+    return mmb;
 
 mmb_free:
-    if(mmb)
-    {
-	    kfree(mmb);
-    }
+    kfree(mmb);
+    mmb = NULL;
 cma_free:
-    if(page)
-    {
-	    dma_release_from_contiguous(mmz->cma_dev, page, count);
-    }
-
-	return NULL;
+    dma_release_from_contiguous(mmz->cma_dev, page, count);
+    return NULL;
 }
 
 static void __mmb_free(hil_mmb_t *mmb)
 {
-	size_t count = mmb->length >> PAGE_SHIFT;
-	struct page *page = phys_to_page(mmb->phys_addr);
+    size_t count = mmb->length >> PAGE_SHIFT;
+    struct page *page = phys_to_page(mmb->phys_addr);
+    hil_mmz_t *mmz = mmb->zone;
 
-	hil_mmz_t *mmz = mmb->zone;
+    if (mmb->flags & HIL_MMB_MAP2KERN_CACHED) {
+        mmb_dcache_flush(mmb);
+    }
 
-	if (mmb->flags & HIL_MMB_MAP2KERN_CACHED) {
-		__cpuc_flush_dcache_area((void *)mmb->kvirt, (size_t)mmb->length);
-		outer_flush_range(mmb->phys_addr, mmb->phys_addr + mmb->length);
-	}
+    dma_release_from_contiguous(mmz->cma_dev, page, count);
 
-	dma_release_from_contiguous(mmz->cma_dev, page, count);
-
-	osal_list_del(&mmb->list);
-	kfree(mmb);
+    osal_list_del(&mmb->list);
+    kfree(mmb);
 }
-
-static int __mmb_unmap(hil_mmb_t* mmb);
-#define MAX_MALLOC_PAGENR  400
 
 static void *__mmb_map2kern(hil_mmb_t *mmb, int cached)
 {
-#ifdef CONFIG_CMA
-	pgprot_t prot;
-	struct page* page = phys_to_page(mmb->phys_addr);
+    pgprot_t prot;
+    struct page *page = phys_to_page(mmb->phys_addr);
 
-	if (mmb->flags & HIL_MMB_MAP2KERN) {
-		/*
-		 * if already mapped to kernel address space.
-		 */
-		if((cached * HIL_MMB_MAP2KERN_CACHED)
-				!= (mmb->flags & HIL_MMB_MAP2KERN_CACHED)) {
-			printk(KERN_ERR "mmb<%s> has been kernel-mapped %s, \
-					can not be re-mapped as %s.",
-					mmb->name,
-					(mmb->flags&HIL_MMB_MAP2KERN_CACHED) ? "cached" : "non-cached",
-					(cached) ? "cached" : "non-cached" );
-			return NULL;
-		}
-		mmb->map_ref++;
-		return mmb->kvirt;
-	}
+    mmz_trace(1, "mmb[phys_addr=%lx,kvirt=%pK,length=%lx]",
+              mmb->phys_addr, mmb->kvirt, mmb->length);
 
-	if (cached) {
-		mmb->flags |= HIL_MMB_MAP2KERN_CACHED;
-		prot = pgprot_kernel;
-	} else {
-		mmb->flags &= ~HIL_MMB_MAP2KERN_CACHED;
-		prot = pgprot_noncached(pgprot_kernel);
-	}
+    if (mmb->flags & HIL_MMB_MAP2KERN) {
+        if ((!!cached * HIL_MMB_MAP2KERN_CACHED) != (mmb->flags & HIL_MMB_MAP2KERN_CACHED)) {
+            pr_err("mmb<%s> has been kernel-mapped %s, can not be re-mapped as %s.",
+                   mmb->name,
+                   (mmb->flags & HIL_MMB_MAP2KERN_CACHED) ? "cached" : "non-cached",
+                   (cached) ? "cached" : "non-cached");
+            return NULL;
+        }
 
-	if (PageHighMem(page)) {
-		int i;
-		struct page **pages;
-		unsigned int pagesnr = mmb->length / PAGE_SIZE;
-		struct page *tmp = page;
-		int array_size = sizeof(struct page *) * pagesnr;
-		struct vm_struct *area;
+        mmz_trace(1, "map[%lx --> %pK]", mmb->phys_addr, mmb->kvirt);
 
-		/*
-		 * Noted: mmb->length would be very large in some cases(for example:
-		 * more than one Giga Bytes). and array_size would be very large as
-		 * well. So, don't use kmalloc here.
-		 */
-		pages = vmalloc(array_size);
-		if (pages == NULL) {
-			printk(KERN_ERR "ptr array(0x%x) vmalloc failed.\n", array_size);
-			return NULL;
-		}
+        mmb->map_ref++;
+        return mmb->kvirt;
+    }
 
-		for (i = 0; i < pagesnr; i++) {
-			*(pages+i) = tmp;
-			tmp++;
-		}
+    prot = arch_kern_pgprot(cached);
 
-		area = __get_vm_area((pagesnr << PAGE_SHIFT), VM_MAP,
-				VMALLOC_START, VMALLOC_END);
-		if (!area) {
-			printk(KERN_ERR "get vm area from high failed!\n");
-			vfree(pages);
-			return NULL;
-		}
+#if __use_vmalloc_space
+    /*
+     * Map into vmalloc space
+     */
+    {
+        int i;
+        struct page **pages = NULL;
+        unsigned int pagesnr = mmb->length / PAGE_SIZE;
+        struct page *tmp = page;
+        int array_size = sizeof(struct page *) * pagesnr;
 
-		if (map_vm_area(area, prot, pages)) {
-			printk(KERN_ERR "map vm area to mmz pages failed!\n");
-			vunmap(area->addr);
-			vfree(pages);
-			return NULL;
-		}
-		mmb->kvirt = area->addr;
-		//mmb->kvirt = vmap(pages, pagesnr, VM_MAP, prot);
+        /*
+         * Noted: mmb->length would be very large in some cases(for example:
+         * more than one Giga Bytes). and array_size would be very large as
+         * well. So, don't use kmalloc here.
+         */
+        pages = vmalloc(array_size);
+        if (pages == NULL) {
+            pr_err("ptr array(0x%x) vmalloc failed.\n", array_size);
+            return NULL;
+        }
 
-		vfree(pages);
-	} else {
-		__dma_remap(page, mmb->length, prot);
-		mmb->kvirt = __va(mmb->phys_addr);
-	}
+        for (i = 0; i < pagesnr; i++) {
+            *(pages + i) = tmp;
+            tmp++;
+        }
 
-	if (NULL == mmb->kvirt) {
-		/*
-		 * you never get here.
-		 */
-		printk(KERN_ERR "mmb[0x%lx, 0x%lx] map to kernel failed\n",
-				mmb->phys_addr, mmb->length);
-		return NULL;
-	}
+        mmb->kvirt = vmap(pages, pagesnr, VM_MAP, prot);
+        vfree(pages);
+        pages = NULL;
+    }
+#else
+    /*
+     * Map into linear space
+     */
+    {
+        dma_pages_remap(page, mmb->length, prot);
+        mmb->kvirt = __va(mmb->phys_addr);
+    }
+#endif
+    if (mmb->kvirt == NULL) {
+        /*
+         * you should never get here.
+         */
+        printk(KERN_ERR "mmb[0x%lx, 0x%lx] map to kernel failed\n",
+               mmb->phys_addr, mmb->length);
+        return NULL;
+    }
 
-	mmb->flags |= HIL_MMB_MAP2KERN;
-	mmb->map_ref++;
+    if (cached) {
+        mmb->flags |= HIL_MMB_MAP2KERN_CACHED;
+    } else {
+        mmb->flags &= ~HIL_MMB_MAP2KERN_CACHED;
+    }
+    mmb->flags |= HIL_MMB_MAP2KERN;
+    mmb->map_ref++;
 
-	return mmb->kvirt;
-    #else
-    return NULL;
-    #endif
+    mmz_trace(1, "map[%lx --> %pK]", mmb->phys_addr, mmb->kvirt);
+
+    return mmb->kvirt;
 }
 
 static int __mmb_unmap(hil_mmb_t *mmb)
 {
-	int ref;
-	struct page* page = phys_to_page(mmb->phys_addr);
+    int ref;
 
-	if (mmb->flags & HIL_MMB_MAP2KERN_CACHED) {
-		__cpuc_flush_dcache_area((void *)mmb->kvirt, (size_t)mmb->length);
-		outer_flush_range(mmb->phys_addr, mmb->phys_addr + mmb->length);
-	}
+    mmz_trace(1, "mmb[phys_addr=%lx,kvirt=%pK,length=%lx]",
+              mmb->phys_addr, mmb->kvirt, mmb->length);
 
-	if (mmb->flags & HIL_MMB_MAP2KERN) {
-		ref = --mmb->map_ref;
-		if (mmb->map_ref != 0)
-			return ref;
+    if (mmb->flags & HIL_MMB_MAP2KERN_CACHED) {
+        mmb_dcache_flush(mmb);
+    }
 
-		//__dma_remap(page, mmb->length, pgprot_kernel);
-		// iounmap(mmb->kvirt);
-	}
+    if (mmb->flags & HIL_MMB_MAP2KERN) {
+        ref = --mmb->map_ref;
+        if (mmb->map_ref != 0) {
+            return ref;
+        }
+    }
 
-	if (PageHighMem(page))
-		vunmap(mmb->kvirt);
-	mmb->kvirt = NULL;
-	mmb->flags &= ~HIL_MMB_MAP2KERN;
-	mmb->flags &= ~HIL_MMB_MAP2KERN_CACHED;
+#if __use_vmalloc_space
+    /*
+     * unmap from vmalloc space.
+     */
+    {
+        vunmap(mmb->kvirt);
+    }
+#endif
+    mmb->kvirt = NULL;
+    mmb->flags &= ~HIL_MMB_MAP2KERN;
+    mmb->flags &= ~HIL_MMB_MAP2KERN_CACHED;
 
-	if ((mmb->flags & HIL_MMB_RELEASED) && (mmb->phy_ref == 0))
-		__mmb_free(mmb);
+    if ((mmb->flags & HIL_MMB_RELEASED) && (mmb->phy_ref == 0)) {
+        __mmb_free(mmb);
+    }
 
-	return 0;
+    return 0;
 }
 
 /*
- * this function is added for some extra-requirements from
- * some customers, and the implementation is not strictly
- * in accordance with our early design idea, logically. FIXME
+ * Map any valid phys address passed by users, to virtual address.
+ * The input phys may not be 4Kbytes aligned.
+ * FIX ME
  */
-static void *__mmf_map(unsigned long phys, int len, int cache)
+static void *__mmf_map(phys_addr_t phys, int len, int cache)
 {
-#ifdef CONFIG_CMA
-	struct page **pages;
-	unsigned int pagesnr = len / PAGE_SIZE;
-	int i;
-	void *virt;
-	pgprot_t prot;
-	struct page* page = phys_to_page(phys);	
-	struct page *tmp = page;
-	int array_size = sizeof(struct page *) * pagesnr;
+    struct page **pages = NULL;
+    unsigned int pagesnr = len / PAGE_SIZE;
+    int i;
+    void *virt = NULL;
+    pgprot_t prot;
+    struct page *page = phys_to_page(phys);
+    struct page *tmp = page;
+    int array_size;
 
-	if (cache) {
-		prot = pgprot_kernel;
-	} else {
-		prot = pgprot_noncached(pgprot_kernel);
-	}
+    mmz_trace(1, "phys=%lx, len=0x%x, cache=%d", (unsigned long)phys, len, cache);
 
-	if (PageHighMem(page)) {
-		struct vm_struct *area;
-		/*
-		 * Noted: length of region may be very large in some cases(for example:
-		 * more than one Giga Bytes). and array_size would be very large as
-		 * well. So, don't use kmalloc here.
-		 */
-		pages = vmalloc(array_size);
-		if (pages == NULL)	{
-			printk(KERN_ERR "ptr array(0x%x) vmalloc failed.\n", array_size);
-			return NULL;
-		}
+    /*
+     * if the given phys is not page aligned, we need to
+     * map one more page for the leftover.
+     */
+    if (((phys & 0xfff) + len) > PAGE_SIZE) {
+        pagesnr += 1;
+    }
 
-		for (i = 0; i < pagesnr; i++) {
-			*(pages+i) = tmp;
-			tmp++;
-		}
+    array_size = sizeof(struct page *) * pagesnr;
 
-		area = __get_vm_area((pagesnr << PAGE_SHIFT), VM_MAP,
-				VMALLOC_START, VMALLOC_END);
-		if (!area) {
-			printk(KERN_ERR "get vm area from high failed!\n");
-			vfree(pages);
-			return NULL;
-		}
+    prot = arch_kern_pgprot(cache);
 
-		if (map_vm_area(area, prot, pages)) {
-			printk(KERN_ERR "map vm area to mmz pages failed!\n");
-			vunmap(area->addr);
-			vfree(pages);
-			return NULL;
-		}
-		virt = area->addr;
+#if __use_vmalloc_space
+    /*
+     * Map into vmalloc space.
+     */
+    {
+        /*
+         * Noted: length of region may be very large in some cases(for example:
+         * more than one Giga Bytes). and array_size would be very large as
+         * well. So, don't use kmalloc here.
+         */
+        pages = vmalloc(array_size);
+        if (pages == NULL) {
+            printk(KERN_ERR "ptr vmalloc %d failed.\n", array_size);
+            return NULL;
+        }
 
-		//virt = vmap(pages, pagesnr, VM_MAP, prot);
-		vfree(pages);
-	} else {
-		__dma_remap(page, len, prot);
-		virt = __va(phys);
-	}
+        for (i = 0; i < pagesnr; i++) {
+            *(pages + i) = tmp;
+            tmp++;
+        }
 
-	return virt;
-    #else
-    return NULL;
-    #endif
+        virt = vmap(pages, pagesnr, VM_MAP, prot);
+        vfree(pages);
+        pages = NULL;
+
+        if (virt == NULL) {
+            return NULL;
+        }
+
+        virt += (phys & 0xfff);
+    }
+#else
+    /*
+     * Map into linear space
+     */
+    {
+        dma_pages_remap(page, len, prot);
+        virt = __va(phys);
+    }
+#endif
+
+    mmz_trace(1, "map[%lx --> %pK]", (unsigned long)phys, virt);
+
+    return virt;
 }
 
-/*
- * this function is added for some extra-requirements from
- * some customers, and the implementation is not strictly
- * in accordance with our early design idea, logically. FIXME
- */
 static void __mmf_unmap(void *virt)
 {
-	unsigned long vaddr = (unsigned long)virt;
-	if ((vaddr >= VMALLOC_START) && (vaddr < VMALLOC_END))
-		vunmap(virt);
+    unsigned long vaddr = (unsigned long)(uintptr_t)virt;
+
+    mmz_trace(1, "virt=%pK", virt);
+
+    /*
+     * virtual address to be vunmaped should be page aligned
+     */
+    vaddr &= 0xfffff000;
+
+    if ((vaddr >= VMALLOC_START) && (vaddr < VMALLOC_END)) {
+        vunmap ((void *)(uintptr_t)vaddr);
+    }
 }
 
 static int __allocator_init(char *s)
 {
-    #ifdef CONFIG_CMA
-	hil_mmz_t *zone = NULL;
-	char *line;
-	struct cma_zone *cma_zone = NULL;
-	int attempted = 0, registered = 0;
+#ifdef CONFIG_CMA
+    hil_mmz_t *zone = NULL;
+    char *line = NULL;
+    struct cma_zone *cma_zone = NULL;
+    int attempted = 0, registered = 0;
 
-	while ((line = strsep(&s, ":")) != NULL) {
-		int i;
-		char *argv[6];
-		extern struct cma_zone * hisi_get_cma_zone(const char* name);
-		/*
-		 * FIXME: We got 4 args in "line", formated "argv[0],argv[1],argv[2],argv[3],argv[4]".
-		 * eg: "<mmz_name>,<gfp>,<phys_start_addr>,<size>,<alloc_type>"
-		 * For more convenient, "hard code" are used such as "arg[0]", i.e.
-		 */
-		for (i=0; (argv[i] = strsep(&line, ",")) != NULL;)
-			if (++i == ARRAY_SIZE(argv)) break;
+    while ((line = strsep(&s, ":")) != NULL) {
+        int i;
+        char *argv[6]; /* 6: cmdline include six arguments */
+        /*
+         * FIX ME: We got 4 args in "line", formated as
+         * "argv[0],argv[1],argv[2],argv[3],argv[4]".
+         * eg: "<mmz_name>,<gfp>,<phys_start>,<size>,<alloc_type>"
+         * For more convenient, "hard code" are used such as "arg[0]", i.e.
+         */
+        for (i = 0; (argv[i] = strsep(&line, ",")) != NULL;)
+            if (++i == ARRAY_SIZE(argv)) {
+                break;
+            }
 
-		cma_zone = hisi_get_cma_zone(argv[0]);
-		if (!cma_zone) {
-			printk(KERN_ERR"can't get cma zone info:%s\n",argv[0]);
-			continue;
-		}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
+        /* Mainline kernels: use default CMA area, no vendor zone lookup */
+        cma_zone = NULL;
+        {
+            struct cma *default_cma = dev_get_cma_area(NULL);
+            if (default_cma) {
+                static struct cma_zone default_zone;
+                default_zone.gfp = 0;
+                default_zone.phys_start = cma_get_base(default_cma);
+                default_zone.nbytes = cma_get_size(default_cma);
+                cma_zone = &default_zone;
+            }
+        }
+#else
+        {
+            extern struct cma_zone *hisi_get_cma_zone(const char *name);
+            cma_zone = hisi_get_cma_zone(argv[0]);
+        }
+#endif
+        if (cma_zone == NULL) {
+            printk(KERN_ERR "can't get cma zone info:%s\n", argv[0]);
+            continue;
+        }
 
-		if (i == 4) {
-			zone = hil_mmz_create("null",0,0,0);
-			if (zone == NULL) {
-				continue;
-			}
+        if (i == 4) { /* 4: had parse four args */
+            zone = hil_mmz_create("null", 0, 0, 0);
+            if (zone == NULL) {
+                continue;
+            }
 
-			strlcpy(zone->name, argv[0], HIL_MMZ_NAME_LEN);
+            compat_strlcpy(zone->name, argv[0], HIL_MMZ_NAME_LEN);
 
-			printk("cmz zone gfp 0x%lx, phys 0x%lx, nbytes 0x%lx\n",
-					cma_zone->gfp,
-					cma_zone->phys_start,
-					cma_zone->nbytes);
-			zone->gfp = cma_zone->gfp;
-			zone->phys_start = cma_zone->phys_start;
-			zone->nbytes = cma_zone->nbytes;
-			zone->cma_dev = &cma_zone->pdev;
-		} else if (i == 6) {
-			zone = hil_mmz_create_v2("null",0,0,0,0,0);
+            printk("cmz zone gfp 0x%lx, phys 0x%lx, nbytes 0x%lx\n",
+                   cma_zone->gfp,
+                   cma_zone->phys_start,
+                   cma_zone->nbytes);
+            zone->gfp = cma_zone->gfp;
+            zone->phys_start = cma_zone->phys_start;
+            zone->nbytes = cma_zone->nbytes;
+            zone->cma_dev = &cma_zone->pdev;
 
-			if (zone == NULL) {
-				continue;
-			}
+            if (zone->nbytes > g_max_malloc_size) {
+                g_max_malloc_size = zone->nbytes;
+            }
+        } else if (i == 6) { /* 6: had parse six args */
+            zone = hil_mmz_create_v2("null", 0, 0, 0, 0, 0);
+            if (zone == NULL) {
+                continue;
+            }
 
-			strlcpy(zone->name, argv[0], HIL_MMZ_NAME_LEN);
+            compat_strlcpy(zone->name, argv[0], HIL_MMZ_NAME_LEN);
 
-			zone->gfp = cma_zone->gfp;
-			zone->phys_start = cma_zone->phys_start;
-			zone->nbytes = cma_zone->nbytes;
-			zone->alloc_type = cma_zone->alloc_type;
-			zone->block_align = cma_zone->block_align;
-			zone->cma_dev = &cma_zone->pdev;
-		} else {
-			printk(KERN_ERR "MMZ: your parameter num is not correct!\n");
-			continue;
-		}
+            zone->gfp = cma_zone->gfp;
+            zone->phys_start = cma_zone->phys_start;
+            zone->nbytes = cma_zone->nbytes;
+            zone->alloc_type = cma_zone->alloc_type;
+            zone->block_align = cma_zone->block_align;
+            zone->cma_dev = &cma_zone->pdev;
 
-		attempted++;
-		if (hil_mmz_register(zone)) {
-			printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n", hil_mmz_fmt_arg(zone));
-			hil_mmz_destroy(zone);
-		} else {
-			registered++;
-		}
+            if (zone->nbytes > g_max_malloc_size) {
+                g_max_malloc_size = zone->nbytes;
+            }
+        } else {
+            printk(KERN_ERR "Input parameter num incorrect!\n");
+            continue;
+        }
 
-		zone = NULL;
-	}
+        attempted++;
+        if (hil_mmz_register(zone)) {
+            printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n",
+                   hil_mmz_fmt_arg(zone));
+            hil_mmz_destroy(zone);
+        } else {
+            registered++;
+        }
 
-	if (attempted > 0 && registered == 0) {
-		printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
-				attempted);
-		return -ENODEV;
-	}
-    #endif
-	return 0;
+        zone = NULL;
+    }
+
+    if (attempted > 0 && registered == 0) {
+        printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
+                attempted);
+        return -ENODEV;
+    }
+#endif
+
+    return 0;
 }
 
 int cma_allocator_setopt(struct mmz_allocator *allocator)
 {
-	allocator->init = __allocator_init;
-	allocator->mmb_alloc = __mmb_alloc;
-	allocator->mmb_alloc_v2 = __mmb_alloc_v2;
-	allocator->mmb_map2kern = __mmb_map2kern;
-	allocator->mmb_unmap = __mmb_unmap;
-	allocator->mmb_free = __mmb_free;
-	allocator->mmf_map = __mmf_map;
-	allocator->mmf_unmap = __mmf_unmap;
-	return 0;
-}
+    allocator->init = __allocator_init;
+    allocator->mmb_alloc = __mmb_alloc;
+    allocator->mmb_alloc_v2 = __mmb_alloc_v2;
+    allocator->mmb_map2kern = __mmb_map2kern;
+    allocator->mmb_unmap = __mmb_unmap;
+    allocator->mmb_free = __mmb_free;
+    allocator->mmf_map = __mmf_map;
+    allocator->mmf_unmap = __mmf_unmap;
 
+    return 0;
+}

--- a/kernel/osal/hi3519v101/mmz/hisi_allocator.c
+++ b/kernel/osal/hi3519v101/mmz/hisi_allocator.c
@@ -1,21 +1,8 @@
-/* media-mem.c
- *
- * Copyright (c) 2006 Hisilicon Co., Ltd.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
- *
+/*
+ * Copyright (c) Hisilicon Technologies Co., Ltd. 2016-2019.
+ * Description: hisi allocator source file.
+ * Author: Hisilicon multimedia software group
+ * Create: 2016-11-11
  */
 
 #include <linux/fs.h>
@@ -27,528 +14,569 @@
 #include <linux/list.h>
 #include <asm/cacheflush.h>
 #include <linux/version.h>
-
-//#include "media-mem.h"
-#include "osal_mmz.h"
 #include "allocator.h"
+#include "osal_mmz.h"
 
+#include "../../../compat/kernel_compat.h"
+
+/* media-mem.c owns these; hisi_allocator.c references them via the
+ * begin_list_for_each_mmz macro in osal_mmz.h. cv500's osal_mmz.h
+ * publishes extern decls under g_mmz_list; V3A's older header uses
+ * the unprefixed name mmz_list (matches the definition in media-mem.c)
+ * but doesn't declare extern. Declare here for the cv500-imported
+ * cma_allocator/hisi_allocator TUs. */
 extern struct osal_list_head mmz_list;
-
 extern int anony;
-extern int mmb_number; /* for mmb id */
+/* hil_mmz_unregister is exported from media-mem.c (V3A) — declared here
+ * since 3519v101's osal_mmz.h doesn't list it. */
+extern int hil_mmz_unregister(hil_mmz_t *zone);
+
+long long g_hi_max_malloc_size = 0x40000000UL;        /* 1GB */
 
 static unsigned long _strtoul_ex(const char *s, char **ep, unsigned int base)
 {
-        char *__end_p;
-        unsigned long __value;
+    char *__end_p = NULL;
+    unsigned long __value;
 
-        __value = simple_strtoul(s,&__end_p,base);
+    __value = simple_strtoul(s, &__end_p, base);
 
-        switch(*__end_p) {
+    switch (*__end_p) {
         case 'm':
         case 'M':
-                __value <<= 10;
+            __value <<= 10; /* 10: 1M=1024k, left shift 10bit */
+            /* fall-through */
         case 'k':
         case 'K':
-                __value <<= 10;
-                if(ep)
-                        (*ep) = __end_p + 1;
+            __value <<= 10; /* 10: 1K=1024Byte, left shift 10bit */
+            if (ep != NULL) {
+                (*ep) = __end_p + 1;
+            }
+            /* fall-through */
         default:
-                break;
-        }
+            break;
+    }
 
-        return __value;
+    return __value;
 }
 
 static unsigned long find_fixed_region(unsigned long *region_len,
-		hil_mmz_t *mmz,
-		unsigned long size,
-		unsigned long align)
+                                       hil_mmz_t *mmz,
+                                       unsigned long size,
+                                       unsigned long align)
 {
-	unsigned long start;
-	unsigned long fixed_start = 0;
-	unsigned long fixed_len = -1;
-	unsigned long len =0;
-	unsigned long blank_len =0;
-	hil_mmb_t *p = NULL;
+    unsigned long start;
+    unsigned long fixed_start = 0;
+    unsigned long fixed_len = -1;
+    unsigned long len;
+    unsigned long blank_len;
+    hil_mmb_t *p = NULL;
 
-	mmz_trace_func();
-	align = mmz_grain_align(align);
-	if(align == 0)align = MMZ_GRAIN;
-	start = mmz_align2(mmz->phys_start, align);
-	len = mmz_grain_align(size);
+    mmz_trace_func();
+    align = mmz_grain_align(align);
+    if (align == 0) {
+        align = MMZ_GRAIN;
+    }
+    start = mmz_align2(mmz->phys_start, align);
+    len = mmz_grain_align(size);
 
-	osal_list_for_each_entry(p,&mmz->mmb_list, list) {
-		hil_mmb_t *next;
-		mmz_trace(4,"p->phys_addr=0x%08lX p->length = %luKB \t",
-				p->phys_addr, p->length/SZ_1K);
-		next = list_entry(p->list.next, __typeof__(*p), list);
-		mmz_trace(4,",next = 0x%08lX\n\n", next->phys_addr);
-		/*if p is the first entry or not*/
-		if(osal_list_first_entry(&mmz->mmb_list, __typeof__(*p), list) == p) {
-			blank_len = p->phys_addr - start;
-			if((blank_len < fixed_len) && (blank_len>=len)) {
-				fixed_len = blank_len;
-				fixed_start = start;
-				mmz_trace(4,"%d: fixed_region: start=0x%08lX, len=%luKB\n",
-						__LINE__, fixed_start, fixed_len/SZ_1K);
-			}
-		}
-		start = mmz_align2((p->phys_addr + p->length),align);
-		
-		/*if aglin is larger than mmz->nbytes, it would trigger the BUG_ON */
-		//BUG_ON((start < mmz->phys_start) || (start > (mmz->phys_start + mmz->nbytes)));
-		
-		/*if we have to alloc after the last node*/
-		if (osal_list_is_last(&p->list, &mmz->mmb_list)) {
-			blank_len = mmz->phys_start + mmz->nbytes - start;
-			if ((blank_len < fixed_len) && (blank_len >= len)){
-				fixed_len = blank_len;
-				fixed_start = start;
-				mmz_trace(4,"%d: fixed_region: start=0x%08lX, len=%luKB\n",
-						__LINE__, fixed_start, fixed_len/SZ_1K);
-				break;
-			} else {
-				if(fixed_len != -1)
-					goto out;
-				fixed_start = 0;
-				mmz_trace(4,"%d: fixed_region: start=0x%08lX, len=%luKB\n",
-						__LINE__, fixed_start, fixed_len/SZ_1K);
-				goto out;
-			}
-		}
-		/* blank is too small */
-		if ((start + len) > next->phys_addr) {
-			mmz_trace(4,"start=0x%08lX ,len=%lu,next=0x%08lX\n",
-					start,len,next->phys_addr);
-			continue;
-		}
-		blank_len = next->phys_addr - start;
-		if((blank_len < fixed_len) && (blank_len >= len)) {
-			fixed_len = blank_len;
-			fixed_start = start;
-			mmz_trace(4,"%d: fixed_region: start=0x%08lX, len=%luKB\n",
-					__LINE__, fixed_start, fixed_len/SZ_1K);
-		}
-	}
+    osal_list_for_each_entry(p, &mmz->mmb_list, list) {
+        hil_mmb_t *next = NULL;
+        mmz_trace(4, "p->phys_addr=0x%08lX p->length = %luKB \t", /* 4: log debug level */
+                  p->phys_addr, p->length / SZ_1K);
+        next = osal_list_entry(p->list.next, typeof(*p), list);
+        mmz_trace(4, ",next = 0x%08lX\n\n", next->phys_addr); /* 4: log debug level */
+        /*
+         * if p is the first entry or not.
+         */
+        if (osal_list_first_entry(&mmz->mmb_list, typeof(*p), list) == p) {
+            blank_len = p->phys_addr - start;
+            if ((blank_len < fixed_len) && (blank_len >= len)) {
+                fixed_len = blank_len;
+                fixed_start = start;
+                mmz_trace(4, "%d: fixed_region: start=0x%08lX, len=%luKB\n", /* 4: log debug level */
+                          __LINE__, fixed_start, fixed_len / SZ_1K);
+            }
+        }
+        start = mmz_align2((p->phys_addr + p->length), align);
+        /* if aglin is larger than mmz->nbytes, it would trigger the BUG_ON */
+        /* if we have to alloc after the last node.  */
+        if (osal_list_is_last(&p->list, &mmz->mmb_list)) {
+            blank_len = mmz->phys_start + mmz->nbytes - start;
+            if ((blank_len < fixed_len) && (blank_len >= len)) {
+                fixed_len = blank_len;
+                fixed_start = start;
+                mmz_trace(4, "fixed_region: start=0x%08lX, len=%luKB\n", /* 4: log debug level */
+                          fixed_start, fixed_len / SZ_1K);
+                break;
+            } else {
+                if (fixed_len != -1) {
+                    goto out;
+                }
+                fixed_start = 0;
+                mmz_trace(4, "fixed_region: start=0x%08lX, len=%luKB\n", /* 4: log debug level */
+                          fixed_start, fixed_len / SZ_1K);
+                goto out;
+            }
+        }
+        /* blank is too small */
+        if ((start + len) > next->phys_addr) {
+            mmz_trace(4, "start=0x%08lX ,len=%lu,next=0x%08lX\n", /* 4: log debug level */
+                      start, len, next->phys_addr);
+            continue;
+        }
+        blank_len = next->phys_addr - start;
+        if ((blank_len < fixed_len) && (blank_len >= len)) {
+            fixed_len = blank_len;
+            fixed_start = start;
+            mmz_trace(4, "fixed_region: start=0x%08lX, len=%luKB\n", /* 4: log debug level */
+                      fixed_start, fixed_len / SZ_1K);
+        }
+    }
 
-	if ((mmz_grain_align(start+len) <= (mmz->phys_start + mmz->nbytes))
-			&& (start >= mmz->phys_start)
-			&& (start < (mmz->phys_start + mmz->nbytes))) {
-		fixed_len = len;
-		fixed_start = start;
-		mmz_trace(4,"%d: fixed_region: start=0x%08lX, len=%luKB\n",
-				__LINE__, fixed_start, fixed_len/SZ_1K);
-	} else {
-		fixed_start = 0;
-		mmz_trace(4,"%d: fixed_region: start=0x%08lX, len=%luKB\n",
-				__LINE__, fixed_start, len/SZ_1K);
-	}
+    if ((mmz_grain_align(start + len) <= (mmz->phys_start + mmz->nbytes)) &&
+        (start >= mmz->phys_start) &&
+        (start < (mmz->phys_start + mmz->nbytes))) {
+            fixed_len = len;
+            fixed_start = start;
+            mmz_trace(4, "fixed_region: start=0x%08lX, len=%luKB\n", /* 4: log debug level */
+                      fixed_start, fixed_len / SZ_1K);
+    } else {
+        fixed_start = 0;
+        mmz_trace(4, "fixed_region: start=0x%08lX, len=%luKB\n", /* 4: log debug level */
+                  fixed_start, len / SZ_1K);
+    }
 out:
-	*region_len = len;
-	return fixed_start;
+    *region_len = len;
+    return fixed_start;
 }
 
 static unsigned long find_fixed_region_from_highaddr(unsigned long *region_len,
-		hil_mmz_t *mmz,
-		unsigned long size,
-		unsigned long align)
+                                                     hil_mmz_t *mmz, unsigned long size, unsigned long align)
 {
-	int i, j;
-	unsigned long fixed_start=0;
-	unsigned long fixed_len=~1;
+    int j;
+    unsigned int i;
+    unsigned long fixed_start = 0;
+    unsigned long fixed_len = ~1;
 
-	mmz_trace_func();
+    mmz_trace_func();
 
-	i = mmz_length2grain(mmz->nbytes);
+    i = mmz_length2grain(mmz->nbytes);
 
-	for(; i>0; i--) {
-		unsigned long start;
-		unsigned long len;
-		unsigned long start_highaddr;
-		
-		if(mmz_get_bit(mmz,i))
-			continue;
+    for (; i > 0; i--) {
+        unsigned long start;
+        unsigned long len;
+        unsigned long start_highaddr;
 
-		len = 0;
-		start_highaddr = mmz_pos2phy_addr(mmz,i);
-		for(; i>0; i--) {
-			if(mmz_get_bit(mmz,i)) {
-				break;
-			}
+        if (mmz_get_bit(mmz, i)) {
+            continue;
+        }
 
-			len += MMZ_GRAIN;
-		}
+        len = 0;
+        start_highaddr = mmz_pos2phy_addr(mmz, i);
+        for (; i > 0; i--) {
+            if (mmz_get_bit(mmz, i)) {
+                break;
+            }
 
-		if(len>=size) {
-			j = mmz_phy_addr2pos(mmz, mmz_align2low(start_highaddr-size, align));
-			//align = mmz_grain_align(align)/MMZ_GRAIN;
-			//start = mmz_pos2phy_addr(mmz, j - align);
-			start = mmz_pos2phy_addr(mmz, j);
-			if((start_highaddr - len <= start) && (start <= start_highaddr - size)){
-				fixed_len = len;
-				fixed_start = start;
-				break;
-			}				
-						
-			mmz_trace(1,"fixed_region: start=0x%08lX, len=%luKB",
-					fixed_start, fixed_len/SZ_1K);
-		}
-	}
+            len += MMZ_GRAIN;
+        }
 
-	*region_len = fixed_len;
+        if (len >= size) {
+            j = mmz_phy_addr2pos(mmz, mmz_align2low(start_highaddr - size, align));
+            start = mmz_pos2phy_addr(mmz, j);
+            if ((start_highaddr - len <= start) && (start <= start_highaddr - size)) {
+                fixed_len = len;
+                fixed_start = start;
+                break;
+            }
 
-	return fixed_start;
+            mmz_trace(1, "fixed_region: start=0x%08lX, len=%luKB",
+                      fixed_start, fixed_len / SZ_1K);
+        }
+    }
+
+    *region_len = fixed_len;
+
+    return fixed_start;
 }
 
 static int do_mmb_alloc(hil_mmb_t *mmb)
 {
-	hil_mmb_t *p=NULL;
-	mmz_trace_func();
+    hil_mmb_t *p = NULL;
 
-	/* add mmb sorted */
-	osal_list_for_each_entry(p,&mmb->zone->mmb_list, list) {
-		if(mmb->phys_addr < p->phys_addr)
-			break;
-		if(mmb->phys_addr == p->phys_addr){
-			printk("ERROR: media-mem allocator bad in %s! (%s, %d)",
-					mmb->zone->name,  __FUNCTION__, __LINE__);
-			return -1;
-		}
-	}
-	osal_list_add(&mmb->list, p->list.prev);
+    mmz_trace_func();
 
-	mmz_trace(1,HIL_MMB_FMT_S,hil_mmb_fmt_arg(mmb));
+    /* add mmb sorted */
+    osal_list_for_each_entry(p, &mmb->zone->mmb_list, list) {
+        if (mmb->phys_addr < p->phys_addr) {
+            break;
+        }
+        if (mmb->phys_addr == p->phys_addr) {
+            printk(KERN_ERR "ERROR: media-mem allocator bad in %s! (%s, %d)",
+                   mmb->zone->name, __FUNCTION__, __LINE__);
+        }
+    }
+    osal_list_add(&mmb->list, p->list.prev);
 
-	return 0;
+    mmz_trace(1, HIL_MMB_FMT_S, hil_mmb_fmt_arg(mmb));
+
+    return 0;
 }
 
 static hil_mmb_t *__mmb_alloc(const char *name,
-		unsigned long size,
-		unsigned long align,
-		unsigned long gfp,
-		const char *mmz_name,
-		hil_mmz_t *_user_mmz)
+                              unsigned long size,
+                              unsigned long align,
+                              unsigned long gfp,
+                              const char *mmz_name,
+                              hil_mmz_t *_user_mmz)
 {
-	hil_mmz_t *mmz;
-	hil_mmb_t *mmb;
+    hil_mmz_t *mmz = NULL;
+    hil_mmb_t *mmb = NULL;
 
-	unsigned long start;
-	unsigned long region_len;
+    unsigned long start;
+    unsigned long region_len;
 
-	unsigned long fixed_start=0;
-	unsigned long fixed_len=~1;
-	hil_mmz_t *fixed_mmz=NULL;
+    unsigned long fixed_start = 0;
+    unsigned long fixed_len = ~1;
+    hil_mmz_t *fixed_mmz = NULL;
 
-	mmz_trace_func();
+    mmz_trace_func();
 
-	if(size == 0 || size > 0x40000000UL)
-		return NULL;
-	if(align == 0)
-		align = MMZ_GRAIN;
+    if ((size == 0) || (size > g_hi_max_malloc_size)) {
+        return NULL;
+    }
+    if (align == 0) {
+        align = MMZ_GRAIN;
+    }
 
-	size = mmz_grain_align(size);
+    size = mmz_grain_align(size);
 
-	mmz_trace(1,"size=%luKB, align=%lu", size/SZ_1K, align);
+    mmz_trace(1, "size=%luKB, align=%lu", size / SZ_1K, align);
 
-	begin_list_for_each_mmz(mmz, gfp, mmz_name)
-		if(_user_mmz!=NULL && _user_mmz!=mmz)
-			continue;
+    begin_list_for_each_mmz(mmz, gfp, mmz_name)
 
-		start = find_fixed_region(&region_len, mmz, size, align);
-		if( (fixed_len > region_len) && (start!=0)) {
-			fixed_len = region_len;
-			fixed_start = start;
-			fixed_mmz = mmz;
-		}
-	end_list_for_each_mmz()
+    if ((_user_mmz != NULL) && (_user_mmz != mmz)) {
+        continue;
+    }
 
-	if(fixed_mmz == NULL) {
-		return NULL;
-	}
+    start = find_fixed_region(&region_len, mmz, size, align);
+    if ((fixed_len > region_len) && (start != 0)) {
+        fixed_len = region_len;
+        fixed_start = start;
+        fixed_mmz = mmz;
+    }
+    end_list_for_each_mmz()
 
-	mmb = kmalloc(sizeof(hil_mmb_t), GFP_KERNEL);
-	if (mmb == NULL){
-		return NULL;
-	}
+    if (fixed_mmz == NULL) {
+        return NULL;
+    }
 
-	memset(mmb, 0, sizeof(hil_mmb_t));
-	mmb->zone = fixed_mmz;
-	mmb->phys_addr = fixed_start;
-	mmb->length = size;
-	mmb->id = ++mmb_number;
-	if(name)
-		strlcpy(mmb->name, name, HIL_MMB_NAME_LEN);
-	else 
-		strncpy(mmb->name, "<null>", HIL_MMB_NAME_LEN);
+    mmb = kmalloc(sizeof(hil_mmb_t), GFP_KERNEL);
+    if (mmb == NULL) {
+        return NULL;
+    }
 
-	if(do_mmb_alloc(mmb)) {
-		kfree(mmb);
-		mmb = NULL;
-	}
+    memset(mmb, 0, sizeof(hil_mmb_t));
+    mmb->zone = fixed_mmz;
+    mmb->phys_addr = fixed_start;
+    mmb->length = size;
+    if (name != NULL) {
+        compat_strlcpy(mmb->name, name, HIL_MMB_NAME_LEN);
+    } else {
+        strncpy(mmb->name, "<null>", HIL_MMB_NAME_LEN - 1);
+    }
 
-	return mmb;
+    if (do_mmb_alloc(mmb)) {
+        kfree(mmb);
+        mmb = NULL;
+    }
+
+    return mmb;
 }
 
 static hil_mmb_t *__mmb_alloc_v2(const char *name,
-		unsigned long size,
-		unsigned long align,
-		unsigned long gfp, 
-		const char *mmz_name,
-		hil_mmz_t *_user_mmz,
-		unsigned int order)
+                                 unsigned long size,
+                                 unsigned long align,
+                                 unsigned long gfp,
+                                 const char *mmz_name,
+                                 hil_mmz_t *_user_mmz,
+                                 unsigned int order)
 {
-	hil_mmz_t *mmz;
-	hil_mmb_t *mmb;
-	unsigned int i;
+    hil_mmz_t *mmz = NULL;
+    hil_mmb_t *mmb = NULL;
+    unsigned int i;
 
-	unsigned long start = 0;
-	unsigned long region_len = 0;
+    unsigned long start = 0;
+    unsigned long region_len = 0;
 
-	unsigned long fixed_start=0;
-	unsigned long fixed_len=~1;
-	hil_mmz_t *fixed_mmz=NULL;
+    unsigned long fixed_start = 0;
+    unsigned long fixed_len = ~1;
+    hil_mmz_t *fixed_mmz = NULL;
 
-	mmz_trace_func();
+    mmz_trace_func();
 
-	if(size == 0 || size > 0x40000000UL)
-		return NULL;
-	if(align == 0)
-		align = 1;
-		
-	size = mmz_grain_align(size);
+    if ((size == 0) || (size > 0x40000000UL)) { /* max size 0x40000000 */
+        return NULL;
+    }
+    if (align == 0) {
+        align = 1;
+    }
 
-	mmz_trace(1,"size=%luKB, align=%lu", size/SZ_1K, align);
+    size = mmz_grain_align(size);
 
-	begin_list_for_each_mmz(mmz, gfp, mmz_name)
-		if(_user_mmz!=NULL && _user_mmz!=mmz)
-			continue;
-			
-		if(mmz->alloc_type == SLAB_ALLOC){
-			if((size-1) & size){
-				for(i = 1; i <= 32; i++){
-					if(!((size >> i) & ~0)){
-						size = 1 << i;	
-						break;
-					}						
-				}	
-			}
-		}
-		else if(mmz->alloc_type == EQ_BLOCK_ALLOC){
-			size = mmz_align2(size,mmz->block_align);
-		}
-		if(order == LOW_TO_HIGH){
-			start = find_fixed_region(&region_len, mmz, size, align);
-		}
-		else if(order == HIGH_TO_LOW)
-			start = find_fixed_region_from_highaddr(&region_len, mmz, size, align);
-		if( (fixed_len > region_len) && (start!=0)) {
-			fixed_len = region_len;
-			fixed_start = start;
-			fixed_mmz = mmz;
-		}
-	end_list_for_each_mmz()
+    mmz_trace(1, "size=%luKB, align=%lu", size / SZ_1K, align);
 
-	if(fixed_mmz == NULL) {
-		return NULL;
-	}
+    begin_list_for_each_mmz(mmz, gfp, mmz_name)
 
-	mmb = kmalloc(sizeof(hil_mmb_t), GFP_KERNEL);
-	if (mmb == NULL) {
-	    return NULL;
-	}
+    if ((_user_mmz != NULL) && (_user_mmz != mmz)) {
+        continue;
+    }
 
-	memset(mmb, 0, sizeof(hil_mmb_t));
-	mmb->zone = fixed_mmz;
-	mmb->phys_addr = fixed_start;
-	mmb->length = size;
-	mmb->order = order;
-	if(name)
-		strlcpy(mmb->name, name, HIL_MMB_NAME_LEN);
-	else 
-		strncpy(mmb->name, "<null>", HIL_MMB_NAME_LEN);
+    if (mmz->alloc_type == SLAB_ALLOC) {
+        if ((size - 1) & size) {
+            for (i = 1; i < 32; i++) { /* 32: the max size is 2^(32-1) */
+                if (!((size >> i) & ~0)) {
+                    size = 1 << i;
+                    break;
+                }
+            }
+        }
+    } else if (mmz->alloc_type == EQ_BLOCK_ALLOC) {
+        size = mmz_align2(size, mmz->block_align);
+    }
 
-	if(do_mmb_alloc(mmb)) {
-		kfree(mmb);
-		mmb = NULL;
-	}
+    if (order == LOW_TO_HIGH) {
+        start = find_fixed_region(&region_len, mmz, size, align);
+    } else if (order == HIGH_TO_LOW) {
+        start = find_fixed_region_from_highaddr(&region_len, mmz, size, align);
+    }
 
-	return mmb;
+    if ((fixed_len > region_len) && (start != 0)) {
+        fixed_len = region_len;
+        fixed_start = start;
+        fixed_mmz = mmz;
+    }
+
+    end_list_for_each_mmz()
+
+    if (fixed_mmz == NULL) {
+        return NULL;
+    }
+
+    mmb = kmalloc(sizeof(hil_mmb_t), GFP_KERNEL);
+    if (mmb == NULL) {
+        return NULL;
+    }
+
+    memset(mmb, 0, sizeof(hil_mmb_t));
+    mmb->zone = fixed_mmz;
+    mmb->phys_addr = fixed_start;
+    mmb->length = size;
+    mmb->order = order;
+
+    if (name != NULL) {
+        compat_strlcpy(mmb->name, name, HIL_MMB_NAME_LEN);
+    } else {
+        strncpy(mmb->name, "<null>", HIL_MMB_NAME_LEN);
+    }
+
+    if (do_mmb_alloc(mmb)) {
+        kfree(mmb);
+        mmb = NULL;
+    }
+
+    return mmb;
 }
 
 static void *__mmb_map2kern(hil_mmb_t *mmb, int cached)
 {
-	/*
-	 * already mapped? no need to remap again,
-	 * just return mmb's kernel virtual address.
-	 */
-	if (mmb->flags & HIL_MMB_MAP2KERN) {
-		if ((cached * HIL_MMB_MAP2KERN_CACHED)
-				!= (mmb->flags & HIL_MMB_MAP2KERN_CACHED)) {
-			printk(KERN_ERR "mmb<%s> has been kernel-mapped as %s,\
-					can not be re-mapped as %s.",
-					mmb->name,
-					(mmb->flags&HIL_MMB_MAP2KERN_CACHED) ? "cached" : "non-cached",
-					(cached) ? "cached" : "non-cached" );
-			return NULL;
-		}
+    /*
+      * already mapped? no need to remap again,
+      * just return mmb's kernel virtual address.
+      */
+    if (mmb->flags & HIL_MMB_MAP2KERN) {
+        if ((!!cached * HIL_MMB_MAP2KERN_CACHED) != (mmb->flags & HIL_MMB_MAP2KERN_CACHED)) {
+            printk(KERN_ERR "mmb<%s> has been kernel-mapped as %s, can not be re-mapped as %s.",
+                   mmb->name,
+                   (mmb->flags & HIL_MMB_MAP2KERN_CACHED) ? "cached" : "non-cached",
+                   (cached) ? "cached" : "non-cached");
+            return NULL;
+        }
 
-		mmb->map_ref++;
+        mmb->map_ref++;
 
-		return mmb->kvirt;
-	}
+        return mmb->kvirt;
+    }
 
-	if (cached) {
-		mmb->flags |= HIL_MMB_MAP2KERN_CACHED;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,18,10)
-		mmb->kvirt = ioremap_cached(mmb->phys_addr, mmb->length);
-#else
-		mmb->kvirt = ioremap_cache(mmb->phys_addr, mmb->length);
-#endif
-	} else {
-		mmb->flags &= ~HIL_MMB_MAP2KERN_CACHED;
-		/* ioremap_wc has better performance */ 
-		mmb->kvirt = ioremap_wc(mmb->phys_addr, mmb->length);
-	}
+    if (cached) {
+        mmb->flags |= HIL_MMB_MAP2KERN_CACHED;
+        mmb->kvirt = ioremap_cache(mmb->phys_addr, mmb->length);
+    } else {
+        mmb->flags &= ~HIL_MMB_MAP2KERN_CACHED;
+        /* ioremap_wc has better performance */
+        mmb->kvirt = ioremap_wc(mmb->phys_addr, mmb->length);
+    }
 
-	if(mmb->kvirt) {
-	       	mmb->flags |= HIL_MMB_MAP2KERN;
-		mmb->map_ref++;
-	}
+    if (mmb->kvirt) {
+        mmb->flags |= HIL_MMB_MAP2KERN;
+        mmb->map_ref++;
+    } else {
+        mmb->flags &= ~HIL_MMB_MAP2KERN_CACHED;
+    }
 
-	return mmb->kvirt;
+    return mmb->kvirt;
 }
 
 static void __mmb_free(hil_mmb_t *mmb)
 {
-	if (mmb->flags & HIL_MMB_MAP2KERN_CACHED) {
-		__cpuc_flush_dcache_area((void *)mmb->kvirt, (size_t)mmb->length);
-		outer_flush_range(mmb->phys_addr, mmb->phys_addr + mmb->length);
-	}
+    if (mmb->flags & HIL_MMB_MAP2KERN_CACHED) {
+#ifdef CONFIG_64BIT
+        __flush_dcache_area((void *)mmb->kvirt, (size_t)mmb->length);
+#else
+        __cpuc_flush_dcache_area((void *)mmb->kvirt, (size_t)mmb->length);
+        outer_flush_range(mmb->phys_addr, mmb->phys_addr + mmb->length);
+#endif
+    }
 
-	osal_list_del(&mmb->list);
-	kfree(mmb);
+    osal_list_del(&mmb->list);
+    kfree(mmb);
 }
 
 static int __mmb_unmap(hil_mmb_t *mmb)
 {
-	int ref;
-	
-	if (mmb->flags & HIL_MMB_MAP2KERN_CACHED) {
-		__cpuc_flush_dcache_area((void *)mmb->kvirt, (size_t)mmb->length);
-		outer_flush_range(mmb->phys_addr, mmb->phys_addr + mmb->length);
-	}
+    int ref;
 
-	if(mmb->flags & HIL_MMB_MAP2KERN) {
-		ref = --mmb->map_ref;
-		if(mmb->map_ref !=0) {
-			return ref;
-		}
-		iounmap(mmb->kvirt);
-	}
+    if (mmb->flags & HIL_MMB_MAP2KERN_CACHED) {
+#ifdef CONFIG_64BIT
+        __flush_dcache_area((void *)mmb->kvirt, (size_t)mmb->length);
+#else
+        __cpuc_flush_dcache_area((void *)mmb->kvirt, (size_t)mmb->length);
+        outer_flush_range(mmb->phys_addr, mmb->phys_addr + mmb->length);
+#endif
+    }
 
-	mmb->kvirt = NULL;
-	mmb->flags &= ~HIL_MMB_MAP2KERN;
-	mmb->flags &= ~HIL_MMB_MAP2KERN_CACHED;
+    if (mmb->flags & HIL_MMB_MAP2KERN) {
+        ref = --mmb->map_ref;
+        if (mmb->map_ref != 0) {
+            return ref;
+        }
+        iounmap(mmb->kvirt);
+    }
 
-	if((mmb->flags & HIL_MMB_RELEASED) && mmb->phy_ref ==0) {
-		__mmb_free(mmb);
-	}
+    mmb->kvirt = NULL;
+    mmb->flags &= ~HIL_MMB_MAP2KERN;
+    mmb->flags &= ~HIL_MMB_MAP2KERN_CACHED;
 
-	return 0;
+    if ((mmb->flags & HIL_MMB_RELEASED) && (mmb->phy_ref == 0)) {
+        __mmb_free(mmb);
+    }
+
+    return 0;
 }
 
-static void *__mmf_map(unsigned long phys, int len, int cache)
+static void *__mmf_map(phys_addr_t phys, int len, int cache)
 {
-	void *virt;
-	if (cache) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,18,10)
-		virt = ioremap_cached(phys, len);
-#else
-		virt = ioremap_cache(phys, len);
-#endif
-	} else {
-		virt = ioremap_wc(phys, len);
-	}
+    void *virt = NULL;
+    if (cache) {
+        virt = ioremap_cache(phys, len);
+    } else {
+        virt = ioremap_wc(phys, len);
+    }
 
-	return virt;
+    return virt;
 }
 
 static void __mmf_unmap(void *virt)
 {
-	if (virt)
-	    iounmap(virt);
+    if (virt != NULL) {
+        iounmap(virt);
+    }
 }
 
 static int __allocator_init(char *s)
 {
-	hil_mmz_t *zone = NULL;
-	char *line;
-	int attempted = 0, registered = 0;
+    hil_mmz_t *zone = NULL;
+    char *line = NULL;
+    unsigned long phys_end;
 
-	while ((line = strsep(&s, ":")) != NULL) {
-		int i;
-		char *argv[6];
+    while ((line = strsep(&s, ":")) != NULL) {
+        int i;
+        char *argv[6]; /* 6: cmdline include 6 arguments */
 
-		for (i = 0; (argv[i] = strsep(&line, ",")) != NULL;)
-			if (++i == ARRAY_SIZE(argv))
-				break;
+        for (i = 0; (argv[i] = strsep(&line, ",")) != NULL;) {
+            if (++i == ARRAY_SIZE(argv)) {
+                break;
+            }
+        }
 
-		if (i == 4) {
-			zone = hil_mmz_create("null",0,0,0);
-			if (NULL == zone)
-				continue;
-			strlcpy(zone->name, argv[0], HIL_MMZ_NAME_LEN);
-			zone->gfp = _strtoul_ex(argv[1], NULL, 0);
-			zone->phys_start = _strtoul_ex(argv[2], NULL, 0);
-			zone->nbytes = _strtoul_ex(argv[3], NULL, 0);
-		} else if (i == 6) {
-			zone = hil_mmz_create_v2("null",0,0,0,0,0);
-			if (zone == NULL)
-				continue;
+        if (i == 4) { /* 4: had parse four args */
+            zone = hil_mmz_create("null", 0, 0, 0);
+            if (zone == NULL) {
+                continue;
+            }
 
-			strlcpy(zone->name, argv[0], HIL_MMZ_NAME_LEN);
-			zone->gfp = _strtoul_ex(argv[1], NULL, 0);
-			zone->phys_start = _strtoul_ex(argv[2], NULL, 0);
-			zone->nbytes = _strtoul_ex(argv[3], NULL, 0);
-			zone->alloc_type = _strtoul_ex(argv[4], NULL, 0);
-			zone->block_align = _strtoul_ex(argv[5], NULL, 0);
-		} else {
-			printk(KERN_ERR "error parameters\n");
-			return -EINVAL;
-		}
+            compat_strlcpy(zone->name, argv[0], HIL_MMZ_NAME_LEN); /* 0: the first args */
+            zone->gfp = _strtoul_ex(argv[1], NULL, 0); /* 1: the second args */
+            zone->phys_start = _strtoul_ex(argv[2], NULL, 0); /* 2: the third args */
+            zone->nbytes = _strtoul_ex(argv[3], NULL, 0); /* 3: the fourth args */
+            if (zone->nbytes > g_hi_max_malloc_size) {
+                g_hi_max_malloc_size = zone->nbytes;
+            }
+        } else if (i == 6) { /* 6: had parse six args */
+            zone = hil_mmz_create_v2("null", 0, 0, 0, 0, 0);
+            if (zone == NULL) {
+                continue;
+            }
 
-		//mmz_info_phys_start = zone->phys_start + zone->nbytes - 0x2000;
+            compat_strlcpy(zone->name, argv[0], HIL_MMZ_NAME_LEN); /* 0: the first args */
+            zone->gfp = _strtoul_ex(argv[1], NULL, 0); /* 1: the second args */
+            zone->phys_start = _strtoul_ex(argv[2], NULL, 0); /* 2: the third args */
+            zone->nbytes = _strtoul_ex(argv[3], NULL, 0); /* 3: the fourth args */
+            zone->alloc_type = _strtoul_ex(argv[4], NULL, 0); /* 4: the fifth args */
+            zone->block_align = _strtoul_ex(argv[5], NULL, 0); /* 5: the sixth args */
+            if (zone->nbytes > g_hi_max_malloc_size) {
+                g_hi_max_malloc_size = zone->nbytes;
+            }
+        } else {
+            printk(KERN_ERR "error parameters\n");
+            return -EINVAL;
+        }
 
-		attempted++;
-		if (hil_mmz_register(zone)) {
-			printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n", hil_mmz_fmt_arg(zone));
-			hil_mmz_destroy(zone);
-		} else {
-			registered++;
-		}
-		zone = NULL;
-	}
+        if (hil_mmz_register(zone)) {
+            printk(KERN_WARNING "Add MMZ failed: " HIL_MMZ_FMT_S "\n", hil_mmz_fmt_arg(zone));
+            hil_mmz_destroy(zone);
+            return -1;
+        }
 
-	if (attempted > 0 && registered == 0) {
-		printk(KERN_ERR "MMZ: all %d configured zone(s) failed to register; refusing to load\n",
-				attempted);
-		return -ENODEV;
-	}
+        /* if phys_end is maxinum value (ex, 0xFFFFFFFF 32bit) */
+        phys_end = (zone->phys_start + zone->nbytes);
+        if ((phys_end == 0) && (zone->nbytes >= PAGE_SIZE)) {
+            /* reserve last PAGE_SIZE memory */
+            zone->nbytes = zone->nbytes - PAGE_SIZE;
+        }
 
-	return 0;
+        /* if phys_end exceed 0xFFFFFFFF (32bit), wraping error */
+        if ((zone->phys_start > phys_end) && (phys_end != 0)) {
+            printk(KERN_ERR "MMZ: parameter is not correct! Address exceeds 0xFFFFFFFF\n");
+            hil_mmz_unregister(zone);
+            hil_mmz_destroy(zone);
+            return -1;
+        }
+        zone = NULL;
+    }
+
+    return 0;
 }
 
 int hisi_allocator_setopt(struct mmz_allocator *allocator)
 {
-	allocator->init = __allocator_init;
-	allocator->mmb_alloc = __mmb_alloc;
-	allocator->mmb_alloc_v2 = __mmb_alloc_v2;
-	allocator->mmb_map2kern = __mmb_map2kern;
-	allocator->mmb_unmap = __mmb_unmap;
-	allocator->mmb_free = __mmb_free;
-	allocator->mmf_map = __mmf_map;
-	allocator->mmf_unmap = __mmf_unmap;
-	return 0;
+    allocator->init = __allocator_init;
+    allocator->mmb_alloc = __mmb_alloc;
+    allocator->mmb_alloc_v2 = __mmb_alloc_v2;
+    allocator->mmb_map2kern = __mmb_map2kern;
+    allocator->mmb_unmap = __mmb_unmap;
+    allocator->mmb_free = __mmb_free;
+    allocator->mmf_map = __mmf_map;
+    allocator->mmf_unmap = __mmf_unmap;
+    return 0;
 }
-

--- a/kernel/osal/hi3519v101/mmz/media-mem.c
+++ b/kernel/osal/hi3519v101/mmz/media-mem.c
@@ -60,7 +60,7 @@
 
 
 OSAL_LIST_HEAD(mmz_list);
-static DEFINE_SEMAPHORE(mmz_lock);
+static compat_DEFINE_SEMAPHORE(mmz_lock);
 
 int anony = 0;
 module_param(anony, int, S_IRUGO);
@@ -529,9 +529,9 @@ EXPORT_SYMBOL(hil_mmb_free);
 #define MACH_MMB(p, val, member) do{\
     hil_mmz_t *__mach_mmb_zone__; \
     (p) = NULL;\
-    list_for_each_entry(__mach_mmb_zone__,&mmz_list, list) { \
+    osal_list_for_each_entry(__mach_mmb_zone__,&mmz_list, list) { \
         hil_mmb_t *__mach_mmb__;\
-        list_for_each_entry(__mach_mmb__,&__mach_mmb_zone__->mmb_list, list) { \
+        osal_list_for_each_entry(__mach_mmb__,&__mach_mmb_zone__->mmb_list, list) { \
             if(__mach_mmb__->member == (val)){ \
                 (p) = __mach_mmb__; \
                 break;\
@@ -553,6 +553,9 @@ EXPORT_SYMBOL(hil_mmb_getby_phys);
 unsigned long usr_virt_to_phys(unsigned long virt)
 {
     pgd_t *pgd;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+    p4d_t *p4d;
+#endif
     pud_t *pud;
     pmd_t *pmd;
     pte_t *pte;
@@ -577,7 +580,19 @@ unsigned long usr_virt_to_phys(unsigned long virt)
         return 0;
     }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+    /* 5.0 added a 5th level (P4D). On 4-level archs (ARM) p4d_offset
+     * folds into a no-op returning the pgd cast, but the type must be
+     * walked explicitly because pud_offset() in 6.5+ rejects a pgd_t*. */
+    p4d = p4d_offset(pgd, virt);
+    if (p4d_none(*p4d)) {
+        printk("error: not mapped in p4d!\n");
+        return 0;
+    }
+    pud = pud_offset(p4d, virt);
+#else
     pud = pud_offset(pgd, virt);
+#endif
     if (pud_none(*pud)) {
         printk("error: not mapped in pud!\n");
         return 0;
@@ -619,9 +634,9 @@ EXPORT_SYMBOL(usr_virt_to_phys);
 #define MACH_MMB_2(p, val, member, Outoffset) do{\
     hil_mmz_t *__mach_mmb_zone__; \
     (p) = NULL;\
-    list_for_each_entry(__mach_mmb_zone__,&mmz_list, list) { \
+    osal_list_for_each_entry(__mach_mmb_zone__,&mmz_list, list) { \
         hil_mmb_t *__mach_mmb__;\
-        list_for_each_entry(__mach_mmb__,&__mach_mmb_zone__->mmb_list, list) { \
+        osal_list_for_each_entry(__mach_mmb__,&__mach_mmb_zone__->mmb_list, list) { \
             if ((__mach_mmb__->member <= (val)) && ((__mach_mmb__->length + __mach_mmb__->member) > (val))){ \
                 (p) = __mach_mmb__; \
                 Outoffset = val - __mach_mmb__->member;\
@@ -788,6 +803,15 @@ static int __init media_mem_proc_init(void)
 }
 #else
 
+#ifdef COMPAT_USE_PROC_OPS
+static struct proc_ops mmz_proc_ops = {
+    .proc_open    = mmz_proc_open,
+    .proc_read    = seq_read,
+    .proc_write   = mmz_write_proc,
+    .proc_lseek   = seq_lseek,
+    .proc_release = seq_release,
+};
+#else
 static struct file_operations mmz_proc_ops = {
     .owner = THIS_MODULE,
     .open = mmz_proc_open,
@@ -795,6 +819,7 @@ static struct file_operations mmz_proc_ops = {
     .write = mmz_write_proc,
     .release = seq_release,
 };
+#endif
 
 static int __init media_mem_proc_init(void)
 {
@@ -831,7 +856,7 @@ static void mmz_exit_check(void)
 
     mmz_trace_func();
 
-    list_for_each_safe(p, n, &mmz_list) {
+    osal_list_for_each_safe(p, n, &mmz_list) {
         pmmz = osal_list_entry(p,hil_mmz_t,list);
         printk(KERN_WARNING "MMZ force removed: " HIL_MMZ_FMT_S "\n", hil_mmz_fmt_arg(pmmz));
         hil_mmz_unregister(pmmz);

--- a/kernel/osal/hi3519v101/mmz_arm.h
+++ b/kernel/osal/hi3519v101/mmz_arm.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Hisilicon Technologies Co., Ltd. 2016-2019.
+ * Description: osal mmz arm header file.
+ * Author: Hisilicon multimedia software group
+ * Create: 2016-11-11
+ */
+
+#ifndef __MMZ_ARCH_OPS_HEADER__
+#define __MMZ_ARCH_OPS_HEADER__
+
+#if defined(CONFIG_ARM64)
+/* this function is used to change memory's property. */
+static void dma_pages_remap(struct page *page, size_t size, pgprot_t prot) {}
+
+static void dma_buffer_clear(struct page *page, size_t size)
+{
+    memset(page_address(page), 0, size);
+    __flush_dcache_area(page_address(page), size);
+}
+
+static void mmb_dcache_flush(hil_mmb_t *mmb)
+{
+    __flush_dcache_area((void *)mmb->kvirt, (size_t)mmb->length);
+}
+
+static pgprot_t arch_kern_pgprot(int cache)
+{
+    if (cache) {
+        return PAGE_KERNEL;
+    }
+
+    return __pgprot(PROT_NORMAL_NC);
+}
+
+#elif defined(CONFIG_ARM)
+#include <asm/highmem.h>
+#include <asm/pgtable.h>
+
+static void dma_buffer_clear(struct page *page, size_t size)
+{
+    /* __dma_clear_buffer not exported in 6.x+ — use memset + cache flush */
+    void *ptr = page_address(page);
+    if (ptr) {
+        memset(ptr, 0, size);
+        __cpuc_flush_dcache_area(ptr, size);
+        outer_flush_range(page_to_phys(page), page_to_phys(page) + size);
+    }
+}
+
+static void mmb_dcache_flush(hil_mmb_t *mmb)
+{
+    __cpuc_flush_dcache_area((void *)mmb->kvirt, (size_t)mmb->length);
+
+    outer_flush_range(mmb->phys_addr, mmb->phys_addr + mmb->length);
+}
+
+static pgprot_t arch_kern_pgprot(int cache)
+{
+    if (cache) {
+        return pgprot_kernel;
+    }
+
+    return pgprot_noncached(pgprot_kernel);
+}
+
+#else
+#error no proper arch selected(CONFIG_ARM64/CONFIG_ARM)!
+#endif
+
+#endif

--- a/kernel/osal/hi3519v101/osal.c
+++ b/kernel/osal/hi3519v101/osal.c
@@ -72,10 +72,10 @@ static int osal_probe(struct platform_device *pdev)
     return 0;
 }
 
-static int osal_remove(struct platform_device *pdev)
+static compat_platform_remove_ret osal_remove(struct platform_device *pdev)
 {
 	osal_exit();
-    return 0;
+	compat_platform_remove_return;
 }
 
 static const struct of_device_id osal_match[] = {

--- a/kernel/osal/hi3519v101/osal_addr.c
+++ b/kernel/osal/hi3519v101/osal_addr.c
@@ -57,7 +57,7 @@ EXPORT_SYMBOL(osal_copy_to_user);
 
 int osal_access_ok(int type, const void *addr, unsigned long size)
 {
-    return access_ok(type, addr, size);
+    return compat_access_ok(type, addr, size);
 }
 EXPORT_SYMBOL(osal_access_ok);
 

--- a/kernel/osal/hi3519v101/osal_device.c
+++ b/kernel/osal/hi3519v101/osal_device.c
@@ -659,7 +659,7 @@ EXPORT_SYMBOL(osal_remap_pfn_range);
 
 int osal_io_remap_pfn_range(osal_vm_t *vm, unsigned long addr, unsigned long pfn, unsigned long size){
     struct vm_area_struct *v = (struct vm_area_struct *)(vm->vm);
-    v->vm_flags |= VM_IO;
+    compat_vm_flags_set(v, VM_IO);
     if(0 == size)
     {
         return -EPERM;

--- a/kernel/osal/hi3519v101/osal_dma.c
+++ b/kernel/osal/hi3519v101/osal_dma.c
@@ -1,6 +1,20 @@
 #include "hi_osal.h"
-#include <linux/hidmac.h>
 #include <linux/module.h>
+#include <linux/version.h>
+
+/* linux/hidmac.h is a 3.18 vendor BSP header (no mainline equivalent).
+ * On mainline kernels the cv300 ISP blob still references the osal_dmac_*
+ * wrappers — link cleanly with -ENOSYS stubs (no DMA exercised in the
+ * boot+login+eth0 path). CLAUDE.md prefers shims in kernel_compat.h, but
+ * the include itself fails on mainline so the conditional must live here. */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
+#include <linux/hidmac.h>
+#else
+static inline int dmac_register_isr(unsigned int ch, void *pisr) { return -ENOSYS; }
+static inline int dmac_channel_free(unsigned int ch) { return -ENOSYS; }
+static inline int do_dma_llim2m_isp(unsigned int *src, unsigned int *dst,
+                                    unsigned int *len, unsigned int num) { return -ENOSYS; }
+#endif
 
 int osal_dmac_register_isr(unsigned int channel, void *pisr){
     return dmac_register_isr(channel, pisr);

--- a/kernel/osal/hi3519v101/osal_proc.c
+++ b/kernel/osal/hi3519v101/osal_proc.c
@@ -79,14 +79,24 @@ static int osal_procopen(struct inode *inode, struct file *file)
     return single_open(file, osal_seq_show, sentry);
 }
 
+#ifdef COMPAT_USE_PROC_OPS
+static struct proc_ops osal_proc_ops = {
+    .proc_open    = osal_procopen,
+    .proc_read    = seq_read,
+    .proc_write   = osal_procwrite,
+    .proc_lseek   = seq_lseek,
+    .proc_release = single_release,
+};
+#else
 static struct file_operations osal_proc_ops = {
     .owner   = THIS_MODULE,
     .open    = osal_procopen,
     .read    = seq_read,
     .write   = osal_procwrite,
-    .llseek  = seq_lseek, 
+    .llseek  = seq_lseek,
     .release = single_release
-}; 
+};
+#endif
 
 osal_proc_entry_t *osal_create_proc_entry(const char *name, osal_proc_entry_t *parent){
 	struct proc_dir_entry *entry = NULL;

--- a/kernel/osal/hi3519v101/osal_timer.c
+++ b/kernel/osal/hi3519v101/osal_timer.c
@@ -8,7 +8,80 @@
 #include <linux/rtc.h>
 #include "hi_osal.h"
 
+/* Linux 4.15 timer rework removed struct timer_list .data and changed the
+ * callback signature from void(*)(unsigned long) to void(*)(struct timer_list*).
+ * Same shim pattern as kernel/osal/hi3516cv500/osal_timer.c — wrap the
+ * timer_list in a compat struct so the legacy osal_timer_t API (which
+ * publishes function/data as void(*)(unsigned long) and unsigned long) keeps
+ * working unchanged. */
+#ifdef COMPAT_TIMER_SETUP
+struct osal_v3a_timer_compat {
+    struct timer_list tl;
+    void (*function)(unsigned long);
+    unsigned long data;
+};
 
+static void osal_v3a_timer_shim_callback(struct timer_list *t)
+{
+    struct osal_v3a_timer_compat *ot =
+        container_of(t, struct osal_v3a_timer_compat, tl);
+    if (ot->function)
+        ot->function(ot->data);
+}
+
+int osal_timer_init(osal_timer_t *timer){
+    struct osal_v3a_timer_compat *ot = NULL;
+
+    if(timer == NULL){
+        osal_printk("%s - parameter invalid!\n", __FUNCTION__);
+        return -1;
+    }
+
+    ot = kmalloc(sizeof(*ot), GFP_KERNEL);
+    if(ot == NULL){
+        osal_printk("%s - kmalloc error!\n", __FUNCTION__);
+        return -1;
+    }
+    memset(ot, 0, sizeof(*ot));
+    timer_setup(&ot->tl, osal_v3a_timer_shim_callback, 0);
+    timer->timer = ot;
+    return 0;
+}
+EXPORT_SYMBOL(osal_timer_init);
+
+int osal_set_timer(osal_timer_t *timer, unsigned long interval){
+    struct osal_v3a_timer_compat *ot = NULL;
+    if(timer == NULL || timer->timer == NULL || timer->function == NULL || interval == 0){
+        osal_printk("%s - parameter invalid!\n", __FUNCTION__);
+        return -1;
+    }
+    ot = timer->timer;
+    ot->function = timer->function;
+    ot->data = timer->data;
+    return mod_timer(&ot->tl, jiffies + msecs_to_jiffies(interval));
+}
+EXPORT_SYMBOL(osal_set_timer);
+
+int osal_del_timer(osal_timer_t *timer){
+    struct osal_v3a_timer_compat *ot = NULL;
+    if(timer == NULL || timer->timer == NULL || timer->function == NULL){
+        osal_printk("%s - parameter invalid!\n", __FUNCTION__);
+        return -1;
+    }
+    ot = timer->timer;
+    return del_timer(&ot->tl);
+}
+EXPORT_SYMBOL(osal_del_timer);
+
+int osal_timer_destory(osal_timer_t *timer){
+    struct osal_v3a_timer_compat *ot = timer->timer;
+    del_timer(&ot->tl);
+    kfree(ot);
+    timer->timer=NULL;
+    return 0;
+}
+EXPORT_SYMBOL(osal_timer_destory);
+#else /* pre-4.15: legacy init_timer */
 int osal_timer_init(osal_timer_t *timer){
     struct timer_list *t = NULL;
 
@@ -61,6 +134,7 @@ int osal_timer_destory(osal_timer_t *timer){
     return 0;
 }
 EXPORT_SYMBOL(osal_timer_destory);
+#endif
 
 unsigned long osal_msleep(unsigned int msecs){
     return  msleep_interruptible(msecs);

--- a/kernel/osal_v3a_shim/v3a_shim.c
+++ b/kernel/osal_v3a_shim/v3a_shim.c
@@ -1,0 +1,647 @@
+/*
+ * V3A (hi3519v101) OSAL shim — re-exports kernel APIs and stubs vendor BSP
+ * symbols that the binary blobs in kernel/obj/hi3519v101/ import directly.
+ * Targets Linux 7.0 on Cortex-A7/A17 (QEMU emulates as single Cortex-A7).
+ *
+ * Hi3519V101 blobs were compiled against Hi3519V101 SDK V1.0.5.0 atop
+ * kernel 3.18.20. They embed call sites verbatim — no OSAL abstraction
+ * for kernel APIs that have since been renamed, removed, or inlined.
+ *
+ * Three categories of symbols re-exported here:
+ *
+ *  (a) kernel APIs renamed by the memory-allocation profiling rework
+ *      (kmalloc_noprof / kmem_cache_alloc_noprof / vmalloc_noprof — 6.5+)
+ *      and the timer/sysctl reworks (timer_delete_sync 7.0,
+ *      register_sysctl_paths/table removed 6.6);
+ *
+ *  (b) ARM helpers and per-arch glue gone from mainline
+ *      (__memzero, _raw_spin_lock_irqsave/unlock_irqrestore, __current,
+ *      arm926_flush_*, arm_dma_ops, dma_alloc_from_coherent);
+ *
+ *  (c) vendor BSP symbols the blob references but openhisilicon has no
+ *      source for and the mainline kernel does not provide
+ *      (dis_irq_handle[] GIC SGI array, hios_mcc_* multi-core RPC,
+ *      hil_is_phys_in_mmz / hil_map_mmz_check_phys MMZ predicates,
+ *      pcit_create_task, get_pf_window_base, g_reg_otp_base_va,
+ *      lowercase cmpi_* renames the V3A vendor SDK introduced).
+ *
+ * Must load BEFORE any V3A blob module (load_hisilicon order:
+ * open_osal → open_v3a_shim → open_sys_config → open_base → ...).
+ */
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/printk.h>
+#include <linux/timer.h>
+#include <linux/sysctl.h>
+#include <linux/string.h>
+#include <linux/types.h>
+#include <linux/version.h>
+#include <linux/sched.h>
+#include <linux/slab.h>
+#include <linux/proc_fs.h>
+#include <linux/vmalloc.h>
+#include <linux/device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+#include <linux/spinlock.h>
+#include <linux/jiffies.h>
+#include <linux/math64.h>
+#include <linux/random.h>
+#include <stdarg.h>
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("V3A (hi3519v101) OSAL shim — re-exports removed-since-3.18 kernel APIs and stubs vendor BSP symbols");
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+
+/* ============================================================
+ * (a) memory-profiling renames (kmalloc_noprof / vmalloc_noprof
+ * /kmem_cache_alloc_noprof) introduced in 6.5+, and other API
+ * removals.
+ * ============================================================ */
+
+/* __kmalloc (renamed __kmalloc_noprof in 6.5). */
+void *__v3a_shim_kmalloc(size_t size, gfp_t flags)
+{
+	return __kmalloc_noprof(size, flags);
+}
+#undef __kmalloc
+extern void *__kmalloc(size_t size, gfp_t flags)
+	__attribute__((alias("__v3a_shim_kmalloc")));
+EXPORT_SYMBOL(__kmalloc);
+
+/* kmem_cache_alloc (became macro 7.0). */
+void *__v3a_shim_kmem_cache_alloc(struct kmem_cache *s, gfp_t flags)
+{
+	return kmem_cache_alloc_noprof(s, flags);
+}
+#undef kmem_cache_alloc
+extern void *kmem_cache_alloc(struct kmem_cache *s, gfp_t flags)
+	__attribute__((alias("__v3a_shim_kmem_cache_alloc")));
+EXPORT_SYMBOL(kmem_cache_alloc);
+
+/* vmalloc (became macro 7.0). */
+void *__v3a_shim_vmalloc(unsigned long size)
+{
+	return vmalloc_noprof(size);
+}
+#undef vmalloc
+extern void *vmalloc(unsigned long size)
+	__attribute__((alias("__v3a_shim_vmalloc")));
+EXPORT_SYMBOL(vmalloc);
+
+/* printk (renamed _printk 6.0). */
+asmlinkage __printf(1, 2) int __v3a_shim_printk(const char *fmt, ...)
+{
+	va_list args;
+	int r;
+
+	va_start(args, fmt);
+	r = vprintk(fmt, args);
+	va_end(args);
+	return r;
+}
+#undef printk
+extern __printf(1, 2) int printk(const char *fmt, ...)
+	__attribute__((alias("__v3a_shim_printk")));
+EXPORT_SYMBOL(printk);
+
+/* __memzero (ARM-specific lib helper, gone). */
+void __memzero(void *ptr, size_t n)
+{
+	memset(ptr, 0, n);
+}
+EXPORT_SYMBOL(__memzero);
+
+/* del_timer_sync (renamed timer_delete_sync 7.0). */
+#undef del_timer_sync
+int del_timer_sync(struct timer_list *timer)
+{
+	return timer_delete_sync(timer);
+}
+EXPORT_SYMBOL(del_timer_sync);
+
+/* dev_err (macro that funnels through _dev_err — blob references the
+ * macro-name symbol; provide variadic wrapper via dev_vprintk_emit). */
+#undef dev_err
+asmlinkage __printf(2, 3) void dev_err(const struct device *dev,
+				       const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	dev_vprintk_emit(3 /* KERN_ERR */, dev, fmt, args);
+	va_end(args);
+}
+EXPORT_SYMBOL(dev_err);
+
+/* dev_warn (KERN_WARNING; same shape as dev_err). */
+#undef dev_warn
+asmlinkage __printf(2, 3) void dev_warn(const struct device *dev,
+					const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	dev_vprintk_emit(4 /* KERN_WARNING */, dev, fmt, args);
+	va_end(args);
+}
+EXPORT_SYMBOL(dev_warn);
+
+/* msecs_to_jiffies (became static inline; blob references it as symbol). */
+#undef msecs_to_jiffies
+unsigned long msecs_to_jiffies(const unsigned int m)
+{
+	return (m * (unsigned long)HZ + (MSEC_PER_SEC - 1)) / MSEC_PER_SEC;
+}
+EXPORT_SYMBOL(msecs_to_jiffies);
+
+/* __mutex_init (extern in mutex.h; not exported by 6.x kernels). The
+ * Kbuild macro rename suppresses the header prototype so we can supply
+ * the symbol from this TU; #undef restores the legacy name for our
+ * own declaration. */
+#undef __mutex_init
+void __v3a_shim___mutex_init(struct mutex *lock, const char *name,
+			     struct lock_class_key *key)
+{
+	memset(lock, 0, sizeof(*lock));
+	atomic_long_set(&lock->owner, 0);
+	raw_spin_lock_init(&lock->wait_lock);
+	INIT_LIST_HEAD(&lock->wait_list);
+}
+extern void __mutex_init(struct mutex *lock, const char *name,
+			 struct lock_class_key *key)
+	__attribute__((alias("__v3a_shim___mutex_init")));
+EXPORT_SYMBOL(__mutex_init);
+
+/* module_put / try_module_get — static inline in modules.h on modern
+ * kernels. Suppress via Kbuild macro rename then #undef here so the
+ * extern legacy symbol declarations below don't collide with the
+ * (now renamed) header inlines. Best-effort no-op for QEMU boot — the
+ * blobs call these for /dev/* misc-device refcounts and the kernel
+ * has its own internal refcount independently. */
+#undef module_put
+void __v3a_shim_module_put_impl(struct module *module)
+{
+	/* no-op */
+}
+extern void module_put(struct module *module)
+	__attribute__((alias("__v3a_shim_module_put_impl")));
+EXPORT_SYMBOL(module_put);
+
+#undef try_module_get
+bool __v3a_shim_try_module_get_impl(struct module *module)
+{
+	return true;
+}
+extern bool try_module_get(struct module *module)
+	__attribute__((alias("__v3a_shim_try_module_get_impl")));
+EXPORT_SYMBOL(try_module_get);
+
+/* warn_slowpath_null (renamed warn_slowpath_fmt in 5.x). The replacement
+ * __warn_printk() is not exported either, so just emit a plain printk
+ * and barrier — semantics are best-effort. */
+void warn_slowpath_null(const char *file, int line)
+{
+	printk(KERN_WARNING "WARNING at %s:%d\n", file, line);
+}
+EXPORT_SYMBOL(warn_slowpath_null);
+
+/* of_property_read_u32_array became inline wrapper over
+ * of_property_read_variable_u32_array(). */
+#undef of_property_read_u32_array
+int of_property_read_u32_array(const struct device_node *np,
+			       const char *propname, u32 *out_values,
+			       size_t sz)
+{
+	int ret = of_property_read_variable_u32_array(np, propname,
+						      out_values, sz, 0);
+	if (ret >= 0 && (size_t)ret != sz)
+		return -EOVERFLOW;
+	return ret >= 0 ? 0 : ret;
+}
+EXPORT_SYMBOL(of_property_read_u32_array);
+
+/* register_sysctl_table — removed in 6.6 (commit c1d967dd49a3). Best
+ * effort: count entries and register flat under /proc/sys/hisi/. */
+struct ctl_table_header *register_sysctl_table(struct ctl_table *table)
+{
+	int count = 0;
+	while (table && table[count].procname)
+		count++;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+	return register_sysctl_sz("hisi", table, count);
+#else
+	return register_sysctl("hisi", table);
+#endif
+}
+EXPORT_SYMBOL(register_sysctl_table);
+
+/* register_sysctl_paths (removed 6.6 — same flat handling as _table). */
+struct ctl_path {
+	const char *procname;
+};
+struct ctl_table_header *register_sysctl_paths(const struct ctl_path *path,
+					       struct ctl_table *table)
+{
+	int count = 0;
+	while (table && table[count].procname)
+		count++;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+	return register_sysctl_sz("hisi", table, count);
+#else
+	return register_sysctl("hisi", table);
+#endif
+}
+EXPORT_SYMBOL(register_sysctl_paths);
+
+/* ============================================================
+ * (b) ARM helpers and per-arch glue gone from mainline.
+ * ============================================================ */
+
+/* __current — ARM-specific accessor. The blob references it as a raw
+ * symbol; modern kernels access `current` via per-CPU read of sp_el0
+ * (arm64) or by reading thread_info from the stack base (arm32). On
+ * arm32 mainline the `current` macro expands to get_current() which
+ * is a static inline; the legacy `__current` symbol the blob expects
+ * is gone. Provide a global pointer so the symbol resolves; runtime
+ * dereferences will read whatever was last written. The blob only
+ * uses this for diagnostic prints (per cv300 vendor analysis) — it
+ * is NOT load-bearing for the boot/eth path. */
+struct task_struct *__current_storage = NULL;
+extern struct task_struct *__current
+	__attribute__((alias("__current_storage")));
+EXPORT_SYMBOL(__current);
+
+/* arm926_flush_kern_cache_all / arm926_flush_kern_dcache_area — the
+ * Hi3519V101 die actually has Cortex-A17 + A7 cores (ARMv7), NOT ARM926.
+ * The blob has these symbols as dead vendor-SDK leftovers (cv300 family
+ * shared blob compile target). Stub as no-op flushes — on Cortex-A7 the
+ * generic flush_cache_all() / flush_dcache_page() paths handle cache
+ * coherence; if the blob ever called these (it shouldn't, since the
+ * code paths are CPU-feature gated) the runtime would mis-flush, but
+ * since they're dead they should never fire. */
+void arm926_flush_kern_cache_all(void)
+{
+	flush_cache_all();
+}
+EXPORT_SYMBOL(arm926_flush_kern_cache_all);
+
+void arm926_flush_kern_dcache_area(void *addr, size_t size)
+{
+	/* arm32 mainline exposes __cpuc_flush_dcache_area; arm64 renamed
+	 * __flush_dcache_area to dcache_clean_inval_poc at 5.15. The
+	 * symbol here is a vendor-SDK leftover (V3A blob was compiled
+	 * with ARM926 dispatch tables active even though the SoC die
+	 * is Cortex-A17 + A7). In practice this call site is dead at
+	 * runtime — gated by a CPU-feature check the blob does on
+	 * probe. Stub to a generic full-cache flush so worst-case
+	 * correctness wins over performance. */
+	flush_cache_all();
+}
+EXPORT_SYMBOL(arm926_flush_kern_dcache_area);
+
+/* arm_dma_ops — old per-arch DMA ops vector, replaced by per-device
+ * dma_ops in modern kernels. Provide an empty placeholder so the blob
+ * symbol resolves; any blob that actually dereferenced this would
+ * NULL-deref a function pointer, which would be visible immediately.
+ * Empirically the blobs only take its address (for cache-op wiring) so
+ * a non-NULL symbol is enough. */
+const struct dma_map_ops arm_dma_ops = { 0 };
+EXPORT_SYMBOL(arm_dma_ops);
+
+/* dma_alloc_from_coherent / dma_release_from_coherent — replaced by
+ * dma_alloc_from_dev_coherent / dma_release_from_dev_coherent in 4.18+,
+ * neither of which is exported in modern kernels. The blob uses these
+ * to opt-in to a per-device coherent reserved memory pool; returning 0
+ * (= "this device has no coherent pool") makes the blob fall back to
+ * the generic dma_alloc_coherent() path, which works on QEMU. */
+int dma_alloc_from_coherent(struct device *dev, ssize_t size,
+			    dma_addr_t *dma_handle, void **ret)
+{
+	*ret = NULL;
+	return 0;
+}
+EXPORT_SYMBOL(dma_alloc_from_coherent);
+
+int dma_release_from_coherent(struct device *dev, int order, void *vaddr)
+{
+	return 0;
+}
+EXPORT_SYMBOL(dma_release_from_coherent);
+
+/* dma_supported — replaced by per-ops .dma_supported callback. Blob
+ * calls it as a top-level function; return 1 (always supported) on
+ * QEMU and most hardware paths. */
+int dma_supported(struct device *dev, u64 mask)
+{
+	return 1;
+}
+EXPORT_SYMBOL(dma_supported);
+
+/* _raw_spin_lock_irqsave / _raw_spin_unlock_irqrestore — debug-only
+ * exports in modern kernels (lockdep). When CONFIG_DEBUG_SPINLOCK is
+ * off, the raw spinlock ops are inline. Provide non-debug wrappers
+ * that the blob can link to. */
+#undef _raw_spin_lock_irqsave
+unsigned long _raw_spin_lock_irqsave(raw_spinlock_t *lock)
+{
+	unsigned long flags;
+	local_irq_save(flags);
+	preempt_disable();
+	arch_spin_lock(&lock->raw_lock);
+	return flags;
+}
+EXPORT_SYMBOL(_raw_spin_lock_irqsave);
+
+#undef _raw_spin_unlock_irqrestore
+void _raw_spin_unlock_irqrestore(raw_spinlock_t *lock, unsigned long flags)
+{
+	arch_spin_unlock(&lock->raw_lock);
+	preempt_enable();
+	local_irq_restore(flags);
+}
+EXPORT_SYMBOL(_raw_spin_unlock_irqrestore);
+
+/* ============================================================
+ * (c) vendor BSP symbols — provide stubs so the blob links.
+ *     Runtime behavior is best-effort: code paths that actually
+ *     exercise these features (PCIV multi-SoC, GIC SGI, OTP)
+ *     will return -ENOSYS / 0 / NULL.
+ * ============================================================ */
+
+/* dis_irq_handle — the GIC SGI handler array vendor BSP defined for
+ * cross-CPU IRQ forwarding (used in dual-core A17+A7 big.LITTLE).
+ * On mainline this array doesn't exist. osal_interrupt.c references
+ * it under CONFIG_ARM_GIC. Provide a 2-entry static array (matches
+ * DIS_IRQ_CNT in osal_interrupt.c). */
+struct gic_sgi_handle_v3a {
+	unsigned int irq;
+	void (*handle)(unsigned int cpu_intrf,
+		       unsigned int irq_num,
+		       struct pt_regs *regs);
+};
+struct gic_sgi_handle_v3a dis_irq_handle[2] = {
+	{ .irq = 0xF, .handle = NULL },
+	{ .irq = 0xF, .handle = NULL },
+};
+EXPORT_SYMBOL(dis_irq_handle);
+
+/* hios_mcc_* — Hi3519V101's multi-core comms RPC (A17 host ↔ A7 cmpt).
+ * V3A blobs (pciv, pciv_fmw) link these unconditionally even when MCC
+ * isn't used (PCIV is for cross-SoC video relay over PCIe; on a single
+ * QEMU instance MCC never opens). Stub all to -ENOSYS / no-op. */
+int hios_mcc_open(int port) { return -ENOSYS; }
+EXPORT_SYMBOL(hios_mcc_open);
+int hios_mcc_close(int handle) { return 0; }
+EXPORT_SYMBOL(hios_mcc_close);
+int hios_mcc_check_remote(int target_id) { return -ENOSYS; }
+EXPORT_SYMBOL(hios_mcc_check_remote);
+int hios_mcc_getlocalid(void) { return 0; }
+EXPORT_SYMBOL(hios_mcc_getlocalid);
+int hios_mcc_getremoteids(int *ids, int max) { return 0; }
+EXPORT_SYMBOL(hios_mcc_getremoteids);
+int hios_mcc_sendto(int handle, const void *buf, int len, int target_id)
+{
+	return -ENOSYS;
+}
+EXPORT_SYMBOL(hios_mcc_sendto);
+int hios_mcc_setopt(int handle, int opt, const void *value, int len)
+{
+	return -ENOSYS;
+}
+EXPORT_SYMBOL(hios_mcc_setopt);
+
+/* pcit_create_task — PCI tunneling task; only invoked when PCIE relay
+ * is active. Same as MCC: stub. */
+int pcit_create_task(void *args) { return -ENOSYS; }
+EXPORT_SYMBOL(pcit_create_task);
+
+/* get_pf_window_base — PCI Express PCIe-physfunc window base accessor.
+ * Returns 0 (no window). */
+unsigned long get_pf_window_base(int idx) { return 0; }
+EXPORT_SYMBOL(get_pf_window_base);
+
+/* g_reg_otp_base_va — OTP register window. Vendor BSP defined this as
+ * a global pointer; mainline has no OTP driver. NULL placeholder. */
+void __iomem *g_reg_otp_base_va = NULL;
+EXPORT_SYMBOL(g_reg_otp_base_va);
+
+/* g_stVouExpFunc — VOU export function table. open_vo.ko (disabled via
+ * DISABLE_VO=1 in firmware build) would normally provide this; on
+ * neo we ship a stub here so hi_user.ko's link resolves. */
+void *g_stVouExpFunc = NULL;
+EXPORT_SYMBOL(g_stVouExpFunc);
+
+/* init_timer_key — modern signature requires
+ * void (*)(struct timer_list *). Blobs were built with the legacy
+ * void (*)(unsigned long). Cast and call timer_setup — the symbol
+ * resolves; runtime correctness is broken for blobs that touch
+ * timer->data (the field is gone). The blobs affected here are
+ * pciv_fmw (PCI tunneling) — never exercised on QEMU boot/eth path. */
+void __v3a_shim_init_timer_key(struct timer_list *timer,
+			       void (*func)(struct timer_list *),
+			       unsigned int flags,
+			       const char *name,
+			       struct lock_class_key *key)
+{
+	timer_setup(timer, func, flags);
+}
+extern void init_timer_key(struct timer_list *timer,
+			   void (*func)(struct timer_list *),
+			   unsigned int flags,
+			   const char *name, struct lock_class_key *key)
+	__attribute__((alias("__v3a_shim_init_timer_key")));
+EXPORT_SYMBOL(init_timer_key);
+
+/* hil_is_phys_in_mmz / hil_map_mmz_check_phys — MMZ-side predicates
+ * the blob calls to validate physical addresses before mapping. The
+ * canonical implementations live in our mmz/media-mem.c (hil_mmb_*
+ * lookup), but the symbol names diverge. Forward to safe defaults:
+ * is_phys_in_mmz → 0 (assume NOT in MMZ, fall through to ioremap path);
+ * map_mmz_check_phys → 0 success. */
+int hil_is_phys_in_mmz(unsigned long phys, unsigned long size)
+{
+	return 0;
+}
+EXPORT_SYMBOL(hil_is_phys_in_mmz);
+
+int hil_map_mmz_check_phys(unsigned long phys, unsigned long size)
+{
+	return 0;
+}
+EXPORT_SYMBOL(hil_map_mmz_check_phys);
+
+/* CMPI_* (uppercase, missing-from-blob set) — the V3A vendor blob
+ * does NOT implement these five (cv300 generation got them from a
+ * different vendor SDK). They're called from blob code paths but
+ * never exercised in the QEMU boot/eth path. Stub to safe values. */
+int CMPI_CreateProc(const char *name, void *ops, void *data)
+{
+	return 0;
+}
+EXPORT_SYMBOL(CMPI_CreateProc);
+
+int CMPI_RemoveProc(const char *name) { return 0; }
+EXPORT_SYMBOL(CMPI_RemoveProc);
+
+int CMPI_RegisterDevice(int devno, const char *name, void *ops, void *data)
+{
+	return 0;
+}
+EXPORT_SYMBOL(CMPI_RegisterDevice);
+
+int CMPI_UnRegisterDevice(int devno, const char *name) { return 0; }
+EXPORT_SYMBOL(CMPI_UnRegisterDevice);
+
+int CMPI_UserCopy(void *to, const void *from, unsigned long n)
+{
+	return copy_to_user(to, from, n);
+}
+EXPORT_SYMBOL(CMPI_UserCopy);
+
+/* cmpi_* (lowercase) — V3A's later-vintage refactor renamed several
+ * CMPI primitives. Provide self-contained stubs (do NOT forward to the
+ * uppercase CMPI_* counterparts in base.o — that would create a
+ * v3a_shim -> open_base cyclic module dependency). The lowercase
+ * variants are not exercised on the QEMU boot/eth path. */
+
+int cmpi_register_module(void *mod_info) { return 0; }
+EXPORT_SYMBOL(cmpi_register_module);
+
+int cmpi_unregister_module(int mod_id) { return 0; }
+EXPORT_SYMBOL(cmpi_unregister_module);
+
+int cmpi_get_module_name(int mod_id, char *name) { return 0; }
+EXPORT_SYMBOL(cmpi_get_module_name);
+
+int cmpi_get_module_func_by_id(int mod_id) { return 0; }
+EXPORT_SYMBOL(cmpi_get_module_func_by_id);
+
+void *cmpi_mmz_free(unsigned int phy_addr, void *vir_addr) { return NULL; }
+EXPORT_SYMBOL(cmpi_mmz_free);
+
+int cmpi_mmz_malloc_cached(char *cpMmzName, char *pBufName,
+			   unsigned int *pu32PhyAddr, void **ppVitAddr,
+			   int s32Len)
+{
+	return -ENOMEM;
+}
+EXPORT_SYMBOL(cmpi_mmz_malloc_cached);
+
+int cmpi_mmz_malloc_nocache(char *cpMmzName, char *pBufName,
+			    unsigned int *pu32PhyAddr, void **ppVitAddr,
+			    int s32Len)
+{
+	return -ENOMEM;
+}
+EXPORT_SYMBOL(cmpi_mmz_malloc_nocache);
+
+void *cmpi_remap_cached(unsigned long phys, unsigned long size)
+{
+	return ioremap_cache(phys, size);
+}
+EXPORT_SYMBOL(cmpi_remap_cached);
+
+void *cmpi_remap_nocache(unsigned long phys, unsigned long size)
+{
+	return ioremap(phys, size);
+}
+EXPORT_SYMBOL(cmpi_remap_nocache);
+
+void cmpi_unmap(void *vaddr)
+{
+	iounmap((void __iomem *)vaddr);
+}
+EXPORT_SYMBOL(cmpi_unmap);
+
+/* ============================================================
+ * Missing OSAL helpers — should arguably live in osal/hi3519v101
+ * but the source was sparse. Define them here for now.
+ * ============================================================ */
+
+s64 osal_div_s64(s64 dividend, s32 divisor)
+{
+	return div_s64(dividend, divisor);
+}
+EXPORT_SYMBOL(osal_div_s64);
+
+s64 osal_div64_s64(s64 dividend, s64 divisor)
+{
+	return div64_s64(dividend, divisor);
+}
+EXPORT_SYMBOL(osal_div64_s64);
+
+u64 osal_div_u64(u64 dividend, u32 divisor)
+{
+	return div_u64(dividend, divisor);
+}
+EXPORT_SYMBOL(osal_div_u64);
+
+u32 osal_random(void)
+{
+	return get_random_u32();
+}
+EXPORT_SYMBOL(osal_random);
+
+int osal_call_usermodehelper_force(char *path, char **argv, char **envp,
+				   int wait)
+{
+	return call_usermodehelper(path, argv, envp, wait);
+}
+EXPORT_SYMBOL(osal_call_usermodehelper_force);
+
+/* osal_klib_f* — vendor kernel-side file I/O. On modern kernels with
+ * set_fs() gone, file I/O from kernel is done via kernel_read/write.
+ * Stub to safe no-ops for QEMU boot path; full impl would mirror
+ * cv300's filp_open + kernel_read/write approach. */
+void *osal_klib_fopen(const char *path, int flags, int mode)
+{
+	return NULL;
+}
+EXPORT_SYMBOL(osal_klib_fopen);
+
+int osal_klib_fclose(void *fp) { return 0; }
+EXPORT_SYMBOL(osal_klib_fclose);
+
+int osal_klib_fread(void *buf, size_t size, void *fp) { return 0; }
+EXPORT_SYMBOL(osal_klib_fread);
+
+int osal_klib_fwrite(const void *buf, size_t size, void *fp) { return 0; }
+EXPORT_SYMBOL(osal_klib_fwrite);
+
+unsigned char osal_platform_get_modparam_uchar(void *pdev, const char *name)
+{
+	return 0;
+}
+EXPORT_SYMBOL(osal_platform_get_modparam_uchar);
+
+unsigned short osal_platform_get_modparam_ushort(void *pdev, const char *name)
+{
+	return 0;
+}
+EXPORT_SYMBOL(osal_platform_get_modparam_ushort);
+
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) */
+
+static int __init v3a_shim_init(void)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+	pr_info("v3a_shim: hi3519v101 OSAL shim ready "
+		"(printk, kmalloc, vmalloc, kmem_cache_alloc, dev_err/warn, "
+		"register_sysctl_table/paths, dis_irq_handle, hios_mcc_*, "
+		"hil_*, cmpi_*, osal_div_*)\n");
+#else
+	pr_info("v3a_shim: no-op on this kernel (<5.0); legacy symbols "
+		"still natively exported\n");
+#endif
+	return 0;
+}
+
+static void __exit v3a_shim_exit(void)
+{
+}
+
+module_init(v3a_shim_init);
+module_exit(v3a_shim_exit);

--- a/kernel/piris/hi3519v101/piris.c
+++ b/kernel/piris/hi3519v101/piris.c
@@ -349,11 +349,11 @@ static long piris_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
 #ifndef __HuaweiLite__
     if (_IOC_DIR(cmd) & _IOC_READ)
     {
-        err = !access_ok(VERIFY_WRITE, (void __user*)arg, _IOC_SIZE(cmd));
+        err = !compat_access_ok(VERIFY_WRITE, (void __user*)arg, _IOC_SIZE(cmd));
     }
     else if (_IOC_DIR(cmd) & _IOC_WRITE)
     {
-        err =  !access_ok(VERIFY_READ, (void __user*)arg, _IOC_SIZE(cmd));
+        err =  !compat_access_ok(VERIFY_READ, (void __user*)arg, _IOC_SIZE(cmd));
     }
 
     if (err)
@@ -450,7 +450,9 @@ static struct miscdevice gstPirisDev =
 
 #ifdef __HuaweiLite__
 void piris_timer_cb(UINT32 arg)
-#else 
+#elif defined(COMPAT_TIMER_SETUP)
+void piris_timer_cb(struct timer_list *t)
+#else
 void piris_timer_cb(unsigned long arg)
 #endif
 {
@@ -460,7 +462,11 @@ void piris_timer_cb(unsigned long arg)
     unsigned char bits;
     unsigned long u32Flags;
 
+#ifdef COMPAT_TIMER_SETUP
+    PIRIS_DEV* pstPiris = from_timer(pstPiris, t, timer);
+#else
     PIRIS_DEV* pstPiris = (PIRIS_DEV*)arg;
+#endif
 
     spin_lock_irqsave(&pstPiris->lock, u32Flags);
     if (pstPiris->src_pos == pstPiris->dest_pos)
@@ -646,6 +652,9 @@ int piris_init(void)
         u32Interval = HZ / PIRIS_PPS;
         LOS_SwtmrCreate(u32Interval, LOS_SWTMR_MODE_PERIOD, piris_timer_cb, &p_piris_dev[i]->u16TimerID, (UINT32)p_piris_dev[i]);
         LOS_SwtmrStart(p_piris_dev[i]->u16TimerID);
+#elif defined(COMPAT_TIMER_SETUP)
+        timer_setup(&p_piris_dev[i]->timer, piris_timer_cb, 0);
+        p_piris_dev[i]->timer.expires = jiffies + HZ; /* one second */
 #else
     	init_timer(&p_piris_dev[i]->timer);
         p_piris_dev[i]->timer.function = piris_timer_cb;
@@ -727,11 +736,11 @@ static int piris_probe(struct platform_device *pdev)
     piris_init();
     return 0;
 }
-static int piris_remove(struct platform_device *pdev)
+static compat_platform_remove_ret piris_remove(struct platform_device *pdev)
 {
     printk("<%s> is called\n",__FUNCTION__);
     piris_exit();
-    return 0;
+    compat_platform_remove_return;
 }
 static const struct of_device_id piris_match[] = {
         { .compatible = "hisilicon,piris" },

--- a/kernel/pwm/hi3519v101/pwm.c
+++ b/kernel/pwm/hi3519v101/pwm.c
@@ -37,7 +37,9 @@
 
 
 #ifndef __HuaweiLite__
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0)
 #include <mach/io.h>/* for IO_ADDRESS */
+#endif
 #ifdef CONFIG_HISI_SNAPSHOT_BOOT
 #include "himedia.h"
 #endif
@@ -522,11 +524,11 @@ static int pwm_probe(struct platform_device *pdev)
     pwm_init();
     return 0;
 }
-static int pwm_remove(struct platform_device *pdev)
+static compat_platform_remove_ret pwm_remove(struct platform_device *pdev)
 {
     printk("<%s> is called\n",__FUNCTION__);
     pwm_exit();
-    return 0;
+    compat_platform_remove_return;
 }
 static const struct of_device_id pwm_match[] = {
         { .compatible = "hisilicon,pwm" },

--- a/kernel/sensor_i2c/hi3519v101/sensor_i2c.c
+++ b/kernel/sensor_i2c/hi3519v101/sensor_i2c.c
@@ -8,6 +8,11 @@
 #include <linux/delay.h>
 #include "isp_ext.h"
 
+/* hi_i2c_master_send was a vendor BVT wrapper. Mainline uses i2c_master_send. */
+#ifndef hi_i2c_master_send
+#define hi_i2c_master_send i2c_master_send
+#endif
+
 #define I2C_MAX_NUM 2
 
 static struct i2c_board_info hi_info =

--- a/kernel/sensor_spi/hi3519v101/sensor_spi.c
+++ b/kernel/sensor_spi/hi3519v101/sensor_spi.c
@@ -68,7 +68,15 @@ MODULE_PARM_DESC(sensor, "sensor name");
 #ifndef __HuaweiLite__
 struct spi_master *hi_master[SPI_BUS_NUM_MAX];
 struct spi_device *hi_spi[SPI_BUS_NUM_MAX][2];
+/* spi_bus_type became `const struct bus_type` in 6.x.
+ * compat_spi_busnum_to_controller (in kernel_compat.h) replaces
+ * spi_busnum_to_master after 6.4. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+#include <linux/spi/spi.h>
+#define spi_busnum_to_master(num) compat_spi_busnum_to_controller(num)
+#else
 extern struct bus_type   spi_bus_type;
+#endif
 
 
 #define SPI_MSG_NUM		30

--- a/kernel/sys_config/hi3519v101/sys_config.c
+++ b/kernel/sys_config/hi3519v101/sys_config.c
@@ -22,11 +22,11 @@
 #include <linux/delay.h>
 #include <linux/io.h>
 #include <linux/module.h>
+#include <linux/of.h>
 #include <linux/of_device.h>
 #include <linux/platform_device.h>
 #include <linux/kernel.h>
 #include <linux/slab.h>
-#include <linux/of_device.h>
 
 #define PIN_CTRL_NAME "pinctrl-single,pins"
 
@@ -136,9 +136,9 @@ static int hibvt_pinctrl_probe(struct platform_device *pdev)
 	return hibvt_sys_init(pdev);
 }
 
-static int hibvt_pinctrl_remove(struct platform_device *pdev)
+static compat_platform_remove_ret hibvt_pinctrl_remove(struct platform_device *pdev)
 {
-	return 0;
+	compat_platform_remove_return;
 }
 
 static struct platform_driver hibvt_pinctrl_driver = {


### PR DESCRIPTION
## Summary

V3A (Hi3519V101 / Hi3516AV200, ARMv7 Cortex-A17+A7) is the last HiSilicon SoC family without modern-kernel support. This PR ports OSAL + peripheral drivers + adds an `osal_v3a_shim` module that re-exports kernel APIs the binary blobs reference but mainline has renamed/removed/inlined since 3.18.

- **V3A OSAL/peripheral source-level kernel-compat fixes** — `access_ok`/`platform_remove`/`timer_setup`/`vm_flags_set`/`proc_ops`/`hidmac` shims; pwm/piris/sensor_i2c/sensor_spi/sys_config patches; `mmz/{hisi,cma}_allocator.c` + `himedia/*` refreshed from the already-modernized cv500 variants; `mmz_arm.h` added.
- **`kernel/osal_v3a_shim/v3a_shim.c`** (new, ~650 LoC) — mirrors `osal_v{1,2,2a}_shim/` pattern. Re-exports ~30 renamed/removed kernel APIs (printk → _printk, kmalloc/kmem_cache/vmalloc _noprof variants, dev_err/dev_warn, register_sysctl_table/paths, raw spinlock ops, init_timer_key, __memzero, __current, arm926_flush_*, dma_*_from_coherent, warn_slowpath_null, ...) AND stubs vendor BSP symbols that have no mainline equivalent (dis_irq_handle[], hios_mcc_*, hil_*, pcit_create_task, g_reg_otp_base_va, g_stVouExpFunc, cmpi_* lowercase, CMPI_{Create,Remove}Proc, CMPI_{Register,UnRegister}Device, CMPI_UserCopy, osal_div_*, osal_klib_*, osal_random, osal_call_usermodehelper_force, osal_platform_get_modparam_*). Body gated to `>= 5.0` so the lite (3.18) target compiles as a no-op stub.
- **`kernel/init/hi3519v101/{base,sys,viu,vou,ai,aio,venc,pciv_fmw}_init.c`** — extended from skeletons to re-export each blob's legacy `__ksymtab_*` entries via modern `EXPORT_SYMBOL` so modpost picks them up under the modern 16-byte `struct kernel_symbol` format. Every new block is gated under `#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)` so the 3.18 lite target keeps the blob's pre-existing legacy ksymtab intact (see commit `d1b39c49` rationale).
- **`kernel/compat/kernel_compat.h`** — adds `compat_i2c_new_device` (normalises ERR_PTR → NULL on 5.2+) and `COMPAT_REEXPORT_BLOB_SYMBOL` macro (re-export only on `>= 5.0` where modpost ignores the legacy 8-byte format).
- **`kernel/hi3519v101.kbuild`** — wires the shim module; gates `pm.o` behind `ifndef DISABLE_PM` (firmware build passes `DISABLE_PM=1`).

## Verification

| Layer | Result |
|---|---|
| `hi3519v101_neo` kernel 7.0 build | modpost clean; depmod zero cycles; 27× `hi3519v101_*.ko` + `v3a_shim.ko` install |
| `hi3519v101_neo` QEMU end-to-end | boots to `openipc-hi3519v101 login:`; eth0 DHCP lease 10.0.2.15 via HiGMAC V200 at 0x10050000; no Oops/panic/BUG in dmesg |
| `hi3519v101_lite` kernel 3.18 QEMU regression | bit-for-bit dmesg match vs nightly upstream (627 filtered lines, only kernel build counter differs) |
| `hi3516av200_ultimate` real-hardware regression | dlab lab camera: 27/27 modules load (sys/viu/vpss/venc/aenc/aio/h264e/h265e/jpege/acodec/mipi_rx all back); zero `Unknown symbol` errors in dmesg; matches restored baseline |

Real-hardware regression test caught a regression the QEMU lite test missed: the original V3A init-wrapper extensions used `module_param(vi_vpss_online, ...)` declarations that — on kernel 3.18 — interfered with the linker preserving the blob's legacy `__ksymtab_vi_vpss_online` entry in the merged `.ko`. Commit `d1b39c49` fixes by gating every new `extern X + module_param + COMPAT_REEXPORT_BLOB_SYMBOL` block under `>= 5.0`. Validated on `openipc-hi3516av200.dlab.torturelabs.com`.

## Test plan

- [x] hi3519v101_neo opensdk builds clean against `openipc/linux:upstream-patches` (Linux 7.0)
- [x] hi3519v101_neo boots end-to-end under qemu-system-arm with eth0 DHCP
- [x] hi3519v101_lite no-regression vs nightly upstream under qemu-system-arm
- [x] hi3516av200_ultimate real-hardware regression test — module set matches baseline byte-for-byte (minus `open_hwrng` which is firmware-side, not in this PR's scope)
- [ ] Firmware companion PR: `hi3519v101_neo_defconfig` + `hi3519v101.neo.config` + `neo-post-image.sh` + `hisilicon-opensdk.mk` v3a_shim install + `.github/workflows/build.yml` CI matrix row (`hi3519v101_neo / 7.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)