### PR TITLE
ci: update qemu-hisilicon clone URLs to OpenIPC org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -679,7 +679,7 @@ jobs:
   #
   # qemu-ive-ops
   #
-  # Builds QEMU with HiSilicon machine models from widgetii/qemu-hisilicon
+  # Builds QEMU with HiSilicon machine models from OpenIPC/qemu-hisilicon
   # (cached by pinned SHA), builds the vendored kernel/ive_neo/test/qemu
   # register test as a static ARM binary, wraps in cpio, boots under
   # qemu-system-arm -M hi3516ev300 with a downloaded OpenIPC kernel, and
@@ -706,9 +706,9 @@ jobs:
             ive_base: '0x11230000'
             # CV500 family (cv500/av300): IVE @ 0x11230000.
     env:
-      # Pinned SHA of widgetii/qemu-hisilicon. Bump this when upstream
+      # Pinned SHA of OpenIPC/qemu-hisilicon. Bump this when upstream
       # changes machine-model register semantics. The cv500 machine
-      # gained hisi-ive at 0x11230000 in widgetii/qemu-hisilicon#99 —
+      # gained hisi-ive at 0x11230000 in OpenIPC/qemu-hisilicon#99 —
       # cv500 regression coverage requires that SHA or later.
       QEMU_HISILICON_SHA: master
     steps:
@@ -725,7 +725,7 @@ jobs:
 
       - name: Clone qemu-hisilicon
         run: |
-          git clone --depth 1 https://github.com/widgetii/qemu-hisilicon.git /tmp/qemu-hisilicon
+          git clone --depth 1 https://github.com/OpenIPC/qemu-hisilicon.git /tmp/qemu-hisilicon
           cd /tmp/qemu-hisilicon
           echo "SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
@@ -798,7 +798,7 @@ jobs:
   #
   # Mirrors qemu-ive-ops for the NNIE block: boots an ARM initramfs
   # under qemu-system-arm with the hisi-nnie machine model
-  # (widgetii/qemu-hisilicon, added alongside hisi-ive) and runs a
+  # (OpenIPC/qemu-hisilicon, added alongside hisi-ive) and runs a
   # register-level smoke test against it.
   #
   # The test binary (kernel/nnie_neo/test/qemu/test-nnie-forward.c) is
@@ -821,7 +821,7 @@ jobs:
           - machine: hi3516cv500
             firmware: hi3516cv500
     env:
-      # Bump when widgetii/qemu-hisilicon changes the hisi-nnie model.
+      # Bump when OpenIPC/qemu-hisilicon changes the hisi-nnie model.
       QEMU_HISILICON_SHA: master
     steps:
       - uses: actions/checkout@v4
@@ -837,7 +837,7 @@ jobs:
 
       - name: Clone qemu-hisilicon
         run: |
-          git clone --depth 1 https://github.com/widgetii/qemu-hisilicon.git /tmp/qemu-hisilicon
+          git clone --depth 1 https://github.com/OpenIPC/qemu-hisilicon.git /tmp/qemu-hisilicon
           cd /tmp/qemu-hisilicon
           echo "SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
@@ -1060,7 +1060,7 @@ jobs:
 
       - name: Clone qemu-hisilicon
         run: |
-          git clone --depth 1 https://github.com/widgetii/qemu-hisilicon.git /tmp/qemu-hisilicon
+          git clone --depth 1 https://github.com/OpenIPC/qemu-hisilicon.git /tmp/qemu-hisilicon
           cd /tmp/qemu-hisilicon
           echo "SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Replaces the proprietary SDK that HiSilicon ships to camera manufacturers. Used 
 | V5 | hi3516cv610 | hi3516cv610, hi3516cv608 | Cortex-A7 | `hi3516cv6xx` |
 | V5 | hi3519dv500 | hi3519dv500, hi3516dv500 | Cortex-A55 (aarch64) | `hi3519dv500` |
 
-Generation labels match [qemu-hisilicon](https://github.com/widgetii/qemu-hisilicon). The hi3516ev200 and gk7205v200 are pin-compatible — the same source compiles for both via `CHIPARCH`. A [conversion script](scripts/hi2gk.sh) translates between HiSilicon and Goke naming.
+Generation labels match [qemu-hisilicon](https://github.com/OpenIPC/qemu-hisilicon). The hi3516ev200 and gk7205v200 are pin-compatible — the same source compiles for both via `CHIPARCH`. A [conversion script](scripts/hi2gk.sh) translates between HiSilicon and Goke naming.
 
 ## How HiSilicon SDK modules work
 
@@ -430,7 +430,7 @@ Every push and PR runs **22 jobs**:
 
 Plus 3 mainline kernel builds for hi3516ev300_neo (6.6, 6.18, 7.0).
 
-**QEMU boot smoke-tests** (8 platforms): CV100, CV200, AV100, CV300, 3519V101, CV500, EV200, GK7205V200 — boots OpenIPC firmware under [qemu-hisilicon](https://github.com/widgetii/qemu-hisilicon) and verifies the kernel reaches userspace.
+**QEMU boot smoke-tests** (8 platforms): CV100, CV200, AV100, CV300, 3519V101, CV500, EV200, GK7205V200 — boots OpenIPC firmware under [qemu-hisilicon](https://github.com/OpenIPC/qemu-hisilicon) and verifies the kernel reaches userspace.
 
 **Library checks** (3 jobs): header syntax + ABI struct sizes, ARM cross-compile + symbol verification, QEMU IVE register regression.
 

--- a/bootrom/README
+++ b/bootrom/README
@@ -63,7 +63,7 @@ start the CPU there. This is end-to-end evidence the reversal matches
 what the silicon does, not just plausible-looking C.
 
 Requires qemu-hisilicon with the maskrom -bios path
-(widgetii/qemu-hisilicon#98 or later):
+(OpenIPC/qemu-hisilicon#98 or later):
 
   cd ~/git/qemu-hisilicon && bash qemu/setup.sh   # one-time
 
@@ -109,7 +109,7 @@ CI gate
 A `bootrom RE compile-gate` job in this repo's .github/workflows/build.yml
 builds re.elf and diffs its function-symbol set against
 .expected-symbols (drift in either direction fails the diff). A
-separate `maskrom-av300` job in widgetii/qemu-hisilicon runs the two
+separate `maskrom-av300` job in OpenIPC/qemu-hisilicon runs the two
 end-to-end QEMU checks above on every PR — handshake-pattern match
 and ACK-advance — gating any future qemu-hisilicon change against
 silently breaking the bootrom path.

--- a/kernel/ive_neo/test/qemu/README.md
+++ b/kernel/ive_neo/test/qemu/README.md
@@ -21,7 +21,7 @@ register layout the driver expects will fail this test.
 
 ## Upstream
 
-- **Source**: `widgetii/qemu-hisilicon`, path `qemu-boot/test-ive-ops.c`
+- **Source**: `OpenIPC/qemu-hisilicon`, path `qemu-boot/test-ive-ops.c`
 - **Last synced**: commit `9e1ea1d` ("Add IVE register tests to CI:
   19 ops verified on every push")
 - **Upstream license**: same as the clean-room driver (GPL-2.0)
@@ -59,14 +59,14 @@ KERNEL=/path/to/uImage.hi3516ev300 \
 ```
 
 You can get `qemu-system-arm` with the HiSilicon machine models from
-[widgetii/qemu-hisilicon](https://github.com/widgetii/qemu-hisilicon).
+[OpenIPC/qemu-hisilicon](https://github.com/OpenIPC/qemu-hisilicon).
 An `openipc.hi3516ev300-nor-lite.tgz` with a matching kernel is in
 every OpenIPC firmware release.
 
 ## Running in CI
 
 `.github/workflows/build.yml` has a `qemu-ive-ops` job that:
-1. Builds `qemu-system-arm` from `widgetii/qemu-hisilicon` (cached)
+1. Builds `qemu-system-arm` from `OpenIPC/qemu-hisilicon` (cached)
 2. Downloads an `openipc.hi3516ev300-nor-lite.tgz` release tarball
 3. Runs `make` in this directory to build the cpio
 4. Launches QEMU with the kernel + cpio and greps for `Result: N/N passed`

--- a/kernel/ive_neo/test/qemu/run-qemu.sh
+++ b/kernel/ive_neo/test/qemu/run-qemu.sh
@@ -6,7 +6,7 @@
 #
 # Requirements:
 #   - qemu-system-arm binary with HiSilicon machine models
-#     (from widgetii/qemu-hisilicon; not bundled here).
+#     (from OpenIPC/qemu-hisilicon; not bundled here).
 #     Pass the path via QEMU=... or make sure it's on PATH.
 #   - uImage.hi3516ev300 kernel image (from OpenIPC firmware release).
 #     Pass via KERNEL=... or place it next to this script.


### PR DESCRIPTION
The `qemu-hisilicon` repo was transferred from a personal account to the OpenIPC organisation (`OpenIPC/qemu-hisilicon`). GitHub creates a redirect from the old URL, but CI should reference the canonical location.

## Changes
- `qemu-ive-ops` job: update clone URL and comments
- `qemu-nnie-forward` job: update clone URL and comments
- Boot-test job: update clone URL

All three jobs cloned from the old personal-account URL; all now point to `github.com/OpenIPC/qemu-hisilicon`.