### PR TITLE
mipi_rx: skip the openipc_frame_ts vsync IRQ block on V4

### DIFF
--- a/kernel/mipi_rx/mipi_rx_hal.c
+++ b/kernel/mipi_rx/mipi_rx_hal.c
@@ -1977,7 +1977,9 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
 {
 	volatile mipi_rx_sys_regs_t *mipi_rx_sys_regs = get_mipi_rx_sys_regs();
 	volatile lvds_ctrl_regs_t *lvds_ctrl_regs;
+#if !defined(hi3516ev200) && !defined(gk7205v200)
 	volatile mipi_ctrl_regs_t *mipi_ctrl_regs;
+#endif
 	int i = 0;
 
 	for (i = 0; i < MIPI_RX_MAX_PHY_NUM; i++) {
@@ -1997,6 +1999,7 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
 	 * the 0→1 transition; the per-event-type 1 ms dedupe in
 	 * openipc_frame_ts still backstops cv500's double-vsync quirk.
 	 */
+#if !defined(hi3516ev200) && !defined(gk7205v200)
 	for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {
 		static bool s_vsync_was_set[MIPI_RX_MAX_DEV_NUM];
 		unsigned int mipi_int, lvds_int;
@@ -2020,6 +2023,7 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
 			openipc_frame_ts_push(i, OPENIPC_FT_EVT_MIPI_FS);
 		s_vsync_was_set[i] = vsync_now;
 	}
+#endif
 
 	for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {
 		lvds_ctrl_regs = get_lvds_ctrl_regs(i);

--- a/kernel/mipi_rx/mipi_rx_hal.h
+++ b/kernel/mipi_rx/mipi_rx_hal.h
@@ -17,8 +17,13 @@
  * where openipc_frame_ts dispatches it. Error-stat bits unchanged. */
 #define MIPI_INT_VSYNC     (1u << 4)   /* MIPI_CTRL_INT.int_vsync */
 #define LVDS_INT_VSYNC     (1u << 28)  /* LVDS_CTRL_INT.lvds_vsync */
+#if defined(hi3516ev200) || defined(gk7205v200)
+#define MIPI_CTRL_INT_MASK (0x00030003)
+#define LVDS_CTRL_INT_MASK (0x0f110000)
+#else
 #define MIPI_CTRL_INT_MASK (0x00030013)
 #define LVDS_CTRL_INT_MASK (0x1f110000)
+#endif
 #define MIPI_FRAME_INT_MASK (0x000f0000)
 #define MIPI_PKT_INT1_MASK (0x0001000f)
 #define MIPI_PKT_INT2_MASK (0x000f000f)


### PR DESCRIPTION
## Summary

Fixes #194. PR #155 wired a vsync→`openipc_frame_ts` dispatch into the **generic** top-level `kernel/mipi_rx/mipi_rx_hal.{c,h}`. That file is built only by SoCs taking the default `else` branch of `kernel/Kbuild` — in practice V4 (`hi3516ev200`, `gk7205v200`). cv500 has its own `kernel/mipi_rx/hi3516cv500/` copy that received the parallel change correctly; V2/V2A/V3 take per-family `.kbuild` and don't touch this file.

The new IRQ body W1C-clears `MIPI_CTRL_INT_RAW.vsync` and `LVDS_CTRL_INT_RAW.lvds_vsync` inside `mipi_rx_interrupt_route()`. On V4 hardware that desyncs MIPI row reception and the frame falls apart.

Gate the new vsync block and the mask widening to non-V4 only. cv500 keeps the feature through its own per-SoC source file.

## Verified on hardware

`gk7205v300` lab camera + IMX335 sensor + `lite` variant from OpenIPC/firmware. Same scene (color checker) across three builds:

| Build | opensdk | `open_mipi_rx.ko` srcversion | depends | Image |
|---|---|---|---|---|
| `nightly-20260521-932db82` (LKG) | `74d8a65` (pre-#155) | `9F6077B785E512DDED501D6` | `open_osal,open_sys_config` | clean |
| `nightly-20260522-7d32f00` (first-bad) | `28a30ca` (post-#155) | `8EF923DF907C1F7F3C6898E` | `+open_openipc_frame_ts` | heavy horizontal tearing, underexposure |
| this PR (`28a30ca` + patch) | `28a30ca` + this commit | `64D9F91D0C23EE5FB79F14A` | `open_osal,open_sys_config` | clean, matches LKG |

The patched module's `depends` line matches LKG — confirms the `#if defined(hi3516ev200) || defined(gk7205v200)` guard removes the `openipc_frame_ts_push` call site at compile time on V4.

## Field reports (closing #194)

- hi3516ev300 / sp2305 — torn image
- gk7205v200 / os02g10 — \`Timeout from venc channel 0\` in majestic logs
- gk7205v300 / sc223a — \`Timeout from venc channel 0\` in majestic logs

All V4. Sensors where the stream collapses entirely show the timeout; sensors where partial frames still flow (like IMX335 in the lab) show the visible tearing.

## Test plan

- [x] Patch applies cleanly on current head
- [x] \`make BOARD=gk7205v300_lite\` on OpenIPC/firmware @ master builds clean (4:13, uImage 1834/2048 KB, rootfs.squashfs 5104/5120 KB)
- [x] Flashed via \`sysupgrade -k -r --archive=...\`, RTSP snapshot post-reboot clean
- [ ] Run the openhisilicon QEMU-boot matrix to confirm no other CHIPARCH regresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)