### PR TITLE
ci: add hi3516av200_neo QEMU boot matrix row

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1087,6 +1087,21 @@ jobs:
             variant: neo
             mem: 256M
             append: "console=ttyAMA0,115200 mem=32M root=/dev/ram0 rootfstype=squashfs"
+          # av200_neo (V3A / Cortex-A7 in QEMU; real silicon is A17+A7
+          # big.LITTLE distinguished from v101 only by SCSYSID0 sub-variant
+          # byte). Kernel 7.0 with the open_v3a_shim re-exports landed in
+          # openhisilicon#188 + the legacy __ksymtab_* preservation fix in
+          # #190. Firmware-side target is OpenIPC/firmware#2137 — tarball
+          # openipc.hi3516av200-nor-neo.tgz is published by the firmware
+          # nightly. mem=128M to match the V3A osmem/totalmem split
+          # load_hisilicon uses (kernel 0x80000000+128M, MMZ at
+          # 0x88000000+384M); higher mem= overlaps MMZ and trips
+          # `MMZ conflict to kernel memory` on insmod.
+          - machine: hi3516av200
+            firmware: hi3516av200
+            variant: neo
+            mem: 256M
+            append: "console=ttyAMA0,115200 mem=128M root=/dev/ram0 rootfstype=squashfs"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Follow-up to [#191](https://github.com/OpenIPC/openhisilicon/pull/191) — adds the QEMU smoke-test row for V3A neo that was deferred while waiting for the firmware nightly to publish `openipc.hi3516av200-nor-neo.tgz`. That tarball is now in the [latest release](https://github.com/OpenIPC/firmware/releases/tag/latest).

`mem=128M` is load-bearing: the V3A `load_hisilicon` defaults `os_mem_size=128M` so MMZ starts at `0x80000000 + 128M = 0x88000000` and runs through `0x9FFFFFFF` (384M). A larger kernel `mem=` (e.g. `mem=256M`) would claim `0x80000000-0x8FFFFFFF` and **overlap MMZ at 0x88000000**, tripping `ERROR: Conflict MMZ: PHYS(0x88000000, 0x9FFFFFFF) ... MMZ conflict to kernel memory (0x80000000, 0x8FFFFFFF)` on insmod and cascading into `Unknown symbol` across every consumer module. The `mem=32M` append used by cv200/av100/cv300 rows would also work but 128M matches the production OS/MMZ split V3A firmware actually ships.

## Verification

Downloaded `openipc.hi3516av200-nor-neo.tgz` from latest release, booted via:

```sh
qemu-system-arm -M hi3516av200 -m 256M \
  -kernel uImage.hi3516av200 \
  -initrd rootfs.squashfs.hi3516av200 \
  -append "console=ttyAMA0,115200 mem=128M root=/dev/ram0 rootfstype=squashfs" \
  -net nic,model=hisi-gmac -net user,net=10.0.2.0/24
```

- ✅ Boots to `openipc-hi3516av200 login:`
- ✅ eth0 DHCP via HiGMAC: `udhcpc: lease of 10.0.2.15 obtained from 10.0.2.2`
- ✅ No Oops/panic/BUG/Call Trace in dmesg

🤖 Generated with [Claude Code](https://claude.com/claude-code)