### PR TITLE
kernel/sensor_i2c/hi3516cv200: don't clobber vendor hi_i2c_master_send (V2A i2c-in-IRQ fix)

### DIFF
--- a/kernel/sensor_i2c/hi3516cv200/sensor_i2c.c
+++ b/kernel/sensor_i2c/hi3516cv200/sensor_i2c.c
@@ -10,20 +10,28 @@
 #include <linux/delay.h>
 #include "isp_ext.h"
 
-/* HiSi vendor i2c extensions don't exist in mainline. Map to standard
- * i2c_master_send/recv. Drop the 16-bit reg/data flags — sensors that
- * require 16-bit register addressing will be broken at runtime (not at
- * build), needs follow-up kernel patch for true 16-bit support. */
-#ifndef hi_i2c_master_send
-#define hi_i2c_master_send i2c_master_send
-#endif
-#ifndef hi_i2c_master_recv
-#define hi_i2c_master_recv i2c_master_recv
-#endif
+/*
+ * OpenIPC's hisilicon-hi3516cv200 kernel patches i2c with a vendor
+ * extension: `hi_i2c_master_send` calls `hibvt_i2c_xfer` directly,
+ * bypassing i2c-core's rt_mutex_trylock so it is safe from the ISP_ISR
+ * hot path. The vendor uapi i2c.h also defines I2C_M_16BIT_REG and
+ * I2C_M_16BIT_DATA so the controller can switch reg/data width per
+ * transfer. On mainline kernels neither exists; we fall back to the
+ * standard i2c API (which WARNs from atomic context via
+ * rt_mutex_trylock — see OpenIPC/firmware#2144) and lose true 16-bit
+ * sensor addressing until a kernel-side patch lands.
+ *
+ * Gate the entire compat shim on the I2C_M_16BIT_REG macro — it is
+ * the only macro symbol the vendor provides that the preprocessor can
+ * see. The function symbol `hi_i2c_master_send` is an extern, so a
+ * naive `#ifndef hi_i2c_master_send` triggers the macro fallback even
+ * on the vendor kernel, silently routing all sensor writes through
+ * rt_mutex_trylock and making AE writes fail from ISR context.
+ */
 #ifndef I2C_M_16BIT_REG
+#define hi_i2c_master_send i2c_master_send
+#define hi_i2c_master_recv i2c_master_recv
 #define I2C_M_16BIT_REG 0
-#endif
-#ifndef I2C_M_16BIT_DATA
 #define I2C_M_16BIT_DATA 0
 #endif
 


### PR DESCRIPTION
## Summary

`abadb7cf` ([#162](https://github.com/OpenIPC/openhisilicon/pull/162) "kernel/hi3516cv200: bring up V2 generation against Linux 7.0") added two compat shims to `kernel/sensor_i2c/hi3516cv200/sensor_i2c.c`:

```c
#ifndef hi_i2c_master_send
#define hi_i2c_master_send i2c_master_send
#endif
#ifndef I2C_M_16BIT_REG
#define I2C_M_16BIT_REG 0
#endif
```

The `#ifndef I2C_M_16BIT_REG` check is correct — that symbol is a real macro in OpenIPC's `hisilicon-hi3516cv200` kernel (`include/uapi/linux/i2c.h` defines it as `0x0002`), so the preprocessor sees it and skips the fallback.

The `#ifndef hi_i2c_master_send` check is **wrong**. `hi_i2c_master_send` is exported by `drivers/i2c/busses/i2c-hibvt.c` as an `extern` function — an `EXPORT_SYMBOL`'d symbol, **not** a preprocessor macro. The preprocessor cannot see extern function symbols, so `#ifndef hi_i2c_master_send` always evaluated to true and the `#define hi_i2c_master_send i2c_master_send` macro fired even on vendor kernels, silently routing every sensor write through `i2c_master_send` → `i2c_transfer` → `rt_mutex_trylock` instead of the vendor's `hi_i2c_master_send` → `hibvt_i2c_xfer` direct-xfer path.

The vendor extern is IRQ-safe by design — `hibvt_i2c_xfer` is called directly with no i2c-core locking. The mainline path is **not** IRQ-safe: `rt_mutex_trylock` (kernel/locking/rtmutex.c:1545) WARNs and returns `0` in hardirq/softirq context, `i2c_transfer` returns `-EAGAIN`, and every sensor write from inside `ISP_IntBottomHalf` (called from `ISP_ISR`) silently fails. Sensor exposure/gain never updates and AE becomes a no-op control loop. Per-sensor symptom:
- **OV2735** (OpenIPC/firmware#2144 reporter): sensor's internal AGC winds to max gain → image >96 % white.
- **soi_f22** (lab cam): sensor stays at boot-default exposure → image dim, looks "stable" only because nothing is changing.

## Fix

Gate the entire mainline-fallback block on `I2C_M_16BIT_REG`, which the preprocessor can actually see. On vendor kernel the macro exists, the block is skipped, vendor `hi_i2c_master_send` is used unchanged. On mainline both fallbacks fire together — `hi_i2c_master_send` becomes `i2c_master_send` AND the 16-bit flag defines become `0`, which is the consistent state #162 was attempting to reach. The asymmetric handling (function aliased but flags preserved) is what made the bug invisible at review — the build still worked, only the runtime path silently changed.

## Verification on `openipc-hi3518ev200.dlab.torturelabs.com` (soi_f22)

Replaced only `sensor_i2c.ko` on the cam via overlay, reboot, no other changes:

| metric | before fix (rom #186) | after fix |
|---|---|---|
| `dmesg` rt_mutex_trylock WARN | 3+ | **0** |
| AE Error | -44 (diverging) | 10 (converged) |
| AE Iso / Again | 800 / 8192 (sensor-default fallback) | 400 / 4096 (actively adjusted) |
| `/image.jpg` size | 53 KB (sensor stuck) | 108 KB (proper exposure) |
| 20 s frame brightness (RTSP, 10 fps, 160×90) | n/a — stuck | mean=109.0, stdev=**0.16** (0.15 % variance) |

A periodic 5-second brightness spike that I initially mis-attributed to the AE control loop turned out to be `S97qrscan` toggling GPIO-34 on the lab cam — entirely unrelated to this fix.

## Closes

- OpenIPC/firmware#2144 — the real root cause (#196's threaded-IRQ workaround treated a symptom; this PR is the canonical fix and obviates that one).

## Fixes

- `abadb7cf` (#162 "kernel/hi3516cv200: bring up V2 generation against Linux 7.0")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
