### PR TITLE
kernel/mipi_rx/hi3516cv500: remove openipc_frame_ts vsync IRQ block (V4A magenta cast + VENC timeout fix)

### DIFF
--- a/kernel/mipi_rx/hi3516cv500/mipi_rx_hal.c
+++ b/kernel/mipi_rx/hi3516cv500/mipi_rx_hal.c
@@ -2326,49 +2326,10 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
 {
     volatile mipi_rx_sys_regs_t *mipi_rx_sys_regs = get_mipi_rx_sys_regs();
     volatile lvds_ctrl_regs_t *lvds_ctrl_regs = NULL;
-    volatile mipi_ctrl_regs_t *mipi_ctrl_regs;
     int i = 0;
 
     for (i = 0; i < MIPI_RX_MAX_PHY_NUM; i++) {
         mipi_rx_phy_cil_int_statis(i);
-    }
-
-    /*
-     * Frame-start dispatch (openipc_frame_ts). Runs outside the
-     * CHN_INT_RAW gate below because vsync IRQs alone don't set it.
-     * MIPI CSI-2 and LVDS vsync bits are W1C'd independently in case
-     * both are wired up, but openipc_frame_ts_push fires at most once
-     * per device per IRQ so consumers get one event per physical frame.
-     */
-    /*
-     * Edge-detect on the raw vsync bits per device — see the
-     * matching comment in kernel/mipi_rx/mipi_rx_hal.c for the
-     * level-held-bit reasoning. cv500 also has the ~30–80 µs
-     * double-vsync quirk that the 1 ms openipc_frame_ts dedupe
-     * absorbs as a second line of defence.
-     */
-    for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {
-        static bool s_vsync_was_set[MIPI_RX_MAX_DEV_NUM];
-        unsigned int mipi_int, lvds_int;
-        bool vsync_now = false;
-
-        mipi_ctrl_regs = get_mipi_ctrl_regs(i);
-        lvds_ctrl_regs = get_lvds_ctrl_regs(i);
-
-        mipi_int = mipi_ctrl_regs->MIPI_CTRL_INT.u32;
-        lvds_int = lvds_ctrl_regs->LVDS_CTRL_INT.u32;
-
-        if (mipi_int & MIPI_INT_VSYNC) {
-            vsync_now = true;
-            mipi_ctrl_regs->MIPI_CTRL_INT_RAW.u32 = MIPI_INT_VSYNC;
-        }
-        if (lvds_int & LVDS_INT_VSYNC) {
-            vsync_now = true;
-            lvds_ctrl_regs->LVDS_CTRL_INT_RAW.u32 = LVDS_INT_VSYNC;
-        }
-        if (vsync_now && !s_vsync_was_set[i])
-            openipc_frame_ts_push(i, OPENIPC_FT_EVT_MIPI_FS);
-        s_vsync_was_set[i] = vsync_now;
     }
 
     for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {

--- a/kernel/mipi_rx/hi3516cv500/mipi_rx_hal.h
+++ b/kernel/mipi_rx/hi3516cv500/mipi_rx_hal.h
@@ -15,12 +15,8 @@
 #define MIPI_RX_MIN_EXT_DATA_TYPE_BIT_WIDTH    8
 
 #define MIPI_CIL_INT_MASK   0x00003f3f
-/* Vsync bits unmasked so frame-start propagates to mipi_rx_interrupt_route,
- * where openipc_frame_ts dispatches it. Error-stat bits unchanged. */
-#define MIPI_INT_VSYNC      (1u << 4)   /* MIPI_CTRL_INT.int_vsync */
-#define LVDS_INT_VSYNC      (1u << 28)  /* LVDS_CTRL_INT.lvds_vsync */
-#define MIPI_CTRL_INT_MASK  0x00030013
-#define LVDS_CTRL_INT_MASK  0x1f110000
+#define MIPI_CTRL_INT_MASK  0x00030003
+#define LVDS_CTRL_INT_MASK  0x0f110000 /* lvds_vsync_msk and lane0~3_sync_err_msk ignore, not err int */
 #define MIPI_FRAME_INT_MASK 0x000f0000
 #define MIPI_PKT_INT1_MASK  0x0001000f
 #define MIPI_PKT_INT2_MASK  0x000f000f


### PR DESCRIPTION
## Summary

#155 (May 22, "Add openipc_frame_ts: sensor frame-start chrdev") added a MIPI vsync IRQ dispatch block to `kernel/mipi_rx/hi3516cv500/mipi_rx_hal.c`'s `mipi_rx_interrupt_route()`:

```c
for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {
    ...
    if (mipi_int & MIPI_INT_VSYNC) {
        vsync_now = true;
        mipi_ctrl_regs->MIPI_CTRL_INT_RAW.u32 = MIPI_INT_VSYNC;   // W1C
    }
    if (lvds_int & LVDS_INT_VSYNC) {
        vsync_now = true;
        lvds_ctrl_regs->LVDS_CTRL_INT_RAW.u32 = LVDS_INT_VSYNC;   // W1C
    }
    if (vsync_now && !s_vsync_was_set[i])
        openipc_frame_ts_push(i, OPENIPC_FT_EVT_MIPI_FS);
    s_vsync_was_set[i] = vsync_now;
}
```

PR-time validation was 21 fps on an av300 bench at 100 monotonic events. Under sustained **4K30fps load** (IMX415 sensor on a `hi3516av300_lite` production board) the block destabilises the MIPI pipeline:

- Periodic `Timeout from venc channel 0` errors in majestic (11 / 4 min on the freshly-flashed `nightly-20260527-3ec25c3`).
- Persistent **magenta colour cast** in the output image (sensor bayer rows misaligned → RGGB decode picks up the wrong colour channel per row, AWB then computes weird gain ratios trying to compensate).
- Visible "flicker" — frames dropping and recovering against the magenta-tinted baseline.

This is the identical pattern to the V4 regression that #195 fixed in the generic `kernel/mipi_rx/mipi_rx_hal.c`. cv500's per-arch copy of the same hook carries the same hazard: unmasking `MIPI_CTRL_INT.vsync` (bit 4) and `LVDS_CTRL_INT.lvds_vsync` (bit 28) raises IRQ at the line-rate the vsync indicator pulses, and the W1C clear inside the ISR top half collides with the MIPI controller's internal frame-state machine on cv500-class silicon just like it did on V4.

## Fix

Drop the vsync block + revert the mask widening (`MIPI_CTRL_INT_MASK 0x00030013 → 0x00030003`, `LVDS_CTRL_INT_MASK 0x1f110000 → 0x0f110000`).

cv500 keeps the `ISP_FEND` event source (added in #178, lives in `kernel/isp/arch/hi3516cv500/mkp/src/isp.c`, fires from the ISP IRQ — left untouched here). Consumers that want a per-frame timestamp on cv500 still get one via ISP_FEND; they just lose the MIPI_FS edge until a non-IRQ-disrupting hook lands.

## Verified on hardware

`openipc-hi3516av300.dlab.torturelabs.com` (Sony IMX415, 4K30fps, hi3516av300_lite), swap of just the patched `open_mipi_rx.ko` onto a stock-flashed cam via overlay:

| | pre-fix (master + opensdk `073e6e8`) | post-fix (this PR) |
|---|---|---|
| `Timeout from venc` count | 11 / 4 min | **0 / 90 s** |
| `rt_mutex_trylock` WARN | 0 | 0 |
| RTSP 20 s luma stdev (10 fps, 160×90) | n/a — stream drops | **0.22 (0.18 %)** |
| Per-channel ratios | R/G≈1.4, B/G≈3.0 (magenta cast) | R/G=1.21, B/G=0.91 (scene-correct warm) |
| Visible image | magenta cast, drops | correct colours, stable |

## Refs

- #155 — introduced the cv500 vsync block
- #178 — added cv500 ISP_FEND event (still in place after this PR)
- #195 — V4 sibling fix (gated the same hook off in the generic mipi_rx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
