### PR TITLE
kernel/hi3516cv200: recognize the gc2023_mipi sensor type

### DIFF
--- a/kernel/sys_config/hi3516cv200/sys_config.c
+++ b/kernel/sys_config/hi3516cv200/sys_config.c
@@ -609,6 +609,16 @@ static void insert_sns(void)
 
 		sys_write_reg(0x2003002c, 0xc4001);			// sensor unreset, clk 24MHz, VI 99MHz
 	}
+    else if (!strcmp(sensor, "gc2023_mipi"))
+	{
+		// MIPI variant — GC2023 wired to CSI-2 (e.g. VStarcam Hi3518EV200),
+		// uses gc2023_mipi_1080p.ini; the parallel VI pads stay unmuxed so
+		// the MIPI PHY keeps the pins
+		sys_write_reg(0x200f0040, 0x2);    			// I2C0_SCL
+		sys_write_reg(0x200f0044, 0x2);    			// I2C0_SDA
+
+		sys_write_reg(0x2003002c, 0xc4001);			// sensor unreset, clk 24MHz, VI 99MHz
+	}
     else if (!strcmp(sensor, "ov2710_dc"))
 	{
 		// DVP/parallel variant — uses libsns_ov2710_dc.so via ov2710_dc_1080p.ini


### PR DESCRIPTION
## What

Add a `gc2023_mipi` arm to the hi3516cv200 `open_sys_config` sensor table: I2C0 pinmux + 24 MHz sensor clock, parallel VI pads left alone so the MIPI PHY keeps the pins. Mechanical mirror of the existing `ov2710_mipi` arm.

## Why

Companion to OpenIPC/firmware#2248, which adds the `gc2023_mipi` identity to `load_hisilicon` and a `gc2023_mipi_1080p.ini`. `open_sys_config` falls through to `sensor_type '%s' is error!!!` for names it does not know; that is non-fatal (the script's `devmem` writes run afterwards and win), but it leaves an alarming line in every boot log and lets the two pinmux tables drift. The OV2710 MIPI addition updated both tables; this restores that symmetry for GC2023.

Raised by @widgetii in the review of OpenIPC/firmware#2248.

## Verification

The register writes are hardware-verified in their `devmem` form: they are exactly what the `load_hisilicon` arm issues on a VStarcam Hi3518EV200 with the GC2023 wired to MIPI (I2C reaches the sensor, MIPI PHY delivers frames with the vendor MIPI libsns — full bring-up record in OpenIPC/firmware#2243). This kernel arm is a byte-for-byte mirror of the `ov2710_mipi` arm apart from the name and comment; I have not built the cv200 kernel tree standalone.
