### PR TITLE
acodec: retune the ADC when a clock change invalidates it

### DIFF
--- a/kernel/acodec/acodec_init.c
+++ b/kernel/acodec/acodec_init.c
@@ -3,18 +3,158 @@
 #include <linux/printk.h>
 
 #include "type.h"
+#include "osal.h"
 
 extern int acodec_init(void);
 extern void acodec_exit(void);
 extern unsigned int init_delay_time;
 module_param(init_delay_time, uint, S_IRUGO);
 
+#if defined(gk7205v200) || defined(hi3516ev200)
+#define ACODEC_RCTUNE_WATCHDOG
+#endif
+
+#ifdef ACODEC_RCTUNE_WATCHDOG
+
+/*
+ * The inner codec tunes its ADC RC network whenever ACODEC_SET_I2S1_FS pulses
+ * en_rctune, and the code it latches is only correct for the codec clock that
+ * was running at the time. Register 0x18 reports that live: bit 3 stays set
+ * for as long as the tuning still matches the clock.
+ *
+ * Enabling an AI device reprograms the AIAO TX0 clock, which invalidates a
+ * tuning that was correct a moment earlier, and nothing recalibrates
+ * afterwards. Traced on gk7205v200 inside a single 70 ms window: 0x18 read
+ * 0x3F with the codec fully configured, then 0x25 the instant
+ * AIAO_CLK_TX0_CRG/CFG moved. From there the ADC modulator runs mistuned and
+ * settles into a limit cycle -- an audible tone at fs*39/1024 and its
+ * harmonics, up to 20 dB over the noise floor, lasting as long as the device
+ * stays up. Confirmed on gk7205v200 and hi3516ev200. See OpenIPC/majestic#285.
+ *
+ * The codec cannot observe the clock moving, but it can observe the result.
+ * Watch the validity bit and retune when it goes stale: that is the same pulse
+ * the SET_I2S1_FS ioctl issues, so the tuning follows the clock no matter
+ * which consumer moves it, or when.
+ */
+
+#define ACODEC_REGS_BASE 0x100f0000
+#define ACODEC_REGS_SIZE 0x1000
+
+#define ACODEC_ANAREG1 0x04
+#define ACODEC_EN_RCTUNE (1u << 1)
+#define ACODEC_CAL_STATUS 0x18
+#define ACODEC_CAL_VALID (1u << 3)
+
+/* One retune settles it, so a second is a long time to sound wrong. Once it is
+ * clear the tuning will not take, stop pulsing every second over a codec
+ * somebody may be reading from. */
+#define ACODEC_POLL_MS 1000
+#define ACODEC_POLL_STUCK_MS 10000
+#define ACODEC_RETUNE_LIMIT 10
+
+static int rctune_watchdog = 1;
+module_param(rctune_watchdog, int, S_IRUGO);
+MODULE_PARM_DESC(rctune_watchdog,
+		 "retune the ADC when a clock change invalidates it (default 1)");
+
+static void *acodec_regs;
+static osal_timer_t rctune_timer;
+static unsigned int rctune_failures;
+
+#define acodec_readl(off) osal_readl((uintptr_t)acodec_regs + (off))
+#define acodec_writel(v, off) osal_writel(v, (uintptr_t)acodec_regs + (off))
+
+static void acodec_rctune(void)
+{
+	unsigned int anareg1 = acodec_readl(ACODEC_ANAREG1);
+
+	acodec_writel(anareg1 & ~ACODEC_EN_RCTUNE, ACODEC_ANAREG1);
+	osal_udelay(30);
+	acodec_writel(anareg1 | ACODEC_EN_RCTUNE, ACODEC_ANAREG1);
+}
+
+static void acodec_rctune_check(unsigned long data)
+{
+	unsigned long period = ACODEC_POLL_MS;
+
+	if (acodec_readl(ACODEC_CAL_STATUS) & ACODEC_CAL_VALID) {
+		rctune_failures = 0;
+	} else {
+		acodec_rctune();
+
+		rctune_failures++;
+		if (rctune_failures == 1)
+			osal_printk("acodec: ADC tuning stale after a clock "
+				    "change, retuning\n");
+		else if (rctune_failures == ACODEC_RETUNE_LIMIT)
+			osal_printk("acodec: ADC tuning will not latch, "
+				    "backing off\n");
+
+		if (rctune_failures >= ACODEC_RETUNE_LIMIT)
+			period = ACODEC_POLL_STUCK_MS;
+	}
+
+	osal_set_timer(&rctune_timer, period);
+}
+
+static void acodec_rctune_watchdog_init(void)
+{
+	if (!rctune_watchdog)
+		return;
+
+	acodec_regs = osal_ioremap(ACODEC_REGS_BASE, ACODEC_REGS_SIZE);
+	if (acodec_regs == NULL) {
+		osal_printk("acodec: cannot map codec registers, ADC tuning "
+			    "will not be maintained\n");
+		return;
+	}
+
+	if (osal_timer_init(&rctune_timer)) {
+		osal_iounmap(acodec_regs);
+		acodec_regs = NULL;
+		return;
+	}
+
+	rctune_timer.function = acodec_rctune_check;
+	rctune_timer.data = 0;
+	osal_set_timer(&rctune_timer, ACODEC_POLL_MS);
+}
+
+static void acodec_rctune_watchdog_exit(void)
+{
+	if (acodec_regs == NULL)
+		return;
+
+	osal_del_timer(&rctune_timer);
+	osal_timer_destory(&rctune_timer);
+	osal_iounmap(acodec_regs);
+	acodec_regs = NULL;
+}
+
+#else /* no inner codec we know the tuning-status register of */
+
+static void acodec_rctune_watchdog_init(void)
+{
+}
+static void acodec_rctune_watchdog_exit(void)
+{
+}
+
+#endif
+
 static __init int acodec_mod_init(void)
 {
-	return acodec_init();
+	int ret = acodec_init();
+
+	if (ret)
+		return ret;
+
+	acodec_rctune_watchdog_init();
+	return 0;
 }
 static __exit void acodec_mod_exit(void)
 {
+	acodec_rctune_watchdog_exit();
 	acodec_exit();
 }
 

--- a/kernel/acodec/acodec_init.c
+++ b/kernel/acodec/acodec_init.c
@@ -1,6 +1,8 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/printk.h>
+#include <linux/jiffies.h>
+#include <linux/workqueue.h>
 
 #include "type.h"
 #include "osal.h"
@@ -57,8 +59,16 @@ module_param(rctune_watchdog, int, S_IRUGO);
 MODULE_PARM_DESC(rctune_watchdog,
 		 "retune the ADC when a clock change invalidates it (default 1)");
 
+/* Deliberately not osal_timer_t: osal_del_timer() and osal_timer_destory() are
+ * both del_timer() rather than del_timer_sync(), and destroy kfree()s the timer
+ * on top. A callback that re-arms itself -- this one does -- can then still be
+ * running while the module frees the timer and unmaps the registers underneath
+ * it, which load_goke's remove_audio would hit on every teardown. Delayed work
+ * cancels synchronously, and it runs the retune in process context rather than
+ * busy-waiting 30 us in a softirq. */
 static void *acodec_regs;
-static osal_timer_t rctune_timer;
+static struct delayed_work rctune_work;
+static bool rctune_stopping;
 static unsigned int rctune_failures;
 
 #define acodec_readl(off) osal_readl((uintptr_t)acodec_regs + (off))
@@ -73,7 +83,7 @@ static void acodec_rctune(void)
 	acodec_writel(anareg1 | ACODEC_EN_RCTUNE, ACODEC_ANAREG1);
 }
 
-static void acodec_rctune_check(unsigned long data)
+static void acodec_rctune_check(struct work_struct *work)
 {
 	unsigned long period = ACODEC_POLL_MS;
 
@@ -94,7 +104,10 @@ static void acodec_rctune_check(unsigned long data)
 			period = ACODEC_POLL_STUCK_MS;
 	}
 
-	osal_set_timer(&rctune_timer, period);
+	/* Checked before re-arming, so a cancel that lands while this callback
+	 * is running cannot be outlived by the work it queues. */
+	if (!rctune_stopping)
+		schedule_delayed_work(&rctune_work, msecs_to_jiffies(period));
 }
 
 static void acodec_rctune_watchdog_init(void)
@@ -109,15 +122,9 @@ static void acodec_rctune_watchdog_init(void)
 		return;
 	}
 
-	if (osal_timer_init(&rctune_timer)) {
-		osal_iounmap(acodec_regs);
-		acodec_regs = NULL;
-		return;
-	}
-
-	rctune_timer.function = acodec_rctune_check;
-	rctune_timer.data = 0;
-	osal_set_timer(&rctune_timer, ACODEC_POLL_MS);
+	rctune_stopping = false;
+	INIT_DELAYED_WORK(&rctune_work, acodec_rctune_check);
+	schedule_delayed_work(&rctune_work, msecs_to_jiffies(ACODEC_POLL_MS));
 }
 
 static void acodec_rctune_watchdog_exit(void)
@@ -125,8 +132,9 @@ static void acodec_rctune_watchdog_exit(void)
 	if (acodec_regs == NULL)
 		return;
 
-	osal_del_timer(&rctune_timer);
-	osal_timer_destory(&rctune_timer);
+	rctune_stopping = true;
+	cancel_delayed_work_sync(&rctune_work);
+
 	osal_iounmap(acodec_regs);
 	acodec_regs = NULL;
 }


### PR DESCRIPTION
Closes #208 (the mechanism, not the framing — see below).

## What happens

The v750 inner codec tunes its ADC RC network whenever `ACODEC_SET_I2S1_FS` pulses `en_rctune`, and the code it latches is only correct for the codec clock that was running at the time. Register `0x18` reports that live: bit 3 stays set while the tuning still matches the clock. Nothing in the driver reads or writes that offset — I disassembled `acodec_log.o` to check — so it is pure hardware status.

Enabling an AI device reprograms the AIAO TX0 clock, which invalidates a tuning that was correct a moment earlier. Traced on gk7205v200 by sampling the status and clock registers continuously across a cold boot; three distinct states in the entire trace:

```
t=39.39  0x18=0x3F  AIAO140=0x000DFB24 AIAO144=0x00000131  idle
t=43.31  0x18=0x3F  AIAO140=0x000DFB24 AIAO144=0x00000131  codec configured
t=43.38  0x18=0x25  AIAO140=0x00095218 AIAO144=0x0000C117  AI enabled
```

The calibration never fails — it is valid at t=43.31 and invalidated 70 ms later. Nothing recalibrates afterwards, so the ADC modulator runs mistuned and settles into a limit cycle: an audible tone at `fs*39/1024` and its harmonics, up to 20 dB over the noise floor, for as long as the device stays up. Reported downstream as OpenIPC/majestic#285.

**This corrects #208 as I first filed it.** I blamed the missing staged vref settle. That cannot be the cause: the module loads tens of seconds before any consumer starts, so vref has long settled by the time the invalidating calibration happens — and the original reporter had already shown that delaying the consumer's first start by 40 s changes nothing. The staged-power-up deviation from the vendor's U-Boot build of the same driver is real and worth fixing on its own, but it is a separate item.

## The change

The codec cannot observe the clock moving, but it can observe the result. Poll the validity bit on a 1 s timer and re-pulse `en_rctune` when it goes stale — the same pulse `SET_I2S1_FS` issues. The tuning then follows the clock whichever consumer moves it, or when.

Backs off to 10 s after 10 consecutive failures rather than pulsing every second over a codec somebody may be reading from, logs the first retune and the back-off, and `rctune_watchdog=0` disables it. Guarded to the parts whose status register is known — `gk7205v200` and `hi3516ev200`, both confirmed on hardware; `ccflags-y` already defines `-D$(CHIPARCH)`, so the chip name is available as a macro. It maps the codec block itself rather than depending on `pAcodec`, which `open_aio` exports but may leave NULL.

## Verification

gk7205v200, 16 kHz mono, first consumer start after a cold boot. Capture rms and the 609.375 Hz fundamental over the local noise floor:

| acodec module | consumer | `0x100F0018` | rms (LSB) | 609 Hz | driver log |
|---|---|---|---|---|---|
| stock | unpatched | `0x25` | 41.4 | +3.8 dB, harmonics to +11.7 | — |
| this | unpatched | `0x2E` | 5.2 | +3.2 dB, no comb | one retune, logged |
| this | retunes itself | `0x2E` | 5.4 | +3.5 dB, no comb | silent over 75 s |

Row 2 is the point: an **unpatched** consumer, comb gone by itself, with

```
acodec: ADC tuning stale after a clock change, retuning
```

The row 1 control **reloads the stock module** immediately before the consumer starts and still comes up mistuned. That control matters: the blob's own init writes `en_rctune` 0 then 1 a millisecond apart, which is a real pulse, so without it a reload could have been what cured things. It is not — the invalidating clock change happens afterwards.

Row 3 is a consumer already fixed to retune after enabling AI. The watchdog costs two register reads a second and never fires; the two fixes are independent and do not fight.

Built against openipc/linux `goke-gk7205v200` (4.9.37), `CHIPARCH=gk7205v200 KO_LOG=nolog`; vermagic matches the shipped module exactly.
