### PR TITLE
osal: wait for the timer callback before freeing the timer

### DIFF
--- a/kernel/osal/include/osal.h
+++ b/kernel/osal/include/osal.h
@@ -534,6 +534,8 @@ extern int osal_hrtimer_destory(osal_hrtimer_t *phrtimer);
 extern int osal_timer_init(osal_timer_t *timer);
 extern int osal_set_timer(osal_timer_t *timer, unsigned long interval); // ms
 extern int osal_del_timer(osal_timer_t *timer);
+/* Waits for a callback already running; process context only. */
+extern int osal_del_timer_sync(osal_timer_t *timer);
 extern int osal_timer_destory(osal_timer_t *timer);
 
 extern unsigned long osal_msleep(unsigned int msecs);

--- a/kernel/osal/linux/kernel/osal_timer.c
+++ b/kernel/osal/linux/kernel/osal_timer.c
@@ -27,6 +27,50 @@ int osal_hrtimer_destory(osal_hrtimer_t *phrtimer)
 }
 
 /*
+ * del_timer() returns as soon as the timer is off the list; it does not wait
+ * for a callback already running on another CPU. Deleting and then freeing --
+ * which osal_timer_destory() does -- therefore leaves that callback writing
+ * into memory that has just gone away, and a callback that re-arms itself goes
+ * on to schedule a freed timer. OpenIPC/openhisilicon#210.
+ *
+ * del_timer_sync() waits, but it cannot be used from interrupt context: it
+ * spins for the handler, which deadlocks when the handler is on this CPU.
+ * Destroying a timer from an interrupt cannot be made safe at all -- there is
+ * no way to know the handler is not running -- so keep the old behaviour there
+ * and name it, rather than trading silent corruption for a hang.
+ *
+ * del_timer_sync() on its own is still not enough for a callback that re-arms
+ * itself: it waits for that callback, which has already put the timer back on
+ * the list by the time it returns. The rtc temperature poll does exactly this
+ * and ships as a blob, so it cannot be given a stop flag. Repeat until a pass
+ * finds nothing pending -- at that point no handler is running and nothing is
+ * queued -- and bound it, because a callback re-arming with no delay would
+ * otherwise spin here forever.
+ */
+#define OSAL_TIMER_STOP_TRIES 5
+
+static void osal_timer_stop(struct timer_list *t)
+{
+	int i;
+
+	if (in_interrupt()) {
+		osal_printk(
+			"%s - called from interrupt, cannot wait for the timer callback\n",
+			__FUNCTION__);
+		del_timer(t);
+		return;
+	}
+
+	for (i = 0; i < OSAL_TIMER_STOP_TRIES; i++) {
+		if (!del_timer_sync(t))
+			return;
+	}
+
+	osal_printk("%s - timer keeps re-arming itself, gave up after %d tries\n",
+		    __FUNCTION__, OSAL_TIMER_STOP_TRIES);
+}
+
+/*
  * On kernels 4.15+, timer_setup() replaces init_timer() and the callback
  * signature changes from void(*)(unsigned long) to void(*)(struct timer_list*).
  *
@@ -99,10 +143,28 @@ int osal_del_timer(osal_timer_t *timer)
 }
 EXPORT_SYMBOL(osal_del_timer);
 
+/* Callers legitimately use osal_del_timer() from an interrupt, and from inside
+ * the timer's own callback, to mean "stop re-arming"; neither can wait. This is
+ * the variant for callers in process context that need the callback finished
+ * before they tear down what it touches. */
+int osal_del_timer_sync(osal_timer_t *timer)
+{
+	struct osal_timer_compat *ot = NULL;
+	if ((timer == NULL) || (timer->timer == NULL) ||
+	    (timer->function == NULL)) {
+		osal_printk("%s - parameter invalid!\n", __FUNCTION__);
+		return -1;
+	}
+	ot = timer->timer;
+	osal_timer_stop(&ot->tl);
+	return 0;
+}
+EXPORT_SYMBOL(osal_del_timer_sync);
+
 int osal_timer_destory(osal_timer_t *timer)
 {
 	struct osal_timer_compat *ot = timer->timer;
-	del_timer(&ot->tl);
+	osal_timer_stop(&ot->tl);
 	kfree(ot);
 	timer->timer = NULL;
 	return 0;
@@ -160,10 +222,25 @@ int osal_del_timer(osal_timer_t *timer)
 }
 EXPORT_SYMBOL(osal_del_timer);
 
+/* See the COMPAT_TIMER_SETUP branch above. */
+int osal_del_timer_sync(osal_timer_t *timer)
+{
+	struct timer_list *t = NULL;
+	if ((timer == NULL) || (timer->timer == NULL) ||
+	    (timer->function == NULL)) {
+		osal_printk("%s - parameter invalid!\n", __FUNCTION__);
+		return -1;
+	}
+	t = timer->timer;
+	osal_timer_stop(t);
+	return 0;
+}
+EXPORT_SYMBOL(osal_del_timer_sync);
+
 int osal_timer_destory(osal_timer_t *timer)
 {
 	struct timer_list *t = timer->timer;
-	del_timer(t);
+	osal_timer_stop(t);
 	kfree(t);
 	timer->timer = NULL;
 	return 0;

--- a/kernel/osal/linux/kernel/osal_timer.c
+++ b/kernel/osal/linux/kernel/osal_timer.c
@@ -49,7 +49,9 @@ int osal_hrtimer_destory(osal_hrtimer_t *phrtimer)
  */
 #define OSAL_TIMER_STOP_TRIES 5
 
-static void osal_timer_stop(struct timer_list *t)
+/* 0 when the timer is off the list with no callback running, -1 when that could
+ * not be established -- the caller must not free it in that case. */
+static int osal_timer_stop(struct timer_list *t)
 {
 	int i;
 
@@ -58,16 +60,17 @@ static void osal_timer_stop(struct timer_list *t)
 			"%s - called from interrupt, cannot wait for the timer callback\n",
 			__FUNCTION__);
 		del_timer(t);
-		return;
+		return -1;
 	}
 
 	for (i = 0; i < OSAL_TIMER_STOP_TRIES; i++) {
 		if (!del_timer_sync(t))
-			return;
+			return 0;
 	}
 
 	osal_printk("%s - timer keeps re-arming itself, gave up after %d tries\n",
 		    __FUNCTION__, OSAL_TIMER_STOP_TRIES);
+	return -1;
 }
 
 /*
@@ -156,15 +159,23 @@ int osal_del_timer_sync(osal_timer_t *timer)
 		return -1;
 	}
 	ot = timer->timer;
-	osal_timer_stop(&ot->tl);
-	return 0;
+	return osal_timer_stop(&ot->tl);
 }
 EXPORT_SYMBOL(osal_del_timer_sync);
 
 int osal_timer_destory(osal_timer_t *timer)
 {
 	struct osal_timer_compat *ot = timer->timer;
-	osal_timer_stop(&ot->tl);
+
+	if (osal_timer_stop(&ot->tl)) {
+		/* Leaking the wrapper is the lesser fault: freeing one that is
+		 * still queued, or whose callback may still be running, is the
+		 * use-after-free this exists to prevent. */
+		osal_printk("%s - timer still live, leaked rather than freed\n",
+			    __FUNCTION__);
+		return -1;
+	}
+
 	kfree(ot);
 	timer->timer = NULL;
 	return 0;
@@ -232,15 +243,21 @@ int osal_del_timer_sync(osal_timer_t *timer)
 		return -1;
 	}
 	t = timer->timer;
-	osal_timer_stop(t);
-	return 0;
+	return osal_timer_stop(t);
 }
 EXPORT_SYMBOL(osal_del_timer_sync);
 
 int osal_timer_destory(osal_timer_t *timer)
 {
 	struct timer_list *t = timer->timer;
-	osal_timer_stop(t);
+
+	if (osal_timer_stop(t)) {
+		/* See the COMPAT_TIMER_SETUP branch above. */
+		osal_printk("%s - timer still live, leaked rather than freed\n",
+			    __FUNCTION__);
+		return -1;
+	}
+
 	kfree(t);
 	timer->timer = NULL;
 	return 0;


### PR DESCRIPTION
Closes #210.

## The bug

`osal_del_timer()` and `osal_timer_destory()` are both `del_timer()`, in the `COMPAT_TIMER_SETUP` branch and the pre-4.15 one alike, and destroy `kfree()`s the timer on top. `del_timer()` returns as soon as the timer is off the list — it does not wait for a callback already running on another CPU. A teardown that lands while the callback runs therefore frees the timer underneath it, and a callback that re-arms itself then schedules freed memory.

`kernel/rtc/hi3519v101/hi_rtc.c` is exactly that shape: `temperature_detection()` is the callback (L999) and ends by re-arming itself (L803), while `rtc_exit()` deletes and destroys (L1062). It ships as a blob, so it cannot be given a stop flag from here.

## The change

Make the destroy path wait. Two constraints shaped it:

**`del_timer_sync()` cannot be used from interrupt context** — it spins for the handler and deadlocks when that handler is on this CPU. Keep `del_timer()` there and name it in the log, because destroying a timer from an interrupt cannot be made safe in the first place, and a hang would be worse than what it replaces.

**`del_timer_sync()` alone is not enough against a self-re-arming callback** — it waits for the callback that has already put the timer back on the list. Repeat until a pass finds nothing pending, bounded so a callback re-arming with no delay cannot spin forever.

**`osal_del_timer()` is deliberately left alone.** This is the part worth checking me on. Callers use it from inside the timer's own callback *and* from hard IRQ context to mean "stop re-arming":

| driver | in the callback | in the IRQ handler |
|---|---|---|
| `ir/hi3516cv300/hiir.c` | L193 | L224, L251 |
| `ir/hi3516cv500/hiir.c` | L207 | L223, L264 |
| `ir/hi3519v101/hiir.c` | L192 | L216, L243 |

Making that one synchronous — which was the first suggestion on #210 — would deadlock all three. `osal_del_timer_sync()` is added instead, for callers in process context that need the callback finished before tearing down what it touches.

## Who this fixes

The two IR drivers built from source call `osal_timer_destory()` at exit and have callbacks that do not re-arm, so the destroy change covers them with no driver-side change.

The blob users get it for free, which is the point — they cannot be patched, only the code under them can: `vi`, `vpss`, `chnl`, `pm`, `rtc`, `vdec`, `dis` across gk7205v200, hi3516ev200, hi3516cv300, hi3516cv500, hi3516cv6xx and hi3519v101.

## Verification

Built the way the firmware builds it — buildroot, `gk7205v200_lite`, with `HISILICON_OPENSDK_OVERRIDE_SRCDIR` pointed at this tree — and run on a lab gk7205v200. 104188 bytes against the shipped 103400, vermagic identical, and it boots the full 36-module stack with video serving.

| exercise | result |
|---|---|
| boot with the patched osal | 36 modules, `open_osal 63022` with 60 users, JPEG off the camera |
| 10 × `load_goke -a` (full teardown + reload — every osal timer user destroyed and re-created) | 36 modules back every cycle, no rmmod refusals |
| 8 × SIGHUP (pipeline rebuilds under majestic) | clean |
| final teardown + reload, then a capture | clean |

Zero oops, zero warnings across all of it. **No `osal_timer_stop` lines at all**, which is the informative part: on this part nothing destroys a timer from interrupt context, and nothing re-armed past the retry bound. Both new log lines stayed silent.

Camera restored to the shipped module afterwards and re-verified healthy.

One thing worth recording for anyone else testing kernel changes here: a module built *outside* buildroot is not loadable on the shipped firmware. My first attempt oopsed in `media_bus_init` during device registration — that was the build environment, not the change; a pristine build of the same tree was already 106824 bytes against the shipped 103400. Matching vermagic is necessary but not sufficient without `CONFIG_MODVERSIONS`. The buildroot override above is the way to do it.

Two new log lines make the residual cases visible rather than silent:

```
osal_timer_stop - called from interrupt, cannot wait for the timer callback
osal_timer_stop - timer keeps re-arming itself, gave up after 5 tries
```

If either shows up on another part, it identifies a caller worth looking at.
