### PR TITLE
ci: build hi3519dv500 (V5 aarch64) in the Build SDK matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
             board: hi3516av100_lite
           - platform: hi3519v101
             board: hi3519v101_lite
+          - platform: hi3519dv500
+            board: hi3519dv500_ultimate
           - platform: hi3516ev300
             board: hi3516ev300_neo
             kernel: "7.0"


### PR DESCRIPTION
Adds **hi3519dv500** to the `Build SDK` CI matrix, so the V5 aarch64 kernel modules + sensors build on every openhisilicon change.

Now possible because the firmware side landed: [OpenIPC/firmware #2205](https://github.com/OpenIPC/firmware/pull/2205) enabled `hisilicon-opensdk` for hi3519dv500 (on top of #2203 board + #2204 CI). The generic `Build OpenHisilicon` step clones firmware master, sets `hisilicon-opensdk` `SITE=local` to this checkout, and runs `make BOARD=hi3519dv500_ultimate br-hisilicon-opensdk` — building the **53 `open_*.ko` + 8 sensor `.so`** from source against linux 5.10.0 (aarch64).

First V5 entry in this matrix (cv6xx/hi3520dv200 aren't here yet). Validated locally: the same `br-hisilicon-opensdk` build succeeds end-to-end.