### PR TITLE
kernel/obj/hi3519v101: ship .cmd stubs for blob .o files

### DIFF
--- a/kernel/obj/hi3519v101/.acodec.o.cmd
+++ b/kernel/obj/hi3519v101/.acodec.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/acodec.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_adec.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_adec.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_adec.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_aenc.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_aenc.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_aenc.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_ai.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_ai.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_ai.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_aio.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_aio.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_aio.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_ao.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_ao.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_ao.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_base.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_base.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_base.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_chnl.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_chnl.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_chnl.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_fisheye.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_fisheye.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_fisheye.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_h264e.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_h264e.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_h264e.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_h265e.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_h265e.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_h265e.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_ir.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_ir.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_ir.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_isp.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_isp.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_isp.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_ive.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_ive.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_ive.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_jpege.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_jpege.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_jpege.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_pciv.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_pciv.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_pciv.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_pciv_fmw.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_pciv_fmw.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_pciv_fmw.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_photo.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_photo.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_photo.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_pm.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_pm.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_pm.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_rc.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_rc.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_rc.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_region.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_region.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_region.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_rtc.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_rtc.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_rtc.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_sys.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_sys.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_sys.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_tde.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_tde.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_tde.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_vedu.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_vedu.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_vedu.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_venc.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_venc.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_venc.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_vgs.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_vgs.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_vgs.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_viu.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_viu.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_viu.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_vou.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_vou.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_vou.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_vpss.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_vpss.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_vpss.o := :

--- a/kernel/obj/hi3519v101/.hi3519v101_wdt.o.cmd
+++ b/kernel/obj/hi3519v101/.hi3519v101_wdt.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hi3519v101_wdt.o := :

--- a/kernel/obj/hi3519v101/.hifb.o.cmd
+++ b/kernel/obj/hi3519v101/.hifb.o.cmd
@@ -1,0 +1,1 @@
+savedcmd_kernel/obj/hi3519v101/hifb.o := :


### PR DESCRIPTION
## Summary

Follow-up to #188 — modern modpost requires per-blob `.o.cmd` files (savedcmd stubs) to satisfy the kernel build system's dependency tracking when linking prebuilt vendor binaries into our `open_*.ko` modules. `.gitignore` excludes `.*.cmd` by default so the stubs need a force-add (`-f`).

Without these, V3A neo (kernel 7.0) modpost fails with:

```
./obj/hi3519v101/.hi3519v101_photo.o.cmd: No such file or directory
make[5]: *** [Module.symvers] Error 1
```

Found via [OpenIPC/firmware#2137](https://github.com/OpenIPC/firmware/pull/2137) CI run on the `Firmware (hi3516av200_neo)` matrix row.

Same fix that landed for cv100 in [488a76f1](https://github.com/OpenIPC/openhisilicon/commit/488a76f1) — 32 stubs, one per blob in `kernel/obj/hi3519v101/`, each containing the single line `savedcmd_kernel/obj/hi3519v101/<blob> := :`.

## Verification

- Local `hi3516av200_neo` firmware build: clean (1910 KB uImage, 5800 KB rootfs, 32 `hi3519v101_*.ko` + `v3a_shim.ko` installed under `/lib/modules/7.0.0/hisilicon/`).
- QEMU smoke test (`qemu-system-arm -M hi3516av200`): boots to `openipc-hi3516av200 login:`, eth0 DHCP via HiGMAC succeeds, no Oops/panic/BUG in dmesg.

## Test plan

- [x] `hi3519v101_lite` still builds clean (32 `.cmd` files are pure additions, no impact on lite/3.18 path)
- [x] `hi3516av200_neo` firmware builds clean against this branch (verified locally with OVERRIDE_SRCDIR)
- [x] QEMU boot test passes
- [ ] OpenIPC/firmware#2137 CI re-runs green after this lands + opensdk pin bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)