### PR TITLE
cipher: build open_cipher.ko for hi3516ev200

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -61,6 +61,9 @@ include $(src)/sensor_i2c/Kbuild
 include $(src)/sensor_spi/Kbuild
 include $(src)/mipi_rx/Kbuild
 include $(src)/openipc_frame_ts/Kbuild
+# Guarded on CHIPARCH inside; only hi3516ev200 builds a cipher module here,
+# and hi3516cv500 builds its own from hi3516cv500.kbuild.
+include $(src)/cipher/Kbuild
 #+user
 
 ifneq ($(filter $(CHIPARCH),hi3516ev200 gk7205v200),)

--- a/kernel/cipher/Kbuild
+++ b/kernel/cipher/Kbuild
@@ -1,0 +1,91 @@
+#
+# kernel/cipher — the Cipher (crypto) engine, for chips built by the generic
+# branch of kernel/Kbuild rather than by their own <chip>.kbuild.
+#
+# hi3516cv500 builds this module from its own kbuild and does not come through
+# here. This file exists for hi3516ev200 (and so hi3516ev300), whose firmware
+# has never packaged a cipher module at all: the vendor prebuilt from the
+# Hi3516EV200 SDK cannot load against an OpenIPC rootfs, and there was no
+# source build to fall back on.
+#
+# ITS OWN TREE, like every other chip under kernel/cipher/. Reusing cv500's
+# source with -DCHIP_TYPE_hi3516ev200 was tried first and is a worse idea than
+# it looks: cv500's tree is a later SDK vintage (the 2019 rewrite), the two
+# differ by some 30k lines, and it carries no drv_osal_hi3516ev200.h at all.
+# The tree here is the one from Hi3516EV200_SDK_V1.0.1.2 that was built and
+# checked on an hi3516ev300 -- 600 differential AES-CTR cases byte-identical
+# to mbedTLS -- so it is the version known to drive this silicon correctly.
+# Only include/ and src/ are vendored; the SDK's sample/, buildin/ and patch/
+# trees are not built here.
+#
+# WHAT IT IS FOR. AES-128-CTR at SRTP packet sizes, where a userspace streamer
+# would otherwise do it on the CPU. Measured on an hi3516ev300 against the
+# mbedTLS 2.25 the rootfs ships, 1100-byte buffers: 87.6 us of CPU in software
+# against 42.0 through the engine, a 52% cut. More is saved in CPU than in
+# wall clock, because the driver sleeps on its completion interrupt and hands
+# the core back while the block works -- which is the scarce resource on these
+# parts. The engine also carries a TRNG and RSA that nothing uses yet.
+#
+# Not built for gk7205v200, which shares this branch: it is the same
+# generation on paper, but Goke ships its cipher as a differently-named module
+# against a different userspace, and nothing here has been measured on one.
+#
+
+ifeq ($(CHIPARCH),hi3516ev200)
+
+EV200_CIPHER = cipher/hi3516ev200/src
+
+$(PREFIX)cipher-objs := \
+	$(EV200_CIPHER)/drv/cipher_initdevice.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/core/drv_symc_v100.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/core/drv_symc_v200.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/core/drv_hash_v100.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/core/drv_hash_v200.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/core/drv_ifep_rsa_v100.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/core/drv_trng_v100.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/core/drv_trng_v200.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/core/drv_lib.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/crypto/cryp_symc.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/crypto/cryp_hash.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/crypto/cryp_trng.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/crypto/cryp_rsa.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/kapi_symc.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/kapi_hash.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/kapi_rsa.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/kapi_trng.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/kapi_dispatch.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/mbedtls/bignum.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/mbedtls/md.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/mbedtls/rsa.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/mbedtls/asn1parse.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/mbedtls/oid.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/mbedtls/platform_util.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/mbedtls/rsa_internal.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/ext_aead.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/ext_hash.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/ext_symc.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/ext_sm3.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/drivers/extend/ext_sm4.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/osal/drv_osal_init_linux.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/osal/drv_osal_sys_linux.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/compat/hi_drv_compat.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/compat/drv_klad.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/compat/hal_efuse.o \
+	$(EV200_CIPHER)/drv/cipher_v1.0/compat/hal_otp.o
+
+# Self-contained: hi_type.h is vendored into the tree above rather than
+# borrowed from include/hi3516cv500, which looks interchangeable and is not --
+# HI_PHYS_ADDR_T is signed there and unsigned here. Borrowing it also let
+# include/hi3516cv500/hi_types.h shadow this tree's own, which is where the
+# HI_HANDLE_* macros live.
+ccflags-y += -I$(src)/cipher/hi3516ev200/include
+ccflags-y += -I$(src)/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/include
+ccflags-y += -I$(src)/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/include
+ccflags-y += -I$(src)/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include
+ccflags-y += -I$(src)/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include
+ccflags-y += -I$(src)/cipher/hi3516ev200/src/drv/cipher_v1.0/compat
+ccflags-y += -DCHIP_TYPE_hi3516ev200 -DAMP_NONSECURE_VERSION
+
+obj-m += $(PREFIX)cipher.o
+
+endif

--- a/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/core/drv_symc_v200.c
+++ b/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/core/drv_symc_v200.c
@@ -309,7 +309,16 @@ static hi_s32 drv_symc_wait_irq(hi_u32 chn_num, symc_hard_context *ctx, hi_u32 t
         module_disable(CRYPTO_MODULE_ID_SM4);
     }
 
-    if ((ret <= 0x00) && (ret != -ERESTARTSYS)) {
+    /*
+     * -ERESTARTSYS was excluded here, which let a wait cut short by a signal
+     * fall through to HI_SUCCESS below. crypto_queue_wait_timeout is
+     * wait_event_interruptible_timeout, so that is reachable whenever the
+     * calling thread takes a signal -- and the caller then copies out a
+     * buffer the engine may not have finished writing, with no error
+     * anywhere. Ciphertext is meant to look like noise, so nothing downstream
+     * can tell. Report it instead and let the caller retry or fall back.
+     */
+    if (ret <= 0x00) {
         hi_log_error("wait done timeout, chn=%d\n", chn_num);
         hi_log_print_func_err(crypto_queue_wait_timeout, ret);
         drv_symc_get_err_code(chn_num);

--- a/kernel/cipher/hi3516ev200/include/drv_cipher_kapi.h
+++ b/kernel/cipher/hi3516ev200/include/drv_cipher_kapi.h
@@ -1,0 +1,718 @@
+/******************************************************************************
+
+  Copyright (C), 2011-2014, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : drv_cipher_kapi.h
+  Version       : Initial Draft
+  Author        : Hisilicon hisecurity team
+  Created       :
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+
+#ifndef __TEE_DRV_CIPHER_KAPI_H__
+#define __TEE_DRV_CIPHER_KAPI_H__
+
+#ifdef HI_PLATFORM_TYPE_TEE
+#include "hi_tee_cipher.h"
+#include "tee_drv_cipher_compat.h"
+#else
+#include "hi_unf_cipher.h"
+#include "hi_common_cipher.h"
+#include "hi_cipher_compat.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif    /* __cplusplus */
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      crypto */
+
+/*! \success */
+#undef  HI_SUCCESS
+#define HI_SUCCESS                      (0)
+
+/*! \failure */
+#undef  HI_FAILURE
+#define HI_FAILURE                      (-1)
+
+#ifndef MAX
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
+#ifndef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+/*width of word*/
+#define WORD_WIDTH                      (4)
+#define WORD_BIT_WIDTH                  (32)
+#define U32_MAX_SIZE                    (0xFFFFFFFF)
+
+/*width of double word*/
+#define DOUBLE_WORD_WIDTH               (8)
+
+#ifndef SM2_LEN_IN_WROD
+#define SM2_LEN_IN_WROD                 (8)
+#define SM2_LEN_IN_BYTE                 (32)
+#endif
+
+/*! \big coding transform to litte coding*/
+#define CPU_TO_BE16(v) (((v)<< 8) | ((v)>>8))
+
+#define CPU_TO_BE32(v) ((((hi_u32)(v))>>24)           | \
+                        ((((hi_u32)(v))>>8)&0xff00)   | \
+                        ((((hi_u32)(v))<<8)&0xff0000) | \
+                        (((hi_u32)(v))<<24))
+
+#define CPU_TO_BE64(x) ((hi_u64)(                         \
+        (((hi_u64)(x) & (hi_u64)0x00000000000000ffULL) << 56) |   \
+        (((hi_u64)(x) & (hi_u64)0x000000000000ff00ULL) << 40) |   \
+        (((hi_u64)(x) & (hi_u64)0x0000000000ff0000ULL) << 24) |   \
+        (((hi_u64)(x) & (hi_u64)0x00000000ff000000ULL) <<  8) |   \
+        (((hi_u64)(x) & (hi_u64)0x000000ff00000000ULL) >>  8) |   \
+        (((hi_u64)(x) & (hi_u64)0x0000ff0000000000ULL) >> 24) |   \
+        (((hi_u64)(x) & (hi_u64)0x00ff000000000000ULL) >> 40) |   \
+        (((hi_u64)(x) & (hi_u64)0xff00000000000000ULL) >> 56)))
+
+/*! \defined the base error code */
+#define HI_BASE_ERR_BASE                (0x400)
+#define HI_BASE_ERR_BASE_SYMC           (HI_BASE_ERR_BASE + 0x100)
+#define HI_BASE_ERR_BASE_HASH           (HI_BASE_ERR_BASE + 0x200)
+#define HI_BASE_ERR_BASE_RSA            (HI_BASE_ERR_BASE + 0x300)
+#define HI_BASE_ERR_BASE_TRNG           (HI_BASE_ERR_BASE + 0x400)
+#define HI_BASE_ERR_BASE_SM2            (HI_BASE_ERR_BASE + 0x500)
+
+#define CRYPTO_MAGIC_NUM          (0xc0704d19)
+
+/*! \enumeration module_id*/
+typedef enum {
+    CRYPTO_MODULE_ID_SYMC,        /*!<  Symmetric Cipher */
+    CRYPTO_MODULE_ID_SYMC_KEY,    /*!<  Symmetric Cipher key */
+    CRYPTO_MODULE_ID_HASH,        /*!<  Message Digest */
+    CRYPTO_MODULE_ID_IFEP_RSA,    /*!<  Asymmetric developed by IFEP */
+    CRYPTO_MODULE_ID_SIC_RSA,     /*!<  Asymmetric developed by SIC */
+    CRYPTO_MODULE_ID_TRNG,        /*!<  Random Data Generation */
+    CRYPTO_MODULE_ID_SM2,         /*!<  Public Key Cryptographic Algorithm Based on Elliptic Curves */
+    CRYPTO_MODULE_ID_SM4,         /*!<  SM4 */
+    CRYPTO_MODULE_ID_SMMU,        /*!<  SMMU */
+    CRYPTO_MODULE_ID_CNT,         /*!<  Count of module id */
+} module_id;
+
+#define CRYPTO_UNUSED(x)    ((x)=(x))
+
+#define HASH_BLOCK_SIZE          (64)
+
+#define CRYPTO_IOC_NA            (0U)
+#define CRYPTO_IOC_W             (1U)
+#define CRYPTO_IOC_R             (2U)
+#define CRYPTO_IOC_RW            (3U)
+
+#define HI_ID_CIPHER             (0x4D)
+
+#define CIPHER_NAME              "HI_CIPHER"
+#define UMAP_DEVNAME_CIPHER      "cipher"
+#define UMAP_MIN_MINOR_CIPHER    (50)
+
+#define CRYPTO_IOC(dir,type,nr,size) \
+    (((dir) << 30) | ((size) << 16) | ((type) << 8) | ((nr) << 0))
+
+#define CRYPTO_IOR(nr,size)    CRYPTO_IOC(CRYPTO_IOC_R, HI_ID_CIPHER,(nr), size)
+#define CRYPTO_IOW(nr,size)    CRYPTO_IOC(CRYPTO_IOC_W, HI_ID_CIPHER,(nr), size)
+#define CRYPTO_IOWR(nr,size)   CRYPTO_IOC(CRYPTO_IOC_RW, HI_ID_CIPHER,(nr),size)
+
+#define CRYPTO_IOC_DIR(cmd)       (((cmd) >> 30) & 0x03)
+#define CRYPTO_IOC_TYPE(cmd)      (((cmd) >> 8) & 0xFF)
+#define CRYPTO_IOC_NR(cmd)        (((cmd) >> 0) & 0xFF)
+#define CRYPTO_IOC_SIZE(cmd)      (((cmd) >> 16) & 0x3FFF)
+
+#define CRYPTO_CMD_SYMC_CREATEHANDLE   CRYPTO_IOR(0x00, sizeof(symc_create_t))
+#define CRYPTO_CMD_SYMC_DESTROYHANDLE  CRYPTO_IOW (0x01, sizeof(symc_destroy_t))
+#define CRYPTO_CMD_SYMC_CONFIGHANDLE   CRYPTO_IOW (0x02, sizeof(symc_config_t))
+#define CRYPTO_CMD_SYMC_ENCRYPT        CRYPTO_IOW (0x03, sizeof(symc_encrypt_t))
+#define CRYPTO_CMD_SYMC_ENCRYPTMULTI   CRYPTO_IOW (0x04, sizeof(symc_encrypt_multi_t))
+#define CRYPTO_CMD_SYMC_GETTAG         CRYPTO_IOWR(0x05, sizeof(aead_tag_t))
+#define CRYPTO_CMD_HASH_START          CRYPTO_IOWR(0x06, sizeof(hash_start_t))
+#define CRYPTO_CMD_HASH_UPDATE         CRYPTO_IOW (0x07, sizeof(hash_update_t))
+#define CRYPTO_CMD_HASH_FINISH         CRYPTO_IOWR(0x08, sizeof(hash_finish_t))
+#define CRYPTO_CMD_RSA_ENC             CRYPTO_IOWR(0x09, sizeof(rsa_info_t))
+#define CRYPTO_CMD_RSA_DEC             CRYPTO_IOWR(0x0a, sizeof(rsa_info_t))
+#define CRYPTO_CMD_RSA_SIGN            CRYPTO_IOWR(0x0b, sizeof(rsa_info_t))
+#define CRYPTO_CMD_RSA_VERIFY          CRYPTO_IOWR(0x0c, sizeof(rsa_info_t))
+#define CRYPTO_CMD_TRNG                CRYPTO_IOWR(0x0d, sizeof(trng_t))
+#define CRYPTO_CMD_SYMC_GET_CONFIG     CRYPTO_IOWR(0x0e, sizeof(symc_get_config_t))
+#define CRYPTO_CMD_KLAD_KEY            CRYPTO_IOWR(0x0f, sizeof(klad_key_t))
+#define CRYPTO_CMD_COUNT               0x10
+
+#define CHECK_EXIT(_expr) \
+    do { \
+        if ((ret = (_expr)) != HI_SUCCESS) { \
+            HI_LOG_PRINT_FUNC_ERR((_expr), ret); \
+            goto exit__; \
+        } \
+    } while (0)
+
+#ifdef CIPHER_DEBUG_TEST_SUPPORT
+#define HI_PRINT_HEX(name, str, len) \
+    {\
+        hi_u32 _i = 0;\
+        hi_u8 *_str; \
+        _str = (hi_u8*)(str); \
+        HI_PRINT("[%s]:\n", (name));\
+        for ( _i = 0 ; _i < (len); _i++ )\
+        {\
+            if( (_i % 16 == 0) && (_i != 0)) HI_PRINT("\n");\
+            HI_PRINT("\\x%02x", *((_str)+_i));\
+        }\
+        HI_PRINT("\n");\
+    }
+#else
+#define HI_PRINT_HEX print_string
+#endif
+
+/*! \AES KEY size */
+#define SYMC_KEY_SIZE       (32)
+
+/*! \SM1 SK size */
+#define SYMC_SM1_SK_SIZE    (16)
+
+/*! \AES IV size */
+#define AES_IV_SIZE         (16)
+
+/*! \AES BLOCK size */
+#define AES_BLOCK_SIZE      (16)
+
+/*! \DES IV size */
+#define DES_IV_SIZE         (8)
+
+/*! \aead tag length */
+#define AEAD_TAG_SIZE                  (16)
+#define AEAD_TAG_SIZE_IN_WORD          (4)
+
+/*! \bits in a byte */
+#define BITS_IN_BYTE                   (8)
+
+/*! \hash result max size */
+#define HASH_RESULT_MAX_SIZE           (64)
+
+#ifndef CHIP_TYPE_hi3516ev200
+/*! \hash result max size in word */
+#define HASH_RESULT_MAX_SIZE_IN_WORD   (16)
+#else
+/*! \hash result max size in word */
+#define HASH_RESULT_MAX_SIZE_IN_WORD   (8)
+#endif
+
+/*! capacity upport */
+#define CRYPTO_CAPACITY_SUPPORT        (1)
+#define CRYPTO_CAPACITY_NONSUPPORT     (0)
+
+/* max length of SM2 ID */
+#define SM2_ID_MAX_LEN                 (0x1FFF)
+
+/*! Define the time out */
+#define CRYPTO_TIME_OUT                (6000)
+#define MS_TO_US                       (1000)
+
+/* result size */
+#define SHA1_RESULT_SIZE           (20)  /* SHA1 */
+#define SHA224_RESULT_SIZE         (28)  /* SHA224 */
+#define SHA256_RESULT_SIZE         (32)  /* SHA256 */
+#define SHA384_RESULT_SIZE         (48)  /* SHA384 */
+#define SHA512_RESULT_SIZE         (64)  /* SHA512 */
+#define SM3_RESULT_SIZE            (32)  /* SM3 */
+
+/* rsa key length */
+#define RSA_MIN_KEY_LEN           (128)
+#define RSA_MAX_KEY_LEN           (512)
+#define RSA_KEY_BITWIDTH_1024     (128)
+#define RSA_KEY_BITWIDTH_2048     (256)
+#define RSA_KEY_BITWIDTH_3072     (384)
+#define RSA_KEY_BITWIDTH_4096     (512)
+#define RSA_KEY_EXPONENT_VALUE1   (0X3)
+#define RSA_KEY_EXPONENT_VALUE2   (0X10001)
+
+/*! \the source of hash message */
+typedef enum {
+    HASH_CHUNCK_SRC_LOCAL,     /*!<  Local buffer, e.g. Kernel  */
+    HASH_CHUNCK_SRC_USER,      /*!<  User buffer, use copy_from_user to read data */
+} hash_chunk_src;
+
+/*! \union of compat addr*/
+typedef union {
+    hi_void *p;                /*!<  virtual address */
+    const hi_void *cp;         /*!<  const virtual address */
+    unsigned long long phy;    /*!<  physical address */
+    unsigned int word[2];      /*!<  double word of address */
+} compat_addr;
+
+extern compat_addr compat_addr_zero;
+#define ADDR_H32(addr)          addr.word[1]  /*!<  High 32 bit of hi_u64 */
+#define ADDR_L32(addr)          addr.word[0]  /*!<  Low 32 bit of hi_u64 */
+#define ADDR_U64(addr)          addr.phy      /*!<  64 bit of hi_u64 */
+#define ADDR_VIA(addr)          addr.p        /*!<  buffer point */
+#define ADDR_VIA_CONST(addr)    addr.cp       /*!<  const buffer point */
+#define ADDR_NULL        compat_addr_zero     /*!<  buffer point */
+
+#define ADDR_P_H32(addr) addr->word[1]  /*!<  High 32 bit of hi_u64 */
+#define ADDR_P_L32(addr) addr->word[0]  /*!<  Low 32 bit of hi_u64 */
+#define ADDR_P_U64(addr) addr->phy      /*!<  64 bit of hi_u64 */
+#define ADDR_P_VIA(addr) addr->p        /*!<  buffer point */
+
+/*! \struct of Symmetric cipher create */
+typedef struct {
+    hi_u32 id;              /*!< to store the id of soft channel */
+    hi_u32 reserve;         /*!<  reserve to make align at 64bit */
+} symc_create_t;
+
+/*! \struct of Symmetric cipher destroy */
+typedef struct {
+    hi_u32 id;              /*!< id of soft channel */
+    hi_u32 reserve;         /*!<  reserve to make align at 64bit */
+} symc_destroy_t;
+
+/*! \struct of Symmetric cipher configure infomation */
+typedef struct {
+    hi_u32 id;                           /*!<  Id of soft channel */
+    hi_u32 hard_key;                     /*!<  Use hard key or not */
+    hi_cipher_alg alg;                   /*!<  Symmetric cipher algorithm */
+    hi_cipher_work_mode mode;            /*!<  Symmetric cipher algorithm */
+    hi_cipher_bit_width width;           /*!<  Symmetric cipher bit width */
+    hi_cipher_key_length klen;           /*!<  Symmetric cipher key length */
+    hi_cipher_sm1_round sm1_round_num;   /*!<  The round number of sm1 */
+    hi_u8 fkey[SYMC_KEY_SIZE];           /*!< first  key buffer, defualt */
+    hi_u8 skey[SYMC_KEY_SIZE];           /*!< second key buffer */
+    hi_u8 iv[AES_IV_SIZE];               /*!<  IV buffer */
+    hi_u32 ivlen;                        /*!<  IV length */
+    hi_u32 iv_usage;                     /*!<  Usage of IV */
+    hi_u32 reserve;                      /*!<  reserve to make align at 64bit */
+    compat_addr aad;                     /*!<  Associated Data */
+    hi_u32  alen;                        /*!<  Associated Data Length */
+    hi_u32  tlen;                        /*!<  Tag length */
+} symc_config_t;
+
+typedef enum {
+    SYMC_OPERATION_ENCRYPT = 0,
+    SYMC_OPERATION_DECRYPT = 1,
+    SYMC_OPERATION_ENCRYPT_VIA = 0x10,
+    SYMC_OPERATION_DECRYPT_VIA = 0x11,
+} symc_operation_type;
+
+/*! \struct of Symmetric cipher encrypt/decrypt */
+typedef struct {
+    hi_u32 id;              /*!<  Id of soft channel */
+    hi_u32 length;          /*!<  Length of the encrypted data */
+    hi_u32 operation;       /*!<  operation type*/
+    hi_u32 last;            /*!<  last or not */
+    compat_addr input;      /*!<  Physical address of the input data */
+    compat_addr output;     /*!<  Physical address of the output data */
+} symc_encrypt_t;
+
+/*! \struct of Symmetric cipher multiple encrypt/decrypt */
+typedef struct {
+    hi_u32 id;             /*!<  Id of soft channel */
+    compat_addr pkg;       /*!<  Buffer of package infomation */
+    hi_u32 pkg_num;        /*!<  Number of package infomation */
+    hi_u32 operation;      /*!<  Decrypt or encrypt */
+} symc_encrypt_multi_t;
+
+/*! \struct of Symmetric cipher get tag */
+typedef struct {
+    hi_u32 id;                            /*!<  Id of soft channel */
+    hi_u32 tag[AEAD_TAG_SIZE_IN_WORD];    /*!<  Buffer of tag */
+    hi_u32 taglen ;                       /*!<  Length of tag */
+} aead_tag_t;
+
+/*! \struct of Symmetric cipher get ctrl */
+typedef struct {
+    hi_u32 id;                            /*!<  Id of soft channel */
+    hi_cipher_ctrl  ctrl;                 /*!<  control infomation */
+} symc_get_config_t;
+
+/*! \struct of Hash start */
+typedef struct {
+    hi_u32 id;                            /*!<  Id of soft channel */
+    hi_cipher_hash_type  type;            /*!<  HASH type */
+    compat_addr key;                      /*!<  HMAC key */
+    hi_u32 keylen;                        /*!<  HMAC key */
+    hi_u32 reserve;                       /*!<  reserve for align at 64bit */
+} hash_start_t;
+
+/*! \struct of Hash update */
+typedef struct {
+    hi_u32 id;             /*!<  Id of soft channel */
+    hi_u32 length;         /*!<  Length of the message */
+    compat_addr input;     /*!<  Message data buffer */
+    hash_chunk_src src;    /*!<  source of hash message */
+    hi_u32 reserve;        /*!<  reserve for align at 64bit */
+} hash_update_t;
+
+/*! \struct of Hash update */
+typedef struct {
+    hi_u32 id;             /*!<  Id of soft channel */
+    hi_u32 hash[HASH_RESULT_MAX_SIZE_IN_WORD]; /*!<  buffer holding the hash data */
+    hi_u32 hashlen;        /*!<  length of the hash data */
+    hi_u32 reserve;        /*!<  reserve for align at 64bit */
+} hash_finish_t;
+
+/*! \struct of rsa encrypt/decrypt */
+typedef struct {
+    hi_cipher_rsa_enc_scheme scheme; /*!<  RSA encryption scheme */
+    hi_u16 public;             /** Type of key, true-public or false-private */
+    hi_u16 ca_type;            /** ca Type of key */
+    hi_u32 klen;               /*!<  length of rsa key */
+    hi_u32 e;                  /*!<  The public exponent */
+    compat_addr d;             /*!<  The private exponent */
+    compat_addr n;             /*!<  The modulus */
+    compat_addr p;             /*!<  The p factor of N */
+    compat_addr q;             /*!<  The q factor of N */
+    compat_addr qp;            /*!<  The 1/q mod p CRT param */
+    compat_addr dp;            /*!<  The d mod (p - 1) CRT param */
+    compat_addr dq;            /*!<  The d mod (q - 1) CRT param */
+    compat_addr in;            /*!<  input data to be encryption */
+    compat_addr out;           /*!<  output data of encryption */
+    hi_u32 inlen;              /*!<  length of input data to be encryption */
+    hi_u32 outlen;             /*!<  length of output data */
+} rsa_info_t;
+
+/** RSA PKCS style key */
+typedef struct {
+    /** Type of key, true-public or false-private */
+    hi_u8 public;
+    /** The key source */
+    hi_u8 ca_type;
+    /** The key length */
+    hi_u16 klen;
+    /** The public exponent */
+    hi_u32 e;
+    /** The private exponent */
+    hi_u8 *d;
+    /** The modulus */
+    hi_u8 *n;
+    /** The p factor of n */
+    hi_u8 *p;
+    /** The q factor of n */
+    hi_u8 *q;
+    /** The 1/q mod p CRT param */
+    hi_u8 *qp;
+    /** The d mod (p - 1) CRT param */
+    hi_u8 *dp;
+    /** The d mod (q - 1) CRT param */
+    hi_u8 *dq;
+    /** The buffer size alloc for n */
+    hi_u32 bufsize;
+} cryp_rsa_key;
+
+/*! \struct of klad key */
+typedef struct {
+    hi_u32 keysel;
+    hi_u32 target;
+    hi_u32 clear[AES_BLOCK_SIZE / WORD_WIDTH];
+    hi_u32 encrypt[AES_BLOCK_SIZE / WORD_WIDTH];
+} klad_key_t;
+
+/*! \struct of trng */
+typedef struct {
+    hi_u32 randnum;     /*!<  randnum rand number  */
+    hi_u32 timeout;     /*!<  time out  */
+} trng_t;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      crypto*/
+/** @{*/  /** <!-- [link]*/
+
+/**
+\brief   Kapi Init.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_symc_init(hi_void);
+
+/**
+\brief   Kapi Deinit.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_symc_deinit(hi_void);
+
+/**
+\brief   Kapi release.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_symc_release(hi_void);
+
+/**
+\brief   Create symc handle.
+\param[in]  id The channel number.
+\param[in]  uuid The user identification.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_symc_create(hi_u32 *id);
+
+/**
+\brief   Destroy symc handle.
+\param[in]  id The channel number.
+\param[in]  uuid The user identification.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_symc_destroy(hi_u32 id);
+
+/**
+\brief  set work params.
+* \param[in]  id The channel number.
+* \param[in]  hard_key whether use the hard key or not.
+* \param[in]  alg The symmetric cipher algorithm.
+* \param[in]  mode The symmetric cipher mode.
+* \param[in]  sm1_round_num The round number of sm1.
+* \param[in]  fkey first  key buffer, defualt
+* \param[in]  skey second key buffer, expand
+* \param[in]  klen The key length.
+* \param[in]  aad      Associated Data
+* \param[in]  alen     Associated Data Length
+* \param[in]  tlen     Tag length
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_symc_config(hi_u32 id,
+                        hi_u32 hard_key,
+                        hi_cipher_alg alg,
+                        hi_cipher_work_mode work_mode,
+                        hi_cipher_bit_width bit_width,
+                        hi_cipher_key_length key_len,
+                        hi_cipher_sm1_round sm1_round_num,
+                        hi_u8 *fkey, hi_u8 *skey,
+                        hi_u8 *iv, hi_u32 ivlen, hi_u32 iv_usage,
+                        compat_addr aad, hi_u32 alen, hi_u32 tlen);
+
+/**
+\brief  get work params.
+* \param[in]  id   The channel number.
+* \param[out] ctrl infomation.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_symc_get_config(hi_u32 id, hi_cipher_ctrl *ctrl);
+
+/**
+ * \brief          SYMC  buffer encryption/decryption.
+ *
+ * Note: Due to the nature of aes you should use the same key schedule for
+ * both encryption and decryption.
+ *
+ * \param[in] id     The channel number.
+ * \param input      buffer holding the input data
+ * \param output     buffer holding the output data
+ * \param length     length of the input data
+ * \param operation  decrypt or encrypt
+ *
+ * \return           0 if successful
+ */
+hi_s32 kapi_symc_crypto(hi_u32 id, compat_addr input,
+                        compat_addr output, hi_u32 length,
+                        hi_u32 operation, hi_u32 last);
+
+/**
+ * \brief            SYMC  via buffer encryption/decryption.
+ *
+ * Note: Due to the nature of aes you should use the same key schedule for
+ * both encryption and decryption.
+ *
+ * \param[in] id     The channel number.
+ * \param input      buffer holding the input data
+ * \param output     buffer holding the output data
+ * \param length     length of the input data
+ * \param operation  decrypt or encrypt
+ *
+ * \return           0 if successful
+ */
+hi_s32 kapi_symc_crypto_via(hi_u32 id, compat_addr input,
+                            compat_addr output, hi_u32 length,
+                            hi_u32 operation, hi_u32 last,
+                            hi_u32 is_from_user);
+
+/**
+ * \brief            SYMC multiple buffer encryption/decryption.
+ *
+ * Note: Due to the nature of aes you should use the same key schedule for
+ * both encryption and decryption.
+ *
+ * \param[in] id     The channel number.
+ * \param pkg        Buffer of package infomation
+ * \param pkg_num    Number of package infomation
+ * \param operation  decrypt or encrypt
+ * \param last       last or not
+ *
+ * \return           0 if successful
+ */
+hi_s32 kapi_symc_crypto_multi(hi_u32 id, const hi_void *pkg,
+                              hi_u32 pkg_num, hi_u32 operation,
+                              hi_u32 last);
+
+/**
+ * \brief          SYMC multiple buffer encryption/decryption.
+ * \param[in]  id  The channel number.
+ * \param[in]  tag tag data of CCM/GCM
+ *
+ * \return         0 if successful
+ */
+hi_s32 kapi_aead_get_tag(hi_u32 id, hi_u32 tag[AEAD_TAG_SIZE_IN_WORD], hi_u32 *taglen);
+
+/**
+\brief   Kapi Init.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_hash_init(hi_void);
+
+/**
+\brief   Kapi Deinit.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_hash_deinit(hi_void);
+
+/**
+ * \brief          HASH context setup.
+ *
+ *
+ * \param[out] id      The channel number.
+ * \param[in]  type    Hash type
+ * \param[in]  key     hmac key
+ * \param[in]  keylen  hmac key length
+ *
+ * \return         0 if successful
+ */
+hi_s32 kapi_hash_start(hi_u32 *id, hi_cipher_hash_type type,
+                       hi_u8 *key, hi_u32 keylen);
+
+/**
+ * \brief          HASH process buffer.
+ *
+ * \param[in] id       The channel number.
+ * \param[in] input    buffer holding the input data
+ * \param[in] length   length of the input data
+ * \param[in] src      source of hash message
+ *
+ * \return         0 if successful
+ */
+hi_s32 kapi_hash_update(hi_u32 id, hi_u8 *input, hi_u32 length,
+                        hash_chunk_src src);
+
+/**
+ * \brief          HASH final digest.
+ *
+ * \param[in]  id      The channel number.
+ * \param[out] hash    buffer holding the hash data
+ * \param[out] hashlen length of the hash data
+ *
+ * \return         0 if successful
+ */
+hi_s32 kapi_hash_finish(hi_u32 id, hi_u8 *hash, hi_u32 *hashlen);
+
+/**
+\brief   hash release.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_hash_release(hi_void);
+
+/**
+\brief   Kapi Init.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_rsa_init(hi_void);
+
+/**
+\brief   Kapi Deinitialize.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_rsa_deinit(hi_void);
+
+/**
+* \brief RSA encryption a plaintext with a RSA private key.
+*
+* \param[in] key:       rsa key struct.
+* \param[in] scheme:    rsa encrypt/decrypt scheme.
+* \param[in] in:        input data to be encryption
+* \param[out] inlen:    length of input data to be encryption
+* \param[out] out:      output data of encryption
+* \param[out] outlen:   length of output data to be encryption
+* \retval ::HI_SUCCESS  Call this API successful
+* \retval ::HI_FAILURE  Call this API fails.
+*/
+hi_s32 kapi_rsa_encrypt(cryp_rsa_key *key,
+                        hi_cipher_rsa_enc_scheme scheme,
+                        hi_u8 *in, hi_u32 inlen,
+                        hi_u8 *out, hi_u32 *outlen);
+
+/**
+* \brief RSA decryption a ciphertext with a RSA public key.
+*
+* \param[in] key:       rsa key struct.
+* \param[in] scheme:    rsa encrypt/decrypt scheme.
+* \param[in] in:        input data to be encryption
+* \param[in] inlen:     length of input data to be encryption
+* \param[out] out:      output data to be encryption
+* \param[out] outlen:   length of output data to be encryption
+* \retval ::HI_SUCCESS  Call this API successful
+* \retval ::HI_FAILURE  Call this API fails.
+*/
+hi_s32 kapi_rsa_decrypt(cryp_rsa_key *key,
+                        hi_cipher_rsa_enc_scheme scheme,
+                        hi_u8 *in, hi_u32 inlen,
+                        hi_u8 *out, hi_u32 *outlen);
+
+/**
+* \brief RSA signature a context with appendix, where a signer's RSA private key is used.
+*
+* \param[in] key:       rsa key struct.
+* \param[in] scheme:    rsa signature/verify scheme.
+* \param[in] in:        input data to be encryption
+* \param[in] inlen:     length of input data to be encryption
+* \param[in] hash:      hash value of context,if NULL, let hash = Hash(context) automatically
+* \param[out] out:      output data to be encryption
+* \param[out] outlen:   length of output data to be encryption
+* \param[in]  src       source of hash message
+* \param[in]  uuid uuid The user identification.
+* \retval ::HI_SUCCESS  Call this API successful
+* \retval ::HI_FAILURE  Call this API fails.
+*/
+hi_s32 kapi_rsa_sign_hash(cryp_rsa_key *key,
+                         hi_cipher_rsa_sign_scheme scheme,
+                         hi_u8 *hash, hi_u32 hlen,
+                         hi_u8 *sign, hi_u32 *signlen);
+
+/**
+* \brief RSA verify a ciphertext with a RSA public key.
+*
+* \param[in]  key_info: encryption struct.
+* \param[in]  in:       input data to be encryption
+* \param[out] inlen:    length of input data to be encryption
+* \param[in]  hash:     hash value of context,if NULL, let hash = Hash(context) automatically
+* \param[out] out:      output data to be encryption
+* \param[out] outlen:   length of output data to be encryption
+* \param[in]  src       source of hash message
+* \retval ::HI_SUCCESS  Call this API successful
+* \retval ::HI_FAILURE  Call this API fails.
+*/
+hi_s32 kapi_rsa_verify_hash(cryp_rsa_key *key,
+                            hi_cipher_rsa_sign_scheme scheme,
+                            hi_u8 *hash, hi_u32 hlen,
+                            hi_u8 *sign, hi_u32 signlen);
+
+/**
+\brief get rand number.
+\param[out]  randnum rand number.
+\param[in]   timeout time out.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_trng_get_random(hi_u32 *randnum, hi_u32 timeout);
+
+/* cipher kapi_test */
+hi_void kapi_test(hi_void);
+
+/** @}*/  /** <!-- ==== API Code end ====*/
+
+#ifdef __cplusplus
+}
+#endif    /* __cplusplus */
+
+#endif    /* End of #ifndef __DRV_CIPHER_KAPI_H__*/

--- a/kernel/cipher/hi3516ev200/include/hi_cipher_compat.h
+++ b/kernel/cipher/hi3516ev200/include/hi_cipher_compat.h
@@ -1,0 +1,352 @@
+#ifndef __HI_CIPHER_COMPAT_H__
+#define __HI_CIPHER_COMPAT_H__
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif
+#endif /* __cplusplus */
+
+/* enum typedef */
+/* Cipher work mode */
+typedef enum
+{
+    HI_CIPHER_WORK_MODE_ECB     = 0x0,  /* Electronic codebook (ECB) mode, ECB has been considered insecure and it is
+                                           recommended not to use it.*/
+    HI_CIPHER_WORK_MODE_CBC,            /* Cipher block chaining (CBC) mode*/
+    HI_CIPHER_WORK_MODE_CFB,            /* Cipher feedback (CFB) mode*/
+    HI_CIPHER_WORK_MODE_OFB,            /* Output feedback (OFB) mode*/
+    HI_CIPHER_WORK_MODE_CTR,            /* Counter (CTR) mode*/
+    HI_CIPHER_WORK_MODE_CCM,            /* Counter (CCM) mode*/
+    HI_CIPHER_WORK_MODE_GCM,            /* Counter (GCM) mode*/
+    HI_CIPHER_WORK_MODE_CBC_CTS,        /* Cipher block chaining CipherStealing mode*/
+    HI_CIPHER_WORK_MODE_BUTT,
+    HI_CIPHER_WORK_MODE_INVALID = 0xffffffff,
+}hi_cipher_work_mode;
+
+/* Cipher algorithm */
+typedef enum
+{
+    HI_CIPHER_ALG_DES           = 0x0,  /* Data encryption standard (DES) algorithm,DES has been considered
+                                           insecure and it is recommended not to use it. */
+    HI_CIPHER_ALG_3DES          = 0x1,  /* 3DES algorithm */
+    HI_CIPHER_ALG_AES           = 0x2,  /* Advanced encryption standard (AES) algorithm */
+    HI_CIPHER_ALG_SM1           = 0x3,  /* SM1 algorithm*/
+    HI_CIPHER_ALG_SM4           = 0x4,  /* SM4 algorithm*/
+    HI_CIPHER_ALG_DMA           = 0x5,  /* DMA copy*/
+    HI_CIPHER_ALG_BUTT          = 0x6,
+    HI_CIPHER_ALG_INVALID       = 0xffffffff,
+}hi_cipher_alg;
+
+/* Key length */
+typedef enum
+{
+    HI_CIPHER_KEY_AES_128BIT    = 0x0,  /* 128-bit key for the AES algorithm */
+    HI_CIPHER_KEY_AES_192BIT    = 0x1,  /* 192-bit key for the AES algorithm */
+    HI_CIPHER_KEY_AES_256BIT    = 0x2,  /* 256-bit key for the AES algorithm */
+    HI_CIPHER_KEY_DES_3KEY      = 0x2,  /* Three keys for the DES algorithm */
+    HI_CIPHER_KEY_DES_2KEY      = 0x3,  /* Two keys for the DES algorithm */
+    HI_CIPHER_KEY_DEFAULT       = 0x0,  /* Default key length, DES-8, SM1-48, SM4-16 */
+    HI_CIPHER_KEY_INVALID       = 0xffffffff,
+}hi_cipher_key_length;
+
+/* Cipher bit width */
+typedef enum
+{
+    HI_CIPHER_BIT_WIDTH_64BIT   = 0x0,  /* 64-bit width */
+    HI_CIPHER_BIT_WIDTH_8BIT    = 0x1,  /* 8-bit width */
+    HI_CIPHER_BIT_WIDTH_1BIT    = 0x2,  /* 1-bit width */
+    HI_CIPHER_BIT_WIDTH_128BIT  = 0x3,  /* 128-bit width */
+    HI_CIPHER_BIT_WIDTH_INVALID = 0xffffffff,
+}hi_cipher_bit_width;
+
+/* Key ladder selecting parameters */
+typedef enum
+{
+    HI_CIPHER_KEY_SRC_USER      = 0x0,  /**< User Key*/
+    HI_CIPHER_KEY_SRC_KLAD_1,           /**< KLAD Key 1*/
+    HI_CIPHER_KEY_SRC_KLAD_2,           /**< KLAD Key 2*/
+    HI_CIPHER_KEY_SRC_KLAD_3,           /**< KLAD Key 3*/
+    HI_CIPHER_KEY_SRC_BUTT,
+    HI_CIPHER_KEY_SRC_INVALID   = 0xffffffff,
+}hi_cipher_ca_type;
+
+/** Klad target */
+typedef enum {
+    HI_CIPHER_KLAD_TARGET_AES   = 0x0,  /**< Klad for AES*/
+    HI_CIPHER_KLAD_TARGET_RSA,          /**< Klad for RSA*/
+    HI_CIPHER_KLAD_TARGET_BUTT,
+} hi_cipher_klad_target;
+
+/* Encryption/Decryption type selecting */
+typedef enum
+{
+    HI_CIPHER_TYPE_NORMAL       = 0x0,
+    HI_CIPHER_TYPE_COPY_AVOID,
+    HI_CIPHER_TYPE_BUTT,
+    HI_CIPHER_TYPE_INVALID      = 0xffffffff,
+}hi_cipher_type;
+
+/* SM1 round config */
+typedef enum
+{
+    HI_CIPHER_SM1_ROUND_08      = 0x00, /* SM1 round 08 */
+    HI_CIPHER_SM1_ROUND_10      = 0x01, /* SM1 round 10 */
+    HI_CIPHER_SM1_ROUND_12      = 0x02, /* SM1 round 12 */
+    HI_CIPHER_SM1_ROUND_14      = 0x03, /* SM1 round 14 */
+    HI_CIPHER_SM1_ROUND_BUTT,
+    HI_CIPHER_SM1_ROUND_INVALID = 0xffffffff,
+}hi_cipher_sm1_round;
+
+/* Hash algrithm type */
+typedef enum
+{
+    HI_CIPHER_HASH_TYPE_SHA1,
+    HI_CIPHER_HASH_TYPE_SHA224,
+    HI_CIPHER_HASH_TYPE_SHA256,
+    HI_CIPHER_HASH_TYPE_SHA384,
+    HI_CIPHER_HASH_TYPE_SHA512,
+    HI_CIPHER_HASH_TYPE_HMAC_SHA1,
+    HI_CIPHER_HASH_TYPE_HMAC_SHA224,
+    HI_CIPHER_HASH_TYPE_HMAC_SHA256,
+    HI_CIPHER_HASH_TYPE_HMAC_SHA384,
+    HI_CIPHER_HASH_TYPE_HMAC_SHA512,
+    HI_CIPHER_HASH_TYPE_SM3,
+    HI_CIPHER_HASH_TYPE_BUTT,
+    HI_CIPHER_HASH_TYPE_INVALID = 0xffffffff,
+}hi_cipher_hash_type;
+
+/* Rsa encrypt and decrypt scheme */
+typedef enum
+{
+    HI_CIPHER_RSA_ENC_SCHEME_NO_PADDING  = 0x00, /* without padding */
+    HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_0,       /* PKCS#1 block type 0 padding*/
+    HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_1,       /* PKCS#1 block type 1padding*/
+    HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_2,       /* PKCS#1 block type 2 padding*/
+    HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA1,    /* PKCS#1 RSAES-OAEP-SHA1 padding*/
+    HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA224,  /* PKCS#1 RSAES-OAEP-SHA224 padding*/
+    HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA256,  /* PKCS#1 RSAES-OAEP-SHA256   padding*/
+    HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA384,  /* PKCS#1 RSAES-OAEP-SHA384   padding*/
+    HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA512,  /* PKCS#1 RSAES-OAEP-SHA512   padding*/
+    HI_CIPHER_RSA_ENC_SCHEME_RSAES_PKCS1_V1_5,   /* PKCS#1 RSAES-PKCS1_V1_5    padding*/
+    HI_CIPHER_RSA_ENC_SCHEME_BUTT,
+    HI_CIPHER_RSA_ENC_SCHEME_INVALID    = 0xffffffff,
+}hi_cipher_rsa_enc_scheme;
+
+/* Rsa sign and verify scheme */
+typedef enum
+{
+    HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA1 = 0x100, /* PKCS#1 RSASSA_PKCS1_V15_SHA1 signature*/
+    HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA224,       /* PKCS#1 RSASSA_PKCS1_V15_SHA224 signature*/
+    HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA256,       /* PKCS#1 RSASSA_PKCS1_V15_SHA256 signature*/
+    HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA384,       /* PKCS#1 RSASSA_PKCS1_V15_SHA384 signature*/
+    HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA512,       /* PKCS#1 RSASSA_PKCS1_V15_SHA512 signature*/
+    HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA1,         /* PKCS#1 RSASSA_PKCS1_PSS_SHA1 signature*/
+    HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA224,       /* PKCS#1 RSASSA_PKCS1_PSS_SHA224 signature*/
+    HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA256,       /* PKCS#1 RSASSA_PKCS1_PSS_SHA256 signature*/
+    HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA384,       /* PKCS#1 RSASSA_PKCS1_PSS_SHA1 signature*/
+    HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA512,       /* PKCS#1 RSASSA_PKCS1_PSS_SHA256 signature*/
+    HI_CIPHER_RSA_SIGN_SCHEME_BUTT,
+    HI_CIPHER_RSA_SIGN_SCHEME_INVALID               = 0xffffffff,
+}hi_cipher_rsa_sign_scheme;
+
+/* struct define */
+/* Cipher control parameters */
+typedef struct
+{
+    hi_u32 bit1_iv     : 2;              /* Initial Vector change flag, 0-don't set, 1-set IV for first package, 2-set
+                                            IV for each package  */
+    hi_u32 bits_reserve: 30;             /* Reserved */
+}hi_cipher_ctrl_change_flag;
+
+/* Structure of the cipher type */
+typedef struct
+{
+    hi_cipher_type cipher_type;
+}hi_cipher_atts;
+
+/* Structure of the cipher control information */
+typedef struct
+{
+    hi_u32 key[8];                   /* Key input */
+    hi_u32 iv[4];                    /* Initialization vector (IV) */
+    hi_bool key_by_ca;               /* Encryption using advanced conditional access (CA) or decryption using keys */
+    hi_cipher_ca_type ca_type;       /* Select keyladder type when using advanced CA */
+    hi_cipher_alg alg;               /* Cipher algorithm */
+    hi_cipher_bit_width bit_width;   /* Bit width for encryption or decryption */
+    hi_cipher_work_mode work_mode;   /* Operating mode */
+    hi_cipher_key_length key_len;    /* Key length */
+    hi_cipher_ctrl_change_flag change_flags; /* control information exchange choices, we default all woulde be change
+                                                except they have been in the choices */
+} hi_cipher_ctrl;
+
+/* Structure of the cipher AES control information */
+typedef struct
+{
+    hi_u32 even_key[8];                      /* Key input, default use this key*/
+    hi_u32 odd_key[8];                       /* Key input, only valid for Multi encrypt/decrypt*/
+    hi_u32 iv[4];                            /* Initialization vector (IV) */
+    hi_cipher_bit_width bit_width;           /* Bit width for encryption or decryption */
+    hi_cipher_key_length key_len;            /* Key length */
+    hi_cipher_ctrl_change_flag change_flags; /* control information exchange choices, we default all woulde be change
+                                                except they have been in the choices */
+} hi_cipher_ctrl_aes;
+
+/* Structure of the cipher AES CCM/GCM control information */
+typedef struct
+{
+    hi_u32 key[8];                       /* Key input */
+    hi_u32 iv[4];                        /* Initialization vector (IV) */
+    hi_cipher_key_length key_len;        /* Key length */
+    hi_u32 iv_len;                       /* IV lenght for CCM/GCM, which is an element of {7, 8, 9, 10, 11, 12, 13}
+                                            for CCM, and is an element of [1-16] for GCM*/
+    hi_u32 tag_len;                      /* Tag lenght for CCM which is an element of {4,6,8,10,12,14,16}*/
+    hi_u32 a_len;                        /* Associated data for CCM and GCM*/
+    hi_size_t a_phy_addr;                /* Physical address of Associated data  for CCM and GCM*/
+} hi_cipher_ctrl_aes_ccm_gcm;
+
+/* Structure of the cipher DES control information */
+typedef struct
+{
+    hi_u32 key[2];                           /* Key input */
+    hi_u32 iv[2];                            /* Initialization vector (IV) */
+    hi_cipher_bit_width bit_width;           /* Bit width for encryption or decryption */
+    hi_cipher_ctrl_change_flag change_flags; /* Control information exchange choices, we default all woulde be change
+                                                except they have been in the choices */
+} hi_cipher_ctrl_des;
+
+/* Structure of the cipher 3DES control information */
+typedef struct
+{
+    hi_u32 key[6];
+    hi_u32 iv[2];                            /* Initialization vector (IV) */
+    hi_cipher_bit_width bit_width;           /* Bit width for encryption or decryption */
+    hi_cipher_key_length key_len;            /* Key length */
+    hi_cipher_ctrl_change_flag change_flags; /* control information exchange choices, we default all woulde be change
+                                                except they have been in the choices */
+} hi_cipher_ctrl_3des;
+
+/* Structure of the cipher SM1 control information */
+typedef struct
+{
+    hi_u32 ek[4];                            /* Key of EK input */
+    hi_u32 ak[4];                            /* Key of AK input */
+    hi_u32 sk[4];                            /* Key of SK input */
+    hi_u32 iv[4];                            /* Initialization vector (IV) */
+    hi_cipher_bit_width bit_width;           /* Bit width for encryption or decryption */
+    hi_cipher_sm1_round sm1_round;           /* SM1 round number, should be 8, 10, 12 or 14*/
+    hi_cipher_ctrl_change_flag change_flags; /* control information exchange choices, we default all woulde be change
+                                                except they have been in the choices */
+} hi_cipher_ctrl_sm1;
+
+/* Structure of the cipher SM4 control information */
+typedef struct
+{
+    hi_u32 key[4];                           /* Key input */
+    hi_u32 iv[4];                            /* Initialization vector (IV) */
+    hi_cipher_ctrl_change_flag change_flags; /* control information exchange choices, we default all woulde be change
+                                                except they have been in the choices */
+} hi_cipher_ctrl_sm4;
+
+/* Expand Structure of the cipher control information */
+typedef struct
+{
+    hi_cipher_alg alg;              /* Cipher algorithm */
+    hi_cipher_work_mode work_mode;  /* Operating mode */
+    hi_bool key_by_ca;              /* Encryption using advanced conditional access (CA) or decryption using keys */
+    /*  Parameter for special algorithm
+        for AES, the pointer should point to hi_cipher_ctrl_aes;
+        for AES_CCM or AES_GCM, the pointer should point to hi_cipher_ctrl_aes_ccm_gcm;
+        for DES, the pointer should point to hi_cipher_ctrl_des;
+        for 3DES, the pointer should point to hi_cipher_ctrl_3des;
+        for SM1, the pointer should point to hi_cipher_ctrl_sm1;
+        for SM4, the pointer should point to hi_cipher_ctrl_sm4;
+    */
+    hi_void *param;
+} hi_cipher_ctrl_ex;
+
+/* Cipher data */
+typedef struct
+{
+    hi_size_t src_phy_addr;     /* phy address of the original data */
+    hi_size_t dest_phy_addr;    /* phy address of the purpose data */
+    hi_u32 byte_length;         /* Cigher data length*/
+    hi_bool odd_key;            /* Use odd key or even key*/
+} hi_cipher_data;
+
+/* Hash init struct input */
+typedef struct
+{
+    hi_u8 *hmac_key;
+    hi_u32 hmac_key_len;
+    hi_cipher_hash_type sha_type;
+}hi_cipher_hash_atts;
+
+/* RSA public key struct */
+typedef struct
+{
+    hi_u8  *n;        /* Point to public modulus  */
+    hi_u8  *e;        /* Point to public exponent */
+    hi_u16 n_len;     /* Length of public modulus, max value is 512Byte*/
+    hi_u16 e_len;     /* Length of public exponent, max value is 512Byte*/
+}hi_cipher_rsa_pub_key;
+
+/* RSA private key struct */
+typedef struct
+{
+    hi_u8 *n;         /* Public modulus    */
+    hi_u8 *e;         /* Public exponent   */
+    hi_u8 *d;         /* Private exponent  */
+    hi_u8 *p;         /* 1st prime factor  */
+    hi_u8 *q;         /* 2nd prime factor  */
+    hi_u8 *dp;        /* d % (p - 1) */
+    hi_u8 *dq;        /* d % (q - 1) */
+    hi_u8 *qp;        /* 1 / (q % p) */
+    hi_u16 n_len;     /* Length of public modulus */
+    hi_u16 e_len;     /* Length of public exponent */
+    hi_u16 d_len;     /* Length of private exponent */
+    hi_u16 p_len;     /* Length of 1st prime factor,should be half of u16NLen */
+    hi_u16 q_len;     /* Length of 2nd prime factor,should be half of u16NLen */
+    hi_u16 dp_len;    /* Length of D % (P - 1),should be half of u16NLen */
+    hi_u16 dq_len;    /* Length of D % (Q - 1),should be half of u16NLen */
+    hi_u16 qp_len;    /* Length of 1 / (Q % P),should be half of u16NLen */
+}hi_cipher_rsa_pri_key;
+
+/* RSA public key encryption struct input */
+typedef struct
+{
+    hi_cipher_rsa_enc_scheme scheme;    /* RSA encryption scheme */
+    hi_cipher_rsa_pub_key pub_key;      /* RSA private key struct */
+    hi_cipher_ca_type ca_type;          /* CA type*/
+}hi_cipher_rsa_pub_enc;
+
+/* RSA private key decryption struct input */
+typedef struct
+{
+    hi_cipher_rsa_enc_scheme scheme;    /* RSA encryption scheme */
+    hi_cipher_rsa_pri_key pri_key;      /* RSA private key struct */
+    hi_cipher_ca_type ca_type;          /* CA type*/
+}hi_cipher_rsa_pri_enc;
+
+/* RSA signature struct input */
+typedef struct
+{
+    hi_cipher_rsa_sign_scheme scheme;   /* RSA signature scheme*/
+    hi_cipher_rsa_pri_key pri_key;      /* RSA private key struct */
+    hi_cipher_ca_type ca_type;          /* CA type*/
+ }hi_cipher_rsa_sign;
+
+/* RSA signature verify struct input */
+typedef struct
+{
+    hi_cipher_rsa_sign_scheme scheme;   /* RSA signature scheme*/
+    hi_cipher_rsa_pub_key pub_key;      /* RSA public key struct */
+ }hi_cipher_rsa_verify;
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* __cplusplus */
+
+#endif /* __HI_CIPHER_COMPAT_H__ */

--- a/kernel/cipher/hi3516ev200/include/hi_common_cipher.h
+++ b/kernel/cipher/hi3516ev200/include/hi_common_cipher.h
@@ -1,0 +1,48 @@
+#ifndef __HI_COMMON_CIPHER__
+#define __HI_COMMON_CIPHER__
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif
+#endif /* __cplusplus */
+
+#define  HI_ERR_CIPHER_NOT_INIT                     (HI_S32)(0x804D0001)
+#define  HI_ERR_CIPHER_INVALID_HANDLE               (HI_S32)(0x804D0002)
+#define  HI_ERR_CIPHER_INVALID_POINT                (HI_S32)(0x804D0003)
+#define  HI_ERR_CIPHER_INVALID_PARA                 (HI_S32)(0x804D0004)
+#define  HI_ERR_CIPHER_FAILED_INIT                  (HI_S32)(0x804D0005)
+#define  HI_ERR_CIPHER_FAILED_GETHANDLE             (HI_S32)(0x804D0006)
+#define  HI_ERR_CIPHER_FAILED_RELEASEHANDLE         (HI_S32)(0x804D0007)
+#define  HI_ERR_CIPHER_FAILED_CONFIGAES             (HI_S32)(0x804D0008)
+#define  HI_ERR_CIPHER_FAILED_CONFIGDES             (HI_S32)(0x804D0009)
+#define  HI_ERR_CIPHER_FAILED_ENCRYPT               (HI_S32)(0x804D000A)
+#define  HI_ERR_CIPHER_FAILED_DECRYPT               (HI_S32)(0x804D000B)
+#define  HI_ERR_CIPHER_BUSY                         (HI_S32)(0x804D000C)
+#define  HI_ERR_CIPHER_NO_AVAILABLE_RNG             (HI_S32)(0x804D000D)
+#define  HI_ERR_CIPHER_FAILED_MEM                   (HI_S32)(0x804D000E)
+#define  HI_ERR_CIPHER_UNAVAILABLE                  (HI_S32)(0x804D000F)
+#define  HI_ERR_CIPHER_OVERFLOW                     (HI_S32)(0x804D0010)
+#define  HI_ERR_CIPHER_HARD_STATUS                  (HI_S32)(0x804D0011)
+#define  HI_ERR_CIPHER_TIMEOUT                      (HI_S32)(0x804D0012)
+#define  HI_ERR_CIPHER_UNSUPPORTED                  (HI_S32)(0x804D0013)
+#define  HI_ERR_CIPHER_REGISTER_IRQ                 (HI_S32)(0x804D0014)
+#define  HI_ERR_CIPHER_ILLEGAL_UUID                 (HI_S32)(0x804D0015)
+#define  HI_ERR_CIPHER_ILLEGAL_KEY                  (HI_S32)(0x804D0016)
+#define  HI_ERR_CIPHER_INVALID_ADDR                 (HI_S32)(0x804D0017)
+#define  HI_ERR_CIPHER_INVALID_LENGTH               (HI_S32)(0x804D0018)
+#define  HI_ERR_CIPHER_ILLEGAL_DATA                 (HI_S32)(0x804D0019)
+#define  HI_ERR_CIPHER_RSA_SIGN                     (HI_S32)(0x804D001A)
+#define  HI_ERR_CIPHER_RSA_VERIFY                   (HI_S32)(0x804D001B)
+#define  HI_ERR_CIPHER_MEMSET_S_FAILED              (HI_S32)(0x804D001C)
+#define  HI_ERR_CIPHER_MEMCPY_S_FAILED              (HI_S32)(0x804D001D)
+#define  HI_ERR_CIPHER_RSA_CRYPT_FAILED             (HI_S32)(0x804D001E)
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* __cplusplus */
+
+#endif /* __CRYP_CIPHER_H__ */
+

--- a/kernel/cipher/hi3516ev200/include/hi_type.h
+++ b/kernel/cipher/hi3516ev200/include/hi_type.h
@@ -1,0 +1,116 @@
+/******************************************************************************
+ * Copyright (C) Hisilicon Technologies Co., Ltd. 2005-2019. All rights reserved.
+ * Description: Common data types of the system.
+ * Author: Hisilicon multimedia software group
+ * Create: 2005-4-23
+******************************************************************************/
+
+#ifndef __HI_TYPE_H__
+#define __HI_TYPE_H__
+
+#ifdef __KERNEL__
+
+#include <linux/types.h>
+#else
+
+#include <stdint.h>
+#endif
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C"{
+#endif
+#endif /* __cplusplus */
+
+/*--------------------------------------------------------------------------------------------------------------*
+ * Defintion of basic data types. The data types are applicable to both the application layer and kernel codes. *
+ *--------------------------------------------------------------------------------------------------------------*/
+/*************************** Structure Definition ****************************/
+/** \addtogroup      Common_TYPE */
+/** @{ */  /** <!-- [Common_TYPE] */
+
+typedef unsigned char           HI_UCHAR;
+typedef unsigned char           HI_U8;
+typedef unsigned short          HI_U16;
+typedef unsigned int            HI_U32;
+typedef unsigned long           HI_UL;
+typedef uintptr_t               HI_UINTPTR_T;
+
+typedef char                    HI_CHAR;
+typedef signed char             HI_S8;
+typedef short                   HI_S16;
+typedef int                     HI_S32;
+typedef long                    HI_SL;
+
+typedef float                   HI_FLOAT;
+typedef double                  HI_DOUBLE;
+
+#ifndef _M_IX86
+    typedef unsigned long long  HI_U64;
+    typedef long long           HI_S64;
+#else
+    typedef unsigned __int64    HI_U64;
+    typedef __int64             HI_S64;
+#endif
+
+typedef unsigned long           HI_SIZE_T;
+typedef unsigned long           HI_LENGTH_T;
+typedef long int                HI_PHYS_ADDR_T;
+
+typedef unsigned int            HI_HANDLE;
+
+/*----------------------------------------------*
+ * const defination                             *
+ *----------------------------------------------*/
+typedef enum {
+    HI_FALSE = 0,
+    HI_TRUE  = 1,
+} HI_BOOL;
+
+#ifndef NULL
+    #define NULL                0L
+#endif
+
+#define HI_NULL                 0L
+#define HI_SUCCESS              0
+#define HI_FAILURE              (-1)
+
+#define HI_VOID                 void
+
+typedef unsigned char           hi_uchar;
+typedef unsigned char           hi_u8;
+typedef unsigned short          hi_u16;
+typedef unsigned int            hi_u32;
+typedef unsigned long long      hi_u64;
+typedef unsigned long           hi_ulong;
+
+typedef char                    hi_char;
+typedef signed char             hi_s8;
+typedef short                   hi_s16;
+typedef int                     hi_s32;
+typedef long long               hi_s64;
+typedef long                    hi_slong;
+
+typedef float                   hi_float;
+typedef double                  hi_double;
+
+typedef void                    hi_void;
+
+typedef unsigned long           hi_size_t;
+typedef unsigned long           hi_length_t;
+
+typedef hi_u32                  hi_handle;
+
+typedef HI_BOOL                 hi_bool;
+typedef HI_UINTPTR_T            hi_uintptr_t;
+
+/** @} */  /** <!-- ==== Structure Definition end ==== */
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* __cplusplus */
+
+#endif /* __HI_TYPE_H__ */
+

--- a/kernel/cipher/hi3516ev200/include/hi_types.h
+++ b/kernel/cipher/hi3516ev200/include/hi_types.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+ Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+******************************************************************************
+File Name     : hi_types.h
+Version       : Initial Draft
+Author        : Hisilicon multimedia software group
+Created       : 2005/4/23
+Last Modified :
+Description   : Common data types of the system.
+Function List :
+History       :
+******************************************************************************/
+#ifndef __HI_TYPES_H__
+#define __HI_TYPES_H__
+
+#include "hi_type.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif
+#endif /* __cplusplus */
+
+/*--------------------------------------------------------------------------------------------------------------*
+ * Defintion of basic data types. The data types are applicable to both the application layer and kernel codes. *
+ *--------------------------------------------------------------------------------------------------------------*/
+/*************************** Structure Definition ****************************/
+/** \addtogroup      Common_TYPE */
+/** @{ */  /** <!-- [Common_TYPE] */
+
+/**
+
+define of HI_HANDLE :
+bit31                                                           bit0
+  |<----   16bit --------->|<---   8bit    --->|<---  8bit   --->|
+  |--------------------------------------------------------------|
+  |      HI_MOD_ID_E       |  mod defined data |     chnID       |
+  |--------------------------------------------------------------|
+
+mod defined data: private data define by each module(for example: sub-mod id), usually, set to 0.
+*/
+
+#define HI_HANDLE_MAKEHANDLE(mod, privatedata, chnid)  (hi_handle)( (((mod)& 0xffff) << 16) | ((((privatedata)& 0xff) << 8) ) | (((chnid) & 0xff)) )
+
+#define HI_HANDLE_GET_MODID(handle)     (((handle) >> 16) & 0xffff)
+#define HI_HANDLE_GET_PriDATA(handle)   (((handle) >> 8) & 0xff)
+#define HI_HANDLE_GET_CHNID(handle)     (((handle)) & 0xff)
+
+
+/** @} */  /** <!-- ==== Structure Definition end ==== */
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* __cplusplus */
+
+#endif /* __HI_TYPE_H__ */
+

--- a/kernel/cipher/hi3516ev200/include/hi_unf_cipher.h
+++ b/kernel/cipher/hi3516ev200/include/hi_unf_cipher.h
@@ -1,0 +1,855 @@
+/******************************************************************************
+
+Copyright (C), 2015-2016, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+File Name : hi_tee_cipher.h
+Version : Initial Draft
+Author : Hisilicon multimedia software group
+Created : 2016/06/08
+Description :
+History :
+1.Date : 2016/06/08
+Author : z00268517
+Modification: Created file
+
+*******************************************************************************/
+/**
+* \file
+* \brief Describes the API about the cipher.
+*/
+
+#ifndef __HI_UNF_CIPHER_H__
+#define __HI_UNF_CIPHER_H__
+
+#include "hi_types.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif
+#endif /* __cplusplus */
+/*************************** Structure Definition ****************************/
+/** \addtogroup      CIPHER */
+/** @{ */  /** <!-- [CIPHER] */
+
+/** max length of SM2, unit: word */
+#define SM2_LEN_IN_WROD                   (8)
+
+/** max length of SM2, unit: byte */
+#define SM2_LEN_IN_BYTE                   (SM2_LEN_IN_WROD * 4)
+
+/** CIPHER set IV for first package */
+#define CIPHER_IV_CHANGE_ONE_PKG        (1)
+
+/** CIPHER set IV for first package */
+#define CIPHER_IV_CHANGE_ALL_PKG        (2)
+
+/** Cipher work mode */
+typedef enum hiHI_UNF_CIPHER_WORK_MODE_E
+{
+    HI_UNF_CIPHER_WORK_MODE_ECB,        /**<Electronic codebook (ECB) mode*/
+    HI_UNF_CIPHER_WORK_MODE_CBC,        /**<Cipher block chaining (CBC) mode*/
+    HI_UNF_CIPHER_WORK_MODE_CFB,        /**<Cipher feedback (CFB) mode*/
+    HI_UNF_CIPHER_WORK_MODE_OFB,        /**<Output feedback (OFB) mode*/
+    HI_UNF_CIPHER_WORK_MODE_CTR,        /**<Counter (CTR) mode*/
+    HI_UNF_CIPHER_WORK_MODE_CCM,        /**<Counter (CCM) mode*/
+    HI_UNF_CIPHER_WORK_MODE_GCM,        /**<Counter (GCM) mode*/
+    HI_UNF_CIPHER_WORK_MODE_CBC_CTS,    /**<Cipher block chaining CipherStealing mode*/
+    HI_UNF_CIPHER_WORK_MODE_BUTT,
+    HI_UNF_CIPHER_WORK_MODE_INVALID  = 0xffffffff,
+}HI_UNF_CIPHER_WORK_MODE_E;
+
+/** Cipher algorithm */
+typedef enum hiHI_UNF_CIPHER_ALG_E
+{
+    HI_UNF_CIPHER_ALG_DES           = 0x0,  /**< Data encryption standard (DES) algorithm */
+    HI_UNF_CIPHER_ALG_3DES          = 0x1,  /**< 3DES algorithm */
+    HI_UNF_CIPHER_ALG_AES           = 0x2,  /**< Advanced encryption standard (AES) algorithm */
+    HI_UNF_CIPHER_ALG_SM1           = 0x3,  /**<SM1 algorithm*/
+    HI_UNF_CIPHER_ALG_SM4           = 0x4,  /**<SM4 algorithm*/
+    HI_UNF_CIPHER_ALG_DMA           = 0x5,  /**<DMA copy*/
+    HI_UNF_CIPHER_ALG_BUTT          = 0x6,
+    HI_UNF_CIPHER_ALG_INVALID       = 0xffffffff,
+}HI_UNF_CIPHER_ALG_E;
+
+/** Key length */
+typedef enum hiHI_UNF_CIPHER_KEY_LENGTH_E
+{
+    HI_UNF_CIPHER_KEY_AES_128BIT    = 0x0,  /**< 128-bit key for the AES algorithm */
+    HI_UNF_CIPHER_KEY_AES_192BIT    = 0x1,  /**< 192-bit key for the AES algorithm */
+    HI_UNF_CIPHER_KEY_AES_256BIT    = 0x2,  /**< 256-bit key for the AES algorithm */
+    HI_UNF_CIPHER_KEY_DES_3KEY      = 0x2,  /**< Three keys for the DES algorithm */
+    HI_UNF_CIPHER_KEY_DES_2KEY      = 0x3,  /**< Two keys for the DES algorithm */
+    HI_UNF_CIPHER_KEY_DEFAULT       = 0x0,  /**< default key length, DES-8, SM1-48, SM4-16 */
+    HI_UNF_CIPHER_KEY_INVALID       = 0xffffffff,
+}HI_UNF_CIPHER_KEY_LENGTH_E;
+
+/** Cipher bit width */
+typedef enum hiHI_UNF_CIPHER_BIT_WIDTH_E
+{
+    HI_UNF_CIPHER_BIT_WIDTH_64BIT   = 0x0,  /**< 64-bit width */
+    HI_UNF_CIPHER_BIT_WIDTH_8BIT    = 0x1,  /**< 8-bit width */
+    HI_UNF_CIPHER_BIT_WIDTH_1BIT    = 0x2,  /**< 1-bit width */
+    HI_UNF_CIPHER_BIT_WIDTH_128BIT  = 0x3,  /**< 128-bit width */
+    HI_UNF_CIPHER_BIT_WIDTH_INVALID = 0xffffffff,
+}HI_UNF_CIPHER_BIT_WIDTH_E;
+
+/** Cipher control parameters */
+typedef struct hiTEE_CIPHER_CTRL_CHANGE_FLAG_S
+{
+    HI_U32   bit1IV:2;              /**< Initial Vector change flag, 0-don't set, 1-set IV for first package, 2-set IV for each package  */
+    HI_U32   bitsResv:30;           /**< Reserved */
+}HI_UNF_CIPHER_CTRL_CHANGE_FLAG_S;
+
+/** Key ladder selecting parameters */
+typedef enum hiTEE_CIPHER_CA_TYPE_E
+{
+    HI_UNF_CIPHER_KEY_SRC_USER       = 0x0,  /**< User Key*/
+    HI_UNF_CIPHER_KEY_SRC_KLAD_1,           /**< KLAD Key 1*/
+    HI_UNF_CIPHER_KEY_SRC_KLAD_2,           /**< KLAD Key 2*/
+    HI_UNF_CIPHER_KEY_SRC_KLAD_3,           /**< KLAD Key 3*/
+    HI_UNF_CIPHER_KEY_SRC_BUTT,
+    HI_UNF_CIPHER_KEY_SRC_INVALID = 0xffffffff,
+}HI_UNF_CIPHER_CA_TYPE_E;
+
+/** Encryption/Decryption type selecting */
+typedef enum
+{
+    HI_UNF_CIPHER_KLAD_TARGET_AES       = 0x0,  /**< Klad for AES*/
+    HI_UNF_CIPHER_KLAD_TARGET_RSA,              /**< Klad for RSA*/
+    HI_UNF_CIPHER_KLAD_TARGET_BUTT,
+}HI_UNF_CIPHER_KLAD_TARGET_E;
+
+/** Encryption/Decryption type selecting */
+typedef enum
+{
+    HI_UNF_CIPHER_TYPE_NORMAL  = 0x0,
+    HI_UNF_CIPHER_TYPE_COPY_AVOID,
+    HI_UNF_CIPHER_TYPE_BUTT,
+    HI_UNF_CIPHER_TYPE_INVALID = 0xffffffff,
+}HI_UNF_CIPHER_TYPE_E;
+
+/** Structure of the cipher type */
+typedef struct
+{
+    HI_UNF_CIPHER_TYPE_E enCipherType;
+}HI_UNF_CIPHER_ATTS_S;
+
+/** sm1 round config */
+typedef enum hiHI_UNF_CIPHER_SM1_ROUND_E
+{
+    HI_UNF_CIPHER_SM1_ROUND_08 = 0x00,            /**< sm1 round 08 */
+    HI_UNF_CIPHER_SM1_ROUND_10 = 0x01,            /**< sm1 round 10 */
+    HI_UNF_CIPHER_SM1_ROUND_12 = 0x02,            /**< sm1 round 12 */
+    HI_UNF_CIPHER_SM1_ROUND_14 = 0x03,            /**< sm1 round 14 */
+    HI_UNF_CIPHER_SM1_ROUND_BUTT,
+    HI_UNF_CIPHER_SM1_ROUND_INVALID  = 0xffffffff,
+}HI_UNF_CIPHER_SM1_ROUND_E;
+
+/** Structure of the cipher control information */
+typedef struct hiHI_UNF_CIPHER_CTRL_S
+{
+    HI_U32 u32Key[8];                               /**< Key input */
+    HI_U32 u32IV[4];                                /**< Initialization vector (IV) */
+    HI_BOOL bKeyByCA;                               /**< Encryption using advanced conditional access (CA) or decryption using keys */
+    HI_UNF_CIPHER_CA_TYPE_E enCaType;               /**< Select keyladder type when using advanced CA */
+    HI_UNF_CIPHER_ALG_E enAlg;                      /**< Cipher algorithm */
+    HI_UNF_CIPHER_BIT_WIDTH_E enBitWidth;           /**< Bit width for encryption or decryption */
+    HI_UNF_CIPHER_WORK_MODE_E enWorkMode;           /**< Operating mode */
+    HI_UNF_CIPHER_KEY_LENGTH_E enKeyLen;            /**< Key length */
+    HI_UNF_CIPHER_CTRL_CHANGE_FLAG_S stChangeFlags; /**< control information exchange choices, we default all would be change except they have been in the choices */
+} HI_UNF_CIPHER_CTRL_S;
+
+/** Structure of the cipher AES control information */
+typedef struct hiHI_UNF_CIPHER_CTRL_AES_S
+{
+    HI_U32 u32EvenKey[8];                           /**< Key input, default use this key*/
+    HI_U32 u32OddKey[8];                            /**< Key input, only valid for Multi encrypt/decrypt*/
+    HI_U32 u32IV[4];                                /**< Initialization vector (IV) */
+    HI_UNF_CIPHER_BIT_WIDTH_E enBitWidth;           /**< Bit width for encryption or decryption */
+    HI_UNF_CIPHER_KEY_LENGTH_E enKeyLen;            /**< Key length */
+    HI_UNF_CIPHER_CTRL_CHANGE_FLAG_S stChangeFlags; /**< control information exchange choices, we default all woulde be change except they have been in the choices */
+} HI_UNF_CIPHER_CTRL_AES_S;
+
+/** Structure of the cipher AES CCM/GCM control information */
+typedef struct hiHI_UNF_CIPHER_CTRL_AES_CCM_GCM_S
+{
+    HI_U32 u32Key[8];                               /**< Key input */
+    HI_U32 u32IV[4];                                /**< Initialization vector (IV) */
+    HI_UNF_CIPHER_KEY_LENGTH_E enKeyLen;            /**< Key length */
+    HI_U32 u32IVLen;                                /**< IV lenght for CCM/GCM, which is an element of {4,6,8,10,12,14,16} for CCM, and is an element of [1-16] for GCM*/
+    HI_U32 u32TagLen;                               /**< Tag lenght for CCM which is an element of {4,6,8,10,12,14,16}*/
+    HI_U32 u32ALen;                                 /**< Associated data for CCM and GCM*/
+    HI_SIZE_T szAPhyAddr;                             /**< Physical address of Associated data for CCM and GCM*/
+} HI_UNF_CIPHER_CTRL_AES_CCM_GCM_S;
+
+/** Structure of the cipher DES control information */
+typedef struct hiHI_UNF_CIPHER_CTRL_DES_S
+{
+    HI_U32 u32Key[2];                               /**< Key input */
+    HI_U32 u32IV[2];                                /**< Initialization vector (IV) */
+    HI_UNF_CIPHER_BIT_WIDTH_E enBitWidth;           /**< Bit width for encryption or decryption */
+    HI_UNF_CIPHER_CTRL_CHANGE_FLAG_S stChangeFlags; /**< control information exchange choices, we default all woulde be change except they have been in the choices */
+} HI_UNF_CIPHER_CTRL_DES_S;
+
+/** Structure of the cipher 3DES control information */
+typedef struct hiHI_UNF_CIPHER_CTRL_3DES_S
+{
+    HI_U32 u32Key[6];                               /**< Key input */
+    HI_U32 u32IV[2];                                /**< Initialization vector (IV) */
+    HI_UNF_CIPHER_BIT_WIDTH_E enBitWidth;           /**< Bit width for encryption or decryption */
+    HI_UNF_CIPHER_KEY_LENGTH_E enKeyLen;            /**< Key length */
+    HI_UNF_CIPHER_CTRL_CHANGE_FLAG_S stChangeFlags; /**< control information exchange choices, we default all woulde be change except they have been in the choices */
+} HI_UNF_CIPHER_CTRL_3DES_S;
+
+/** Structure of the cipher SM1 control information */
+typedef struct hiHI_UNF_CIPHER_CTRL_SM1_S
+{
+    HI_U32 u32EK[4];                               /**< Key of EK input */
+    HI_U32 u32AK[4];                               /**< Key of AK input */
+    HI_U32 u32SK[4];                               /**< Key of SK input */
+    HI_U32 u32IV[4];                                /**< Initialization vector (IV) */
+    HI_UNF_CIPHER_BIT_WIDTH_E enBitWidth;           /**< Bit width for encryption or decryption */
+    HI_UNF_CIPHER_SM1_ROUND_E enSm1Round;           /**< SM1 round number, should be 8, 10, 12 or 14*/
+    HI_UNF_CIPHER_CTRL_CHANGE_FLAG_S stChangeFlags; /**< control information exchange choices, we default all woulde be change except they have been in the choices */
+} HI_UNF_CIPHER_CTRL_SM1_S;
+
+/** Structure of the cipher SM4 control information */
+typedef struct hiHI_UNF_CIPHER_CTRL_SM4_S
+{
+    HI_U32 u32Key[4];                               /**< Key  input */
+    HI_U32 u32IV[4];                                /**< Initialization vector (IV) */
+    HI_UNF_CIPHER_CTRL_CHANGE_FLAG_S stChangeFlags; /**< control information exchange choices, we default all woulde be change except they have been in the choices */
+} HI_UNF_CIPHER_CTRL_SM4_S;
+
+/** Expand Structure of the cipher control information */
+typedef struct hiHI_UNF_CIPHER_CTRL_EX_S
+{
+    HI_UNF_CIPHER_ALG_E enAlg;                      /**< Cipher algorithm */
+    HI_UNF_CIPHER_WORK_MODE_E enWorkMode;           /**< Operating mode */
+    HI_BOOL bKeyByCA;                               /**< Encryption using advanced conditional access (CA) or decryption using keys */
+    /**< Parameter for special algorithm
+        for AES, the pointer should point to HI_UNF_CIPHER_CTRL_AES_S;
+        for AES_CCM or AES_GCM, the pointer should point to HI_UNF_CIPHER_CTRL_AES_CCM_GCM_S;
+        for DES, the pointer should point to HI_UNF_CIPHER_CTRL_DES_S;
+        for 3DES, the pointer should point to HI_UNF_CIPHER_CTRL_3DES_S;
+        for SM1, the pointer should point to HI_UNF_CIPHER_CTRL_SM1_S;
+        for SM4, the pointer should point to HI_UNF_CIPHER_CTRL_SM4_S;
+    */
+    HI_VOID *pParam;
+} HI_UNF_CIPHER_CTRL_EX_S;
+
+/** Cipher data */
+typedef struct hiHI_UNF_CIPHER_DATA_S
+{
+    HI_SIZE_T szSrcPhyAddr;     /**< phy address of the original data */
+    HI_SIZE_T szDestPhyAddr;    /**< phy address of the purpose data */
+    HI_U32 u32ByteLength;     /**< cigher data length*/
+    HI_BOOL bOddKey;          /**< Use odd key or even key*/
+} HI_UNF_CIPHER_DATA_S;
+
+/** Hash algrithm type */
+typedef enum hiHI_UNF_CIPHER_HASH_TYPE_E
+{
+    HI_UNF_CIPHER_HASH_TYPE_SHA1,
+    HI_UNF_CIPHER_HASH_TYPE_SHA224,
+    HI_UNF_CIPHER_HASH_TYPE_SHA256,
+    HI_UNF_CIPHER_HASH_TYPE_SHA384,
+    HI_UNF_CIPHER_HASH_TYPE_SHA512,
+    HI_UNF_CIPHER_HASH_TYPE_HMAC_SHA1,
+    HI_UNF_CIPHER_HASH_TYPE_HMAC_SHA224,
+    HI_UNF_CIPHER_HASH_TYPE_HMAC_SHA256,
+    HI_UNF_CIPHER_HASH_TYPE_HMAC_SHA384,
+    HI_UNF_CIPHER_HASH_TYPE_HMAC_SHA512,
+    HI_UNF_CIPHER_HASH_TYPE_SM3,
+    HI_UNF_CIPHER_HASH_TYPE_BUTT,
+    HI_UNF_CIPHER_HASH_TYPE_INVALID  = 0xffffffff,
+}HI_UNF_CIPHER_HASH_TYPE_E;
+
+/** Hash init struct input */
+typedef struct
+{
+    HI_U8 *pu8HMACKey;
+    HI_U32 u32HMACKeyLen;
+    HI_UNF_CIPHER_HASH_TYPE_E eShaType;
+}HI_UNF_CIPHER_HASH_ATTS_S;
+
+typedef enum hiHI_UNF_CIPHER_RSA_ENC_SCHEME_E
+{
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_NO_PADDING,            /**< without padding */
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_0,          /**< PKCS#1 block type 0 padding*/
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_1,          /**< PKCS#1 block type 1 padding*/
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_2,          /**< PKCS#1 block type 2 padding*/
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA1,       /**< PKCS#1 RSAES-OAEP-SHA1 padding*/
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA224,     /**< PKCS#1 RSAES-OAEP-SHA224 padding*/
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA256,     /**< PKCS#1 RSAES-OAEP-SHA256 padding*/
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA384,     /**< PKCS#1 RSAES-OAEP-SHA384 padding*/
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA512,     /**< PKCS#1 RSAES-OAEP-SHA512 padding*/
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_RSAES_PKCS1_V1_5,      /**< PKCS#1 RSAES-PKCS1_V1_5 padding*/
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_BUTT,
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_INVALID  = 0xffffffff,
+}HI_UNF_CIPHER_RSA_ENC_SCHEME_E;
+
+typedef enum hiHI_UNF_CIPHER_RSA_SIGN_SCHEME_E
+{
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA1 = 0x100, /**< PKCS#1 RSASSA_PKCS1_V15_SHA1 signature*/
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA224,       /**< PKCS#1 RSASSA_PKCS1_V15_SHA224 signature*/
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA256,       /**< PKCS#1 RSASSA_PKCS1_V15_SHA256 signature*/
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA384,       /**< PKCS#1 RSASSA_PKCS1_V15_SHA384 signature*/
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA512,       /**< PKCS#1 RSASSA_PKCS1_V15_SHA512 signature*/
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA1,         /**< PKCS#1 RSASSA_PKCS1_PSS_SHA1 signature*/
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA224,       /**< PKCS#1 RSASSA_PKCS1_PSS_SHA224 signature*/
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA256,       /**< PKCS#1 RSASSA_PKCS1_PSS_SHA256 signature*/
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA384,       /**< PKCS#1 RSASSA_PKCS1_PSS_SHA1 signature*/
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA512,       /**< PKCS#1 RSASSA_PKCS1_PSS_SHA256 signature*/
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_BUTT,
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_INVALID  = 0xffffffff,
+}HI_UNF_CIPHER_RSA_SIGN_SCHEME_E;
+
+typedef struct
+{
+    HI_U8  *pu8N;              /**< point to public modulus  */
+    HI_U8  *pu8E;              /**< point to public exponent */
+    HI_U16 u16NLen;            /**< length of public modulus, max value is 512Byte*/
+    HI_U16 u16ELen;            /**< length of public exponent, max value is 512Byte*/
+}HI_UNF_CIPHER_RSA_PUB_KEY_S;
+
+/** RSA private key struct */
+typedef struct
+{
+    HI_U8 *pu8N;                      /*!<  public modulus    */
+    HI_U8 *pu8E;                      /*!<  public exponent   */
+    HI_U8 *pu8D;                      /*!<  private exponent  */
+    HI_U8 *pu8P;                      /*!<  1st prime factor  */
+    HI_U8 *pu8Q;                      /*!<  2nd prime factor  */
+    HI_U8 *pu8DP;                     /*!<  D % (P - 1)       */
+    HI_U8 *pu8DQ;                     /*!<  D % (Q - 1)       */
+    HI_U8 *pu8QP;                     /*!<  1 / (Q % P)       */
+    HI_U16 u16NLen;                   /**< length of public modulus */
+    HI_U16 u16ELen;                   /**< length of public exponent */
+    HI_U16 u16DLen;                   /**< length of private exponent */
+    HI_U16 u16PLen;                   /**< length of 1st prime factor */
+    HI_U16 u16QLen;                   /**< length of 2nd prime factor */
+    HI_U16 u16DPLen;                  /**< length of D % (P - 1) */
+    HI_U16 u16DQLen;                  /**< length of D % (Q - 1) */
+    HI_U16 u16QPLen;                  /**< length of 1 / (Q % P) */
+}HI_UNF_CIPHER_RSA_PRI_KEY_S;
+
+/** RSA public key encryption struct input */
+typedef struct
+{
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_E enScheme;   /** RSA encryption scheme*/
+    HI_UNF_CIPHER_RSA_PUB_KEY_S stPubKey;      /** RSA private key struct */
+    HI_UNF_CIPHER_CA_TYPE_E enCaType;
+}HI_UNF_CIPHER_RSA_PUB_ENC_S;
+
+/** RSA private key decryption struct input */
+typedef struct
+{
+    HI_UNF_CIPHER_RSA_ENC_SCHEME_E enScheme; /** RSA encryption scheme */
+    HI_UNF_CIPHER_RSA_PRI_KEY_S stPriKey;    /** RSA public key struct */
+    HI_UNF_CIPHER_CA_TYPE_E enCaType;
+}HI_UNF_CIPHER_RSA_PRI_ENC_S;
+
+/** RSA signature struct input */
+typedef struct
+{
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_E enScheme;  /** RSA signature scheme*/
+    HI_UNF_CIPHER_RSA_PRI_KEY_S stPriKey;      /** RSA private key struct */
+    HI_UNF_CIPHER_CA_TYPE_E enCaType;
+ }HI_UNF_CIPHER_RSA_SIGN_S;
+
+/** RSA signature verify struct input */
+typedef struct
+{
+    HI_UNF_CIPHER_RSA_SIGN_SCHEME_E enScheme; /** RSA signature scheme*/
+    HI_UNF_CIPHER_RSA_PUB_KEY_S stPubKey;     /** RSA public key struct */
+ }HI_UNF_CIPHER_RSA_VERIFY_S;
+
+/** @} */  /** <!-- ==== Structure Definition End ==== */
+
+
+#define HI_UNF_CIPHER_Open(HI_VOID) HI_UNF_CIPHER_Init(HI_VOID);
+#define HI_UNF_CIPHER_Close(HI_VOID) HI_UNF_CIPHER_DeInit(HI_VOID);
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      CIPHER */
+/** @{ */  /** <!-- [CIPHER] */
+/* ---CIPHER---*/
+/**
+\attention \n
+This API is used to start the cipher device.
+\param N/A
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\retval ::HI_ERR_CIPHER_FAILED_INIT  The cipher device fails to be initialized.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_Init(HI_VOID);
+
+/**
+\brief  Deinit the cipher device.
+\attention \n
+This API is used to stop the cipher device. If this API is called repeatedly, HI_SUCCESS is returned, but only the first operation takes effect.
+
+\param N/A
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_DeInit(HI_VOID);
+
+/**
+\brief Obtain a cipher handle for encryption and decryption.
+
+\param[out] phCipher Cipher handle
+\param[in] cipher attributes
+\retval ::HI_SUCCESS Call this API successful.
+\retval ::HI_FAILURE Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\retval ::HI_ERR_CIPHER_INVALID_POINT  The pointer is null.
+\retval ::HI_ERR_CIPHER_FAILED_GETHANDLE  The cipher handle fails to be obtained, because there are no available cipher handles.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_CreateHandle(HI_HANDLE* phCipher, const HI_UNF_CIPHER_ATTS_S *pstCipherAttr);
+
+/**
+\attention \n
+This API is used to destroy existing cipher handles.
+
+\param[in] hCipher Cipher handle
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_DestroyHandle(HI_HANDLE hCipher);
+
+/**
+\brief Configures the cipher control information.
+\attention \n
+Before encryption or decryption, you must call this API to configure the cipher control information.
+The first 64-bit data and the last 64-bit data should not be the same when using TDES algorithm.
+
+\param[in] hCipher Cipher handle.
+\param[in] pstCtrl Cipher control information.
+\retval ::HI_SUCCESS Call this API successful.
+\retval ::HI_FAILURE Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\retval ::HI_ERR_CIPHER_INVALID_POINT  The pointer is null.
+\retval ::HI_ERR_CIPHER_INVALID_PARA  The parameter is invalid.
+\retval ::HI_ERR_CIPHER_INVALID_HANDLE  The handle is invalid.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_ConfigHandle(HI_HANDLE hCipher, const HI_UNF_CIPHER_CTRL_S* pstCtrl);
+
+/**
+\brief Configures the cipher control information.
+\attention \n
+Before encryption or decryption, you must call this API to configure the cipher control information.
+The first 64-bit data and the last 64-bit data should not be the same when using TDES algorithm.
+
+\param[in] hCipher Cipher handle.
+\param[in] pstExCtrl Cipher control information.
+\retval ::HI_SUCCESS Call this API successful.
+\retval ::HI_FAILURE Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\retval ::HI_ERR_CIPHER_INVALID_POINT  The pointer is null.
+\retval ::HI_ERR_CIPHER_INVALID_PARA  The parameter is invalid.
+\retval ::HI_ERR_CIPHER_INVALID_HANDLE  The handle is invalid.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_ConfigHandleEx(HI_HANDLE hCipher, const HI_UNF_CIPHER_CTRL_EX_S* pstExCtrl);
+
+/**
+\brief Performs encryption.
+
+\attention \n
+This API is used to perform encryption by using the cipher module.
+The length of the encrypted data should be a multiple of 8 in TDES mode and 16 in AES mode. Besides, the length can not be bigger than 0xFFFFF.After this operation, the result will affect next operation.If you want to remove vector, you need to config IV(config pstCtrl->stChangeFlags.bit1IV with 1) by transfering HI_UNF_CIPHER_ConfigHandle.
+\param[in] hCipher Cipher handle
+\param[in] u32SrcPhyAddr Physical address of the source data
+\param[in] u32DestPhyAddr Physical address of the target data
+\param[in] u32ByteLength   Length of the encrypted data
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\retval ::HI_ERR_CIPHER_INVALID_PARA  The parameter is invalid.
+\retval ::HI_ERR_CIPHER_INVALID_HANDLE  The handle is invalid.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_Encrypt(HI_HANDLE hCipher, HI_SIZE_T szSrcPhyAddr, HI_SIZE_T szDestPhyAddr, HI_U32 u32ByteLength);
+
+/**
+\brief Performs decryption.
+
+\attention \n
+This API is used to perform decryption by using the cipher module.
+The length of the decrypted data should be a multiple of 8 in TDES mode and 16 in AES mode. Besides, the length can not be bigger than 0xFFFFF.After this operation, the result will affect next operation.If you want to remove vector, you need to config IV(config pstCtrl->stChangeFlags.bit1IV with 1) by transfering HI_UNF_CIPHER_ConfigHandle.
+\param[in] hCipher Cipher handle.
+\param[in] u32SrcPhyAddr Physical address of the source data.
+\param[in] u32DestPhyAddr Physical address of the target data.
+\param[in] u32ByteLength Length of the decrypted data
+\retval ::HI_SUCCESS Call this API successful.
+\retval ::HI_FAILURE Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\retval ::HI_ERR_CIPHER_INVALID_PARA  The parameter is invalid.
+\retval ::HI_ERR_CIPHER_INVALID_HANDLE  The handle is invalid.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_Decrypt(HI_HANDLE hCipher, HI_SIZE_T szSrcPhyAddr, HI_SIZE_T szDestPhyAddr, HI_U32 u32ByteLength);
+
+/**
+\brief Performs encryption.
+
+\attention \n
+This API is used to perform encryption by using the cipher module.
+The length of the encrypted data should be a multiple of 8 in TDES mode and 16 in AES mode. Besides, the length can not be bigger than 0xFFFFF.After this operation, the result will affect next operation.If you want to remove vector, you need to config IV(config pstCtrl->stChangeFlags.bit1IV with 1) by transfering HI_UNF_CIPHER_ConfigHandle.
+\param[in] hCipher Cipher handle
+\param[in] pu8SrcData: buffer of the source data.
+\param[out] pu8DestData: buffer of the target data
+\param[in] u32ByteLength   Length of the encrypted data
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\retval ::HI_ERR_CIPHER_INVALID_PARA  The parameter is invalid.
+\retval ::HI_ERR_CIPHER_INVALID_HANDLE  The handle is invalid.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_EncryptVir(HI_HANDLE hCipher, const HI_U8 *pu8SrcData, HI_U8 *pu8DestData, HI_U32 u32ByteLength);
+
+/**
+\brief Performs decryption.
+
+\attention \n
+This API is used to perform decryption by using the cipher module.
+The length of the decrypted data should be a multiple of 8 in TDES mode and 16 in AES mode. Besides, the length can not be bigger than 0xFFFFF.After this operation, the result will affect next operation.If you want to remove vector, you need to config IV(config pstCtrl->stChangeFlags.bit1IV with 1) by transfering HI_UNF_CIPHER_ConfigHandle.
+\param[in] hCipher Cipher handle.
+\param[in] pu8SrcData: buffer of the source data.
+\param[out] pu8DestData: buffer of the target data
+\param[in] u32ByteLength Length of the decrypted data
+\retval ::HI_SUCCESS Call this API successful.
+\retval ::HI_FAILURE Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\retval ::HI_ERR_CIPHER_INVALID_PARA  The parameter is invalid.
+\retval ::HI_ERR_CIPHER_INVALID_HANDLE  The handle is invalid.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_DecryptVir(HI_HANDLE hCipher, const HI_U8 *pu8SrcData, HI_U8 *pu8DestData, HI_U32 u32ByteLength);
+
+/**
+\brief Encrypt multiple packaged data.
+\attention \n
+You can not encrypt more than 128 data package one time. When HI_ERR_CIPHER_BUSY return, the data package you send will not be deal, the customer should decrease the number of data package or run cipher again.Note:When encrypting more than one packaged data, every one package will be calculated using initial vector configured by HI_UNF_CIPHER_ConfigHandle.Previous result will not affect the later result.
+\param[in] hCipher cipher handle
+\param[in] pstDataPkg data package ready for cipher
+\param[in] u32DataPkgNum  number of package ready for cipher
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  cipher device have not been initialized
+\retval ::HI_ERR_CIPHER_INVALID_PARA  parameter error
+\retval ::HI_ERR_CIPHER_INVALID_HANDLE  handle invalid
+\retval ::HI_ERR_CIPHER_BUSY  hardware is busy, it can not deal with all data package once time
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_EncryptMulti(HI_HANDLE hCipher, const HI_UNF_CIPHER_DATA_S *pstDataPkg, HI_U32 u32DataPkgNum);
+
+/**
+\brief Get the cipher control information.
+
+\param[in] hCipher Cipher handle.
+\param[in] pstCtrl Cipher control information.
+\retval ::HI_SUCCESS Call this API successful.
+\retval ::HI_FAILURE Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\retval ::HI_ERR_CIPHER_INVALID_POINT  The pointer is null.
+\retval ::HI_ERR_CIPHER_INVALID_PARA  The parameter is invalid.
+\retval ::HI_ERR_CIPHER_INVALID_HANDLE  The handle is invalid.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_GetHandleConfig(HI_HANDLE hCipher, HI_UNF_CIPHER_CTRL_S* pstCtrl);
+
+/**
+\brief Decrypt multiple packaged data.
+\attention \n
+You can not decrypt more than 128 data package one time.When HI_ERR_CIPHER_BUSY return, the data package you send will not be deal, the custmer should decrease the number of data package or run cipher again.Note:When decrypting more than one packaged data, every one package will be calculated using initial vector configured by HI_UNF_CIPHER_ConfigHandle.Previous result will not affect the later result.
+\param[in] hCipher cipher handle
+\param[in] pstDataPkg data package ready for cipher
+\param[in] u32DataPkgNum  number of package ready for cipher
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  cipher device have not been initialized
+\retval ::HI_ERR_CIPHER_INVALID_PARA  parameter error
+\retval ::HI_ERR_CIPHER_INVALID_HANDLE  handle invalid
+\retval ::HI_ERR_CIPHER_BUSY  hardware is busy, it can not deal with all data package once time
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_DecryptMulti(HI_HANDLE hCipher, const HI_UNF_CIPHER_DATA_S *pstDataPkg, HI_U32 u32DataPkgNum);
+
+/**
+\brief Get the tag data of CCM/GCM.
+
+\attention \n
+This API is used to get the tag data of CCM/GCM.
+\param[in] hCipher cipher handle
+\param[out] pu8Tag tag data of CCM/GCM
+\param[in/out] pu32TagLen tag data length of CCM/GCM, the input should be 16 now.
+\retval ::HI_SUCCESS  Call this API succussful.
+\retval ::HI_FAILURE  Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\retval ::HI_ERR_CIPHER_INVALID_PARA  The parameter is invalid.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_GetTag(HI_HANDLE hCipher, HI_U8 *pu8Tag, HI_U32 *pu32TagLen);
+
+/**
+\brief Encrypt the clean key data by KLAD.
+\attention \n
+N/A
+\param[in] enRootKey klad root key.
+\param[in] pu8CleanKey clean key.
+\param[in] enTarget the module who to use this key.
+\param[out] pu8EcnryptKey encrypt key.
+\param[in] u32KeyLen clean key.
+\retval ::HI_SUCCESS Call this API successful.
+\retval ::HI_FAILURE Call this API fails.
+\retval ::HI_ERR_CIPHER_NOT_INIT  The cipher device is not initialized.
+\retval ::HI_ERR_CIPHER_INVALID_POINT  The pointer is null.
+\retval ::HI_ERR_CIPHER_INVALID_PARA  The parameter is invalid.
+\retval ::HI_ERR_CIPHER_INVALID_HANDLE  The handle is invalid.
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_KladEncryptKey(HI_UNF_CIPHER_CA_TYPE_E enRootKey,
+                                    HI_UNF_CIPHER_KLAD_TARGET_E enTarget,
+                                    const HI_U8 *pu8CleanKey, HI_U8* pu8EcnryptKey, HI_U32 u32KeyLen);
+
+/**
+\brief Get the random number.
+
+\attention \n
+This API is used to obtain the random number from the hardware.
+
+\param[out] pu32RandomNumber Point to the random number.
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_GetRandomNumber(HI_U32 *pu32RandomNumber);
+
+/**
+\brief Init the hash module, if other program is using the hash module, the API will return failure.
+
+\attention \n
+N/A
+
+\param[in] pstHashAttr: The hash calculating structure input.
+\param[out] pHashHandle: The output hash handle.
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_HashInit(const HI_UNF_CIPHER_HASH_ATTS_S *pstHashAttr, HI_HANDLE *pHashHandle);
+
+/**
+\brief Calculate the hash, if the size of the data to be calculated is very big and the DDR ram is not enough, this API can calculate the data one block by one block. Attention: The input block length must be 64bytes aligned except for the last block.
+
+\attention \n
+N/A
+
+\param[in] hHashHandl:  Hash handle.
+\param[in] pu8InputData:  The input data buffer.
+\param[in] u32InputDataLen:  The input data length, attention: the block length input must be 64bytes aligned except the last block!
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_HashUpdate(HI_HANDLE hHashHandle, const HI_U8 *pu8InputData, HI_U32 u32InputDataLen);
+
+
+
+/**
+\brief Get the final hash value, after calculate all of the data, call this API to get the final hash value and close the handle.If there is some reason need to interrupt the calculation, this API should also be call to close the handle.
+
+\attention \n
+N/A
+
+\param[in] hHashHandle:  Hash handle.
+\param[out] pu8OutputHash:  The final output hash value.
+
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_HashFinal(HI_HANDLE hHashHandle, HI_U8 *pu8OutputHash);
+
+/**
+\brief RSA encryption a plaintext with a RSA public key.
+
+\attention \n
+N/A
+
+\param[in] pstRsaEnc:   encryption struct.
+\param[in] pu8Input:    input data to be encryption
+\param[out] u32InLen:   length of input data to be encryption
+\param[out] pu8Output: output data to be encryption
+\param[out] pu32OutLen: length of output data to be encryption
+
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_RsaPublicEncrypt(const HI_UNF_CIPHER_RSA_PUB_ENC_S *pstRsaEnc,
+                                  const HI_U8 *pu8Input, HI_U32 u32InLen,
+                                  HI_U8 *pu8Output, HI_U32 *pu32OutLen);
+
+/**
+\brief RSA decryption a ciphertext with a RSA private key.
+
+\attention \n
+N/A
+
+\param[in] pstRsaDec:   decryption struct.
+\param[in] pu8Input:    input data to be decryption
+\param[out] u32InLen:   length of input data to be decryption
+\param[out] pu8Output:  output data to be decryption
+\param[out] pu32OutLen: length of output data to be decryption
+
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_RsaPrivateDecrypt(const HI_UNF_CIPHER_RSA_PRI_ENC_S *pstRsaDec,
+                                    const HI_U8 *pu8Input, HI_U32 u32InLen,
+                                    HI_U8 *pu8Output, HI_U32 *pu32OutLen);
+
+/**
+\brief RSA encryption a plaintext with a RSA private key.
+
+\attention \n
+N/A
+
+\param[in] pstRsaSign:   encryption struct.
+\param[in] pu8Input:     input data to be encryption
+\param[out] u32InLen:   length of input data to be encryption
+\param[out] pu8Output:  output data to be encryption
+\param[out] pu32OutLen: length of output data to be encryption
+
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_RsaPrivateEncrypt(const HI_UNF_CIPHER_RSA_PRI_ENC_S *pstRsaEnc,
+                                    const HI_U8 *pu8Input, HI_U32 u32InLen,
+                                    HI_U8 *pu8Output, HI_U32 *pu32OutLen);
+
+/**
+\brief RSA decryption a ciphertext with a RSA public key.
+
+\attention \n
+N/A
+
+\param[in] pstRsaVerify:   decryption struct.
+\param[in] pu8Input:   input data to be decryption
+\param[out] u32InLen:   length of input data to be decryption
+\param[out] pu8Output: output data to be decryption
+\param[out] pu32OutLen: length of output data to be decryption
+
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_RsaPublicDecrypt(const HI_UNF_CIPHER_RSA_PUB_ENC_S *pstRsaDec,
+                               const HI_U8 *pu8Input, HI_U32 u32InLen,
+                               HI_U8 *pu8Output, HI_U32 *pu32OutLen);
+
+/**
+\brief RSA signature a context with appendix, where a signer's RSA private key is used.
+
+\attention \n
+N/A
+
+\param[in] pstRsaSign:      signature struct.
+\param[in] pu8Input:        input context to be signature.
+\param[in] u32InLen:        length of input context to be signature
+\param[in] pu8HashData:    hash value of context,if NULL, let pu8HashData = Hash(context) automatically
+\param[out] pu8OutSign:    output message of signature
+\param[out] pu32OutSignLen: length of message of signature
+
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_RsaSign(const HI_UNF_CIPHER_RSA_SIGN_S *pstRsaSign,
+                             const HI_U8 *pu8InData, HI_U32 u32InDataLen,
+                             const HI_U8 *pu8HashData,
+                             HI_U8 *pu8OutSign, HI_U32 *pu32OutSignLen);
+
+/**
+\brief RSA signature verification a context with appendix, where a signer's RSA public key is used.
+
+\attention \n
+N/A
+
+\param[in] pstRsaVerify:    signature verification struct.
+\param[in] pu8Input:       input context to be signature verification, maybe null
+\param[in] u32InLen:        length of input context to be signature
+\param[in] pu8HashData:    hash value of context,if NULL, let pu8HashData = Hash(context) automatically
+\param[in] pu8InSign:      message of signature
+\param[in] pu32InSignLen:   length of message of signature
+
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+
+\see \n
+N/A
+*/
+HI_S32 HI_UNF_CIPHER_RsaVerify(const HI_UNF_CIPHER_RSA_VERIFY_S *pstRsaVerify,
+                               const HI_U8 *pu8InData, HI_U32 u32InDataLen,
+                               const HI_U8 *pu8HashData,
+                               const HI_U8 *pu8InSign, HI_U32 u32InSignLen);
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* __cplusplus */
+
+#endif /* __HI_UNF_CIPHER_H__ */
+

--- a/kernel/cipher/hi3516ev200/src/Makefile
+++ b/kernel/cipher/hi3516ev200/src/Makefile
@@ -1,0 +1,99 @@
+
+
+ifeq ($(PARAM_FILE), )
+        PARAM_FILE:=../../../../mpp/Makefile.param
+        include $(PARAM_FILE)
+endif
+
+ifeq ($(KERNELRELEASE),)
+export CIPHER_SRC_BASE=$(PWD)
+endif
+
+include $(CIPHER_SRC_BASE)/api/cipher_v1.0/build.mak
+include $(CIPHER_SRC_BASE)/drv/cipher_v1.0/build.mak
+
+KBUILD_EXTRA_SYMBOLS +="$(OSAL_ROOT)/$(OSTYPE)/kernel/Module.symvers"
+KBUILD_EXTRA_SYMBOLS +="$(MPP_PATH)/cbb/base/Module.symvers"
+
+EXTRA_CFLAGS += -I$(CIPHER_SRC_BASE)/include
+EXTRA_CFLAGS += -I$(CIPHER_SRC_BASE)/../include
+
+EXTRA_CFLAGS += -I$(CIPHER_SRC_BASE)/../arch/$(INTER_DRV)
+EXTRA_CFLAGS += -I$(OSAL_ROOT)/include
+EXTRA_CFLAGS += -I$(REL_DIR)/include
+EXTRA_CFLAGS += $(CIPHER_INS)
+
+DRV_OBJ := $(CIPHER_OBJS)
+
+EXTRA_CFLAGS += -DCHIP_TYPE_$(INTER_DRV)
+EXTRA_CFLAGS += $(CIPHER_CFLAGS)
+EXTRA_CFLAGS += $(DRV_CFLAGS)
+EXTRA_CFLAGS += -DARCH_TYPE_$(ARM_ARCH)
+
+REMOVED_FILES := "*.o" "*.ko" "*.order" "*.symvers" "*.mod" "*.mod.*" "*.cmd" ".tmp_versions" "modules.builtin"
+
+ifeq ($(OSTYPE),liteos)
+EXTRA_CFLAGS += $(CFLAGS)
+endif
+
+DRV_OBJ += drv/cipher_initdevice.o
+
+API_SRCS := api/cipher_v1.0/unf_cipher.c      \
+              api/cipher_v1.0/mpi_cipher.c    \
+              api/cipher_v1.0/sys_cipher.c    \
+              api/cipher_v1.0/user_osal_lib.c
+
+API_OBJS := $(CIPHER_OBJ)
+
+OBJS = $(DRV_OBJ) $(API_OBJS)
+
+TARGET := hi_cipher
+obj-m := hi_cipher.o
+hi_cipher-y += $(DRV_OBJ)
+
+LIBS_LD_CFLAGS +=-L$(REL_DIR)/lib
+LIBS_CFLAGS += -lsecurec
+#*************************************************************************
+# all source file in this module
+SRCS   := $(patsubst %.o,%.c,$(OBJ))
+
+.PHONY: all clean
+
+all: $(OSTYPE)_build
+
+clean :
+	@$(AT)find -L ./ -name "*.d" $(foreach file, $(REMOVED_FILES), -o -name $(file)) | xargs rm -rf
+	@rm -f  libhi_cipher.a libhi_cipher.so
+	@for x in `find $(REL_DIR)/init -name "*cipher_init.o.cmd"`;do rm -rf $$x;done
+	@for x in `find $(REL_DIR)/init -name "*cipher_init.o*"`;do rm -rf $$x;done
+###################################
+liteos_build: $(OBJS)
+	@$(AR) $(ARFLAGS) lib$(TARGET).a $(OBJS)
+	@mkdir -p $(REL_KO) && cp -rf libhi_cipher.a $(REL_KO)
+	@cp $(CIPHER_SRC_BASE)/../include/hi_unf_cipher.h $(REL_INC)
+	@cp $(CIPHER_SRC_BASE)/../include/hi_common_cipher.h $(REL_INC)
+	@cp $(CIPHER_SRC_BASE)/../include/hi_types.h $(REL_INC)
+
+linux_build: $(API_OBJS)
+	@echo -e "\e[0;32;1m... Configs as follow:\e[0;36;1m"
+	@echo ---- CROSS=$(CROSS)
+	@echo ---- HIARCH=$(HIARCH), HICHIP=$(HICHIP), CVER=$(CVER), DBG=$(HIDBG), HI_FPGA=$(HI_FPGA)
+	@echo ---- CPU_TYPE=$(CPU_TYPE)
+	@echo ---- MPP_CFLAGS=$(MPP_CFLAGS)
+	@echo ---- SDK_PATH=$(SDK_PATH) , PARAM_FILE=$(PARAM_FILE)
+	@echo ---- KERNEL_ROOT=$(KERNEL_ROOT)
+	@echo ---- ARCH_ROOT=$(ARCH_ROOT), ARCH_HAL=$(ARCH_HAL)
+	@echo -e "\e[0m"
+	@echo $(EXTRA_CFLAGS)
+	@make -C $(KERNEL_ROOT) M=$(PWD) modules
+	@mkdir -p $(REL_KO) && cp -rf $(TARGET).ko $(REL_KO)
+	@$(CC) $(EXTRA_CFLAGS) $(LIBS_LD_CFLAGS) $(LIBS_CFLAGS) -shared -fPIC -o libhi_cipher.so $(API_SRCS)
+	@$(AR) -rv libhi_cipher.a $(API_OBJS)
+	@cp $(CIPHER_SRC_BASE)/../include/hi_unf_cipher.h $(REL_INC)
+	@cp $(CIPHER_SRC_BASE)/../include/hi_common_cipher.h $(REL_INC)
+	@cp $(CIPHER_SRC_BASE)/../include/hi_types.h $(REL_INC)
+	@mkdir -p $(REL_LIB) && cp libhi_cipher.a libhi_cipher.so $(REL_LIB)
+
+$(OBJS): %.o : %.c
+	@echo $(CC) $< ...
+	@$(CC) $(EXTRA_CFLAGS) $(LIBS_CFLAGS) -c $< -shared -fPIC -o $@

--- a/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/build.mak
+++ b/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/build.mak
@@ -1,0 +1,6 @@
+CIPHER_OBJ += api/cipher_v1.0/unf_cipher.o    \
+              api/cipher_v1.0/mpi_cipher.o    \
+              api/cipher_v1.0/sys_cipher.o    \
+              api/cipher_v1.0/user_osal_lib.o
+
+CIPHER_INS += -I$(CIPHER_SRC_BASE)/api/cipher_v1.0

--- a/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/hi_mpi_cipher.h
+++ b/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/hi_mpi_cipher.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C), Hisilicon Technologies Co., Ltd. 2014-2019. All rights reserved.
+ * Description   : hi_mpi_cipher.h
+ * Author        :
+ * Create        : 2014-01-23
+ */
+
+#ifndef __HI_MPI_CIPHER_H__
+#define __HI_MPI_CIPHER_H__
+
+#include "hi_unf_cipher.h"
+#include "hi_common_cipher.h"
+#include "hi_cipher_compat.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif
+#endif /* __cplusplus */
+
+hi_s32 hi_mpi_cipher_init(hi_void);
+
+hi_s32 hi_mpi_cipher_deinit(hi_void);
+
+hi_s32 hi_mpi_cipher_create_handle(hi_handle *handle,
+                                   const hi_cipher_atts *cipher_atts);
+
+hi_s32 hi_mpi_cipher_destroy_handle(hi_handle handle);
+
+hi_s32 hi_mpi_cipher_config_handle(hi_handle handle, const hi_cipher_ctrl *ctrl);
+
+hi_s32 hi_mpi_cipher_config_handle_ex(hi_handle handle,
+                                      const hi_cipher_ctrl_ex *ctrl_ex);
+
+hi_s32 hi_mpi_cipher_encrypt(hi_handle handle,
+                             hi_size_t src_phy_addr,
+                             hi_size_t dest_phy_addr,
+                             hi_u32 byte_length);
+
+hi_s32 hi_mpi_cipher_decrypt(hi_handle handle,
+                             hi_size_t src_phy_addr,
+                             hi_size_t dest_phy_addr,
+                             hi_u32 byte_length);
+
+hi_s32 hi_mpi_cipher_encrypt_vir(hi_handle handle,
+                                 const hi_u8 *src_data,
+                                 hi_u8 *dest_data,
+                                 hi_u32 byte_length);
+
+hi_s32 hi_mpi_cipher_decrypt_vir(hi_handle handle,
+                                 const hi_u8 *src_data,
+                                 hi_u8 *dest_data,
+                                 hi_u32 byte_length);
+
+hi_s32 hi_mpi_cipher_encrypt_multi(hi_handle handle,
+                                   const hi_cipher_data *data_pkg,
+                                   hi_u32 data_pkg_num);
+
+hi_s32 hi_mpi_cipher_decrypt_multi(hi_handle handle,
+                                   const hi_cipher_data *data_pkg,
+                                   hi_u32 data_pkg_num);
+
+hi_s32 hi_mpi_cipher_get_handle_config(hi_handle handle,
+                                       hi_cipher_ctrl *ctrl);
+
+hi_s32 hi_mpi_cipher_klad_encrypt_key(hi_cipher_ca_type root_key,
+                                      hi_cipher_klad_target target,
+                                      const hi_u8 *clean_key,
+                                      hi_u8 *ecnrypt_key, hi_u32 key_len);
+
+hi_s32 hi_mpi_cipher_hash_init(const hi_cipher_hash_atts *hash_atts,
+                               hi_handle *handle);
+
+hi_s32 hi_mpi_cipher_hash_update(hi_handle handle,
+                                 const hi_u8 *input_data,
+                                 hi_u32 input_data_len);
+
+hi_s32 hi_mpi_cipher_hash_final(hi_handle handle, hi_u8 *output_hash);
+
+hi_s32 hi_mpi_cipher_get_tag(hi_handle handle, hi_u8 *tag, hi_u32 *tag_len);
+
+hi_s32 hi_mpi_cipher_get_random_number(hi_u32 *random_number);
+
+hi_s32 hi_mpi_cipher_get_multi_random_bytes(hi_u8 *random_byte, hi_u32 bytes);
+
+hi_s32 hi_mpi_cipher_rsa_public_encrypt(const hi_cipher_rsa_pub_enc *rsa_enc,
+                                        const hi_u8 *input, hi_u32 in_len,
+                                        hi_u8 *output, hi_u32 *out_len);
+
+hi_s32 hi_mpi_cipher_rsa_private_decrypt(const hi_cipher_rsa_pri_enc *rsa_dec,
+                                         const hi_u8 *input, hi_u32 in_len,
+                                         hi_u8 *output, hi_u32 *out_len);
+
+hi_s32 hi_mpi_cipher_rsa_sign(const hi_cipher_rsa_sign *rsa_sign,
+                              const hi_u8 *in_data, hi_u32 in_data_len,
+                              const hi_u8 *hash_data,
+                              hi_u8 *out_sign, hi_u32 *out_sign_len);
+
+hi_s32 hi_mpi_cipher_rsa_verify(const hi_cipher_rsa_verify *rsa_verify,
+                                const hi_u8 *in_data, hi_u32 in_data_len,
+                                const hi_u8 *hash_data,
+                                const hi_u8 *in_sign, hi_u32 in_sign_len);
+
+hi_s32 hi_mpi_cipher_rsa_private_encrypt(const hi_cipher_rsa_pri_enc *rsa_enc,
+                                         const hi_u8 *input, hi_u32 in_len,
+                                         hi_u8 *output, hi_u32 *out_len);
+
+hi_s32 hi_mpi_cipher_rsa_public_decrypt(const hi_cipher_rsa_pub_enc *rsa_dec,
+                                        const hi_u8 *input, hi_u32 in_len,
+                                        hi_u8 *output, hi_u32 *out_len);
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif
+#endif /* __cplusplus */
+
+#endif /* __hi_mpi_cipher_h__ */

--- a/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/mpi_cipher.c
+++ b/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/mpi_cipher.c
@@ -1,0 +1,1308 @@
+/******************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : mpi_cipher.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "hi_mpi_cipher.h"
+#include "sys_cipher.h"
+#include "user_osal_lib.h"
+
+crypto_mutex  cipher_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+#define HI_CIPHER_LOCK()        (void)crypto_mutex_lock(&cipher_mutex)
+#define HI_CIPHER_UNLOCK()      (void)crypto_mutex_unlock(&cipher_mutex)
+
+#define BYTE_BITS               (8)
+#define CIPHER_MAX_MULTIPAD_NUM (5000)
+#define CENC_SUBSAMPLE_MAX_NUM  (100)
+#define ECDH_MAX_KEY_LEN        (72)
+#define CIPHER_INIT_MAX_NUM     (0x7FFFFFFF)
+#define MAX_TAG_LEN             (16)
+#define SYMC_SM1_EK_AK_SIZE     (32)
+
+/* handle of cipher device */
+hi_s32 cipher_dev_fd = -1;
+
+/* flag of cipher device
+ * indicate the status of device that open or close
+ * <0: close, 0: open>0: multiple initialization
+ */
+static hi_s32 cipher_init_counter = -1;
+
+/* check the device of cipher whether already opend or not */
+#define CHECK_CIPHER_OPEN()\
+    do{\
+        if (0 > cipher_init_counter)\
+        {\
+            HI_LOG_ERROR("cipher init counter %d\n", cipher_init_counter);\
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_NOT_INIT);\
+            return HI_ERR_CIPHER_NOT_INIT;\
+        }\
+    }while(0)
+
+/**
+ * Read E in public key from arry to U32,
+ * so only use last byte0~byte3, others are zero
+ */
+#define CIPHER_GET_PUB_EXPONENT(_e, _rsades) \
+    do{\
+        hi_u8 *_buf = (_rsades)->pub_key.e; \
+        hi_u8 *_pub = (hi_u8*)(_e); \
+        hi_u32 _len = (_rsades)->pub_key.e_len; \
+        hi_u32 _i; \
+        for (_i = 0; _i< MIN(WORD_WIDTH, _len); _i++) \
+        {\
+            _pub[WORD_WIDTH -_i - 1] = _buf[_len - _i - 1];\
+        }\
+    }while(0)
+
+/**
+ * \brief  Init the cipher device.
+ */
+hi_s32 hi_mpi_cipher_init(hi_void)
+{
+    HI_UNF_FUNC_ENTER();
+
+    HI_CIPHER_LOCK();
+
+    if (cipher_init_counter >= CIPHER_INIT_MAX_NUM) {
+        HI_CIPHER_UNLOCK();
+
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_OVERFLOW);
+        return HI_ERR_CIPHER_OVERFLOW;
+    }
+
+    if (cipher_init_counter >= 0) {
+        cipher_init_counter++;
+        HI_CIPHER_UNLOCK();
+
+        HI_UNF_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    cipher_dev_fd = crypto_open("/dev/"UMAP_DEVNAME_CIPHER, O_RDWR, 0);
+    if (cipher_dev_fd < 0) {
+        HI_CIPHER_UNLOCK();
+
+        HI_LOG_PRINT_FUNC_ERR(crypto_open, HI_ERR_CIPHER_FAILED_INIT);
+        return HI_ERR_CIPHER_FAILED_INIT;
+    }
+
+    cipher_init_counter = 0;
+
+    HI_CIPHER_UNLOCK();
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+ * \brief  Deinit the cipher device.
+ */
+hi_s32 hi_mpi_cipher_deinit(hi_void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_CIPHER_LOCK();
+
+    if (cipher_init_counter < 0) {
+        HI_CIPHER_UNLOCK();
+
+        HI_UNF_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    if (cipher_init_counter > 0) {
+        cipher_init_counter--;
+
+        HI_CIPHER_UNLOCK();
+
+        HI_UNF_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    ret = crypto_close(cipher_dev_fd);
+    if (ret != HI_SUCCESS) {
+        HI_CIPHER_UNLOCK();
+
+        HI_LOG_PRINT_FUNC_ERR(crypto_close, ret);
+        return ret;
+    }
+
+    cipher_init_counter = -1;
+
+    HI_CIPHER_UNLOCK();
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+ * \brief Obtain a cipher handle for encryption and decryption.
+ */
+hi_s32 hi_mpi_cipher_create_handle(hi_handle *handle,
+                                   const hi_cipher_atts *cipher_atts)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 id = 0;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(handle == HI_NULL);
+    HI_LOG_CHECK_PARAM(cipher_atts == HI_NULL);
+    HI_LOG_CHECK_PARAM(cipher_atts->cipher_type >= HI_CIPHER_TYPE_BUTT);
+
+    HI_DBG_PRINT_U32(cipher_atts->cipher_type);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = sys_symc_create(&id);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_symc_create, ret);
+        return ret;
+    }
+
+    *handle = (hi_handle)id;
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cipher_get_rsa_attr(hi_u32 scheme, hi_u32 *hash_len,
+                                     hi_cipher_hash_type *sha_type)
+{
+    HI_UNF_FUNC_ENTER();
+
+    switch (scheme) {
+        case HI_CIPHER_RSA_ENC_SCHEME_NO_PADDING:
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_0:
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_1:
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_2:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_PKCS1_V1_5: {
+            *hash_len = 0;
+            *sha_type = HI_CIPHER_HASH_TYPE_BUTT;
+            break;
+        }
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA1:
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA1:
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA1: {
+            *hash_len = SHA1_RESULT_SIZE;
+            *sha_type = HI_CIPHER_HASH_TYPE_SHA1;
+            break;
+        }
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA224:
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA224:
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA224:
+            *hash_len = SHA224_RESULT_SIZE;
+            *sha_type = HI_CIPHER_HASH_TYPE_SHA224;
+            break;
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA256:
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA256:
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA256: {
+            *hash_len = SHA256_RESULT_SIZE;
+            *sha_type = HI_CIPHER_HASH_TYPE_SHA256;
+            break;
+        }
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA384:
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA384:
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA384: {
+            *hash_len = SHA384_RESULT_SIZE;
+            *sha_type = HI_CIPHER_HASH_TYPE_SHA384;
+            break;
+        }
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA512:
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA512:
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA512: {
+            *hash_len = SHA512_RESULT_SIZE;
+            *sha_type = HI_CIPHER_HASH_TYPE_SHA512;
+            break;
+        }
+        default: {
+            HI_ERR_PRINT_U32(scheme);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_UNAVAILABLE);
+            return HI_ERR_CIPHER_UNAVAILABLE;
+        }
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+ * \brief Destroy the existing cipher handle.
+ */
+hi_s32 hi_mpi_cipher_destroy_handle(hi_handle handle)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    CHECK_CIPHER_OPEN();
+
+    ret = sys_symc_destroy(handle);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_symc_destroy, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+ * \brief Configures the cipher control information.
+ */
+hi_s32 hi_mpi_cipher_config_handle(hi_handle handle, const hi_cipher_ctrl *ctrl)
+{
+    hi_u32 ivlen = AES_IV_SIZE;
+    hi_u32 hard_key = 0;
+    hi_u32 key_len = SYMC_KEY_SIZE;
+    compat_addr aad;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctrl == HI_NULL);
+    HI_LOG_CHECK_PARAM(handle == HI_INVALID_HANDLE);
+
+    if ((ctrl->work_mode == HI_CIPHER_WORK_MODE_CCM)
+        || (ctrl->work_mode == HI_CIPHER_WORK_MODE_GCM)) {
+        HI_LOG_ERROR("Invalid work mode ccm or gcm by config handle.\n");
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    if ((ctrl->key_by_ca != HI_TRUE)
+        && (ctrl->key_by_ca != HI_FALSE)
+        && (ctrl->alg != HI_CIPHER_ALG_DMA)) {
+        HI_LOG_ERROR("Invalid key by ca, you should set HI_TRUE or HI_FALSE.\n");
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    if (ctrl->key_by_ca == HI_TRUE) {
+        if (ctrl->ca_type >= HI_CIPHER_KEY_SRC_BUTT) {
+            HI_LOG_ERROR("Invalid ca type,key ca type is HI_TRUE.\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+        hard_key  = ((hi_u32)ctrl->ca_type & 0xFF) << BITS_IN_BYTE;
+        hard_key |= 0x01;
+    }
+
+    CHECK_CIPHER_OPEN();
+
+    ADDR_U64(aad) = 0x00;
+
+    if ((ctrl->alg == HI_CIPHER_ALG_3DES) || (ctrl->alg == HI_CIPHER_ALG_DES)) {
+        ivlen = DES_IV_SIZE;
+    }
+
+    HI_DBG_PRINT_U32(handle);
+    HI_DBG_PRINT_U32(ctrl->key_by_ca);
+    HI_DBG_PRINT_U32(ctrl->alg);
+    HI_DBG_PRINT_U32(ctrl->work_mode);
+    HI_DBG_PRINT_U32(ctrl->bit_width);
+    HI_DBG_PRINT_U32(ctrl->key_len);
+    HI_DBG_PRINT_U32(ivlen);
+    HI_DBG_PRINT_U32(ctrl->change_flags.bit1_iv);
+    HI_DBG_PRINT_U64(ADDR_U64(aad));
+
+    ret = sys_symc_config(handle, hard_key,
+                          ctrl->alg, ctrl->work_mode,
+                          ctrl->bit_width, ctrl->key_len, 0,
+                          (hi_u8 *)ctrl->key, HI_NULL, key_len,
+                          (hi_u8 *)ctrl->iv, ivlen, ctrl->change_flags.bit1_iv,
+                          aad, 0, 0);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_symc_config, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+ * \brief Configures the cipher expand control information.
+ */
+hi_s32 hi_mpi_cipher_config_handle_ex(hi_handle handle,
+                                      const hi_cipher_ctrl_ex *ctrl_ex)
+{
+    hi_cipher_key_length key_len = HI_CIPHER_KEY_DEFAULT;
+    hi_u8 *fkey = HI_NULL;
+    hi_u8 *skey = HI_NULL;
+    hi_u8 *iv = HI_NULL;
+    hi_u32 usage = 0;
+    compat_addr aad;
+    hi_u32 a_len = 0;
+    hi_u32 tag_len = 0;
+    hi_u32 iv_len = 0;
+    hi_u32 key_size = 0;
+    hi_cipher_sm1_round sm1_round = HI_CIPHER_SM1_ROUND_BUTT;
+    hi_cipher_bit_width bit_width = HI_CIPHER_BIT_WIDTH_128BIT;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctrl_ex == HI_NULL);
+    HI_LOG_CHECK_PARAM((ctrl_ex->param == HI_NULL) && (ctrl_ex->alg != HI_CIPHER_ALG_DMA));
+
+    if ((ctrl_ex->key_by_ca != HI_TRUE)
+        && (ctrl_ex->key_by_ca != HI_FALSE)
+        && (ctrl_ex->alg != HI_CIPHER_ALG_DMA)) {
+        HI_LOG_ERROR("Invalid bKeyByCA, you should set HI_TRUE or HI_FALSE.\n");
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    CHECK_CIPHER_OPEN();
+
+    ADDR_U64(aad) = 0x00;
+
+    /*****************************************************************************
+     * for AES, the pointer should point to hi_cipher_ctrl_aes;
+     * for AES_CCM or AES_GCM, the pointer should point to hi_cipher_ctrl_aes_ccm_gcm;
+     * for DES, the pointer should point to hi_cipher_ctrl_des;
+     * for 3DES, the pointer should point to hi_cipher_ctrl_3des;
+     * for SM1, the pointer should point to hi_cipher_ctrl_sm1;
+     * for SM4, the pointer should point to hi_cipher_ctrl_sm4;
+    */
+    switch (ctrl_ex->alg) {
+        case HI_CIPHER_ALG_DES: {
+            hi_cipher_ctrl_des *des_ctrl = (hi_cipher_ctrl_des *)ctrl_ex->param;
+
+            fkey = (hi_u8 *)des_ctrl->key;
+            key_size = sizeof(des_ctrl->key);
+            iv = (hi_u8 *)des_ctrl->iv;
+            usage = des_ctrl->change_flags.bit1_iv;
+            iv_len = DES_IV_SIZE;
+            bit_width = des_ctrl->bit_width;
+
+            break;
+        }
+        case HI_CIPHER_ALG_3DES: {
+            hi_cipher_ctrl_3des *tdes_ctrl = (hi_cipher_ctrl_3des *)ctrl_ex->param;
+
+            fkey = (hi_u8 *)tdes_ctrl->key;
+            key_size = sizeof(tdes_ctrl->key);
+            iv = (hi_u8 *)tdes_ctrl->iv;
+            usage = tdes_ctrl->change_flags.bit1_iv;
+            key_len = tdes_ctrl->key_len;
+            iv_len = DES_IV_SIZE;
+            bit_width = tdes_ctrl->bit_width;
+            break;
+        }
+        case HI_CIPHER_ALG_AES: {
+            if ((ctrl_ex->work_mode == HI_CIPHER_WORK_MODE_CCM)
+                || (ctrl_ex->work_mode == HI_CIPHER_WORK_MODE_GCM)) {
+                hi_cipher_ctrl_aes_ccm_gcm *aes_ccm_gcm_ctrl
+                    = (hi_cipher_ctrl_aes_ccm_gcm *)ctrl_ex->param;
+
+                fkey = (hi_u8 *)aes_ccm_gcm_ctrl->key;
+                key_size = sizeof(aes_ccm_gcm_ctrl->key);
+                iv = (hi_u8 *)aes_ccm_gcm_ctrl->iv;
+                iv_len = aes_ccm_gcm_ctrl->iv_len;
+
+                if (iv_len > AES_IV_SIZE) {
+                    HI_LOG_ERROR("para set CIPHER ccm/gcm iv is invalid, iv_len:0x%x.\n", iv_len);
+                    HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+                    return HI_ERR_CIPHER_INVALID_PARA;
+                }
+
+                tag_len = aes_ccm_gcm_ctrl->tag_len;
+                key_len = aes_ccm_gcm_ctrl->key_len;
+                ADDR_U64(aad) = aes_ccm_gcm_ctrl->a_phy_addr;
+                a_len = aes_ccm_gcm_ctrl->a_len;
+                usage = CIPHER_IV_CHANGE_ONE_PKG;
+            } else {
+                hi_cipher_ctrl_aes *aes_ctrl = (hi_cipher_ctrl_aes *)ctrl_ex->param;
+
+                fkey = (hi_u8 *)aes_ctrl->even_key;
+                skey = (hi_u8 *)aes_ctrl->odd_key;
+                key_size = sizeof(aes_ctrl->even_key);
+                iv = (hi_u8 *)aes_ctrl->iv;
+                usage = aes_ctrl->change_flags.bit1_iv;
+                key_len = aes_ctrl->key_len;
+                bit_width = aes_ctrl->bit_width;
+                iv_len = AES_IV_SIZE;
+            }
+            break;
+        }
+        case HI_CIPHER_ALG_SM1: {
+            hi_cipher_ctrl_sm1 *sm1_ctrl = (hi_cipher_ctrl_sm1 *)ctrl_ex->param;
+            hi_u8 sm1_key[SYMC_SM1_EK_AK_SIZE] = {0};
+
+            ret = memcpy_s(sm1_key, sizeof(sm1_key), sm1_ctrl->ek, sizeof(sm1_ctrl->ek));
+            if (ret != HI_SUCCESS) {
+                HI_LOG_PRINT_FUNC_ERR(memcpy_s, ret);
+                return ret;
+            }
+
+            ret = memcpy_s(sm1_key + sizeof(sm1_ctrl->ek), sizeof(sm1_key) - sizeof(sm1_ctrl->ek), sm1_ctrl->ak,
+                sizeof(sm1_ctrl->ak));
+            if (ret != HI_SUCCESS) {
+                HI_LOG_PRINT_FUNC_ERR(memcpy_s, ret);
+                crypto_zeroize(sm1_key, sizeof(sm1_key));
+                return ret;
+            }
+
+            fkey = (hi_u8 *)sm1_key;
+            skey = (hi_u8 *)sm1_ctrl->sk;
+            key_size = sizeof(sm1_ctrl->ek);
+            iv = (hi_u8 *)sm1_ctrl->iv;
+            usage = sm1_ctrl->change_flags.bit1_iv;
+            key_len = HI_CIPHER_KEY_DEFAULT;
+            sm1_round = sm1_ctrl->sm1_round;
+            bit_width = sm1_ctrl->bit_width;
+            iv_len = AES_IV_SIZE;
+            break;
+        }
+        case HI_CIPHER_ALG_SM4: {
+            hi_cipher_ctrl_sm4 *sm4_ctrl = (hi_cipher_ctrl_sm4 *)ctrl_ex->param;
+
+            fkey = (hi_u8 *)sm4_ctrl->key;
+            key_size = sizeof(sm4_ctrl->key);
+            iv = (hi_u8 *)sm4_ctrl->iv;
+            usage = sm4_ctrl->change_flags.bit1_iv;
+            key_len = HI_CIPHER_KEY_DEFAULT;
+            iv_len = AES_IV_SIZE;
+            break;
+        }
+        case HI_CIPHER_ALG_DMA: {
+            break;
+        }
+        default:
+            HI_LOG_ERROR("para set CIPHER alg is invalid.\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    HI_DBG_PRINT_U32(handle);
+    HI_DBG_PRINT_U32(ctrl_ex->key_by_ca);
+    HI_DBG_PRINT_U32(ctrl_ex->alg);
+    HI_DBG_PRINT_U32(ctrl_ex->work_mode);
+    HI_DBG_PRINT_U32(bit_width);
+    HI_DBG_PRINT_U32(key_len);
+    HI_DBG_PRINT_U32(sm1_round);
+    HI_DBG_PRINT_U32(key_size);
+    HI_DBG_PRINT_U32(iv_len);
+    HI_DBG_PRINT_U32(usage);
+    HI_DBG_PRINT_U64(ADDR_U64(aad));
+    HI_DBG_PRINT_U32(a_len);
+    HI_DBG_PRINT_U32(tag_len);
+
+    ret = sys_symc_config(handle, ctrl_ex->key_by_ca, ctrl_ex->alg,
+                          ctrl_ex->work_mode, bit_width, key_len, sm1_round,
+                          fkey, skey, key_size, iv, iv_len,
+                          usage, aad, a_len, tag_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_symc_config, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+ * \brief Performs encryption.
+ */
+hi_s32 hi_mpi_cipher_encrypt(hi_handle handle, hi_size_t src_phy_addr, hi_size_t dest_phy_addr, hi_u32 byte_length)
+{
+    compat_addr input;
+    compat_addr output;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    CHECK_CIPHER_OPEN();
+
+    ADDR_U64(input) = src_phy_addr;
+    ADDR_U64(output) = dest_phy_addr;
+
+    HI_DBG_PRINT_U32(handle);
+    HI_DBG_PRINT_U64(src_phy_addr);
+    HI_DBG_PRINT_U64(dest_phy_addr);
+    HI_DBG_PRINT_U32(byte_length);
+
+    ret = sys_symc_crypto(handle, input, output, byte_length, SYMC_OPERATION_ENCRYPT);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_symc_crypto, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+ * \brief Performs descryption.
+ */
+hi_s32 hi_mpi_cipher_decrypt(hi_handle handle, hi_size_t src_phy_addr,
+                           hi_size_t dest_phy_addr, hi_u32 byte_length)
+{
+    compat_addr input;
+    compat_addr output;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_DBG_PRINT_U32(handle);
+    HI_DBG_PRINT_U32(src_phy_addr);
+    HI_DBG_PRINT_U32(dest_phy_addr);
+    HI_DBG_PRINT_U32(byte_length);
+
+    CHECK_CIPHER_OPEN();
+
+    ADDR_U64(input) = src_phy_addr;
+    ADDR_U64(output) = dest_phy_addr;
+
+    ret = sys_symc_crypto(handle, input, output, byte_length, SYMC_OPERATION_DECRYPT);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_symc_crypto, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+ * \brief Performs encryption.
+ */
+hi_s32 hi_mpi_cipher_encrypt_vir(hi_handle handle,
+                                 const hi_u8 *src_data,
+                                 hi_u8 *dest_data,
+                                 hi_u32 byte_length)
+{
+    compat_addr input;
+    compat_addr output;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(src_data == HI_NULL);
+    HI_LOG_CHECK_PARAM(dest_data == HI_NULL);
+
+    CHECK_CIPHER_OPEN();
+
+    ADDR_VIA_CONST(input) = src_data;
+    ADDR_VIA(output) = dest_data;
+
+    HI_DBG_PRINT_U32(handle);
+    HI_DBG_PRINT_U32(byte_length);
+
+    ret = sys_symc_crypto(handle, input, output, byte_length, SYMC_OPERATION_ENCRYPT_VIA);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_symc_crypto, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+ * \brief Performs decryption.
+ */
+hi_s32 hi_mpi_cipher_decrypt_vir(hi_handle handle,
+                                 const hi_u8 *src_data,
+                                 hi_u8 *dest_data,
+                                 hi_u32 byte_length)
+{
+    compat_addr input;
+    compat_addr output;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(src_data == HI_NULL);
+    HI_LOG_CHECK_PARAM(dest_data == HI_NULL);
+
+    CHECK_CIPHER_OPEN();
+
+    ADDR_VIA_CONST(input) = src_data;
+    ADDR_VIA(output) = dest_data;
+
+    HI_DBG_PRINT_U32(handle);
+    HI_DBG_PRINT_U32(byte_length);
+
+    ret = sys_symc_crypto(handle, input, output, byte_length, SYMC_OPERATION_DECRYPT_VIA);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_symc_crypto, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+ * \brief Encrypt multiple packaged data.
+ */
+hi_s32 hi_mpi_cipher_encrypt_multi(hi_handle handle,
+                                   const hi_cipher_data *data_pkg,
+                                   hi_u32 data_pkg_num)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    CHECK_CIPHER_OPEN();
+
+    HI_LOG_CHECK_PARAM(data_pkg == HI_NULL);
+    HI_LOG_CHECK_PARAM((data_pkg->odd_key != HI_TRUE) && (data_pkg->odd_key != HI_FALSE));
+    HI_LOG_CHECK_PARAM(data_pkg_num == 0x00);
+    HI_LOG_CHECK_PARAM(data_pkg_num >= CIPHER_MAX_MULTIPAD_NUM);
+
+    HI_DBG_PRINT_U32(handle);
+    HI_DBG_PRINT_U32(data_pkg_num);
+
+    ret = sys_symc_crypto_multi(handle, data_pkg, data_pkg_num, SYMC_OPERATION_ENCRYPT);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_symc_crypto_multi, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+ * \brief Encrypt multiple packaged data.
+ */
+hi_s32 hi_mpi_cipher_decrypt_multi(hi_handle handle,
+                                   const hi_cipher_data *data_pkg,
+                                   hi_u32 data_pkg_num)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(data_pkg == HI_NULL);
+    HI_LOG_CHECK_PARAM((data_pkg->odd_key != HI_TRUE) && (data_pkg->odd_key != HI_FALSE));
+    HI_LOG_CHECK_PARAM(data_pkg_num == 0x00);
+    HI_LOG_CHECK_PARAM(data_pkg_num >= CIPHER_MAX_MULTIPAD_NUM);
+
+    HI_DBG_PRINT_U32(handle);
+    HI_DBG_PRINT_U32(data_pkg_num);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = sys_symc_crypto_multi(handle, data_pkg, data_pkg_num, SYMC_OPERATION_DECRYPT);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_symc_crypto_multi, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_mpi_cipher_get_tag(hi_handle handle, hi_u8 *tag, hi_u32 *tag_len)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(tag == HI_NULL);
+    HI_LOG_CHECK_PARAM(tag_len == HI_NULL);
+    HI_LOG_CHECK_PARAM(*tag_len != MAX_TAG_LEN);
+
+    HI_DBG_PRINT_U32(handle);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = sys_aead_get_tag(handle, tag, tag_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_aead_get_tag, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_mpi_cipher_get_handle_config(hi_handle handle, hi_cipher_ctrl *ctrl)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctrl == HI_NULL);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = sys_symc_get_config(handle, ctrl);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_symc_get_config, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_mpi_cipher_klad_encrypt_key(hi_cipher_ca_type root_key,
+                                      hi_cipher_klad_target target,
+                                      const hi_u8 *clean_key,
+                                      hi_u8 *encrypt_key,
+                                      hi_u32 key_len)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 i;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(root_key >= HI_CIPHER_KEY_SRC_BUTT);
+    HI_LOG_CHECK_PARAM(target >= HI_CIPHER_KLAD_TARGET_BUTT);
+    HI_LOG_CHECK_PARAM(clean_key == HI_NULL);
+    HI_LOG_CHECK_PARAM(HI_NULL == encrypt_key);
+    HI_LOG_CHECK_PARAM((key_len % AES_BLOCK_SIZE) != 0);
+    HI_LOG_CHECK_PARAM(key_len == 0);
+
+    CHECK_CIPHER_OPEN();
+
+    for (i = 0; i < key_len; i += AES_BLOCK_SIZE) {
+        ret = sys_klad_encrypt_key(root_key, target, clean_key + i, encrypt_key + i);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(sys_klad_encrypt_key, ret);
+            return ret;
+        }
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_mpi_cipher_get_random_number(hi_u32 *random_number)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(random_number == HI_NULL);
+
+    ret = sys_trng_get_random(random_number, 0);
+    if (ret != HI_SUCCESS) {
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_mpi_cipher_hash_init(const hi_cipher_hash_atts *hash_atts,
+                               hi_handle *hash_handle)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(hash_atts == HI_NULL);
+    HI_LOG_CHECK_PARAM(hash_handle == HI_NULL);
+
+    HI_DBG_PRINT_U32(hash_atts->sha_type);
+    HI_DBG_PRINT_U32(hash_atts->hmac_key_len);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = sys_hash_start(hash_handle,
+                         hash_atts->sha_type,
+                         hash_atts->hmac_key,
+                         hash_atts->hmac_key_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_hash_start, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_mpi_cipher_hash_update(hi_handle hash_handle,
+                                 const hi_u8 *input_data,
+                                 hi_u32 input_data_len)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(input_data == HI_NULL);
+
+    HI_DBG_PRINT_U32(hash_handle);
+    HI_DBG_PRINT_U32(input_data_len);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = sys_hash_update(hash_handle, input_data, input_data_len, HASH_CHUNCK_SRC_USER);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_hash_update, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_mpi_cipher_hash_final(hi_handle hash_handle, hi_u8 *output_hash)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 hash_len = 0x00;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(output_hash == HI_NULL);
+    HI_LOG_CHECK_PARAM(hash_handle == HI_INVALID_HANDLE);
+
+    HI_DBG_PRINT_U32(hash_handle);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = sys_hash_finish(hash_handle, output_hash, &hash_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_hash_finish, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 check_rsa_pri_key(const hi_cipher_rsa_pri_key *pri_key)
+{
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(pri_key == HI_NULL);
+    HI_LOG_CHECK_PARAM(pri_key->n == HI_NULL);
+    HI_LOG_CHECK_PARAM(pri_key->n_len < RSA_MIN_KEY_LEN);
+    HI_LOG_CHECK_PARAM(pri_key->n_len > RSA_MAX_KEY_LEN);
+
+    if (pri_key->d == HI_NULL) {
+        HI_LOG_CHECK_PARAM(pri_key->p == HI_NULL);
+        HI_LOG_CHECK_PARAM(pri_key->q == HI_NULL);
+        HI_LOG_CHECK_PARAM(pri_key->dp == HI_NULL);
+        HI_LOG_CHECK_PARAM(pri_key->dq == HI_NULL);
+        HI_LOG_CHECK_PARAM(pri_key->qp == HI_NULL);
+        HI_LOG_CHECK_PARAM(pri_key->n_len / 2 != pri_key->p_len);
+        HI_LOG_CHECK_PARAM(pri_key->n_len / 2 != pri_key->q_len);
+        HI_LOG_CHECK_PARAM(pri_key->n_len / 2 != pri_key->dp_len);
+        HI_LOG_CHECK_PARAM(pri_key->n_len / 2 != pri_key->dq_len);
+        HI_LOG_CHECK_PARAM(pri_key->n_len / 2 != pri_key->qp_len);
+    } else {
+        HI_LOG_CHECK_PARAM(pri_key->n_len != pri_key->d_len);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_mpi_cipher_rsa_public_encrypt(const hi_cipher_rsa_pub_enc *rsa_enc,
+                                        const hi_u8 *input, hi_u32 in_len,
+                                        hi_u8 *output, hi_u32 *out_len)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_rsa_key key;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(rsa_enc == HI_NULL);
+    HI_LOG_CHECK_PARAM(input == HI_NULL);
+    HI_LOG_CHECK_PARAM(output == HI_NULL);
+    HI_LOG_CHECK_PARAM(out_len == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_enc->pub_key.n == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_enc->pub_key.e == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_enc->ca_type != HI_CIPHER_KEY_SRC_USER);
+    HI_LOG_CHECK_PARAM(rsa_enc->pub_key.n_len < RSA_MIN_KEY_LEN);
+    HI_LOG_CHECK_PARAM(rsa_enc->pub_key.n_len > RSA_MAX_KEY_LEN);
+    HI_LOG_CHECK_PARAM(rsa_enc->pub_key.n_len < rsa_enc->pub_key.e_len);
+
+    HI_DBG_PRINT_U32(rsa_enc->pub_key.n_len);
+    HI_DBG_PRINT_U32(rsa_enc->scheme);
+    HI_DBG_PRINT_U32(in_len);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = memset_s(&key, sizeof(key), 0, sizeof(key));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    key.public = HI_TRUE;
+    key.klen = rsa_enc->pub_key.n_len;
+    key.n = rsa_enc->pub_key.n;
+    CIPHER_GET_PUB_EXPONENT(&key.e, rsa_enc);
+
+    ret = sys_rsa_encrypt(&key, rsa_enc->scheme,
+                          input, in_len,
+                          output, out_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_rsa_encrypt, ret);
+        crypto_zeroize(&key, sizeof(key));
+        return ret;
+    }
+
+    crypto_zeroize(&key, sizeof(key));
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+
+}
+
+hi_s32 hi_mpi_cipher_rsa_private_decrypt(const hi_cipher_rsa_pri_enc *rsa_dec,
+                                         const hi_u8 *input, hi_u32 in_len,
+                                         hi_u8 *output, hi_u32 *out_len)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_rsa_key key;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(rsa_dec == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_dec->ca_type >= HI_CIPHER_KEY_SRC_BUTT);
+
+    ret = check_rsa_pri_key(&rsa_dec->pri_key);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(check_rsa_pri_key, ret);
+        return ret;
+    }
+
+    HI_LOG_CHECK_PARAM(input == HI_NULL);
+    HI_LOG_CHECK_PARAM(output == HI_NULL);
+    HI_LOG_CHECK_PARAM(out_len == HI_NULL);
+
+    HI_DBG_PRINT_U32(rsa_dec->pri_key.n_len);
+    HI_DBG_PRINT_U32(rsa_dec->scheme);
+    HI_DBG_PRINT_U32(in_len);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = memset_s(&key, sizeof(key), 0, sizeof(key));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    key.public  = HI_FALSE;
+    key.klen    = rsa_dec->pri_key.n_len;
+    key.n       = rsa_dec->pri_key.n;
+    key.d       = rsa_dec->pri_key.d;
+    key.ca_type = rsa_dec->ca_type;
+    key.p       = rsa_dec->pri_key.p;
+    key.q       = rsa_dec->pri_key.q;
+    key.dp      = rsa_dec->pri_key.dp;
+    key.dq      = rsa_dec->pri_key.dq;
+    key.qp      = rsa_dec->pri_key.qp;
+
+    ret = sys_rsa_decrypt(&key,
+                          rsa_dec->scheme,
+                          input, in_len,
+                          output, out_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_rsa_decrypt, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_mpi_cipher_rsa_private_encrypt(const hi_cipher_rsa_pri_enc *rsa_enc,
+                                         const hi_u8 *input, hi_u32 in_len,
+                                         hi_u8 *output, hi_u32 *out_len)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_rsa_key key;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(rsa_enc == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_enc->ca_type >= HI_CIPHER_KEY_SRC_BUTT);
+
+    ret = check_rsa_pri_key(&rsa_enc->pri_key);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(check_rsa_pri_key, ret);
+        return ret;
+    }
+
+    HI_LOG_CHECK_PARAM(input == HI_NULL);
+    HI_LOG_CHECK_PARAM(output == HI_NULL);
+    HI_LOG_CHECK_PARAM(out_len == HI_NULL);
+
+    HI_DBG_PRINT_U32(rsa_enc->pri_key.n_len);
+    HI_DBG_PRINT_U32(rsa_enc->scheme);
+    HI_DBG_PRINT_U32(in_len);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = memset_s(&key, sizeof(key), 0, sizeof(key));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    key.public  = HI_FALSE;
+    key.klen    = rsa_enc->pri_key.n_len;
+    key.n       = rsa_enc->pri_key.n;
+    key.d       = rsa_enc->pri_key.d;
+    key.ca_type  = rsa_enc->ca_type;
+    key.p       = rsa_enc->pri_key.p;
+    key.q       = rsa_enc->pri_key.q;
+    key.dp       = rsa_enc->pri_key.dp;
+    key.dq       = rsa_enc->pri_key.dq;
+    key.qp       = rsa_enc->pri_key.qp;
+
+    ret = sys_rsa_encrypt(&key,
+                          rsa_enc->scheme,
+                          input, in_len,
+                          output, out_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_rsa_encrypt, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+
+hi_s32 hi_mpi_cipher_rsa_public_decrypt(const hi_cipher_rsa_pub_enc *rsa_dec,
+                                        const hi_u8 *input, hi_u32 in_len,
+                                        hi_u8 *output, hi_u32 *out_len)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_rsa_key key;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(rsa_dec == HI_NULL);
+    HI_LOG_CHECK_PARAM(input == HI_NULL);
+    HI_LOG_CHECK_PARAM(output == HI_NULL);
+    HI_LOG_CHECK_PARAM(out_len == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_dec->ca_type != HI_CIPHER_KEY_SRC_USER);
+    HI_LOG_CHECK_PARAM(rsa_dec->pub_key.n == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_dec->pub_key.e == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_dec->pub_key.n_len < RSA_MIN_KEY_LEN);
+    HI_LOG_CHECK_PARAM(rsa_dec->pub_key.n_len > RSA_MAX_KEY_LEN);
+    HI_LOG_CHECK_PARAM(rsa_dec->pub_key.n_len < rsa_dec->pub_key.e_len);
+
+    HI_DBG_PRINT_U32(rsa_dec->scheme);
+    HI_DBG_PRINT_U32(in_len);
+    HI_DBG_PRINT_U32(rsa_dec->pub_key.n_len);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = memset_s(&key, sizeof(key), 0, sizeof(key));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    key.public  = HI_TRUE;
+    key.klen    = rsa_dec->pub_key.n_len;
+    key.n       = rsa_dec->pub_key.n;
+    CIPHER_GET_PUB_EXPONENT(&key.e, rsa_dec);
+
+    ret = sys_rsa_decrypt(&key, rsa_dec->scheme, input, in_len, output, out_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_rsa_decrypt, ret);
+        crypto_zeroize(&key, sizeof(key));
+        return ret;
+    }
+
+    crypto_zeroize(&key, sizeof(key));
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 mpi_cipher_hash(const hi_cipher_hash_type sha_type,
+                              const hi_u8 *in_data, hi_u32 in_data_len,
+                              hi_u8 *hash_data, hi_u32 *hash_len)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_handle hash_id;
+
+    ret = sys_hash_start(&hash_id, sha_type, HI_NULL, 0);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_hash_start, ret);
+        return ret;
+    }
+
+    ret = sys_hash_update(hash_id, in_data, in_data_len, HASH_CHUNCK_SRC_USER);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_hash_update, ret);
+        return ret;
+    }
+
+    ret = sys_hash_finish(hash_id, hash_data, hash_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_hash_finish, ret);
+        return ret;
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_mpi_cipher_rsa_sign(const hi_cipher_rsa_sign *rsa_sign,
+                              const hi_u8 *in_data, hi_u32 in_data_len,
+                              const hi_u8 *hash_data,
+                              hi_u8 *out_sign, hi_u32 *out_sign_len)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_rsa_key key;
+    hi_u8 hash[HASH_RESULT_MAX_SIZE] = {0};
+    const hi_u8 *ptr = HI_NULL;
+    hi_u32 hash_len = 0;
+    hi_cipher_hash_type sha_type = 0;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(rsa_sign == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_sign->ca_type >= HI_CIPHER_KEY_SRC_BUTT);
+
+    ret = check_rsa_pri_key(&rsa_sign->pri_key);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(check_rsa_pri_key, ret);
+        return ret;
+    }
+
+    HI_LOG_CHECK_PARAM(out_sign == HI_NULL);
+    HI_LOG_CHECK_PARAM(out_sign_len == HI_NULL);
+    HI_LOG_CHECK_PARAM((in_data == HI_NULL) && (hash_data == HI_NULL));
+
+    HI_DBG_PRINT_U32(rsa_sign->scheme);
+    HI_DBG_PRINT_U32(rsa_sign->pri_key.n_len);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = cipher_get_rsa_attr(rsa_sign->scheme, &hash_len, &sha_type);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cipher_get_rsa_attr, ret);
+        return ret;
+    }
+
+    HI_DBG_PRINT_U32(hash_len);
+    HI_DBG_PRINT_U32(sha_type);
+
+    /* hash value of context,if NULL, compute hash = Hash(in_data */
+    if (hash_data == HI_NULL) {
+        ret = mpi_cipher_hash(sha_type, in_data, in_data_len, hash, &hash_len);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(mpi_cipher_hash, ret);
+            return ret;
+        }
+        ptr = hash;
+    } else {
+        ptr = hash_data;
+    }
+
+    ret = memset_s(&key, sizeof(key), 0, sizeof(key));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    key.public  = HI_FALSE;
+    key.klen    = rsa_sign->pri_key.n_len;
+    key.n       = rsa_sign->pri_key.n;
+    key.d       = rsa_sign->pri_key.d;
+    key.ca_type  = rsa_sign->ca_type;
+    key.p       = rsa_sign->pri_key.p;
+    key.q       = rsa_sign->pri_key.q;
+    key.dp      = rsa_sign->pri_key.dp;
+    key.dq      = rsa_sign->pri_key.dq;
+    key.qp      = rsa_sign->pri_key.qp;
+
+    ret = sys_rsa_sign_hash(&key, rsa_sign->scheme, ptr, hash_len, out_sign, out_sign_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_rsa_sign_hash, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_mpi_cipher_rsa_verify(const hi_cipher_rsa_verify *rsa_verify,
+                                const hi_u8 *in_data, hi_u32 in_data_len,
+                                const hi_u8 *hash_data,
+                                const hi_u8 *in_sign, hi_u32 in_sign_len)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_rsa_key key;
+    hi_u8 hash[HASH_RESULT_MAX_SIZE] = {0};
+    hi_u32 hash_len = 0;
+    const hi_u8 *ptr = HI_NULL;
+    hi_cipher_hash_type sha_type = 0;
+
+    HI_UNF_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(rsa_verify == HI_NULL);
+    HI_LOG_CHECK_PARAM(in_sign == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_verify->pub_key.n == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_verify->pub_key.e == HI_NULL);
+    HI_LOG_CHECK_PARAM(rsa_verify->pub_key.n_len < RSA_MIN_KEY_LEN);
+    HI_LOG_CHECK_PARAM(rsa_verify->pub_key.n_len > RSA_MAX_KEY_LEN);
+    HI_LOG_CHECK_PARAM((in_data == HI_NULL) && (hash_data == HI_NULL));
+    HI_LOG_CHECK_PARAM(rsa_verify->pub_key.n_len < rsa_verify->pub_key.e_len);
+
+    HI_DBG_PRINT_U32(rsa_verify->scheme);
+    HI_DBG_PRINT_U32(rsa_verify->pub_key.n_len);
+    HI_DBG_PRINT_U32(rsa_verify->scheme);
+
+    CHECK_CIPHER_OPEN();
+
+    ret = cipher_get_rsa_attr(rsa_verify->scheme, &hash_len, &sha_type);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cipher_get_rsa_attr, ret);
+        return ret;
+    }
+
+    HI_DBG_PRINT_U32(sha_type);
+
+    /* hash value of context,if NULL, compute hash = Hash(in_data */
+    if (hash_data == HI_NULL) {
+        ret = mpi_cipher_hash(sha_type, in_data, in_data_len, hash, &hash_len);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(mpi_cipher_hash, ret);
+            return ret;
+        }
+        ptr = hash;
+    } else {
+        ptr = hash_data;
+    }
+
+    HI_DBG_PRINT_U32(hash_len);
+
+    ret = memset_s(&key, sizeof(key), 0, sizeof(key));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    key.public  = HI_TRUE;
+    key.klen    = rsa_verify->pub_key.n_len;
+    key.n       = rsa_verify->pub_key.n;
+    CIPHER_GET_PUB_EXPONENT(&key.e, rsa_verify);
+
+    ret = sys_rsa_verify_hash(&key, rsa_verify->scheme, ptr, hash_len, in_sign, in_sign_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sys_rsa_verify_hash, ret);
+        crypto_zeroize(&key, sizeof(key));
+        return ret;
+    }
+
+    crypto_zeroize(&key, sizeof(key));
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/** @}*/  /** <!-- ==== Compat Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/sys_cipher.c
+++ b/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/sys_cipher.c
@@ -1,0 +1,625 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : sys_cipher.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+
+#include "sys_cipher.h"
+
+/******************************* API Code *****************************/
+/** \addtogroup      symc */
+/** @{*/  /** <!-- [mpi]*/
+
+hi_s32 sys_symc_create(hi_u32 *id)
+{
+    hi_s32 ret = HI_FAILURE;
+    symc_create_t create = {0};
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&create, sizeof(create), 0, sizeof(create));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_SYMC_CREATEHANDLE, &create);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        return ret;
+    }
+
+    *id = create.id;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_symc_destroy(hi_u32 id)
+{
+    symc_destroy_t destroy = {0};
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&destroy, sizeof(destroy), 0, sizeof(destroy));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    destroy.id = id;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_SYMC_DESTROYHANDLE, &destroy);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_symc_config(hi_u32 id,
+                    hi_u32 hard_key,
+                    hi_cipher_alg alg,
+                    hi_cipher_work_mode work_mode,
+                    hi_cipher_bit_width bit_width,
+                    hi_cipher_key_length key_len,
+                    hi_cipher_sm1_round sm1_round_num,
+                    hi_u8 *fkey, hi_u8 *skey, hi_u32 keylen,
+                    hi_u8 *iv, hi_u32 ivlen, hi_u32 iv_usage,
+                    compat_addr aad, hi_u32 alen, hi_u32 tlen)
+{
+    symc_config_t config;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&config, sizeof(config), 0, sizeof(config));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    config.id = id;
+    config.hard_key = hard_key;
+    config.alg = alg;
+    config.mode = work_mode;
+    config.klen = key_len;
+    config.iv_usage = iv_usage;
+    config.sm1_round_num = sm1_round_num;
+    config.aad = aad;
+    config.alen = alen;
+    config.tlen = tlen;
+    config.ivlen = ivlen;
+    config.width = bit_width;
+
+    HI_DBG_PRINT_U32(ivlen);
+    HI_DBG_PRINT_H32(key_len);
+
+    if (fkey != HI_NULL) {
+        ret = memcpy_s(config.fkey, sizeof(config.fkey), fkey, keylen);
+        if (ret != 0) {
+            HI_LOG_PRINT_FUNC_ERR(memcpy_s, ret);
+            return HI_ERR_CIPHER_MEMCPY_S_FAILED;
+        }
+
+        if (alg == HI_CIPHER_ALG_SM1) {
+            /* SM1 key:EK+AK+SK,fkey:EK+AK. */
+            ret = memcpy_s(config.fkey + SYMC_SM1_SK_SIZE, SYMC_SM1_SK_SIZE,
+                           fkey + SYMC_SM1_SK_SIZE, SYMC_SM1_SK_SIZE);
+            if (ret != 0) {
+                HI_LOG_PRINT_FUNC_ERR(memcpy_s, ret);
+                crypto_zeroize(&config, sizeof(config));
+                return HI_ERR_CIPHER_MEMCPY_S_FAILED;
+            }
+        }
+    }
+
+    if (iv != HI_NULL) {
+        ret = memcpy_s(config.iv, sizeof(config.iv), iv, ivlen);
+        if (ret != 0) {
+            HI_LOG_PRINT_FUNC_ERR(memcpy_s, ret);
+            crypto_zeroize(&config, sizeof(config));
+            return HI_ERR_CIPHER_MEMCPY_S_FAILED;
+        }
+    }
+
+    if (skey != HI_NULL) {
+        ret = memcpy_s(config.skey, sizeof(config.skey), skey, keylen);
+        if (ret != 0) {
+            HI_LOG_PRINT_FUNC_ERR(memcpy_s, ret);
+            crypto_zeroize(&config, sizeof(config));
+            return HI_ERR_CIPHER_MEMCPY_S_FAILED;
+        }
+    }
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_SYMC_CONFIGHANDLE, &config);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        crypto_zeroize(&config, sizeof(config));
+        return ret;
+    }
+
+    crypto_zeroize(&config, sizeof(config));
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_symc_get_config(hi_u32 id, hi_cipher_ctrl *ctrl)
+{
+    symc_get_config_t get_config;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&get_config, sizeof(get_config), 0, sizeof(get_config));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    get_config.id = id;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_SYMC_GET_CONFIG, &get_config);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        return ret;
+    }
+
+    ret = memcpy_s(ctrl, sizeof(hi_cipher_ctrl), &get_config.ctrl, sizeof(hi_cipher_ctrl));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memcpy_s, ret);
+        crypto_zeroize(&get_config, sizeof(get_config));
+        return HI_ERR_CIPHER_MEMCPY_S_FAILED;
+    }
+
+    crypto_zeroize(&get_config, sizeof(get_config));
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_symc_crypto(hi_u32 id, const compat_addr input,
+                    const compat_addr output, hi_u32 length,
+                    hi_u32 operation)
+{
+    symc_encrypt_t encrypt;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&encrypt, sizeof(encrypt), 0, sizeof(encrypt));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    encrypt.id = id;
+    encrypt.input = input;
+    encrypt.output = output;
+    encrypt.length = length;
+    encrypt.operation = operation;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_SYMC_ENCRYPT, &encrypt);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_symc_crypto_multi(hi_u32 id, const void *pkg, hi_u32 pkg_num, hi_u32 operation)
+{
+    symc_encrypt_multi_t encrypt_multi;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&encrypt_multi, sizeof(encrypt_multi), 0, sizeof(encrypt_multi));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    encrypt_multi.id = id;
+    ADDR_VIA_CONST(encrypt_multi.pkg) = pkg;
+    encrypt_multi.pkg_num = pkg_num;
+    encrypt_multi.operation = operation;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_SYMC_ENCRYPTMULTI, &encrypt_multi);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_klad_encrypt_key(hi_u32 keysel, hi_u32 target, const hi_u8 clear[AES_BLOCK_SIZE], hi_u8 encrypt[AES_BLOCK_SIZE])
+{
+    klad_key_t klad;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&klad, sizeof(klad), 0, sizeof(klad));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    klad.keysel = keysel;
+    klad.target = target;
+    ret = memcpy_s(klad.clear, AES_BLOCK_SIZE, clear, AES_BLOCK_SIZE);
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memcpy_s, ret);
+        return HI_ERR_CIPHER_MEMCPY_S_FAILED;
+    }
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_KLAD_KEY, &klad);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        return ret;
+    }
+
+    ret = memcpy_s(encrypt, AES_BLOCK_SIZE, klad.encrypt, AES_BLOCK_SIZE);
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memcpy_s, ret);
+        crypto_zeroize(&klad, sizeof(klad));
+        return HI_ERR_CIPHER_MEMCPY_S_FAILED;
+    }
+
+    crypto_zeroize(&klad, sizeof(klad));
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_aead_get_tag(hi_u32 id, hi_u8 *tag, hi_u32 *taglen)
+{
+    hi_s32 ret = HI_FAILURE;
+    aead_tag_t aead_tag;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&aead_tag, sizeof(aead_tag), 0, sizeof(aead_tag));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    aead_tag.id = id;
+    aead_tag.taglen = *taglen;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_SYMC_GETTAG, &aead_tag);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        return ret;
+    }
+
+    ret = memcpy_s(tag, AEAD_TAG_SIZE, aead_tag.tag, aead_tag.taglen);
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memcpy_s, ret);
+        crypto_zeroize(&aead_tag, sizeof(aead_tag));
+        return HI_ERR_CIPHER_MEMCPY_S_FAILED;
+    }
+
+    *taglen = aead_tag.taglen;
+
+    crypto_zeroize(&aead_tag, sizeof(aead_tag));
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_hash_start(hi_u32 *id, hi_cipher_hash_type type,
+                   const hi_u8 *key, hi_u32 keylen)
+{
+    hi_s32 ret = HI_FAILURE;
+    hash_start_t start;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&start, sizeof(start), 0, sizeof(start));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    start.id = 0;
+    start.type = type;
+    start.keylen = keylen;
+    ADDR_VIA_CONST(start.key) = key;
+
+    ret =  CRYPTO_IOCTL(CRYPTO_CMD_HASH_START, &start);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        return ret;
+    }
+
+    *id = start.id;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_hash_update(hi_u32 id, const hi_u8 *input, hi_u32 length, hash_chunk_src src)
+{
+    hi_s32 ret = HI_FAILURE;
+    hash_update_t update;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&update, sizeof(update), 0, sizeof(update));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    update.id = id;
+    ADDR_VIA_CONST(update.input) = input;
+    update.length = length;
+    update.src = src;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_HASH_UPDATE, &update);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_hash_finish(hi_u32 id, hi_u8 *hash, hi_u32 *hashlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    hash_finish_t finish;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&finish, sizeof(finish), 0, sizeof(finish));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    finish.id = id;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_HASH_FINISH, &finish);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        return ret;
+    }
+
+    ret = memcpy_s(hash, HASH_RESULT_MAX_SIZE, finish.hash, finish.hashlen);
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memcpy_s, ret);
+        return HI_ERR_CIPHER_MEMCPY_S_FAILED;
+    }
+
+    *hashlen = finish.hashlen;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_rsa_encrypt(const cryp_rsa_key *key,
+                    hi_cipher_rsa_enc_scheme scheme,
+                    const hi_u8 *in, hi_u32 inlen,
+                    hi_u8 *out, hi_u32 *outlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    rsa_info_t rsa_info;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&rsa_info, sizeof(rsa_info_t), 0, sizeof(rsa_info_t));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    ADDR_VIA_CONST(rsa_info.n) = key->n;
+    ADDR_VIA_CONST(rsa_info.d) = key->d;
+    ADDR_VIA_CONST(rsa_info.p) = key->p;
+    ADDR_VIA_CONST(rsa_info.q) = key->q;
+    ADDR_VIA_CONST(rsa_info.dp) = key->dp;
+    ADDR_VIA_CONST(rsa_info.dq) = key->dq;
+    ADDR_VIA_CONST(rsa_info.qp) = key->qp;
+
+    rsa_info.e = key->e;
+    rsa_info.public = key->public;
+    rsa_info.klen = key->klen;
+    rsa_info.scheme = scheme;
+    ADDR_VIA_CONST(rsa_info.in) = in;
+    rsa_info.inlen = inlen;
+    ADDR_VIA(rsa_info.out) = out;
+    rsa_info.outlen = key->klen;
+    rsa_info.ca_type = key->ca_type;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_RSA_ENC, &rsa_info);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        crypto_zeroize(&rsa_info.e, sizeof(rsa_info.e));
+        return ret;
+    }
+
+    *outlen = rsa_info.outlen;
+
+    crypto_zeroize(&rsa_info.e, sizeof(rsa_info.e));
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_rsa_decrypt(const cryp_rsa_key *key,
+                    hi_cipher_rsa_enc_scheme scheme,
+                    const hi_u8 *in, hi_u32 inlen,
+                    hi_u8 *out, hi_u32 *outlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    rsa_info_t rsa_info;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&rsa_info, sizeof(rsa_info), 0, sizeof(rsa_info));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    ADDR_VIA_CONST(rsa_info.n) = key->n;
+    ADDR_VIA_CONST(rsa_info.d) = key->d;
+    ADDR_VIA_CONST(rsa_info.p) = key->p;
+    ADDR_VIA_CONST(rsa_info.q) = key->q;
+    ADDR_VIA_CONST(rsa_info.dp) = key->dp;
+    ADDR_VIA_CONST(rsa_info.dq) = key->dq;
+    ADDR_VIA_CONST(rsa_info.qp) = key->qp;
+
+    rsa_info.e = key->e;
+    rsa_info.public = key->public;
+    rsa_info.klen = key->klen;
+    rsa_info.scheme = scheme;
+    ADDR_VIA_CONST(rsa_info.in) = in;
+    rsa_info.inlen = inlen;
+    ADDR_VIA(rsa_info.out) = out;
+    rsa_info.outlen = key->klen;
+    rsa_info.ca_type = key->ca_type;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_RSA_DEC, &rsa_info);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        crypto_zeroize(&rsa_info.e, sizeof(rsa_info.e));
+        return ret;
+    }
+
+    *outlen = rsa_info.outlen;
+
+    crypto_zeroize(&rsa_info.e, sizeof(rsa_info.e));
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_rsa_sign_hash(const cryp_rsa_key *key,
+                      hi_cipher_rsa_sign_scheme scheme,
+                      const hi_u8 *hash, hi_u32 hlen,
+                      hi_u8 *sign, hi_u32 *signlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    rsa_info_t rsa_info;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&rsa_info, sizeof(rsa_info), 0, sizeof(rsa_info));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    ADDR_VIA_CONST(rsa_info.n) = key->n;
+    ADDR_VIA_CONST(rsa_info.d) = key->d;
+    ADDR_VIA_CONST(rsa_info.p) = key->p;
+    ADDR_VIA_CONST(rsa_info.q) = key->q;
+    ADDR_VIA_CONST(rsa_info.dp) = key->dp;
+    ADDR_VIA_CONST(rsa_info.dq) = key->dq;
+    ADDR_VIA_CONST(rsa_info.qp) = key->qp;
+
+    rsa_info.e = key->e;
+    rsa_info.public = key->public;
+    rsa_info.klen = key->klen;
+    rsa_info.scheme = scheme;
+    ADDR_VIA_CONST(rsa_info.in) = hash;
+    rsa_info.inlen = hlen;
+    ADDR_VIA(rsa_info.out) = sign;
+    rsa_info.outlen = key->klen;
+    rsa_info.ca_type = key->ca_type;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_RSA_SIGN, &rsa_info);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        crypto_zeroize(&rsa_info.e, sizeof(rsa_info.e));
+        return ret;
+    }
+
+    *signlen = rsa_info.outlen;
+
+    crypto_zeroize(&rsa_info.e, sizeof(rsa_info.e));
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_rsa_verify_hash(const cryp_rsa_key *key,
+                        hi_cipher_rsa_sign_scheme scheme,
+                        const hi_u8 *hash, hi_u32 hlen,
+                        const hi_u8 *sign, hi_u32 signlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    rsa_info_t rsa_info;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&rsa_info, sizeof(rsa_info_t), 0, sizeof(rsa_info_t));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    ADDR_VIA_CONST(rsa_info.n) = key->n;
+
+    rsa_info.e = key->e;
+    rsa_info.public = key->public;
+    rsa_info.klen = key->klen;
+    rsa_info.scheme = scheme;
+    ADDR_VIA_CONST(rsa_info.in) = sign;
+    rsa_info.inlen = signlen;
+    ADDR_VIA_CONST(rsa_info.out) = hash;
+    rsa_info.outlen = hlen;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_RSA_VERIFY, &rsa_info);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(CRYPTO_IOCTL, ret);
+        crypto_zeroize(&rsa_info.e, sizeof(rsa_info.e));
+        return ret;
+    }
+
+    crypto_zeroize(&rsa_info.e, sizeof(rsa_info.e));
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 sys_trng_get_random(hi_u32 *randnum, hi_u32 timeout)
+{
+    hi_s32 ret = HI_FAILURE;
+    trng_t trng;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = memset_s(&trng, sizeof(trng), 0, sizeof(trng));
+    if (ret != 0) {
+        HI_LOG_PRINT_FUNC_ERR(memset_s, ret);
+        return HI_ERR_CIPHER_MEMSET_S_FAILED;
+    }
+
+    trng.timeout = timeout;
+
+    ret = CRYPTO_IOCTL(CRYPTO_CMD_TRNG, &trng);
+    if (ret != HI_SUCCESS) {
+        return ret;
+    }
+
+    *randnum = trng.randnum;
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/** @}*/  /** <!-- ==== API Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/sys_cipher.h
+++ b/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/sys_cipher.h
@@ -1,0 +1,310 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : sys_cipher.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __SYS_CIPHER_H__
+#define __SYS_CIPHER_H__
+
+#include "hi_mpi_cipher.h"
+#include "user_osal_lib.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif    /* __cplusplus */
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      mpi */
+/** @{ */  /** <!--[mpi]*/
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      crypto*/
+/** @{*/  /** <!-- [link]*/
+
+/**
+\brief   mpi Init.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 sys_symc_init(hi_void);
+
+/**
+\brief   Kapi Deinit.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 sys_symc_deinit(hi_void);
+
+/**
+\brief   Create symc handle.
+\param[in]  id The channel number.
+\param[in]  uuid The user identification.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 sys_symc_create(hi_u32 *id);
+
+/**
+\brief   Destroy symc handle.
+\param[in]  id The channel number.
+\param[in]  uuid The user identification.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 sys_symc_destroy(hi_u32 id);
+
+/**
+\brief  set work params.
+* \param[in]  id            The channel number.
+* \param[in]  hard_key      whether use the hard key or not.
+* \param[in]  alg           The symmetric cipher algorithm.
+* \param[in]  work_mode     The symmetric cipher mode.
+* \param[in]  bit_width     The symmetric cipher bit width.
+* \param[in]  key_len       The symmetric cipher key len.
+* \param[in]  sm1_round_num The round number of sm1.
+* \param[in]  fkey          first key buffer, defualt
+* \param[in]  skey          second key buffer, expand
+* \param[in]  keylen        The length of fkey buffer,if skey is not null,equal to the length of skey.
+* \param[in]  iv            iv buffer.
+* \param[in]  ivlen         The length of iv buffer.
+* \param[in]  iv_usage      iv change.
+* \param[in]  aad           Associated Data
+* \param[in]  alen          Associated Data Length
+* \param[in]  tlen          Tag length
+\retval       On success,   HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 sys_symc_config(hi_u32 id,
+                    hi_u32 hard_key,
+                    hi_cipher_alg alg,
+                    hi_cipher_work_mode work_mode,
+                    hi_cipher_bit_width bit_width,
+                    hi_cipher_key_length key_len,
+                    hi_cipher_sm1_round sm1_round_num,
+                    hi_u8 *fkey, hi_u8 *skey, hi_u32 keylen,
+                    hi_u8 *iv, hi_u32 ivlen, hi_u32 iv_usage,
+                    compat_addr aad, hi_u32 alen, hi_u32 tlen);
+
+
+/**
+\brief  get work params.
+* \param[in]  id The channel number.
+* \param[out] ctrl infomation.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 sys_symc_get_config(hi_u32 id, hi_cipher_ctrl *ctrl);
+
+/**
+ * \brief          SYMC  buffer encryption/decryption.
+ *
+ * Note: Due to the nature of aes you should use the same key schedule for
+ * both encryption and decryption.
+ *
+ * \param[in] id   The channel number.
+ * \param input    buffer holding the input data
+ * \param output   buffer holding the output data
+ * \param length   length of the input data
+ * \param decrypt  decrypt or encrypt
+ *
+ * \return         0 if successful
+ */
+hi_s32 sys_symc_crypto(hi_u32 id, const compat_addr input,
+                       const compat_addr output, hi_u32 length,
+                       hi_u32 operation);
+
+/**
+ * \brief          SYMC multiple buffer encryption/decryption.
+ *
+ * Note: Due to the nature of aes you should use the same key schedule for
+ * both encryption and decryption.
+ *
+ * \param[in]  id The channel number.
+ * \param pkg       Buffer of package infomation
+ * \param pkg_num   Number of package infomation
+ * \param decrypt   decrypt or encrypt
+ *
+ * \return         0 if successful
+ */
+hi_s32 sys_symc_crypto_multi(hi_u32 id, const hi_void *pkg,
+                             hi_u32 pkg_num, hi_u32 operation);
+
+/**
+ * \brief          SYMC multiple buffer encryption/decryption.
+ * \param[in]  id The channel number.
+ * \param[in]  tag tag data of CCM/GCM
+ * \param uuid uuid The user identification.
+ *
+ * \return         0 if successful
+ */
+hi_s32 sys_aead_get_tag(hi_u32 id, hi_u8 *tag, hi_u32 *taglen);
+
+/**
+ * \brief       Klad encrypt clear key.
+ * \keysel[in]  keysel root key seclect.
+ * \param[in]   target target seclect
+ * \param[in]   clear clear key
+ * \param[out]  encrypt encrypt key
+ * \param uuid  uuid The user identification.
+ *
+ * \return         0 if successful
+ */
+hi_s32 sys_klad_encrypt_key(hi_u32 keysel, hi_u32 target,
+                            const hi_u8 clear[AES_BLOCK_SIZE],
+                            hi_u8 encrypt[AES_BLOCK_SIZE]);
+
+/**
+\brief   Kapi Init.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 sys_hash_init(hi_void);
+
+/**
+\brief   Kapi Deinit.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 sys_hash_deinit(hi_void);
+
+/**
+ * \brief          HASH context setup.
+ *
+ *
+ * \param[out] id The channel number.
+ * \param[in] type    Hash type
+ * \param[in] key     hmac key
+ * \param[in] keylen  hmac key length
+ *
+ * \return         0 if successful
+ */
+hi_s32 sys_hash_start(hi_u32 *id, hi_cipher_hash_type type,
+                      const hi_u8 *key, hi_u32 keylen);
+
+/**
+ * \brief          HASH process buffer.
+ *
+ * \param[in] id       The channel number.
+ * \param[in] input    buffer holding the input data
+ * \param[in] length   length of the input data
+ * \param[in] src      source of hash message
+ *
+ * \return         0 if successful
+ */
+hi_s32 sys_hash_update(hi_u32 id, const hi_u8 *input, hi_u32 length,
+                       hash_chunk_src src);
+
+/**
+ * \brief          HASH final digest.
+ *
+ * \param[in]  id      The channel number.
+ * \param[out] hash    buffer holding the hash data
+ * \param[out] hashlen length of the hash data
+ * \param[in]  uuid    uuid The user identification.
+ *
+ * \return         0 if successful
+ */
+hi_s32 sys_hash_finish(hi_u32 id, hi_u8 *hash, hi_u32 *hashlen);
+
+/**
+\brief   Kapi Init.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 sys_rsa_init(hi_void);
+
+/**
+\brief   Kapi Deinitialize.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 sys_rsa_deinit(hi_void);
+
+/**
+* \brief RSA encryption a plaintext with a RSA private key.
+*
+* \param[in] key:     rsa key struct.
+* \param[in] scheme:  rsa encrypt/decrypt scheme.
+* \param[in] in:      input data to be encryption
+* \param[out] inlen:  length of input data to be encryption
+* \param[out] out:    output data of encryption
+* \param[out] outlen: length of output data to be encryption
+* \retval HI_SUCCESS  Call this API successful
+* \retval HI_FAILURE  Call this API fails.
+*/
+hi_s32 sys_rsa_encrypt(const cryp_rsa_key *key,
+                       hi_cipher_rsa_enc_scheme scheme,
+                       const hi_u8 *in, hi_u32 inlen,
+                       hi_u8 *out, hi_u32 *outlen);
+
+/**
+* \brief RSA decryption a ciphertext with a RSA public key.
+*
+* \param[in] key:     rsa key struct.
+* \param[in] scheme:  rsa encrypt/decrypt scheme.
+* \param[in] in:      input data to be encryption
+* \param[in] inlen:   length of input data to be encryption
+* \param[out] out:    output data to be encryption
+* \param[out] outlen: length of output data to be encryption
+* \retval HI_SUCCESS  Call this API successful
+* \retval HI_FAILURE  Call this API fails.
+*/
+hi_s32 sys_rsa_decrypt(const cryp_rsa_key *key,
+                       hi_cipher_rsa_enc_scheme scheme,
+                       const hi_u8 *in, hi_u32 inlen,
+                       hi_u8 *out, hi_u32 *outlen);
+
+/**
+* \brief RSA signature a context with appendix, where a signer's RSA private key is used.
+*
+* \param[in] key:     rsa key struct.
+* \param[in] scheme:  rsa signature/verify scheme.
+* \param[in] in:      input data to be encryption
+* \param[in] inlen:   length of input data to be encryption
+* \param[in] hash:    hash value of context,if NULL, let hash = Hash(context) automatically
+* \param[out] out:    output data to be encryption
+* \param[out] outlen: length of output data to be encryption
+* \param[in]  src     source of hash message
+* \param[in]  uuid    uuid The user identification.
+* \retval HI_SUCCESS  Call this API successful
+* \retval HI_FAILURE  Call this API fails.
+*/
+hi_s32 sys_rsa_sign_hash(const cryp_rsa_key *key,
+                         hi_cipher_rsa_sign_scheme scheme,
+                         const hi_u8 *hash, hi_u32 hlen,
+                         hi_u8 *sign, hi_u32 *signlen);
+
+/**
+* \brief RSA verify a ciphertext with a RSA public key.
+*
+* \param[in]  key_info:encryption struct.
+* \param[in]  in:     input data to be encryption
+* \param[in]  inlen:  length of input data to be encryption
+* \param[in]  hash:   hash value of context,if NULL, let hash = Hash(context) automatically
+* \param[out] out:    output data to be encryption
+* \param[out] outlen: length of output data to be encryption
+* \param[in]  src     source of hash message
+* \param[in]  uuid    uuid The user identification.
+* \retval HI_SUCCESS  Call this API successful
+* \retval HI_FAILURE  Call this API fails.
+*/
+hi_s32 sys_rsa_verify_hash(const cryp_rsa_key *key,
+                           hi_cipher_rsa_sign_scheme scheme,
+                           const hi_u8 *hash, hi_u32 hlen,
+                           const hi_u8 *sign, hi_u32 signlen);
+
+/**
+\brief get rand number.
+\param[out]  randnum rand number.
+\param[in]   timeout time out.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 sys_trng_get_random( hi_u32 *randnum, hi_u32 timeout);
+
+/** @}*/  /** <!-- ==== API Code end ====*/
+
+#ifdef __cplusplus
+}
+#endif    /* __cplusplus */
+
+#endif    /* End of #ifndef __MPI_CIPHER_H__*/

--- a/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/unf_cipher.c
+++ b/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/unf_cipher.c
@@ -1,0 +1,489 @@
+/******************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : unf_cipher.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "hi_mpi_cipher.h"
+#include "user_osal_lib.h"
+
+HI_S32 HI_UNF_CIPHER_Init()
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_init();
+    if (ret != HI_SUCCESS)
+    {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_init, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_DeInit(HI_VOID)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_deinit();
+    if (ret != HI_SUCCESS)
+    {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_deinit, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_CreateHandle(HI_HANDLE *phCipher,
+                                  const HI_UNF_CIPHER_ATTS_S *pstCipherAttr)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_create_handle(phCipher, (hi_cipher_atts *)pstCipherAttr);
+    if (ret != HI_SUCCESS)
+    {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_create_handle, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_DestroyHandle(HI_HANDLE hCipher)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_destroy_handle(hCipher);
+    if (ret != HI_SUCCESS)
+    {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_destroy_handle, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_ConfigHandle(HI_HANDLE hCipher,
+                                  const HI_UNF_CIPHER_CTRL_S *pstCtrl)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_config_handle(hCipher, (hi_cipher_ctrl *)pstCtrl);
+    if (ret != HI_SUCCESS)
+    {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_config_handle, ret);
+        return ret;
+    }
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_ConfigHandleEx(HI_HANDLE hCipher,
+                                    const HI_UNF_CIPHER_CTRL_EX_S *pstExCtrl)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_config_handle_ex(hCipher, (hi_cipher_ctrl_ex *)pstExCtrl);
+    if (ret != HI_SUCCESS)
+    {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_config_handle_ex, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_Encrypt(HI_HANDLE hCipher,
+                             HI_SIZE_T u32SrcPhyAddr,
+                             HI_SIZE_T u32DestPhyAddr,
+                             HI_U32 u32ByteLength)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_encrypt(hCipher, u32SrcPhyAddr,
+                                u32DestPhyAddr, u32ByteLength);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_encrypt, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_Decrypt(HI_HANDLE hCipher,
+                             HI_SIZE_T u32SrcPhyAddr,
+                             HI_SIZE_T u32DestPhyAddr,
+                             HI_U32 u32ByteLength)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_decrypt(hCipher, u32SrcPhyAddr,
+                                u32DestPhyAddr, u32ByteLength);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_decrypt, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_EncryptVir(HI_HANDLE hCipher,
+                                const HI_U8 *pu8SrcData,
+                                HI_U8 *pu8DestData,
+                                HI_U32 u32ByteLength)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_encrypt_vir(hCipher, pu8SrcData, pu8DestData, u32ByteLength);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_encrypt_vir, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_DecryptVir(HI_HANDLE hCipher,
+                                const HI_U8 *pu8SrcData,
+                                HI_U8 *pu8DestData,
+                                HI_U32 u32ByteLength)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_decrypt_vir(hCipher, pu8SrcData, pu8DestData, u32ByteLength);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_decrypt_vir, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_EncryptMulti(HI_HANDLE hCipher,
+                                const HI_UNF_CIPHER_DATA_S *pstDataPkg,
+                                HI_U32 u32DataPkgNum)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_encrypt_multi(hCipher,
+                                      (hi_cipher_data *)pstDataPkg,
+                                      u32DataPkgNum);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_encrypt_multi, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_DecryptMulti(HI_HANDLE hCipher,
+                                  const HI_UNF_CIPHER_DATA_S *pstDataPkg,
+                                  HI_U32 u32DataPkgNum)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_decrypt_multi(hCipher,
+                                      (hi_cipher_data *)pstDataPkg,
+                                      u32DataPkgNum);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_decrypt_multi, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_GetTag(HI_HANDLE hCipher, HI_U8 *pu8Tag, HI_U32 *pu32TagLen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_get_tag(hCipher, pu8Tag, pu32TagLen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_get_tag, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_GetHandleConfig(HI_HANDLE hCipherHandle,
+                                     HI_UNF_CIPHER_CTRL_S *pstCtrl)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_get_handle_config(hCipherHandle, (hi_cipher_ctrl *)pstCtrl);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_get_handle_config, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_KladEncryptKey(HI_UNF_CIPHER_CA_TYPE_E enRootKey,
+                                    HI_UNF_CIPHER_KLAD_TARGET_E enTarget,
+                                    const HI_U8 *pu8CleanKey,
+                                    HI_U8 *pu8EcnryptKey,
+                                    HI_U32 u32KeyLen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_klad_encrypt_key((hi_cipher_ca_type)enRootKey,
+                                         (hi_cipher_klad_target)enTarget,
+                                         pu8CleanKey,
+                                         pu8EcnryptKey,
+                                         u32KeyLen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_klad_encrypt_key, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_GetRandomNumber(HI_U32 *pu32RandomNumber)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_get_random_number(pu32RandomNumber);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_get_random_number, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_HashInit(const HI_UNF_CIPHER_HASH_ATTS_S *pstHashAttr,
+                              HI_HANDLE *pHashHandle)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_hash_init((hi_cipher_hash_atts *)pstHashAttr,
+                                  pHashHandle);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_hash_init, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_HashUpdate(HI_HANDLE hHashHandle,
+                                const HI_U8 *pu8InputData,
+                                HI_U32 u32InputDataLen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_hash_update(hHashHandle, pu8InputData, u32InputDataLen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_hash_update, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_HashFinal(HI_HANDLE hHashHandle, HI_U8 *pu8OutputHash)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_hash_final(hHashHandle, pu8OutputHash);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_hash_final, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_RsaPublicEncrypt(const HI_UNF_CIPHER_RSA_PUB_ENC_S *pstRsaEnc,
+                                      const HI_U8 *pu8Input, HI_U32 u32InLen,
+                                      HI_U8 *pu8Output, HI_U32 *pu32OutLen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_rsa_public_encrypt((hi_cipher_rsa_pub_enc *)pstRsaEnc,
+                                           pu8Input, u32InLen,
+                                           pu8Output, pu32OutLen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_rsa_public_encrypt, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+
+}
+
+HI_S32 HI_UNF_CIPHER_RsaPrivateDecrypt(const HI_UNF_CIPHER_RSA_PRI_ENC_S *pstRsaDec,
+                                       const HI_U8 *pu8Input, HI_U32 u32InLen,
+                                       HI_U8 *pu8Output, HI_U32 *pu32OutLen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_rsa_private_decrypt((hi_cipher_rsa_pri_enc *)pstRsaDec,
+                                            pu8Input, u32InLen,
+                                            pu8Output, pu32OutLen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_rsa_private_decrypt, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_RsaPrivateEncrypt(const HI_UNF_CIPHER_RSA_PRI_ENC_S *pstRsaEnc,
+                                       const HI_U8 *pu8Input, HI_U32 u32InLen,
+                                       HI_U8 *pu8Output, HI_U32 *pu32OutLen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_rsa_private_encrypt((hi_cipher_rsa_pri_enc *)pstRsaEnc,
+                                            pu8Input, u32InLen,
+                                            pu8Output, pu32OutLen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_rsa_private_encrypt, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+
+HI_S32 HI_UNF_CIPHER_RsaPublicDecrypt(const HI_UNF_CIPHER_RSA_PUB_ENC_S *pstRsaDec,
+                                      const HI_U8 *pu8Input, HI_U32 u32InLen,
+                                      HI_U8 *pu8Output, HI_U32 *pu32OutLen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_rsa_public_decrypt((hi_cipher_rsa_pub_enc *)pstRsaDec,
+        pu8Input, u32InLen, pu8Output, pu32OutLen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_rsa_public_decrypt, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_RsaSign(const HI_UNF_CIPHER_RSA_SIGN_S *pstRsaSign,
+                             const HI_U8 *pu8InData, HI_U32 u32InDataLen,
+                             const HI_U8 *pu8HashData,
+                             HI_U8 *pu8OutSign, HI_U32 *pu32OutSignLen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_rsa_sign((hi_cipher_rsa_sign *)pstRsaSign,
+                                 pu8InData, u32InDataLen,
+                                 pu8HashData,
+                                 pu8OutSign, pu32OutSignLen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_rsa_sign, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+HI_S32 HI_UNF_CIPHER_RsaVerify(const HI_UNF_CIPHER_RSA_VERIFY_S *pstRsaVerify,
+                               const HI_U8 *pu8InData, HI_U32 u32InDataLen,
+                               const HI_U8 *pu8HashData,
+                               const HI_U8 *pu8InSign, HI_U32 u32InSignLen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_UNF_FUNC_ENTER();
+
+    ret = hi_mpi_cipher_rsa_verify((hi_cipher_rsa_verify*)pstRsaVerify,
+                                   pu8InData, u32InDataLen,
+                                   pu8HashData,
+                                   pu8InSign, u32InSignLen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_mpi_cipher_rsa_verify, ret);
+        return ret;
+    }
+
+    HI_UNF_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/** @}*/  /** <!-- ==== Compat Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/user_osal_lib.c
+++ b/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/user_osal_lib.c
@@ -1,0 +1,85 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : user_osal_lib.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "user_osal_lib.h"
+
+/************************ Internal Structure Definition **********************/
+/** \addtogroup      lib */
+/** @{*/  /** <!-- [osal]*/
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      osal lib */
+/** @{*/  /** <!-- [osal]*/
+
+#ifndef __HuaweiLite__
+void hex2str(char buf[2], hi_u8 val)
+{
+    hi_u8 high, low;
+
+    high = (val >> 4) & 0x0F;
+    low =  val & 0x0F;
+
+    if (high <= 9) {
+        buf[0] = high + '0';
+    } else {
+        buf[0] = (high - 0x0A) + 'A';
+    }
+
+    if (low <= 9) {
+        buf[1] = low + '0';
+    } else {
+        buf[1] = (low - 0x0A) + 'A';
+    }
+
+}
+
+
+/* Implementation that should never be optimized out by the compiler */
+hi_void crypto_zeroize( hi_void *buf, hi_u32 len )
+{
+    volatile unsigned char *p = (unsigned char *)buf;
+
+    if (HI_NULL == buf) {
+        return;
+    }
+
+    while (len--) {
+        *p++ = 0;
+    }
+}
+#endif
+
+hi_void print_string(const hi_s8 *name, hi_u8 *string, hi_u32 size)
+{
+#ifdef HI_CIPHER_TEST_SUPPORT
+    hi_u32 i;
+    hi_s8 buf[4] = {0};
+
+    if (name != HI_NULL) {
+        HI_PRINT("[%s-%p]:\n", name, string);
+    }
+    for (i = 0; i < size; i++) {
+        hex2str(buf, string[i]);
+        HI_PRINT("%c%c ", buf[0], buf[1]);
+        if (((i + 1) % 16) == 0)
+        { HI_PRINT("\n"); }
+    }
+    if (( i % 16) != 0) {
+        HI_PRINT("\n");
+    }
+#endif
+}
+
+/** @}*/  /** <!-- ==== API Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/user_osal_lib.h
+++ b/kernel/cipher/hi3516ev200/src/api/cipher_v1.0/user_osal_lib.h
@@ -1,0 +1,207 @@
+/******************************************************************************
+
+  Copyright (C), 2011-2014, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : user_osal_lib.h
+  Version       : Initial Draft
+  Author        : Hisilicon hisecurity team
+  Created       :
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+
+#ifndef __USER_OSAL_LIB_H__
+#define __USER_OSAL_LIB_H__
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <sys/time.h>
+#include "hi_osal.h"
+#include "hi_types.h"
+#include "hi_debug.h"
+#include "drv_cipher_kapi.h"
+#include "hi_unf_cipher.h"
+#include "sys_cipher.h"
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/*! \****************************** API Declaration *****************************/
+/*! \addtogroup    osal lib */
+/** @{ */  /** <!--[osal]*/
+
+#ifndef HI_PRINT
+#define HI_PRINT                    printf
+#endif
+
+#define crypto_malloc(x)            malloc(x)
+#define crypto_free(x)              free(x)
+
+#define crypto_mutex                pthread_mutex_t
+#define crypto_mutex_init(x)        (hi_void)pthread_mutex_init(x, NULL)
+#define crypto_mutex_lock(x)        (hi_void)pthread_mutex_lock(x)
+#define crypto_mutex_unlock(x)      (hi_void)pthread_mutex_unlock(x)
+#define crypto_mutex_destroy(x)     pthread_mutex_destroy(x)
+
+#define crypto_open(a, b, c)        open(a, b, c)
+#define crypto_close(x)             close(x)
+
+extern hi_s32 cipher_dev_fd;
+#define CRYPTO_IOCTL(cmd, argp)     ioctl(cipher_dev_fd, cmd, argp)
+
+void print_string(const hi_s8 *name, hi_u8 *string, hi_u32 size);
+
+/* Implementation that should never be optimized out by the compiler */
+void crypto_zeroize( hi_void *buf, hi_u32 len );
+
+/**< allow modules to modify, default value is HI_ID_STB, the general module id*/
+#define LOG_D_MODULE_ID             HI_ID_CIPHER
+#define LOG_D_FUNCTRACE             (0)
+#define LOG_D_UNFTRACE              (0)
+
+/**< allow modules to define internel error code, from 0x1000*/
+#define LOG_ERRCODE_DEF(errid)      (hi_u32)(((LOG_D_MODULE_ID) << 16)  | (errid))
+
+/**< General Error Code, All modules can extend according to the rule */
+#define HI_LOG_ERR_MEM              LOG_ERRCODE_DEF(0x0001)      /**< Memory Operation Error */
+#define HI_LOG_ERR_SEM              LOG_ERRCODE_DEF(0x0002)      /**< Semaphore Operation Error */
+#define HI_LOG_ERR_FILE             LOG_ERRCODE_DEF(0x0003)      /**< File Operation Error */
+#define HI_LOG_ERR_LOCK             LOG_ERRCODE_DEF(0x0004)      /**< Lock Operation Error */
+#define HI_LOG_ERR_PARAM            LOG_ERRCODE_DEF(0x0005)      /**< Invalid Parameter */
+#define HI_LOG_ERR_TIMER            LOG_ERRCODE_DEF(0x0006)      /**< Timer error */
+#define HI_LOG_ERR_THREAD           LOG_ERRCODE_DEF(0x0007)      /**< Thread Operation Error */
+#define HI_LOG_ERR_TIMEOUT          LOG_ERRCODE_DEF(0x0008)      /**< Time Out Error */
+#define HI_LOG_ERR_DEVICE           LOG_ERRCODE_DEF(0x0009)      /**< Device Operation Error */
+#define HI_LOG_ERR_STATUS           LOG_ERRCODE_DEF(0x0010)      /**< Status Error */
+#define HI_LOG_ERR_IOCTRL           LOG_ERRCODE_DEF(0x0011)      /**< IO Operation Error */
+#define HI_LOG_ERR_INUSE            LOG_ERRCODE_DEF(0x0012)      /**< In use */
+#define HI_LOG_ERR_EXIST            LOG_ERRCODE_DEF(0x0013)      /**< Have exist */
+#define HI_LOG_ERR_NOEXIST          LOG_ERRCODE_DEF(0x0014)      /**< no exist */
+#define HI_LOG_ERR_UNSUPPORTED      LOG_ERRCODE_DEF(0x0015)      /**< Unsupported */
+#define HI_LOG_ERR_UNAVAILABLE      LOG_ERRCODE_DEF(0x0016)      /**< Unavailable */
+#define HI_LOG_ERR_UNINITED         LOG_ERRCODE_DEF(0x0017)      /**< Uninited */
+#define HI_LOG_ERR_DATABASE         LOG_ERRCODE_DEF(0x0018)      /**< Database Operation Error */
+#define HI_LOG_ERR_OVERFLOW         LOG_ERRCODE_DEF(0x0019)      /**< Overflow */
+#define HI_LOG_ERR_EXTERNAL         LOG_ERRCODE_DEF(0x0020)      /**< External Error */
+#define HI_LOG_ERR_UNKNOWNED        LOG_ERRCODE_DEF(0x0021)      /**< Unknow Error */
+#define HI_LOG_ERR_FLASH            LOG_ERRCODE_DEF(0x0022)      /**< Flash Operation Error*/
+#define HI_LOG_ERR_ILLEGAL_IMAGE    LOG_ERRCODE_DEF(0x0023)      /**< Illegal Image */
+#define HI_LOG_ERR_ILLEGAL_UUID     LOG_ERRCODE_DEF(0x0023)      /**< Illegal UUID */
+#define HI_LOG_ERR_NOPERMISSION     LOG_ERRCODE_DEF(0x0023)      /**< No Permission */
+
+#define HI_LOG_FATAL(fmt...) \
+    do{ \
+        printf("[FATAL-HI_CIPHER]:%s[%d]:",(hi_u8*)__FUNCTION__,__LINE__); \
+        printf(fmt); \
+    }while(0)
+#define HI_LOG_ERROR(fmt...) \
+    do{ \
+        printf("[ERROR-HI_CIPHER]:%s[%d]:",(hi_u8*)__FUNCTION__,__LINE__); \
+        printf(fmt); \
+    }while(0)
+
+#define HI_LOG_WARN(fmt...)
+#define HI_LOG_INFO(fmt...)
+#define HI_LOG_DEBUG(fmt...)
+
+/**< Function trace log, strictly prohibited to expand */
+#define HI_LOG_PRINT_FUNC_WAR(func, err_code)  HI_LOG_WARN("Call %s return [0x%08X]\n", #func, err_code);
+#define HI_LOG_PRINT_FUNC_ERR(func, err_code)  HI_LOG_ERROR("Call %s return [0x%08X]\n", #func, err_code);
+#define HI_LOG_PRINT_ERR_CODE(err_code)        HI_LOG_ERROR("Error Code: [0x%08X]\n", err_code);
+
+/**< Used for displaying more detailed error information */
+#define HI_ERR_PRINT_S32(val)                HI_LOG_ERROR("%s = %d\n",        #val, val)
+#define HI_ERR_PRINT_U32(val)                HI_LOG_ERROR("%s = %u\n",        #val, val)
+#define HI_ERR_PRINT_S64(val)                HI_LOG_ERROR("%s = %lld\n",      #val, val)
+#define HI_ERR_PRINT_U64(val)                HI_LOG_ERROR("%s = %llu\n",      #val, val)
+#define HI_ERR_PRINT_H32(val)                HI_LOG_ERROR("%s = 0x%08X\n",    #val, val)
+#define HI_ERR_PRINT_H64(val)                HI_LOG_ERROR("%s = 0x%016llX\n", #val, val)
+#define HI_ERR_PRINT_STR(val)                HI_LOG_ERROR("%s = %s\n",        #val, val)
+#define HI_ERR_PRINT_VOID(val)               HI_LOG_ERROR("%s = %p\n",        #val, val)
+#define HI_ERR_PRINT_FLOAT(val)              HI_LOG_ERROR("%s = %f\n",        #val, val)
+#define HI_ERR_PRINT_INFO(val)               HI_LOG_ERROR("<%s>\n", val)
+
+/**< Used for displaying more detailed warning information */
+#define HI_LOG_PRINT_S32(val)                HI_LOG_WARN("%s = %d\n",        #val, val)
+#define HI_LOG_PRINT_U32(val)                HI_LOG_WARN("%s = %u\n",        #val, val)
+#define HI_LOG_PRINT_S64(val)                HI_LOG_WARN("%s = %lld\n",      #val, val)
+#define HI_LOG_PRINT_U64(val)                HI_LOG_WARN("%s = %llu\n",      #val, val)
+#define HI_LOG_PRINT_H32(val)                HI_LOG_WARN("%s = 0x%08X\n",    #val, val)
+#define HI_LOG_PRINT_H64(val)                HI_LOG_WARN("%s = 0x%016llX\n", #val, val)
+#define HI_LOG_PRINT_STR(val)                HI_LOG_WARN("%s = %s\n",        #val, val)
+#define HI_LOG_PRINT_VOID(val)               HI_LOG_WARN("%s = %p\n",        #val, val)
+#define HI_LOG_PRINT_FLOAT(val)              HI_LOG_WARN("%s = %f\n",        #val, val)
+#define HI_LOG_PRINT_INFO(val)               HI_LOG_WARN("<%s>\n", val)
+
+/**< Only used for self debug, Can be expanded as needed */
+#define HI_DBG_PRINT_S32(val)                HI_LOG_DEBUG("%s = %d\n",       #val, val)
+#define HI_DBG_PRINT_U32(val)                HI_LOG_DEBUG("%s = %u\n",       #val, val)
+#define HI_DBG_PRINT_S64(val)                HI_LOG_DEBUG("%s = %lld\n",     #val, val)
+#define HI_DBG_PRINT_U64(val)                HI_LOG_DEBUG("%s = %llu\n",     #val, val)
+#define HI_DBG_PRINT_H32(val)                HI_LOG_DEBUG("%s = 0x%08X\n",   #val, val)
+#define HI_DBG_PRINT_H64(val)                HI_LOG_DEBUG("%s = 0x%016llX\n",#val, val)
+#define HI_DBG_PRINT_STR(val)                HI_LOG_DEBUG("%s = %s\n",       #val, val)
+#define HI_DBG_PRINT_VOID(val)               HI_LOG_DEBUG("%s = %p\n",       #val, val)
+#define HI_DBG_PRINT_FLOAT(val)              HI_LOG_DEBUG("%s = %f\n",       #val, val)
+#define HI_DBG_PRINT_INFO(val)               HI_LOG_DEBUG("<%s>\n", val)
+
+#if (LOG_D_FUNCTRACE == 1) || (LOG_D_UNFTRACE == 1)
+#define HI_UNF_FUNC_ENTER()                  HI_LOG_DEBUG(" >>>>>>[Enter]\n")    /**< Only used for unf interface */
+#define HI_UNF_FUNC_EXIT()                   HI_LOG_DEBUG(" <<<<<<[Exit]\n")     /**< Only used for unf interface */
+#else
+#define HI_UNF_FUNC_ENTER()
+#define HI_UNF_FUNC_EXIT()
+#endif
+
+#if LOG_D_FUNCTRACE
+#define HI_LOG_FUNC_ENTER()                  HI_LOG_DEBUG(" =====>[Enter]\n")    /**< Used for all interface except unf */
+#define HI_LOG_FUNC_EXIT()                   HI_LOG_DEBUG(" =====>[Exit]\n")     /**< Used for all interface except unf */
+#else
+#define HI_LOG_FUNC_ENTER()
+#define HI_LOG_FUNC_EXIT()
+#endif
+
+#define HI_LOG_CHECK(fn_func)                                  \
+    do                                                         \
+    {                                                          \
+        hi_s32 _i_err_code = fn_func;                          \
+        if (_i_err_code != HI_SUCCESS)                         \
+        {                                                      \
+            HI_LOG_PRINT_FUNC_ERR(#fn_func, _i_err_code);      \
+        }                                                      \
+    } while (0)
+
+
+#define HI_LOG_CHECK_PARAM(_val)                               \
+    do                                                         \
+    {                                                          \
+        if (_val)                                              \
+        {                                                      \
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA); \
+            return HI_ERR_CIPHER_INVALID_PARA;                 \
+        }                                                      \
+    } while (0)
+
+
+#define HI_LOG_CHECK_INITED(_init_count)                       \
+    do                                                         \
+    {                                                          \
+        if (_init_count == 0)                                  \
+        {                                                      \
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_NOT_INIT);     \
+            return HI_ERR_CIPHER_NOT_INIT;                     \
+        }                                                      \
+    } while (0)
+
+
+#define HI_LOG_PRINT_BLOCK(data, length)
+
+#endif  /* End of #ifndef __USER_OSAL_LIB_H__*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_initdevice.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_initdevice.c
@@ -1,0 +1,106 @@
+#include "hi_types.h"
+#include "drv_osal_lib.h"
+
+extern int  cipher_drv_mod_init(void);
+extern void cipher_drv_mod_exit(void);
+
+#ifndef __HuaweiLite__
+#ifdef IRQ_DTS_SUPPORT
+#include <linux/of_platform.h>
+
+static int hi35xx_cipher_probe(struct platform_device *pdev)
+{
+    hi_u32 irq_num = 0;
+
+#if defined(ARCH_TYPE_amp) && !defined(CRYPTO_SEC_CPU)
+    irq_num = platform_get_irq_byname(pdev, "nonsec_cipher");
+    if (irq_num <= 0) {
+        dev_err(&pdev->dev, "cannot find cipher IRQ\n");
+        return -1;
+    }
+    module_set_irq(CRYPTO_MODULE_ID_SYMC, irq_num);
+
+    irq_num = platform_get_irq_byname(pdev, "nonsec_hash");
+    if (irq_num <= 0) {
+        dev_err(&pdev->dev, "cannot find trng IRQ\n");
+        return -1;
+    }
+    module_set_irq(CRYPTO_MODULE_ID_HASH, irq_num);
+
+    irq_num = platform_get_irq_byname(pdev, "nonsec_rsa");
+    if (irq_num <= 0) {
+        dev_err(&pdev->dev, "cannot find rsa IRQ\n");
+        return -1;
+    }
+    module_set_irq(CRYPTO_MODULE_ID_IFEP_RSA, irq_num);
+#else
+    irq_num = platform_get_irq_byname(pdev, "cipher");
+    if (irq_num <= 0) {
+        dev_err(&pdev->dev, "cannot find cipher IRQ\n");
+        return -1;
+    }
+    module_set_irq(CRYPTO_MODULE_ID_SYMC, irq_num);
+
+    irq_num = platform_get_irq_byname(pdev, "hash");
+    if (irq_num <= 0) {
+        dev_err(&pdev->dev, "cannot find trng IRQ\n");
+        return -1;
+    }
+    module_set_irq(CRYPTO_MODULE_ID_HASH, irq_num);
+
+    irq_num = platform_get_irq_byname(pdev, "rsa");
+    if (irq_num <= 0) {
+        dev_err(&pdev->dev, "cannot find rsa IRQ\n");
+        return -1;
+    }
+    module_set_irq(CRYPTO_MODULE_ID_IFEP_RSA, irq_num);
+#endif
+
+    if (cipher_drv_mod_init() != HI_SUCCESS) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int hi35xx_cipher_remove(struct platform_device *pdev)
+{
+    cipher_drv_mod_exit();
+
+    return 0;
+}
+
+static const struct of_device_id hi35xx_cipher_match[] = {
+    { .compatible = "hisilicon,hisi-cipher" },
+    {},
+};
+MODULE_DEVICE_TABLE(of, hi35xx_cipher_match);
+
+static struct platform_driver hi35xx_cipher_driver = {
+    .probe          = hi35xx_cipher_probe,
+    .remove         = hi35xx_cipher_remove,
+    .driver         = {
+        .name   = "hi35xx_cipher",
+        .of_match_table = hi35xx_cipher_match,
+    },
+};
+
+module_platform_driver(hi35xx_cipher_driver);
+MODULE_LICENSE("GPL");
+#else
+static int __init cipher_mod_init(void)
+{
+    return cipher_drv_mod_init();
+}
+
+static void __exit cipher_mod_exit(void)
+{
+    cipher_drv_mod_exit();
+}
+
+module_init(cipher_mod_init);
+module_exit(cipher_mod_exit);
+
+MODULE_LICENSE("Proprietary");
+#endif
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_initdevice.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_initdevice.c
@@ -63,11 +63,11 @@ static int hi35xx_cipher_probe(struct platform_device *pdev)
     return 0;
 }
 
-static int hi35xx_cipher_remove(struct platform_device *pdev)
+static compat_platform_remove_ret hi35xx_cipher_remove(struct platform_device *pdev)
 {
     cipher_drv_mod_exit();
 
-    return 0;
+    compat_platform_remove_return;
 }
 
 static const struct of_device_id hi35xx_cipher_match[] = {

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/build.mak
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/build.mak
@@ -1,0 +1,15 @@
+CIPHER_DIR := $(CIPHER_SRC_BASE)
+
+#CFG_KAPI_TEST_SUPPORT=y
+
+CIPHER_CFLAGS += -DAMP_NONSECURE_VERSION
+
+include $(CIPHER_DIR)/drv/cipher_v1.0/drivers/build.mak
+include $(CIPHER_DIR)/drv/cipher_v1.0/osal/build.mak
+include $(CIPHER_DIR)/drv/cipher_v1.0/compat/build.mak
+
+ifeq ($(CFG_KAPI_TEST_SUPPORT),y)
+include $(CIPHER_DIR)/drv/cipher_v1.0/test/build.mak
+endif
+
+EXTRA_CFLAGS += $(CIPHER_CFLAGS)

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/build.mak
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/build.mak
@@ -1,0 +1,7 @@
+CIPHER_OBJS += drv/cipher_v1.0/compat/hi_drv_compat.o
+CIPHER_OBJS += drv/cipher_v1.0/compat/drv_klad.o
+CIPHER_OBJS += drv/cipher_v1.0/compat/hal_efuse.o
+CIPHER_OBJS += drv/cipher_v1.0/compat/hal_otp.o
+
+CIPHER_CFLAGS += -I$(CIPHER_DIR)/drv/cipher_v1.0/compat
+

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/drv_klad.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/drv_klad.c
@@ -1,0 +1,266 @@
+/******************************************************************************
+
+  Copyright (C), 2011-2014, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : spacc_intf.c
+  Version       : Initial Draft
+  Author        : Hisilicon hisecurity team
+  Created       :
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "hi_types.h"
+#include "drv_osal_lib.h"
+#include "hal_efuse.h"
+#include "hal_otp.h"
+#include "drv_cipher_kapi.h"
+
+#define KLAD_REG_BASE_ADDR                      cipher_klad_base
+#define KLAD_REG_KLAD_CTRL                      (KLAD_REG_BASE_ADDR + 0x00)
+#define KLAD_REG_DAT_IN                         (KLAD_REG_BASE_ADDR + 0x10)
+#define KLAD_REG_ENC_OUT                        (KLAD_REG_BASE_ADDR + 0x20)
+
+#define CIPHER_WAIT_IDEL_TIMES         1000
+
+static hi_u8 *cipher_klad_base = HI_NULL;
+extern hi_u8 *efuse_otp_reg_base;
+
+hi_s32 hal_cipher_klad_config(hi_u32 chn_id, hi_u32 opt_id, hi_cipher_klad_target target, hi_bool is_decrypt)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 ctrl;
+
+    /* Load efuse or OTP key to KLAD */
+    ret = hal_efuse_otp_load_cipher_key(chn_id, opt_id);
+    if (ret != HI_SUCCESS) {
+        return ret;
+    }
+
+    ctrl  = chn_id << 16;
+    ctrl |= ((hi_u32)target) << 2;     /* cipher klad */
+    ctrl |= ((hi_u32)is_decrypt) << 1; /* decrypt     */
+    ctrl |= 0x00;                      /* start       */
+
+    (hi_void)HAL_CIPHER_WRITE_REG(KLAD_REG_KLAD_CTRL, ctrl);
+
+    return HI_SUCCESS;
+}
+
+hi_void hal_cipher_start_klad(hi_u32 block_num)
+{
+    hi_u32 ctrl = 0;
+    hi_u32 high = 0;
+
+    high = (block_num == 1 ? 1 : 0);
+
+    /* start */
+    (hi_void)HAL_CIPHER_READ_REG(KLAD_REG_KLAD_CTRL, &ctrl);
+    ctrl &= ~(0x01 << 4);
+    ctrl |= high << 4;
+    ctrl |= 0x01;  /* start */
+    (hi_void)HAL_CIPHER_WRITE_REG(KLAD_REG_KLAD_CTRL, ctrl);
+}
+
+hi_void hal_cipher_set_klad_data(hi_u32 *data_in)
+{
+    hi_u32 i = 0;
+
+    for (i = 0; i < 4; i++) {
+        (hi_void)HAL_CIPHER_WRITE_REG(KLAD_REG_DAT_IN + i * 4, data_in[i]);
+    }
+}
+
+hi_void hal_cipher_get_klad_data(hi_u32 *data_out)
+{
+    hi_u32 i = 0;
+
+    for (i = 0; i < 4; i++) {
+        (hi_void)HAL_CIPHER_READ_REG(KLAD_REG_ENC_OUT + i * 4, &data_out[i]);
+    }
+}
+
+hi_s32 hal_cipher_wait_klad_done(hi_void)
+{
+    hi_u32 try_count = 0;
+    hi_u32 ctrl = 0;
+
+    do {
+        HAL_CIPHER_READ_REG(KLAD_REG_KLAD_CTRL, &ctrl);
+        if ((ctrl & 0x01) == 0x00) {
+            return HI_SUCCESS;
+        }
+        try_count++;
+    } while (try_count < CIPHER_WAIT_IDEL_TIMES);
+
+    HI_LOG_ERROR("Klad time out!\n");
+
+    return HI_FAILURE;
+
+}
+
+hi_void hal_cipher_klad_init(hi_void)
+{
+    hi_u32 crg_value = 0;
+    hi_u32 *sys_addr = HI_NULL;
+
+    sys_addr = crypto_ioremap_nocache(KLAD_CRG_ADDR_PHY, 0x100);
+    if (sys_addr == HI_NULL) {
+        HI_LOG_ERROR("ERROR: sys_addr ioremap with nocache failed!!\n");
+        return ;
+    }
+
+    HAL_CIPHER_READ_REG(sys_addr, &crg_value);
+    crg_value |= KLAD_CRG_RESET_BIT;   /* reset */
+    crg_value |= KLAD_CRG_CLOCK_BIT;   /* set the bit 0, clock opened */
+    HAL_CIPHER_WRITE_REG(sys_addr, crg_value);
+
+    /* clock select and cancel reset 0x30100*/
+    crg_value &= (~KLAD_CRG_RESET_BIT); /* cancel reset */
+    crg_value |= KLAD_CRG_CLOCK_BIT;    /* set the bit 0, clock opened */
+    HAL_CIPHER_WRITE_REG(sys_addr, crg_value);
+
+    crypto_iounmap(sys_addr, 0x100);
+}
+
+hi_s32 drv_cipher_klad_init(hi_void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    cipher_klad_base = crypto_ioremap_nocache(KLAD_REG_BASE_ADDR_PHY, 0x100);
+    if (cipher_klad_base == HI_NULL) {
+        HI_LOG_ERROR("ERROR: osal_ioremap_nocache for KLAD failed!!\n");
+        return HI_FAILURE;
+    }
+
+    ret = hal_efuse_otp_init();
+    if (ret != HI_SUCCESS) {
+        crypto_iounmap(cipher_klad_base, 0x100);
+        return ret;
+    }
+
+    hal_cipher_klad_init();
+
+    return HI_SUCCESS;
+}
+
+hi_void drv_cipher_klad_deinit(hi_void)
+{
+    if (cipher_klad_base != HI_NULL) {
+        crypto_iounmap(cipher_klad_base, 0x100);
+        cipher_klad_base = HI_NULL;
+    }
+
+    if (efuse_otp_reg_base != HI_NULL) {
+        crypto_iounmap(efuse_otp_reg_base, 0x100);
+        efuse_otp_reg_base = HI_NULL;
+    }
+
+    return ;
+}
+
+hi_void drv_cipher_input_buf(hi_u8 *buf, hi_u32 length)
+{
+    hi_u32 i;
+    hi_u8 ch;
+
+    for (i = 0; i < length / 2; i++) {
+        ch = buf[i];
+        buf[i] = buf[length - i - 1];
+        buf[length - i - 1] = ch;
+    }
+}
+
+hi_s32 drv_cipher_klad_load_key(hi_u32 chn_id,
+                              hi_cipher_ca_type root_key,
+                              hi_cipher_klad_target target,
+                              hi_u8 *data_in,
+                              hi_u32 key_len)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 i = 0;
+    hi_u32 key[4] = {0};
+    hi_u32 opt_id = 0;;
+
+    if ((root_key < HI_CIPHER_KEY_SRC_KLAD_1) ||
+        (root_key > HI_CIPHER_KEY_SRC_KLAD_3)) {
+        HI_LOG_ERROR("Error: Invalid Root Key src 0x%x!\n", root_key);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+    if (((key_len % 16 ) != 0) || (key_len == 0)) {
+        HI_LOG_ERROR("Error: Invalid key len 0x%x!\n", key_len);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+    if (data_in == HI_NULL) {
+        HI_LOG_ERROR("Error: point for input data is null!\n");
+        return HI_ERR_CIPHER_INVALID_POINT;
+    }
+
+    opt_id = root_key - HI_CIPHER_KEY_SRC_KLAD_1 + 1;
+
+    ret = hal_cipher_klad_config(chn_id, opt_id, target, HI_TRUE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("Error: cipher klad config failed!\n");
+        return ret;
+    }
+
+    for (i = 0; i < key_len / 16; i++) {
+        crypto_memcpy(key, sizeof(key), data_in + i * 16, 16);
+        hal_cipher_set_klad_data(key);
+        hal_cipher_start_klad(i);
+        ret = hal_cipher_wait_klad_done();
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("Error: cipher klad wait done failed!\n");
+            crypto_memset(key, sizeof(key), 0, sizeof(key));
+            return ret;
+        }
+    }
+
+    crypto_memset(key, sizeof(key), 0, sizeof(key));
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_cipher_klad_encrypt_key(hi_cipher_ca_type root_key,
+                                 hi_cipher_klad_target target,
+                                 hi_u32 clean_key[4],
+                                 hi_u32 encrypt_key[4])
+{
+    hi_s32 ret;
+    hi_u32 opt_id;
+
+    if ((root_key < HI_CIPHER_KEY_SRC_KLAD_1) ||
+        (root_key >= HI_CIPHER_KEY_SRC_BUTT)) {
+        HI_LOG_ERROR("Error: Invalid Root Key src 0x%x!\n", root_key);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+    if ((clean_key == HI_NULL) || (encrypt_key == HI_NULL)) {
+        HI_LOG_ERROR("Clean key or encrypt key is null.\n");
+        return HI_ERR_CIPHER_INVALID_POINT;
+    }
+
+    opt_id = root_key - HI_CIPHER_KEY_SRC_KLAD_1 + 1;
+
+    ret = hal_cipher_klad_config(0, opt_id, HI_CIPHER_KLAD_TARGET_AES, HI_FALSE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("Error: cipher klad config failed!\n");
+        return HI_FAILURE;
+    }
+
+    if (target == HI_CIPHER_KLAD_TARGET_RSA) {
+        drv_cipher_input_buf((hi_u8 *)clean_key, 16);
+    }
+
+    hal_cipher_set_klad_data(clean_key);
+    hal_cipher_start_klad(0);
+    ret = hal_cipher_wait_klad_done();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("Error: cipher klad wait done failed!\n");
+        return ret;
+    }
+    hal_cipher_get_klad_data(encrypt_key);
+
+    return HI_SUCCESS;
+}
+

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/drv_klad.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/drv_klad.h
@@ -1,0 +1,31 @@
+#ifndef __DRV_KLAD_H_
+#define __DRV_KLAD_H_
+
+#include "hi_types.h"
+#include "drv_osal_lib.h"
+
+hi_s32 hal_cipher_klad_config(hi_u32 chn_id,
+                             hi_u32 opt_id,
+                             hi_cipher_klad_target target,
+                             hi_bool is_decrypt);
+
+hi_void hal_cipher_start_klad(hi_u32 block_num);
+hi_void hal_cipher_set_klad_data(hi_u32 *data_in);
+hi_void hal_cipher_get_klad_data(hi_u32 *data_out);
+hi_s32 hal_cipher_wait_klad_done(hi_void);
+
+hi_s32 drv_cipher_klad_init(hi_void);
+hi_void drv_cipher_klad_deinit(hi_void);
+
+hi_s32 drv_cipher_klad_load_key(hi_u32 chn_id,
+                              hi_cipher_ca_type root_key,
+                              hi_cipher_klad_target target,
+                              hi_u8 *data_in,
+                              hi_u32 key_len);
+
+hi_s32 drv_cipher_klad_encrypt_key(hi_cipher_ca_type root_key,
+                                 hi_cipher_klad_target target,
+                                 hi_u32 clean_key[4],
+                                 hi_u32 encrypt_key[4]);
+
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hal_efuse.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hal_efuse.c
@@ -1,0 +1,304 @@
+/******************************************************************************
+
+  Copyright (C), 2001-2011, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : SAR_ADC_DRIVER.c
+  Version       : Initial Draft
+  Author        : Hisilicon BVT
+  Created       : 2012/5/2
+  Description   :
+  History       :
+  1.Date        : 2012/5/2
+    Author      : hkf67331
+    Modification: Created file
+
+******************************************************************************/
+#include "hi_types.h"
+#include "drv_osal_lib.h"
+#include "hal_efuse.h"
+
+#ifdef EFUSE_SUPPORT
+
+hi_u8 *efuse_otp_reg_base = HI_NULL;
+
+#define EFUSE_REG_BASE_ADDR  efuse_otp_reg_base
+#define CIPHER_KD_WKEY0      (EFUSE_REG_BASE_ADDR + 0x00)
+#define CIPHER_KD_WKEY1      (EFUSE_REG_BASE_ADDR + 0x04)
+#define CIPHER_KD_WKEY2      (EFUSE_REG_BASE_ADDR + 0x08)
+#define CIPHER_KD_WKEY3      (EFUSE_REG_BASE_ADDR + 0x0c)
+#define CIPHER_KD_CTRL       (EFUSE_REG_BASE_ADDR + 0x10)
+#define CIPHER_KD_STA        (EFUSE_REG_BASE_ADDR + 0x14)
+#define OTP_PGM_TIME         (EFUSE_REG_BASE_ADDR + 0x18)
+#define OTP_RD_TIME          (EFUSE_REG_BASE_ADDR + 0x1c)
+#define OTP_LOGIC_LEVEL      (EFUSE_REG_BASE_ADDR + 0x20)
+#define KD_CTL_MODE_CIPHER_KEY_ADDR(chn_id)  (chn_id<<8)
+#define KD_CTL_MODE_OPT_KEY_ADDR(opt_id)     (opt_id<<4)
+#define KD_CTL_MODE_HASH_KL                   (0x8)
+#define KD_CTL_MODE_OPT_KD                    (0x4)
+#define KD_CTL_MODE_CIPHER_KL                 (0x2)
+#define KD_CTL_MODE_START                     (0x1)
+#define KD_TIME_OUT                           (1000)
+
+#define  REG_SYS_EFUSE_CLK_ADDR_PHY     0x120100D8
+
+/* Define the union cipher_kd_sta */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    cipher_kl_finish       : 1   ; /* [0]  */
+        unsigned int    hash_key_read_busy     : 1   ; /* [1]  */
+        unsigned int    Reserved_3             : 25  ; /* [26..2]  */
+        unsigned int    ctrl_rdy               : 1   ; /* [27]  */
+        unsigned int    ctrl_busy0             : 1   ; /* [28]  */
+        unsigned int    ctrl_busy1             : 1   ; /* [29]  */
+        unsigned int    key_wt_error           : 1   ; /* [30]  */
+        unsigned int    key_wt_finish          : 1   ; /* [31]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} cipher_kd_sta;
+
+static hi_u32 is_efuse_busy_flag = HI_FALSE;
+
+hi_s32 hal_efuse_otp_init(hi_void)
+{
+    hi_u32 crg_value;
+    hi_u32 *sys_addr;
+
+    sys_addr = crypto_ioremap_nocache(REG_SYS_EFUSE_CLK_ADDR_PHY, 0x100);
+    if (sys_addr == HI_NULL) {
+        HI_LOG_ERROR("Error! addr ioremap failed!\n");
+        return HI_FAILURE;
+    }
+
+    HAL_CIPHER_READ_REG(sys_addr, &crg_value);
+    crg_value |= 0x01;/* reset */
+    crg_value |= 0x02;   /* set the bit 0, clock opened */
+    HAL_CIPHER_WRITE_REG(sys_addr, crg_value);
+
+    /* clock select and cancel reset 0x30100*/
+    crg_value &= (~0x01); /* cancel reset */
+    crg_value |= 0x02;   /* set the bit 0, clock opened */
+    HAL_CIPHER_WRITE_REG(sys_addr, crg_value);
+
+    crypto_iounmap(sys_addr, 0x100);
+
+    efuse_otp_reg_base = crypto_ioremap_nocache(ENFUSE_REG_BASE_ADDR_PHY, 0x100);
+    if (efuse_otp_reg_base == HI_NULL) {
+        HI_LOG_ERROR("ERROR: osal_ioremap_nocache for EFUSE failed!!\n");
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_s32 hal_efuse_wait_write_key(hi_void)
+{
+    cipher_kd_sta efuse_sta;
+    hi_u32 ul_start_time = 0;
+    hi_u32 ul_last_time = 0;
+    hi_u32 ul_dura_time = 0;
+
+    /* wait for hash_rdy */
+    ul_start_time = osal_get_tickcount();
+    while (1) {
+        HAL_CIPHER_READ_REG(CIPHER_KD_STA, &efuse_sta.u32);
+        if (efuse_sta.bits.key_wt_finish == 1) {
+            break;
+        }
+
+        ul_last_time = osal_get_tickcount();
+        ul_dura_time = ul_last_time - ul_start_time;
+        if (ul_dura_time >= KD_TIME_OUT ) {
+            HI_LOG_ERROR("Error! efuse write key time out!\n");
+            return HI_FAILURE;
+        }
+
+        osal_msleep(1);
+    }
+    return HI_SUCCESS;
+}
+
+hi_s32 hal_efuse_wait_cipher_load_key(hi_void)
+{
+    cipher_kd_sta efuse_sta;
+    hi_u32 ul_start_time = 0;
+    hi_u32 ul_last_time = 0;
+    hi_u32 ul_dura_time = 0;
+
+    ul_start_time = osal_get_tickcount();
+
+    while (1) {
+        HAL_CIPHER_READ_REG(CIPHER_KD_STA, &efuse_sta.u32);
+        if (efuse_sta.bits.cipher_kl_finish == 1) {
+            break;
+        }
+
+        ul_last_time = osal_get_tickcount();
+        ul_dura_time = (ul_last_time - ul_start_time);
+        if (ul_dura_time >= KD_TIME_OUT ) {
+            HI_LOG_ERROR("Error! efuse load key time out!\n");
+            return HI_FAILURE;
+        }
+        osal_msleep(1);
+    }
+    return HI_SUCCESS;
+}
+
+hi_s32 hal_efuse_wait_hash_load_key(hi_void)
+{
+    cipher_kd_sta efuse_sta;
+    hi_u32 ul_start_time = 0;
+    hi_u32 ul_last_time = 0;
+    hi_u32 ul_dura_time = 0;
+
+    ul_start_time = osal_get_tickcount();
+
+    while (1) {
+        HAL_CIPHER_READ_REG(CIPHER_KD_STA, &efuse_sta.u32);
+        if (efuse_sta.bits.hash_key_read_busy == 0) {
+            break;
+        }
+
+        ul_last_time = osal_get_tickcount();
+        ul_dura_time = (ul_last_time - ul_start_time);
+        if (ul_dura_time >= KD_TIME_OUT ) {
+            HI_LOG_ERROR("Error! efuse load key out!\n");
+            return HI_FAILURE;
+        }
+        osal_msleep(1);
+    }
+    return HI_SUCCESS;
+}
+
+hi_s32 hal_efuse_wait_ready(hi_void)
+{
+    cipher_kd_sta efuse_sta;
+    hi_u32 ul_start_time = 0;
+    hi_u32 ul_last_time = 0;
+    hi_u32 ul_dura_time = 0;
+
+    ul_start_time = osal_get_tickcount();
+
+    while (1) {
+        HAL_CIPHER_READ_REG(CIPHER_KD_STA, &efuse_sta.u32);
+        if (efuse_sta.bits.ctrl_rdy && (!efuse_sta.bits.ctrl_busy1) && (!efuse_sta.bits.ctrl_busy0)) {
+            break;
+        }
+
+        ul_last_time = osal_get_tickcount();
+        ul_dura_time = (ul_last_time - ul_start_time);
+        if (ul_dura_time >= KD_TIME_OUT ) {
+            HI_LOG_ERROR("Error! efuse load key out!\n");
+            return HI_FAILURE;
+        }
+        osal_msleep(1);
+    }
+    return HI_SUCCESS;
+}
+
+hi_s32 hal_efuse_get_err_stat(hi_void)
+{
+    cipher_kd_sta efuse_sta;
+
+    HAL_CIPHER_READ_REG(CIPHER_KD_STA, &efuse_sta.u32);
+    return efuse_sta.bits.key_wt_error;
+}
+
+hi_s32 hal_efuse_write_key(hi_u32 *p_key, hi_u32 opt_id)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 kd_ctl_mode = 0;
+
+    if (is_efuse_busy_flag != HI_FALSE) {
+        return HI_FAILURE;
+    }
+
+    is_efuse_busy_flag = HI_TRUE;
+    kd_ctl_mode = KD_CTL_MODE_OPT_KEY_ADDR(opt_id) | KD_CTL_MODE_OPT_KD | KD_CTL_MODE_START;
+
+    HAL_CIPHER_WRITE_REG(CIPHER_KD_WKEY0, *p_key);
+    HAL_CIPHER_WRITE_REG(CIPHER_KD_WKEY1, *(p_key + 1));
+    HAL_CIPHER_WRITE_REG(CIPHER_KD_WKEY2, *(p_key + 2));
+    HAL_CIPHER_WRITE_REG(CIPHER_KD_WKEY3, *(p_key + 3));
+
+    hal_efuse_wait_ready();
+
+    HAL_CIPHER_WRITE_REG(CIPHER_KD_CTRL, kd_ctl_mode);
+
+    ret = hal_efuse_wait_write_key();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hal_efuse_wait_write_key, ret);
+        is_efuse_busy_flag = HI_FALSE;
+        return ret;
+    }
+
+    ret = hal_efuse_get_err_stat()
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("efuse key is already write.\n");
+        HI_LOG_PRINT_FUNC_ERR(hal_efuse_get_err_stat, ret);
+        is_efuse_busy_flag = HI_FALSE;
+        return ret;
+    }
+
+    is_efuse_busy_flag = HI_FALSE;
+    return HI_SUCCESS;
+}
+
+hi_s32 hal_efuse_otp_load_cipher_key(hi_u32 chn_id, hi_u32 opt_id)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 kd_ctl_mode = 0;
+
+    if (is_efuse_busy_flag != HI_FALSE) {
+        return HI_FAILURE;
+    }
+
+    is_efuse_busy_flag = HI_TRUE;
+
+    kd_ctl_mode = (KD_CTL_MODE_CIPHER_KEY_ADDR(chn_id) \
+                   | KD_CTL_MODE_OPT_KEY_ADDR(opt_id)  \
+                   | KD_CTL_MODE_CIPHER_KL | KD_CTL_MODE_START);
+
+    hal_efuse_wait_ready();
+    HAL_CIPHER_WRITE_REG(CIPHER_KD_CTRL, kd_ctl_mode);
+    ret = hal_efuse_wait_cipher_load_key();
+    if (ret != HI_SUCCESS) {
+        is_efuse_busy_flag = HI_FALSE;
+        HI_LOG_PRINT_FUNC_ERR(hal_efuse_wait_cipher_load_key, ret);
+        return ret;
+    }
+
+    is_efuse_busy_flag = HI_FALSE;
+    return HI_SUCCESS;
+}
+
+hi_s32 hal_efuse_load_hash_key(hi_u32 opt_id)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 kd_ctl_mode = 0;
+
+    if (is_efuse_busy_flag)
+    { return HI_FAILURE; }
+
+    is_efuse_busy_flag = HI_TRUE;
+
+    kd_ctl_mode = (KD_CTL_MODE_OPT_KEY_ADDR(opt_id) | KD_CTL_MODE_HASH_KL | KD_CTL_MODE_START);
+    hal_efuse_wait_ready();
+    HAL_CIPHER_WRITE_REG(CIPHER_KD_CTRL, kd_ctl_mode);
+    ret = hal_efuse_wait_hash_load_key();
+    if (ret != HI_SUCCESS) {
+        is_efuse_busy_flag = HI_FALSE;
+        HI_LOG_PRINT_FUNC_ERR(hal_efuse_wait_hash_load_key, ret);
+        return ret;
+    }
+
+    is_efuse_busy_flag = HI_FALSE;
+    return HI_SUCCESS;
+}
+#endif
+
+

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hal_efuse.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hal_efuse.h
@@ -1,0 +1,18 @@
+#ifndef _HAL_EFUSE_H_
+#define _HAL_EFUSE_H_
+
+#include "hi_types.h"
+
+#define HAL_CIPHER_READ_REG(addr, result)    (*(result) = *(volatile unsigned int *)(hi_uintptr_t)(addr))
+#define HAL_CIPHER_WRITE_REG(addr,result)    (*(volatile unsigned int *)(hi_uintptr_t)(addr) = (result))
+
+#define HAL_SET_BIT(src, bit)               ((src) |= (1<<bit))
+#define HAL_CLEAR_BIT(src,bit)              ((src) &= ~(1<<bit))
+
+hi_s32 hal_efuse_write_key(hi_u32 *p_key, hi_u32 opt_id);
+hi_s32 hal_efuse_otp_load_cipher_key(hi_u32 chn_id, hi_u32 opt_id);
+hi_s32 hal_efuse_load_hash_key(hi_u32 opt_id);
+hi_s32 hal_efuse_otp_init(hi_void);
+
+#endif
+

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hal_otp.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hal_otp.c
@@ -1,0 +1,162 @@
+#include "hi_types.h"
+#include "drv_osal_lib.h"
+#include "hal_otp.h"
+
+#ifdef OTP_SUPPORT
+
+hi_u8 *efuse_otp_reg_base = HI_NULL;
+
+/* OTP init */
+hi_s32 hal_efuse_otp_init(hi_void)
+{
+    hi_u32 crg_value = 0;
+    hi_u32 *sys_addr = HI_NULL;
+
+    sys_addr = crypto_ioremap_nocache(REG_SYS_OTP_CLK_ADDR_PHY, 0x100);
+    if (sys_addr == HI_NULL) {
+        HI_LOG_ERROR("ERROR: sys_addr ioremap with nocache failed!!\n");
+        return HI_FAILURE;
+    }
+
+    HAL_CIPHER_READ_REG(sys_addr, &crg_value);
+#if defined(CHIP_TYPE_hi3559av100)
+    crg_value |= OTP_CRG_RESET_BIT;   /* reset */
+    crg_value |= OTP_CRG_CLOCK_BIT;   /* set the bit 0, clock opened */
+    HAL_CIPHER_WRITE_REG(sys_addr, crg_value);
+
+    /* clock select and cancel reset 0x30100*/
+    crg_value &= (~OTP_CRG_RESET_BIT); /* cancel reset */
+#endif
+    crg_value |= OTP_CRG_CLOCK_BIT;   /* set the bit 0, clock opened */
+    HAL_CIPHER_WRITE_REG(sys_addr, crg_value);
+
+    crypto_iounmap(sys_addr, 0x100);
+
+    efuse_otp_reg_base = crypto_ioremap_nocache(OTP_REG_BASE_ADDR_PHY, 0x100);
+    if (efuse_otp_reg_base == HI_NULL) {
+        HI_LOG_ERROR("ERROR: osal_ioremap_nocache for OTP failed!!\n");
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_s32 hal_otp_wait_free(hi_void)
+{
+    hi_u32 time_out_cnt = 0;
+    hi_u32 reg_value = 0;
+
+    while (1) {
+        HAL_CIPHER_READ_REG(OTP_USER_CTRL_STA, &reg_value);
+        if ((reg_value & 0x1) == 0) {
+            /* bit0:otp_op_busy 0:idle, 1:busy */
+            return HI_SUCCESS;
+        }
+
+        time_out_cnt++;
+        if (time_out_cnt >= 10000) {
+            HI_LOG_ERROR("Otp wait free time out!\n");
+            break;
+        }
+    }
+    return HI_FAILURE;
+}
+
+hi_s32 hal_otp_set_mode(otp_user_work_mode otp_mode)
+{
+    hi_u32 reg_value = otp_mode;
+
+    if (otp_mode >= OTP_UNKOOWN_MODE) {
+        HI_LOG_ERROR("Mode Unknown!\n");
+        return  HI_FAILURE;
+    }
+
+    (hi_void)HAL_CIPHER_WRITE_REG(OTP_USER_WORK_MODE, reg_value);
+    return HI_SUCCESS;
+}
+
+hi_void hal_otp_op_start(hi_void)
+{
+    hi_u32 reg_value = 0x1acce551;
+    (hi_void)HAL_CIPHER_WRITE_REG(OTP_USER_OP_START, reg_value);
+}
+
+hi_s32 hal_otp_wait_op_done(hi_void)
+{
+    hi_u32 time_out_cnt = 0;
+    hi_u32 reg_value = 0;
+
+    while (1) {
+        HAL_CIPHER_READ_REG(OTP_USER_CTRL_STA, &reg_value);
+        if (reg_value & 0x2) {
+            return HI_SUCCESS;
+        }
+
+        time_out_cnt++;
+        if (time_out_cnt >= 10000) {
+            HI_LOG_ERROR("Otp wait op time out!\n");
+            break;
+        }
+    }
+    return HI_FAILURE;
+}
+
+hi_void hal_choose_otp_key(otp_user_key_index which_key)
+{
+    hi_u32 reg_value = 0;
+
+    reg_value = which_key;
+    (hi_void)HAL_CIPHER_WRITE_REG(OTP_USER_KEY_INDEX, reg_value);
+}
+
+hi_s32 is_locked(otp_user_key_index which_key, hi_u32 lock_sta)
+{
+    hi_u32 status = lock_sta;
+
+    if (which_key > OTP_USER_KEY3) {
+        HI_LOG_ERROR("Unsupport Key!\n");
+        return HI_FAILURE;
+    }
+
+    if ((status >> ((hi_u32)which_key + 5)) & 0x1) {
+        HI_LOG_ERROR("Key%d was locked!\n", which_key);
+        return HI_FAILURE;
+    }
+    return HI_SUCCESS;
+}
+
+/* set otp key to klad */
+hi_s32 hal_efuse_otp_load_cipher_key(hi_u32 chn_id, hi_u32 opt_id)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    if (opt_id > OTP_USER_KEY3) {
+        opt_id = OTP_USER_KEY0;
+    }
+
+    ret = hal_otp_wait_free();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hal_otp_wait_free, ret);
+        return ret;
+    }
+
+    hal_choose_otp_key(opt_id);
+
+    ret = hal_otp_set_mode(OTP_LOCK_CIPHER_KEY_MODE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hal_otp_set_mode, ret);
+        return ret;
+    }
+
+    hal_otp_op_start();
+
+    ret = hal_otp_wait_op_done();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hal_otp_wait_op_done, ret);
+        return ret;
+    }
+
+    return  HI_SUCCESS;
+}
+#endif
+

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hal_otp.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hal_otp.h
@@ -1,0 +1,68 @@
+#ifndef __HAL_OTP_H__
+#define __HAL_OTP_H__
+
+#include "hi_types.h"
+#include "hal_efuse.h"
+
+#define OTP_USER_IF_BASE            efuse_otp_reg_base
+#define OTP_USER_WORK_MODE          (OTP_USER_IF_BASE+0x0000)
+#define OTP_USER_OP_START           (OTP_USER_IF_BASE+0x0004)
+#define OTP_USER_KEY_INDEX          (OTP_USER_IF_BASE+0x0008)
+#define OTP_USER_KEY_DATA0          (OTP_USER_IF_BASE+0x000c)
+#define OTP_USER_KEY_DATA1          (OTP_USER_IF_BASE+0x0010)
+#define OTP_USER_KEY_DATA2          (OTP_USER_IF_BASE+0x0014)
+#define OTP_USER_KEY_DATA3          (OTP_USER_IF_BASE+0x0018)
+#define OTP_USER_KEY_DATA4          (OTP_USER_IF_BASE+0x001c)
+#define OTP_USER_KEY_DATA5          (OTP_USER_IF_BASE+0x0020)
+#define OTP_USER_KEY_DATA6          (OTP_USER_IF_BASE+0x0024)
+#define OTP_USER_KEY_DATA7          (OTP_USER_IF_BASE+0x0028)
+#define OTP_USER_KEY_DATA8          (OTP_USER_IF_BASE+0x002c)
+#define OTP_USER_FLAG_VALUE         (OTP_USER_IF_BASE+0x0030)
+#define OTP_USER_FLAG_INDEX         (OTP_USER_IF_BASE+0x0034)
+#define OTP_USER_REV_ADDR           (OTP_USER_IF_BASE+0x0038)
+#define OTP_USER_REV_WDATA          (OTP_USER_IF_BASE+0x003c)
+#define OTP_USER_REV_RDATA          (OTP_USER_IF_BASE+0x0040)
+#define OTP_USER_LOCK_STA0          (OTP_USER_IF_BASE+0x0044)
+#define OTP_USER_LOCK_STA1          (OTP_USER_IF_BASE+0x0048)
+#define OTP_USER_CTRL_STA           (OTP_USER_IF_BASE+0x004c)
+
+typedef enum {
+    OTP_USER_LOCK_STA0_TYPE,
+    OTP_USER_LOCK_STA1_TYPE,
+    OTP_USER_LOCK_UNKNOWN_STA,
+} otp_lock_sta_type;
+
+typedef enum {
+    OTP_READ_LOCK_STA_MODE,
+    OTP_LOCK_CIPHER_KEY_MODE,
+    OTP_WRITE_KEY_ID_OR_PASSWD_MODE,
+    OTP_KEY_ID_OR_PASSWD_CRC_MODE,
+    OTP_SET_FLAG_ENABLE_MODE,
+    OTP_WRITE_USER_ROOM_MODE,
+    OTP_Read_USER_ROOM_MODE,
+    OTP_UNKOOWN_MODE,
+} otp_user_work_mode;
+
+typedef enum {
+    OTP_USER_KEY0,
+    OTP_USER_KEY1,
+    OTP_USER_KEY2,
+    OTP_USER_KEY3,
+    OTP_USER_KEY_JTAG_PW_ID,
+    OTP_USER_KEY_JTAG_PW,
+    OTP_USER_KEY_ROOTKEY,
+    OTP_USER_KEY_UNKNOWN,
+} otp_user_key_index;
+
+typedef enum {
+    OTP_KEY_LENGTH_64BIT,
+    OTP_KEY_LENGTH_128BIT,
+    OTP_KEY_LENGTH_256BIT,
+    OTP_KEY_LENGTH_UNSUPPORT,
+} otp_user_key_length;
+
+hi_s32 hal_efuse_otp_init(hi_void);
+hi_s32 hal_efuse_otp_load_cipher_key(hi_u32 chn_id, hi_u32 opt_id);
+unsigned short calculate_crc16 (const unsigned char *data_array_ptr, unsigned long data_array_length);
+
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hi_drv_compat.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hi_drv_compat.c
@@ -1,0 +1,63 @@
+/******************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : ext_aead.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "drv_symc.h"
+#include "drv_klad.h"
+
+hi_s32 klad_load_hard_key(hi_u32 handle, hi_u32 ca_type, hi_u8 *key, hi_u32 key_len)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    ret = drv_cipher_klad_load_key(handle, ca_type, HI_CIPHER_KLAD_TARGET_AES, key, key_len);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_cipher_klad_load_key, ret);
+        return ret;
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_s32 klad_encrypt_key(hi_u32 keysel, hi_u32 target, hi_u32 clear[4], hi_u32 encrypt[4])
+{
+    hi_s32 ret = HI_FAILURE;
+
+    ret = drv_cipher_klad_encrypt_key(keysel, target, clear, encrypt);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_cipher_klad_encrypt_key, ret);
+        return ret;
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_drv_compat_init(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    ret = drv_cipher_klad_init();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_cipher_klad_init, ret);
+        return ret;
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_s32 hi_drv_compat_deinit(void)
+{
+    drv_cipher_klad_deinit();
+
+    return HI_SUCCESS;
+}
+

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hi_drv_compat.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/compat/hi_drv_compat.h
@@ -1,0 +1,10 @@
+#ifndef _HI_DRV_CPMPAT_H_
+#define _HI_DRV_CPMPAT_H_
+
+hi_s32 hi_drv_compat_init(hi_void);
+hi_s32 hi_drv_compat_deinit(hi_void);
+hi_s32 klad_load_hard_key(hi_u32 handle, hi_u32 ca_type, hi_u8 *key, hi_u32 key_len);
+hi_s32 klad_encrypt_key(hi_u32 keysel, hi_u32 target, hi_u32 clear[4], hi_u32 encrypt[4]);
+
+#endif
+

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/build.mak
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/build.mak
@@ -1,0 +1,38 @@
+CIPHER_CFLAGS += -I$(CIPHER_DIR)/drv/cipher_v1.0/drivers/core/include
+CIPHER_CFLAGS += -I$(CIPHER_DIR)/drv/cipher_v1.0/drivers/crypto/include
+CIPHER_CFLAGS += -I$(CIPHER_DIR)/drv/cipher_v1.0/drivers/extend
+CIPHER_CFLAGS += -I$(CIPHER_DIR)/drv/cipher_v1.0/drivers/extend/include
+
+CIPHER_OBJS +=  drv/cipher_v1.0/drivers/core/drv_symc_v100.o          \
+                drv/cipher_v1.0/drivers/core/drv_symc_v200.o          \
+                drv/cipher_v1.0/drivers/core/drv_hash_v100.o          \
+                drv/cipher_v1.0/drivers/core/drv_hash_v200.o          \
+                drv/cipher_v1.0/drivers/core/drv_ifep_rsa_v100.o      \
+                drv/cipher_v1.0/drivers/core/drv_trng_v100.o          \
+                drv/cipher_v1.0/drivers/core/drv_trng_v200.o          \
+                drv/cipher_v1.0/drivers/core/drv_lib.o
+
+CIPHER_OBJS += drv/cipher_v1.0/drivers/crypto/cryp_symc.o             \
+               drv/cipher_v1.0/drivers/crypto/cryp_hash.o             \
+               drv/cipher_v1.0/drivers/crypto/cryp_trng.o             \
+               drv/cipher_v1.0/drivers/crypto/cryp_rsa.o
+
+CIPHER_OBJS += drv/cipher_v1.0/drivers/kapi_symc.o                    \
+               drv/cipher_v1.0/drivers/kapi_hash.o                    \
+               drv/cipher_v1.0/drivers/kapi_rsa.o                     \
+               drv/cipher_v1.0/drivers/kapi_trng.o                    \
+               drv/cipher_v1.0/drivers/kapi_dispatch.o
+
+CIPHER_OBJS += drv/cipher_v1.0/drivers/extend/mbedtls/bignum.o        \
+               drv/cipher_v1.0/drivers/extend/mbedtls/md.o            \
+               drv/cipher_v1.0/drivers/extend/mbedtls/rsa.o           \
+               drv/cipher_v1.0/drivers/extend/mbedtls/asn1parse.o     \
+               drv/cipher_v1.0/drivers/extend/mbedtls/oid.o           \
+               drv/cipher_v1.0/drivers/extend/mbedtls/platform_util.o \
+               drv/cipher_v1.0/drivers/extend/mbedtls/rsa_internal.o
+
+CIPHER_OBJS += drv/cipher_v1.0/drivers/extend/ext_aead.o              \
+               drv/cipher_v1.0/drivers/extend/ext_hash.o              \
+               drv/cipher_v1.0/drivers/extend/ext_symc.o              \
+               drv/cipher_v1.0/drivers/extend/ext_sm3.o               \
+               drv/cipher_v1.0/drivers/extend/ext_sm4.o

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_hash_v100.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_hash_v100.c
@@ -1,0 +1,370 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_hash_v100.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_hash_v100.h"
+#include "drv_hash.h"
+
+#ifdef CHIP_HASH_VER_V100
+
+/*************************** Structure Definition ****************************/
+/** \addtogroup     hash */
+/** @{ */  /** <!-- [hash] */
+
+/*! \hash 256 result size in word */
+#define HASH256_RESULT_SIZE_IN_WORD   (8)
+
+/*! Define the rec read bit mask */
+#define HASH_READ_MASK_REC            (0x08)
+
+/*! Define the dma read bit mask */
+#define HASH_READ_MASK_DMA            (0x02)
+
+/*! Define the hash read bit mask */
+#define HASH_READ_MASK_HASH           (0x01)
+
+/*! hash is busy ot not */
+#ifdef MHASH_NONSUPPORT
+static hi_u32 hash_busy = HI_FALSE;
+#endif
+
+/** @} */  /** <!-- ==== Structure Definition end ==== */
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      hash */
+/** @{ */  /** <!--[hash]*/
+
+hi_s32 drv_hash_init(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    module_disable(CRYPTO_MODULE_ID_HASH);
+    module_enable(CRYPTO_MODULE_ID_HASH);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_hash_deinit(void)
+{
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_hash_resume(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    module_enable(CRYPTO_MODULE_ID_HASH);
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+void drv_hash_suspend(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    module_disable(CRYPTO_MODULE_ID_HASH);
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+/* wait hash ready */
+static hi_s32 drv_hash_wait_ready(hi_u32 bitmask)
+{
+    hi_u32 i = 0;
+    hash_status ready;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* wait ready */
+    for (i = 0; i < CRYPTO_TIME_OUT; i++) {
+        ready.u32 = HASH_READ(REG_STATUS);
+        if (ready.u32 & bitmask) {
+            break;
+        }
+        if (i <= MS_TO_US) {
+            crypto_udelay(1);  /* short waitting for 1000 us */
+        } else {
+            crypto_msleep(1);  /* long waitting for 5000 ms*/
+        }
+    }
+    if (i >= CRYPTO_TIME_OUT) {
+        HI_LOG_ERROR("error, hash wait done timeout\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_TIMEOUT);
+        return HI_ERR_CIPHER_TIMEOUT;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_hash_config(hi_u32 chn_num, hash_mode mode, hi_u32 state[HASH_RESULT_MAX_SIZE_IN_WORD])
+{
+    hash_ctrl ctrl;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(state == HI_NULL);
+
+    CRYPTO_UNUSED(chn_num);
+
+#ifdef MHASH_NONSUPPORT
+    if (HI_TRUE == hash_busy) {
+        /* the hash already starting, here just return success */
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+    hash_busy = HI_TRUE;
+#endif
+
+    /* wait ready */
+    ret = drv_hash_wait_ready(HASH_READ_MASK_HASH);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_hash_wait_ready, ret);
+        return ret;
+    }
+
+    ctrl.u32 = HASH_READ(REG_CTRL);
+
+    /* only support sha1 and sha256 */
+    if (mode == HASH_MODE_SHA1) {
+        ctrl.bits.sha_sel = 0x00; /* SHA1 */
+    } else if ((mode == HASH_MODE_SHA256) || (mode == HASH_MODE_SHA224)) {
+        ctrl.bits.sha_sel = 0x01; /* SHA256 */
+    } else {
+        HI_LOG_ERROR("error, nonsupport hash mode %d\n", mode);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    /* control configure */
+    ctrl.bits.read_ctrl = 0;  /* 0:read by DMA, 1: read by CPU */
+    ctrl.bits.hmac_flag = 0;  /* 0: raw hash, 1: hmac */
+    ctrl.bits.hardkey_sel = 0;/* 0: cpu key, 1: hard key*/
+    ctrl.bits.small_end_en = 1;/* 0: big, 1: little */
+    ctrl.bits.sha_init_update_en = 1;/* initial hash value from CPU */
+
+    HASH_WRITE(REG_CTRL, ctrl.u32);
+    HI_LOG_INFO("REG_CTRL: 0x%x\n", ctrl.u32);
+
+#ifdef MHASH_NONSUPPORT
+    {
+        sha_start start;
+
+        /* logic don't support config init value of hash
+         * here must set it to max vaule
+         * then reset hash after compute finished
+         */
+        HASH_WRITE(REG_TOTALLEN_LOW, 0xFFFFFFFF);
+        HASH_WRITE(REG_TOTALLEN_HIGH, 0x00);
+
+        /* ready to working,
+         * the hardware still be idle until write the reg of REG_DMA_LEN
+         * so must start the hardware before write DMA addr and length.
+         */
+        start.u32 = HASH_READ(REG_START);
+        start.bits.sha_start = 0x01;
+        HASH_WRITE(REG_START, start.u32);
+        HI_LOG_INFO("REG_START: 0x%x\n", start.u32);
+
+        hash_busy = HI_TRUE;
+    }
+#else
+    {
+        hi_u32 i = 0;
+
+        /* write hash initial value */
+        for (i = 0; i < HASH256_RESULT_SIZE_IN_WORD; i++) {
+            HASH_WRITE(REG_INIT1_UPDATE + i * 4, CPU_TO_BE32(state[i]));
+            HI_LOG_DEBUG("Set hash: 0x%x\n", state[i]);
+        }
+    }
+#endif
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+}
+
+hi_s32 drv_hash_start(hi_u32 chn_num, crypto_mem *mem, hi_u32 length)
+{
+    HI_LOG_FUNC_ENTER();
+
+    /* buffer addr and size must align with word */
+    HI_LOG_CHECK_PARAM((length & 0x03) != 0);
+
+    HI_LOG_DEBUG("MMZ phy 0x%x, length 0x%x\n", ADDR_L32(mem->mmz_addr), length);
+
+    CRYPTO_UNUSED(chn_num);
+
+#ifndef MHASH_NONSUPPORT
+    {
+        sha_start start;
+
+        /* set hash message total length.
+         * in nature here we don't know the total length of message,
+         * here just set the total length to buf_size each hash calculation.
+         * then we can release the hash hardware after each hash calculation.
+         */
+        HASH_WRITE(REG_TOTALLEN_LOW, length);
+
+        /* max length of msg is 2^32, the high 32bit of length always be zero */
+        HASH_WRITE(REG_TOTALLEN_HIGH, 0x00);
+
+        /* ready to working,
+         * the hardware still be idle until write the reg of REG_DMA_LEN
+         * so must start the hardware before write DMA addr and length.
+         */
+        start.u32 = HASH_READ(REG_START);
+        start.bits.sha_start = 0x01;
+        HASH_WRITE(REG_START, start.u32);
+        HI_LOG_INFO("REG_START: 0x%x\n", start.u32);
+    }
+#endif
+
+    /* DMA address and length, at once write the reg of REG_DMA_LEN,
+     * the hardware start working immediately.
+     */
+    HASH_WRITE(REG_DMA_START_ADDR, ADDR_L32(mem->mmz_addr));
+    HASH_WRITE(REG_DMA_LEN, length);
+    HI_LOG_INFO("Hash PHY: 0x%x, size 0x%x\n", ADDR_L32(mem->mmz_addr), length);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_hash_wait_done(hi_u32 chn_num, hi_u32 *state)
+{
+    hi_u32 i = 0;
+    hi_s32 ret = HI_FAILURE;
+    hash_status ready;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(state == HI_NULL);
+
+    CRYPTO_UNUSED(chn_num);
+
+    /* wait ready */
+    ret = drv_hash_wait_ready(HASH_READ_MASK_REC);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_hash_wait_ready, ret);
+        return ret;
+    }
+
+    /* check error code */
+    ready.u32 = HASH_READ(REG_STATUS);
+    if (ready.bits.len_err) {
+        HI_LOG_ERROR("error, hash len err, chn=%d", chn_num);
+        return HI_ERR_CIPHER_OVERFLOW;
+    }
+    HI_LOG_INFO("Status: 0x%x\n", ready.u32);
+
+    /* read hash result */
+    for (i = 0; i < HASH256_RESULT_SIZE_IN_WORD; i++) {
+        state[i] = HASH_READ(REG_SHA_OUT1 + i * 4);
+        HI_LOG_INFO("state[%d] 0x%x\n", i, state[i]);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_hash_reset(hi_u32 chn_num)
+{
+    CRYPTO_UNUSED(chn_num);
+#ifdef MHASH_NONSUPPORT
+
+    HI_LOG_FUNC_ENTER();
+
+    module_disable(CRYPTO_MODULE_ID_HASH);
+    module_enable(CRYPTO_MODULE_ID_HASH);
+    hash_busy = HI_FALSE;
+
+    HI_LOG_INFO("Hash reset ...\n");
+
+    HI_LOG_FUNC_EXIT();
+#endif
+}
+
+hi_s32 drv_hmac256_block(hi_u32 *din, hi_u32 *hamc)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 i = 0;
+    hash_ctrl ctrl;
+
+    HI_LOG_FUNC_ENTER();
+
+    /*1.set hmac padded message ByteLength*/
+    HASH_WRITE(REG_TOTALLEN_LOW, 0x40);
+    HASH_WRITE(REG_TOTALLEN_HIGH, 0x00);
+
+    /*2.set hash ctrl register*/
+    ctrl.u32 = HASH_READ(REG_CTRL);
+    ctrl.bits.read_ctrl = 1;
+    ctrl.bits.sha_sel = 0x1;
+    ctrl.bits.hmac_flag = 1;
+    ctrl.bits.hardkey_sel = 0;
+    ctrl.bits.small_end_en = 1;
+    ctrl.bits.sha_init_update_en = 0;
+    HASH_WRITE (REG_CTRL, ctrl.u32);
+
+    /*3.set start*/
+    HASH_WRITE (REG_START, 0x01);
+
+    /*ready input data*/
+    ret = drv_hash_wait_ready(HASH_READ_MASK_DMA);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_hash_wait_ready, ret);
+        return ret;
+    }
+
+    /*4.set data_in*/
+    for (i = 0; i < HASH_BLOCK_SIZE; i++) {
+        HASH_WRITE(REG_DATA_IN, din[i]);
+    }
+
+    ret = drv_hash_wait_ready(HASH_READ_MASK_HASH);
+    if (ret != HI_SUCCESS) {
+        return ret;
+    }
+
+    /*5.hash ready*/
+    ret = drv_hash_wait_done(HASH_HARD_CHANNEL, hamc);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_hash_wait_done, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_hash_get_capacity(hash_capacity *capacity)
+{
+    crypto_memset(capacity, sizeof(hash_capacity), 0,  sizeof(hash_capacity));
+
+    capacity->sha1   = CRYPTO_CAPACITY_SUPPORT;
+    capacity->sha256 = CRYPTO_CAPACITY_SUPPORT;
+
+#ifndef MHASH_NONSUPPORT
+    capacity->sha224 = CRYPTO_CAPACITY_SUPPORT;
+#endif
+}
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+
+#endif //End of CHIP_HASH_VER_V100

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_hash_v100.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_hash_v100.h
@@ -1,0 +1,102 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_hash_v100.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef _DRV_HASH_V1_H_
+#define _DRV_HASH_V1_H_
+
+#include "drv_osal_lib.h"
+
+/*************************** Internal Structure Definition ****************************/
+/** \addtogroup      hash drivers*/
+/** @{*/  /** <!-- [hash]*/
+
+/*! \Define the offset of reg */
+#define  REG_TOTALLEN_LOW           (0x00)
+#define  REG_TOTALLEN_HIGH          (0x04)
+#define  REG_STATUS                 (0x08)
+#define  REG_CTRL                   (0x0C)
+#define  REG_START                  (0x10)
+#define  REG_DMA_START_ADDR         (0x14)
+#define  REG_DMA_LEN                (0x18)
+#define  REG_DATA_IN                (0x1C)
+#define  REG_REC_LEN1               (0x20)
+#define  REG_REC_LEN2               (0x24)
+#define  REG_SHA_OUT1               (0x30)
+#define  REG_SHA_OUT2               (0x34)
+#define  REG_SHA_OUT3               (0x38)
+#define  REG_SHA_OUT4               (0x3C)
+#define  REG_SHA_OUT5               (0x40)
+#define  REG_SHA_OUT6               (0x44)
+#define  REG_SHA_OUT7               (0x48)
+#define  REG_SHA_OUT8               (0x4C)
+#define  REG_MCU_KEY0               (0x70)
+#define  REG_MCU_KEY1               (0x74)
+#define  REG_MCU_KEY2               (0x78)
+#define  REG_MCU_KEY3               (0x7C)
+#define  REG_KL_KEY0                (0x80)
+#define  REG_KL_KEY1                (0x84)
+#define  REG_KL_KEY2                (0x88)
+#define  REG_KL_KEY3                (0x8C)
+#define  REG_INIT1_UPDATE           (0x90)
+
+/*! \Define the union hash_status */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    hash_rdy        : 1   ; /* [0]  */
+        hi_u32    dma_rdy         : 1   ; /* [1]  */
+        hi_u32    msg_rdy         : 1   ; /* [2]  */
+        hi_u32    rec_rdy         : 1   ; /* [3]  */
+        hi_u32    error_state     : 2   ; /* [5..4]  */
+        hi_u32    len_err         : 1   ; /* [6]  */
+        hi_u32    reserved_1      : 2   ; /* [31..7]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+
+} hash_status;
+
+/*! \Define the union hash_ctrl */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    read_ctrl     : 1  ; /* [0]  */
+        hi_u32    sha_sel       : 2  ; /* [2..1]  */
+        hi_u32    hmac_flag     : 1  ; /* [3]  */
+        hi_u32    hardkey_sel   : 1  ; /* [4]  */
+        hi_u32    small_end_en  : 1  ; /* [5]  */
+        hi_u32    sha_init_update_en  : 1  ; /* [7]  */
+        hi_u32    reserved_1      : 25  ; /* [31..7]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+
+} hash_ctrl;
+
+/*! \Define the union sha_start */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    sha_start     : 1   ; /* [0]  */
+        hi_u32    reserved_1    : 30  ; /* [31..1]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+
+} sha_start;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_hash_v200.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_hash_v200.c
@@ -1,0 +1,773 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_hash_v200.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_hash_v200.h"
+#include "drv_hash.h"
+
+#ifdef CHIP_HASH_VER_V200
+
+/*************************** Structure Definition ****************************/
+/** \addtogroup     hash */
+/** @{ */  /** <!-- [hash] */
+
+/*! hash in entry list size */
+#define HASH_NODE_SIZE             (4096)
+
+/*! hash in entry list size */
+#define HASH_NODE_LIST_SIZE        (HASH_NODE_SIZE * HASH_HARD_CHANNEL_CNT)
+
+/*! hash node dpth */
+#define HASH_MAX_DEPTH                      (127)
+
+#define KLAD_KEY_USE_ERR         0x01
+#define ALG_LEN_ERR              0x02
+#define SMMU_PAGE_UNVLID         0x04
+#define OUT_SMMU_PAGE_NOT_VALID  0x08
+#define KLAD_KEY_WRITE_ERR       0x10
+
+/*! Define the flag of node */
+typedef enum {
+    HASH_CTRL_NONE             = 0x00, /*!<  middle node */
+    HASH_CTRL_HASH_IN_FIRST    = 0x01, /*!<  first node */
+    HASH_CTRL_HASH_IN_LAST     = 0x02, /*!<  last node */
+    HASH_CTRL_COUNT,
+} HASH_CTRL_EN;
+
+/*! spacc digest in entry struct which is defined by hardware, you can't change it */
+struct hash_entry_in {
+    hi_u32    spacc_cmd: 2;     /*!<  reserve */
+    hi_u32    rev1: 6;          /*!<  reserve */
+    hi_u32    hash_ctrl: 6;     /*!<  hash control flag*/
+    hi_u32    rev2: 18;         /*!<  reserve */
+    hi_u32    hash_start_addr;  /*!<  hash message address */
+    hi_u32    hash_alg_length;  /*!<  hash message length */
+    hi_u32    word1;            /*!<  reserve */
+};
+
+/*! Define the context of hash */
+typedef struct {
+    hash_mode  hash_alg;   /*!<  hash mode */
+    struct hash_entry_in *entry_in; /*! spacc digest in entry struct */
+    hi_u32 id_in;                  /*!< current hash nodes to be used */
+    hi_u32 done;                   /*!<  calculation finish flag*/
+    crypto_queue_head  queue;   /*!<  quene list */
+} hash_hard_context;
+
+/*! hash already initialize or not */
+static hi_u32 hash_initialize = HI_FALSE;
+
+/*! dma memory of hash node list*/
+static crypto_mem   hash_dma;
+
+/*! Channel of hash */
+static channel_context hash_hard_channel[CRYPTO_HARD_CHANNEL_MAX];
+
+/** @} */  /** <!-- ==== Structure Definition end ==== */
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      hash */
+/** @{ */  /** <!--[hash]*/
+
+#ifdef HI_CIPHER_DEBUG
+extern int dump_mem(void);
+#endif
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+static hi_u32 hash_done_notify(void)
+{
+    hash_int_raw    int_raw;
+    hash_int_status int_st;
+    hi_u32 chn_mask = 0;
+
+    int_st.u32 = HASH_READ(HASH_INT_STATUS);
+    int_raw.u32 = 0;
+
+    /*just process the valid channel*/
+    int_st.bits.hash_chn_oram_int &= HASH_HARD_CHANNEL_MASK;
+    chn_mask = int_st.bits.hash_chn_oram_int;
+    int_raw.bits.hash_chn_oram_raw = int_st.bits.hash_chn_oram_int;
+
+    HI_LOG_DEBUG("int_st 0x%x, mask 0x%x\n", int_st.u32, chn_mask);
+
+    /*Clean raw int*/
+    HASH_WRITE(HASH_INT_RAW, int_raw.u32);
+
+    return chn_mask;
+}
+
+static hi_u32 symc_done_test(void)
+{
+    cipher_int_status status;
+
+    status.u32 = SYMC_READ(CIPHER_INT_STATUS);
+
+    /*just process the valid channel*/
+    status.bits.cipher_chn_obuf_int &= CIPHER_HARD_CHANNEL_MASK;
+
+    return status.bits.cipher_chn_obuf_int; /* mask */
+}
+
+/*! hash interrupt process function */
+static irqreturn_t hash_interrupt_isr(hi_s32 irq, void *devId)
+{
+    hi_u32 mask = 0, i = 0;
+    hash_hard_context *ctx = HI_NULL;
+    irqreturn_t ret = IRQ_HANDLED;
+
+    CRYPTO_UNUSED(irq);
+
+    mask = hash_done_notify();
+
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        if ((mask >> i) & 0x01) {
+            ctx = (hash_hard_context *)hash_hard_channel[i].ctx;
+            ctx->done = HI_TRUE;
+            HI_LOG_DEBUG("chn %d wake up\n", i);
+            crypto_queue_wait_up(&ctx->queue);
+        }
+    }
+
+    /* symc and hash use the sample interrupt number
+     * so if symc has occur interrupt, we should return IRQ_NONE
+     * to tell system continue to process the symc interrupt.
+     */
+    if (0 != symc_done_test()) {
+        ret = IRQ_NONE;
+    }
+
+    return ret;
+}
+
+/*! hash register interrupt process function */
+static hi_s32 drv_hash_register_interrupt(void)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 int_valid = 0, int_num = 0;
+    hi_u32 i;
+    const char *name;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_HASH, &int_valid, &int_num, &name);
+
+    if (int_valid == HI_FALSE) {
+        return HI_SUCCESS;
+    }
+
+    /* request irq */
+    ret = crypto_request_irq(int_num, hash_interrupt_isr, name);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("Irq request failure, irq = %d", int_num);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_REGISTER_IRQ);
+        return HI_ERR_CIPHER_REGISTER_IRQ;
+    }
+
+    /* initialize queue list*/
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        crypto_queue_init(&((hash_hard_context *)hash_hard_channel[i].ctx)->queue);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/*! hash unregister interrupt process function */
+static void drv_hash_unregister_interrupt(void)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    const char *name;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_HASH, &int_valid, &int_num, &name);
+
+    if (int_valid == HI_FALSE) {
+        return;
+    }
+
+    /* free irq */
+    HI_LOG_DEBUG("hash free irq, num %d, name %s\n", int_num, name);
+    crypto_free_irq(int_num, name);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+/*! set interrupt */
+static void hash_set_interrupt(void)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    const char *name;
+    hash_int_en hash_int_en;
+    hash_int_raw hash_int_raw;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_HASH, &int_valid, &int_num, &name);
+
+    if (int_valid == HI_FALSE) {
+        hash_int_en.u32 = HASH_READ(HASH_INT_EN);
+
+        /*The top interrupt switch only can be enable/disable by secure CPU*/
+        hash_int_en.bits.hash_int_en = 0;
+        hash_int_en.bits.hash_sec_int_en = 0;
+        hash_int_en.bits.hash_chn_oram_en &= ~HASH_HARD_CHANNEL_MASK;
+        HASH_WRITE(HASH_INT_EN, hash_int_en.u32);
+        HI_LOG_INFO("HASH_INT_EN: 0x%x\n", hash_int_en.u32);
+    } else {
+        hash_int_en.u32 = HASH_READ(HASH_INT_EN);
+
+        /*The top interrupt switch only can be enable/disable by secure CPU*/
+        hash_int_en.bits.hash_int_en = 1;
+        hash_int_en.bits.hash_sec_int_en = 1;
+        hash_int_en.bits.hash_chn_oram_en |= HASH_HARD_CHANNEL_MASK;
+        HASH_WRITE(HASH_INT_EN, hash_int_en.u32);
+        HI_LOG_INFO("HASH_INT_EN: 0x%x\n", hash_int_en.u32);
+    }
+
+    /* clear interception
+     * the history of interception may trigge the system to
+     * call the irq function before initialization
+     * when register interrupt, this will cause a system abort.
+     */
+    hash_int_raw.u32 = SYMC_READ(HASH_INT_RAW);
+    hash_int_raw.bits.hash_chn_oram_raw &= HASH_HARD_CHANNEL_MASK; /* clear valid channel */
+    SYMC_WRITE(HASH_INT_RAW, hash_int_raw.u32);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+#endif
+
+static hi_u32 hash_done_try(hi_u32 chn_num)
+{
+    hash_int_raw    int_raw;
+    hi_u32 chn_mask = 0;
+
+    int_raw.u32 = HASH_READ(HASH_INT_RAW);
+    int_raw.bits.hash_chn_oram_raw &= 0x01 << chn_num;
+    chn_mask = int_raw.bits.hash_chn_oram_raw;
+
+    /*Clean raw int*/
+    HASH_WRITE(HASH_INT_RAW, int_raw.u32);
+
+    return chn_mask;
+}
+
+/*! set hash entry */
+static void hash_set_entry(hi_u32 chn, compat_addr dma_addr, void *cpu_addr)
+{
+    hash_hard_context *ctx = (hash_hard_context *)hash_hard_channel[chn].ctx;
+    chann_hash_int_node_cfg hash_in_cfg;
+
+    /*set total num and start addr for hash in node*/
+    hash_in_cfg.u32 = HASH_READ(CHANn_HASH_IN_NODE_CFG(chn));
+    hash_in_cfg.bits.hash_in_node_total_num = HASH_MAX_DEPTH;
+    HASH_WRITE(CHANn_HASH_IN_NODE_CFG(chn), hash_in_cfg.u32);
+    HASH_WRITE(CHANn_HASH_IN_NODE_START_ADDR(chn), ADDR_L32(dma_addr));
+    HASH_WRITE(CHANN_HASH_IN_NODE_START_HIGH(chn), ADDR_H32(dma_addr));
+    HI_LOG_INFO("CHANn_HASH_IN_NODE_CFG[0x%x]: \t0x%x, PHY: 0x%x, VIA %p\n",
+                CHANn_HASH_IN_NODE_CFG(chn), hash_in_cfg.u32, ADDR_L32(dma_addr), cpu_addr);
+
+    ctx->entry_in = (struct hash_entry_in *)cpu_addr;
+    ctx->id_in = hash_in_cfg.bits.hash_in_node_wptr;
+
+    return;
+}
+
+/*! set smmu */
+static void hash_smmu_bypass(void)
+{
+#ifdef CRYPTO_SMMU_SUPPORT
+    hash_in_smmu_en hash_in_smmu_en;
+
+    hash_in_smmu_en.u32 = HASH_READ(HASH_IN_SMMU_EN);
+    hash_in_smmu_en.bits.hash_in_chan_rd_dat_smmu_en |= HASH_HARD_CHANNEL_MASK >> 1;
+    hash_in_smmu_en.bits.hash_in_chan_rd_node_smmu_en &= ~(HASH_HARD_CHANNEL_MASK >> 1);
+    HASH_WRITE(HASH_IN_SMMU_EN, hash_in_smmu_en.u32);
+    HI_LOG_INFO("HASH_IN_SMMU_EN[0x%x]  : 0x%x\n", HASH_IN_SMMU_EN, hash_in_smmu_en.u32);
+#endif
+}
+
+/*! smmu set base address */
+static hi_s32 drv_hash_smmu_base_addr(void)
+{
+#ifdef CRYPTO_SMMU_SUPPORT
+    hi_u64 err_raddr = 0;
+    hi_u64 err_waddr = 0;
+    hi_u64 table_addr = 0;
+
+    /* get table base addr from system api */
+    smmu_get_table_addr(&err_raddr, &err_waddr, &table_addr);
+
+    if (crypto_is_sec_cpu()) {
+        /*smmu page secure table addr*/
+        HASH_WRITE(NORM_SMMU_START_ADDR, (hi_u32)table_addr);
+        HI_LOG_INFO("NORM_SMMU_START_ADDR[0x%x]  : 0x%x\n", NORM_SMMU_START_ADDR, (hi_u32)table_addr);
+    } else {
+        /*smmu page nonsecure table addr*/
+        HASH_WRITE(SEC_SMMU_START_ADDR, (hi_u32)table_addr);
+        HI_LOG_INFO("SEC_SMMU_START_ADDR[0x%x]  : 0x%x\n", SEC_SMMU_START_ADDR, (hi_u32)table_addr);
+    }
+#endif
+
+    return HI_SUCCESS;
+}
+
+/*! set secure channel,
+ *  non-secure CPU can't change the value of SEC_CHN_CFG,
+ *  so non-secure CPU call this function will do nothing.
+ */
+static void drv_hash_enable_secure(void)
+{
+    sec_chn_cfg sec_chn_cfg;
+
+    sec_chn_cfg.u32 = HASH_READ(SEC_CHN_CFG);
+    sec_chn_cfg.bits.hash_sec_chn_cfg |= HASH_HARD_CHANNEL_MASK;
+    HASH_WRITE(SEC_CHN_CFG, sec_chn_cfg.u32);
+    HI_LOG_INFO("SEC_CHN_CFG[0x%x]: 0x%x\n", SEC_CHN_CFG, sec_chn_cfg.u32);
+}
+
+static void hash_print_last_node(hi_u32 chn_num)
+{
+    struct hash_entry_in *in = HI_NULL;
+    hash_hard_context *ctx = HI_NULL;
+
+    ctx = (hash_hard_context *)hash_hard_channel[chn_num].ctx;
+
+    /* get last in node info*/
+    in = &ctx->entry_in[ctx->id_in];
+
+    HI_LOG_ERROR("chn %d, src addr 0x%x, size 0x%x\n",
+                 chn_num, in->hash_start_addr , in->hash_alg_length);
+    CRYPTO_UNUSED(in);
+}
+
+static hi_s32 drv_hash_get_err_code(hi_u32 chn_num)
+{
+    hi_u32 code = 0;
+
+    /* check error code
+     * bit0: klad_key_use_err
+     * bit1: alg_len_err
+     * bit2: smmu_page_unvlid
+     * bit3: out_smmu_page_not_valid
+     * bit4: klad_key_write_err
+     */
+
+    /*read error code*/
+    code = HASH_READ(CALC_ERR);
+
+    if (code & KLAD_KEY_USE_ERR) {
+        HI_LOG_ERROR("hash error: klad_key_use_err, chn %d !!!\n", chn_num);
+    }
+    if (code & ALG_LEN_ERR) {
+        HI_LOG_ERROR("hash error: alg_len_err, chn %d !!!\n", chn_num);
+    }
+    if (code & SMMU_PAGE_UNVLID) {
+        HI_LOG_ERROR("hash error: smmu_page_unvlid, chn %d !!!\n", chn_num);
+    }
+    if (code & OUT_SMMU_PAGE_NOT_VALID) {
+        HI_LOG_ERROR("symc error: out_smmu_page_not_valid, chn %d !!!\n", chn_num);
+    }
+    if (code & KLAD_KEY_WRITE_ERR) {
+        HI_LOG_ERROR("symc error: klad_key_write_err, chn %d !!!\n", chn_num);
+    }
+
+    /*print the inout buffer address*/
+    if (code) {
+        hash_print_last_node(chn_num);
+#ifdef HI_CIPHER_DEBUG
+        tee_hal_backtraces();
+        dump_mem();
+#endif
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    return HI_SUCCESS;
+}
+
+void hash_enrty_init(crypto_mem mem)
+{
+    hi_u32 i;
+    compat_addr mmz_addr;
+    void *cpu_addr = HI_NULL;
+
+    HI_LOG_INFO("symc entry list configure\n");
+    ADDR_U64(mmz_addr) = ADDR_U64(mem.mmz_addr);
+    cpu_addr = mem.dma_virt;
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        if ((HASH_HARD_CHANNEL_MASK >> i) & 0x01) { /*valid channel*/
+            hash_set_entry(i, mmz_addr, cpu_addr);
+            ADDR_U64(mmz_addr) += HASH_NODE_SIZE; /* move to next channel */
+            cpu_addr = (hi_u8 *)cpu_addr + HASH_NODE_SIZE; /* move to next channel */
+        }
+    }
+    return;
+}
+
+hi_s32 drv_hash_init(void)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_s32 ret_error = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (HI_TRUE == hash_initialize) {
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    ret = crypto_channel_init(hash_hard_channel, CRYPTO_HARD_CHANNEL_MAX, sizeof(hash_hard_context));
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, hash channel list init failed\n");
+        HI_LOG_PRINT_FUNC_ERR(crypto_channel_init, ret);
+        return ret;
+    }
+
+    HI_LOG_INFO("enable hash\n");
+    module_enable(CRYPTO_MODULE_ID_HASH);
+
+    HI_LOG_INFO("alloc memory for nodes list\n");
+    ret = hash_mem_create(&hash_dma, SEC_MMZ, "hash_node_list", HASH_NODE_LIST_SIZE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, malloc ddr for hash nodes list failed\n");
+        HI_LOG_PRINT_FUNC_ERR(hash_mem_create, ret);
+        goto __error1;
+    }
+    HI_LOG_INFO("HASH DMA buffer, MMU 0x%x, MMZ 0x%x, VIA %p, size 0x%x\n",
+                ADDR_L32(hash_dma.dma_addr), ADDR_L32(hash_dma.mmz_addr),
+                hash_dma.dma_virt, hash_dma.dma_size);
+
+    HI_LOG_INFO("hash entry list configure\n");
+    hash_enrty_init(hash_dma);
+
+    HI_LOG_INFO("hash SMMU configure\n");
+    hash_smmu_bypass();
+    drv_hash_smmu_base_addr();
+
+    HI_LOG_INFO("hash secure channel configure\n");
+    drv_hash_enable_secure();
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    HI_LOG_INFO("hash interrupt configure\n");
+    hash_set_interrupt();
+
+    HI_LOG_INFO("hash register interrupt function\n");
+    ret = drv_hash_register_interrupt();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, register interrupt failed\n");
+        HI_LOG_PRINT_FUNC_ERR(drv_hash_register_interrupt, ret);
+        ret_error = hash_mem_destory(&hash_dma);
+        if (ret_error != HI_SUCCESS) {
+            HI_LOG_ERROR("error, hash dma crypto mem destory failed.\n");
+            HI_LOG_PRINT_FUNC_ERR(hash_mem_destory, ret_error);
+        }
+        goto __error1;
+    }
+#endif
+
+    hash_initialize = HI_TRUE;
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+__error1:
+    module_disable(CRYPTO_MODULE_ID_HASH);
+    ret_error = crypto_channel_deinit(hash_hard_channel, CRYPTO_HARD_CHANNEL_MAX);
+    if (ret_error != HI_SUCCESS) {
+        HI_LOG_ERROR("error, crypto channel deinit failed.\n");
+        HI_LOG_PRINT_FUNC_ERR(crypto_channel_deinit, ret_error);
+    }
+
+    return ret;
+}
+
+hi_s32 drv_hash_deinit(void)
+{
+    hi_s32 ret = HI_FAILURE;
+    HI_LOG_FUNC_ENTER();
+
+    if (HI_FALSE == hash_initialize) {
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    drv_hash_unregister_interrupt();
+#endif
+
+    ret = hash_mem_destory(&hash_dma);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hash_mem_destory, ret);
+        return ret;
+    }
+    module_disable(CRYPTO_MODULE_ID_HASH);
+    ret = crypto_channel_deinit(hash_hard_channel, CRYPTO_HARD_CHANNEL_MAX);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(crypto_channel_deinit, ret);
+        return ret;
+    }
+
+    hash_initialize = HI_FALSE;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_hash_resume(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_INFO("enable hash\n");
+    module_enable(CRYPTO_MODULE_ID_HASH);
+
+    HI_LOG_INFO("hash entry list configure\n");
+    hash_enrty_init(hash_dma);
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    HI_LOG_INFO("hash interrupt configure\n");
+    hash_set_interrupt();
+#endif
+
+    HI_LOG_INFO("hash SMMU configure\n");
+    hash_smmu_bypass();
+    drv_hash_smmu_base_addr();
+
+    HI_LOG_INFO("hash secure channel configure\n");
+    drv_hash_enable_secure();
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+void drv_hash_suspend(void)
+{
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+/* wait hash ready */
+static hi_s32 drv_hash_wait_ready(hi_u32 chn_num)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    hi_u32 errcode = 0;
+    hi_u32 i;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    module_get_attr(CRYPTO_MODULE_ID_HASH, &int_valid, &int_num, HI_NULL);
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    /* interrupt support, wait irq*/
+    if (int_valid) {
+        hash_hard_context *ctx = HI_NULL;
+
+        ctx = (hash_hard_context *)hash_hard_channel[chn_num].ctx;
+
+        ret = crypto_queue_wait_timeout(ctx->queue, &ctx->done, CRYPTO_TIME_OUT);
+        if ((0x00 < ret) || (-ERESTARTSYS == ret)) {
+            ret = HI_SUCCESS;
+        } else {
+            HI_LOG_ERROR("wait done timeout, chn=%d, ret %d\n", chn_num, ret);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_TIMEOUT);
+            ret = HI_ERR_CIPHER_TIMEOUT;
+        }
+    } else /* interrupt unsupport, query the raw interrupt flag*/
+#endif
+    {
+        for (i = 0; i < CRYPTO_TIME_OUT; i++) {
+            if (hash_done_try(chn_num)) {
+                break;
+            }
+
+            if (MS_TO_US >= i) {
+                crypto_udelay(1);  /* short waitting for 1000 us */
+            } else {
+                crypto_msleep(1);  /* long waitting for 5000 ms*/
+            }
+        }
+        if (CRYPTO_TIME_OUT <= i) {
+            HI_LOG_ERROR("hash wait done timeout, chn=%d\n", chn_num);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_TIMEOUT);
+            ret = HI_ERR_CIPHER_TIMEOUT;
+        } else {
+            ret = HI_SUCCESS;
+        }
+    }
+
+    if (ret != HI_SUCCESS) {
+        errcode = drv_hash_get_err_code(chn_num);
+        HI_LOG_ERROR("hard error code: 0x%x\n", errcode);
+        CRYPTO_UNUSED(errcode);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return ret;
+}
+
+static void hash_addbuf(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size)
+{
+    hash_hard_context *ctx = HI_NULL;
+    hi_u32 id = 0, size = 0;
+    void *addr = HI_NULL;
+
+    ctx = (hash_hard_context *)hash_hard_channel[chn_num].ctx;
+
+    /* clean in entry */
+    id = ctx->id_in++;
+    addr = &ctx->entry_in[id];
+    size = sizeof(struct hash_entry_in);
+
+    crypto_memset(addr, size, 0, size);
+
+    /* set addr and length */
+    ctx->entry_in[id].spacc_cmd = 0x00;
+    ctx->entry_in[id].hash_start_addr = ADDR_L32(buf_phy);
+    ctx->entry_in[id].word1 = ADDR_H32(buf_phy);
+    ctx->entry_in[id].hash_alg_length = buf_size;
+    ctx->entry_in[id].hash_ctrl = HASH_CTRL_HASH_IN_FIRST | HASH_CTRL_HASH_IN_LAST;
+    ctx->id_in %= HASH_MAX_DEPTH;
+    HI_LOG_INFO("add digest in buf: id %d, addr 0x%x, len 0x%x\n",
+                id, ADDR_L32(buf_phy), buf_size);
+
+    return;
+}
+
+hi_s32 drv_hash_config(hi_u32 chn_num, hash_mode mode, hi_u32 state[HASH_RESULT_MAX_SIZE_IN_WORD])
+{
+    hash_hard_context *ctx = HI_NULL;
+    chann_hash_ctrl hash_ctrl;
+    hi_u32 i = 0;
+
+    HI_LOG_CHECK_PARAM(hash_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(((HASH_HARD_CHANNEL_MASK >> chn_num) & 0x01) == 0);
+
+    ctx = (hash_hard_context *)hash_hard_channel[chn_num].ctx;
+    ctx->hash_alg = mode;
+
+    /* Control */
+    hash_ctrl.u32 = HASH_READ(CHANn_HASH_CTRL(chn_num));
+    hash_ctrl.bits.hash_chn_mode = 0;
+    hash_ctrl.bits.hash_chn_agl_sel = mode;
+    HASH_WRITE(CHANn_HASH_CTRL(chn_num), hash_ctrl.u32);
+    HI_LOG_INFO("CTRL: 0x%X\n", hash_ctrl.u32);
+
+    /*Write last state*/
+    for (i = 0; i < HASH_RESULT_MAX_SIZE_IN_WORD; i++) {
+        HASH_WRITE(CHANn_HASH_STATE_VAL_ADDR(chn_num), i);
+        HASH_WRITE(CHANn_HASH_STATE_VAL(chn_num), state[i]);
+    }
+    HI_LOG_INFO("state[0]: 0x%x\n", state[0]);
+
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_hash_start(hi_u32 chn_num, crypto_mem *mem, hi_u32 length)
+{
+    chann_hash_int_node_cfg in_node_cfg;
+    hash_hard_context *ctx = HI_NULL;
+    hi_u32 ptr = 0;
+    crypto_mem *hash_dma_ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(hash_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(((HASH_HARD_CHANNEL_MASK >> chn_num) & 0x01) == 0);
+
+    ctx = (hash_hard_context *)hash_hard_channel[chn_num].ctx;
+
+    if (0 == length) {
+        return HI_SUCCESS;
+    }
+
+    ctx->done = HI_FALSE;
+
+    /* set message addr and length */
+    hash_addbuf(chn_num, mem->dma_addr, length);
+
+    /* configure in-node, only compute one nodes */
+    in_node_cfg.u32 = HASH_READ(CHANn_HASH_IN_NODE_CFG(chn_num));
+    ptr = in_node_cfg.bits.hash_in_node_wptr + 1;
+    in_node_cfg.bits.hash_in_node_wptr = ptr % HASH_MAX_DEPTH;
+    in_node_cfg.bits.hash_in_node_mpackage_int_level = 1;
+
+    /* hash flush cache of hash mem and hash list buffer. */
+    crypto_cpuc_flush_dcache_area(mem->dma_virt, length);
+    hash_dma_ctx = &hash_dma;
+    crypto_cpuc_flush_dcache_area(hash_dma_ctx->dma_virt, HASH_NODE_LIST_SIZE);
+
+    /* Start */
+    HASH_WRITE(CHANn_HASH_IN_NODE_CFG(chn_num), in_node_cfg.u32);
+    HI_LOG_INFO("CHANn_HASH_IN_NODE_CFG: 0x%x\n", in_node_cfg.u32);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_hash_wait_done(hi_u32 chn_num, hi_u32 *state)
+{
+    hi_u32 i = 0;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(hash_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(((HASH_HARD_CHANNEL_MASK >> chn_num) & 0x01) == 0);
+
+    ret = drv_hash_wait_ready(chn_num);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_hash_wait_ready, ret);
+        return ret;
+    }
+
+    /* read hash result */
+    for (i = 0; i < HASH_RESULT_MAX_SIZE_IN_WORD; i++) {
+        HASH_WRITE(CHANn_HASH_STATE_VAL_ADDR(chn_num), i);
+        state[i] = HASH_READ(CHANn_HASH_STATE_VAL(chn_num));
+    }
+    HI_LOG_DEBUG("digest[0]: 0x%x\n", state[0]);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_hash_reset(hi_u32 chn_num)
+{
+    CRYPTO_UNUSED(chn_num);
+}
+
+void drv_hash_get_capacity(hash_capacity *capacity)
+{
+    crypto_memset(capacity, sizeof(hash_capacity), 0,  sizeof(hash_capacity));
+
+    capacity->sha1   = CRYPTO_CAPACITY_SUPPORT;
+    capacity->sha224 = CRYPTO_CAPACITY_SUPPORT;
+    capacity->sha256 = CRYPTO_CAPACITY_SUPPORT;
+    capacity->sha384 = CRYPTO_CAPACITY_SUPPORT;
+    capacity->sha512 = CRYPTO_CAPACITY_SUPPORT;
+    capacity->sm3    = CRYPTO_CAPACITY_SUPPORT;
+
+    return;
+}
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+
+#endif //End of CHIP_HASH_VER_V200

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_hash_v200.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_hash_v200.h
@@ -1,0 +1,193 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_hash_v200.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef _DRV_HASH_V1_H_
+#define _DRV_HASH_V1_H_
+
+#include "drv_osal_lib.h"
+
+/*************************** Internal Structure Definition ****************************/
+/** \addtogroup      hash drivers*/
+/** @{*/  /** <!-- [hash]*/
+
+/*! \Define the offset of reg */
+#define SEC_CHN_CFG                      (0x0304)
+#define CALC_ERR                         (0x0320)
+#define CIPHER_INT_STATUS                (0x0404)
+#define NORM_SMMU_START_ADDR             (0x0440)
+#define SEC_SMMU_START_ADDR              (0x0444)
+#define HASH_INT_STATUS                  (0x0804)
+#define HASH_INT_EN                      (0x0808)
+#define HASH_INT_RAW                     (0x080C)
+#define HASH_IN_SMMU_EN                  (0x0810)
+#define CHAN0_HASH_DAT_IN                (0x0818)
+#define CHAN0_HASH_TOTAL_DAT_LEN         (0x081C)
+#define CHANn_HASH_CTRL(id)              (0x0800 + (id)*0x80)
+#define CHANn_HASH_IN_NODE_CFG(id)       (0x0804 + (id)*0x80)
+#define CHANn_HASH_IN_NODE_START_ADDR(id)(0x0808 + (id)*0x80)
+#define CHANn_HASH_IN_BUF_RPTR(id)       (0x080C + (id)*0x80)
+#define CHANn_HASH_STATE_VAL(id)         (0x0340 + (id)*0x08)
+#define CHANn_HASH_STATE_VAL_ADDR(id)    (0x0344 + (id)*0x08)
+#define CHANN_HASH_IN_NODE_START_HIGH(id)(0x0820 + (id)*0x80)
+
+/* Define the union sec_chn_cfg */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    cipher_sec_chn_cfg    : 8   ; /* [7..0]  */
+        unsigned int    cipher_sec_chn_cfg_lock : 1   ; /* [8]  */
+        unsigned int    reserved_0            : 7   ; /* [15..9]  */
+        unsigned int    hash_sec_chn_cfg      : 8   ; /* [23..16]  */
+        unsigned int    hash_sec_chn_cfg_lock : 1   ; /* [24]  */
+        unsigned int    reserved_1            : 7   ; /* [31..25]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} sec_chn_cfg;
+
+/* Define the union chan0_hash_ctrl */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    hash_ch0_start        : 1   ; /* [0]  */
+        unsigned int    hash_ch0_agl_sel      : 3   ; /* [3..1]  */
+        unsigned int    hash_ch0_hmac_calc_step : 1   ; /* [4]  */
+        unsigned int    hash_ch0_mode         : 1   ; /* [5]  */
+        unsigned int    hash_ch0_key_sel      : 1   ; /* [6]  */
+        unsigned int    reserved_0            : 2   ; /* [8..7]  */
+        unsigned int    hash_ch0_auto_padding_en : 1   ; /* [9]  */
+        unsigned int    hash_ch0_hmac_key_addr : 3   ; /* [12..10]  */
+        unsigned int    hash_ch0_used          : 1   ; /* [13]  */
+        unsigned int    hash_ch0_sec_alarm     : 1   ; /* [13]  */
+        unsigned int    reserved_1            : 17  ; /* [31..15]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} chan0_hash_ctrl;
+
+/* Define the union hash_int_status */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    reserved_0            : 18  ; /* [17..0]  */
+        unsigned int    hash_chn_oram_int     : 8   ; /* [25..18]  */
+        unsigned int    reserved_1            : 6   ; /* [31..26]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} hash_int_status;
+
+/* Define the union hash_int_en */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    reserved_0            : 18  ; /* [17..0]  */
+        unsigned int    hash_chn_oram_en      : 8   ; /* [25..18]  */
+        unsigned int    reserved_1            : 4   ; /* [29..26]  */
+        unsigned int    hash_sec_int_en       : 1   ; /* [30]  */
+        unsigned int    hash_int_en           : 1   ; /* [31]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} hash_int_en;
+
+/* Define the union hash_int_raw */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    reserved_0            : 18  ; /* [17..0]  */
+        unsigned int    hash_chn_oram_raw     : 8   ; /* [25..18]  */
+        unsigned int    reserved_1            : 6   ; /* [31..26]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} hash_int_raw;
+
+/* Define the union cipher_int_status */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    reserved_0            : 1   ; /* [0]  */
+        hi_u32    cipher_chn_ibuf_int   : 7   ; /* [7..1]  */
+        hi_u32    cipher_chn_obuf_int   : 8   ; /* [15..8]  */
+        hi_u32    reserved_1            : 16  ; /* [31..16]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} cipher_int_status;
+
+/* Define the union hash_in_smmu_en */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    hash_in_chan_rd_dat_smmu_en : 7   ; /* [6..0]  */
+        unsigned int    reserved_0            : 9   ; /* [15..7]  */
+        unsigned int    hash_in_chan_rd_node_smmu_en : 7   ; /* [22..16]  */
+        unsigned int    reserved_1            : 9   ; /* [31..23]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} hash_in_smmu_en;
+
+/* Define the union chann_hash_ctrl */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    reserved_0            : 1   ; /* [0]  */
+        unsigned int    hash_chn_agl_sel      : 3   ; /* [3..1]  */
+        unsigned int    reserved_1            : 1   ; /* [4]  */
+        unsigned int    hash_chn_mode         : 1   ; /* [5]  */
+        unsigned int    hash_chn_key_sel      : 1   ; /* [6]  */
+        unsigned int    hash_chn_dat_in_byte_swap_en : 1   ; /* [7]  */
+        unsigned int    hash_chn_dat_in_bit_swap_en : 1   ; /* [8]  */
+        unsigned int    hash_chn_auto_padding_en : 1   ; /* [9]  */
+        unsigned int    hash_chn_hmac_key_addr : 3   ; /* [12..10]  */
+        unsigned int    reserved_2            : 19  ; /* [31..13]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} chann_hash_ctrl;
+
+/* Define the union chann_hash_int_node_cfg */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    hash_in_node_mpackage_int_level : 8   ; /* [7..0]  */
+        unsigned int    hash_in_node_rptr     : 8   ; /* [15..8]  */
+        unsigned int    hash_in_node_wptr     : 8   ; /* [23..16]  */
+        unsigned int    hash_in_node_total_num : 8   ; /* [31..24]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} chann_hash_int_node_cfg;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_ifep_rsa_v100.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_ifep_rsa_v100.c
@@ -1,0 +1,644 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_ifep_rsa_v100.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_ifep_rsa_v100.h"
+#include "drv_srsa.h"
+#include "drv_trng.h"
+#include "drv_klad.h"
+
+#ifdef CHIP_IFEP_RSA_VER_V100
+
+/*************************** Structure Definition ****************************/
+/** \addtogroup     rsa */
+/** @{ */  /** <!-- [rsa] */
+
+
+/*! Define the time out */
+#define RSA_TIME_OUT             5000
+
+/* rsa support rand mask or not */
+#define RSA_SUB_VER_RAND_MASK    (0x20160907)
+#define RSA_SUB_VER_NORMAL       (0x00)
+
+/* crc 16 */
+#define CRC16_TABLE_SIZE          256
+#define U16_MSB                   0x8000
+#define BYTE_MASK                 0xFF
+#define CRC16_POLYNOMIAL          0x1021
+#define BLOCK_BYTES               0x08
+
+/* rsa work mode */
+#define RSA_MODE_EXP              0x00
+#define RSA_MODE_CLEAR_RAM        0x02
+
+/*! rsa already initialize or not */
+static hi_u32 rsa_initialize = HI_FALSE;
+
+/*! Define the context of rsa */
+typedef struct {
+    hi_u32 rsa_sub_ver;
+    hi_u32 done;                   /*!<  calculation finish flag*/
+    crypto_queue_head  queue;   /*!<  quene list */
+} rsa_hard_context;
+
+static rsa_hard_context rsainfo;
+
+/** @} */  /** <!-- ==== Structure Definition end ==== */
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      rsa */
+/** @{ */  /** <!--[rsa]*/
+
+#ifdef RSA_RAND_MASK
+
+static u16 crc_table[CRC16_TABLE_SIZE];
+
+static void drv_rsa_crc16_init(void)
+{
+    u16 remainder;
+    u16 n, m;
+    u16  *local_crc_table = crc_table;
+
+    for (n = 0; n < CRC16_TABLE_SIZE; n ++) {
+        remainder = (HI_U16)n << BITS_IN_BYTE;
+        for (m = BITS_IN_BYTE; m > 0; m --) {
+            if (remainder & U16_MSB) {
+                remainder = (remainder << 1) ^ CRC16_POLYNOMIAL;
+            } else {
+                remainder = (remainder << 1);
+            }
+        }
+        *(local_crc_table + n) = remainder;
+    }
+}
+
+static u16 drv_rsa_crc16_block(u16 crc, hi_u8 block[BLOCK_BYTES], hi_u8 rand_number[BLOCK_BYTES])
+{
+    hi_u8 i, j;
+    hi_u8 val;
+
+    for (i = 0; i < BLOCK_BYTES / WORD_WIDTH; i++) {
+        for (j = 0; j < WORD_WIDTH; j++) {
+            val = block[i * 4 + 3 - j] ^ rand_number[i * 4 + 3 - j];
+            crc = (crc << BITS_IN_BYTE) ^ crc_table[((crc >> BITS_IN_BYTE) ^ val) & BYTE_MASK];
+        }
+    }
+    return crc;
+}
+
+static u16 drv_rsa_key_crc(hi_u8 *n, hi_u8 *k, hi_u32 klen, hi_u32 randnum[2])
+{
+    hi_u32 i;
+    u16 crc = 0;
+
+    for (i = 0; i < klen; i += BLOCK_BYTES) {
+        crc = drv_rsa_crc16_block(crc, n + i, (hi_u8 *)randnum);
+    }
+    for (i = 0; i < klen; i += BLOCK_BYTES) {
+        crc = drv_rsa_crc16_block(crc, k + i, (hi_u8 *)randnum);
+    }
+    return crc;
+}
+#endif
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+
+/*! set interrupt */
+static void rsa_set_interrupt(void)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    sec_rsa_int_en int_en;
+
+    module_get_attr(CRYPTO_MODULE_ID_IFEP_RSA, &int_valid, &int_num, HI_NULL);
+    if (int_valid == HI_FALSE) {
+        return;
+    }
+    if (rsainfo.rsa_sub_ver != RSA_SUB_VER_RAND_MASK) {
+        return;
+    }
+
+    int_en.u32 = IFEP_RSA_READ(REG_SEC_RSA_INT_EN);
+
+    /*The top interrupt switch only can be enable/disable by secure CPU*/
+    int_en.bits.rsa_int_en = 1;
+    int_en.bits.int_en = 1;
+    IFEP_RSA_WRITE(REG_SEC_RSA_INT_EN, int_en.u32);
+    HI_LOG_INFO("RSA_INT_EN: 0x%x\n", int_en.u32);
+
+    return;
+}
+
+static hi_u32 drv_rsa_done_notify(void)
+{
+    sec_rsa_int_status int_st;
+    sec_rsa_int_raw int_raw;
+
+    int_st.u32 = IFEP_RSA_READ(REG_SEC_RSA_INT_STATUS);
+    int_raw.u32 = 0x00;
+
+    HI_LOG_DEBUG("REG_SEC_RSA_INT_STATUS: 0x%x\n", int_st.u32);
+
+    /*Clean raw int*/
+    int_raw.bits.rsa_int_raw = 1;
+    IFEP_RSA_WRITE(REG_SEC_RSA_INT_RAW, int_raw.u32);
+
+    return int_st.bits.rsa_int_status;
+}
+
+/*! rsa interrupt process function */
+static irqreturn_t drv_rsa_interrupt_isr(hi_s32 irq, void *devId)
+{
+    CRYPTO_UNUSED(irq);
+
+    drv_rsa_done_notify();
+
+    rsainfo.done = HI_TRUE;
+    HI_LOG_DEBUG("rsa wake up\n");
+    crypto_queue_wait_up(&rsainfo.queue);
+
+    return IRQ_HANDLED;
+}
+
+/*! rsa register interrupt process function */
+static hi_s32 drv_rsa_register_interrupt(void)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 int_valid = 0, int_num = 0;
+    const char *name;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_IFEP_RSA, &int_valid, &int_num, &name);
+    if (int_valid == HI_FALSE) {
+        return HI_SUCCESS;
+    }
+    if (rsainfo.rsa_sub_ver != RSA_SUB_VER_RAND_MASK) {
+        return HI_SUCCESS;
+    }
+
+    /* request irq */
+    ret = crypto_request_irq(int_num, drv_rsa_interrupt_isr, name);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("Irq request failure, irq = %d", int_num);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_REGISTER_IRQ);
+        return ret;
+    }
+
+    /* initialize queue list*/
+    crypto_queue_init(&rsainfo.queue);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/*! rsa unregister interrupt process function */
+static void drv_rsa_unregister_interrupt(void)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    const char *name = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_IFEP_RSA, &int_valid, &int_num, &name);
+
+    if (int_valid == HI_FALSE) {
+        return;
+    }
+
+    if (rsainfo.rsa_sub_ver != RSA_SUB_VER_RAND_MASK) {
+        return;
+    }
+
+    /* free irq */
+    HI_LOG_INFO("rsa free irq, num %d, name %s\n", int_num, name);
+    crypto_free_irq(int_num, name);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+#endif
+
+hi_s32 drv_rsa_init(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_INFO("enable rsa\n");
+
+    if (rsa_initialize == HI_TRUE) {
+        return HI_SUCCESS;
+    }
+
+#ifdef RSA_RAND_MASK
+    drv_rsa_crc16_init();
+#endif
+
+    module_enable(CRYPTO_MODULE_ID_IFEP_RSA);
+
+    /* RSA request the TRNG must valid */
+    module_enable(CRYPTO_MODULE_ID_TRNG);
+
+    rsainfo.rsa_sub_ver = IFEP_RSA_READ(REG_SEC_RSA_VERSION_ID);
+    HI_LOG_INFO("rsa version 0x%x\n", rsainfo.rsa_sub_ver);
+    module_disable(CRYPTO_MODULE_ID_IFEP_RSA);
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    {
+        hi_s32 ret = HI_FAILURE;
+
+        HI_LOG_INFO("rsa register interrupt function\n");
+        ret = drv_rsa_register_interrupt();
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("error, register interrupt failed\n");
+            HI_LOG_PRINT_FUNC_ERR(drv_rsa_register_interrupt, ret);
+            return ret;
+        }
+    }
+#endif
+
+    rsa_initialize = HI_TRUE;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_rsa_deinit(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    if (rsa_initialize == HI_FALSE) {
+        return HI_SUCCESS;
+    }
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    drv_rsa_unregister_interrupt();
+#endif
+
+    rsa_initialize = HI_FALSE;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static void drv_rsa_resume(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    module_enable(CRYPTO_MODULE_ID_IFEP_RSA);
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    HI_LOG_INFO("RSA interrupt configure\n");
+    rsa_set_interrupt();
+#endif
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+static void drv_rsa_suspend(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    module_disable(CRYPTO_MODULE_ID_IFEP_RSA);
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+static void drv_rsa_set_width(rsa_key_width width)
+{
+    sec_rsa_mod_reg ctrl;
+
+    ctrl.u32 = 0x00;
+    ctrl.bits.sec_rsa_mod_sel = RSA_MODE_EXP;
+    ctrl.bits.sec_rsa_key_width = width;
+    IFEP_RSA_WRITE(REG_SEC_RSA_MOD_REG, ctrl.u32);
+    HI_LOG_INFO("REG_SEC_RSA_MOD_REG 0x%x\n", ctrl.u32);
+    return;
+}
+
+static hi_s32 drv_rsa_set_key(hi_u32 ca_type, hi_u8 *n, hi_u8 *d, hi_u32 klen, hi_u32 random[2])
+{
+    hi_u32 i = 0, id = 0;
+    hi_u32 val = 0x00;
+    hi_s32 ret = HI_FAILURE;
+
+    /**
+     * The even word shell XOR with even random[0]
+     * The odd word shell XOR with odd random[1]
+     * The random may be zero.
+     * Must set N before set E.
+     * The E must padding with zero.
+     */
+
+    /* Set N */
+    for (i = 0; i < klen; i += WORD_WIDTH) {
+        crypto_memcpy(&val, sizeof(hi_u32), n + i, WORD_WIDTH);
+        val ^= random[id];
+        IFEP_RSA_WRITE(REG_SEC_RSA_WSEC_REG, val);
+
+        /* switch between even and odd */
+        id ^= 0x01;
+    }
+
+    /* Set D */
+    if (ca_type != HI_CIPHER_KEY_SRC_USER) {
+        ret = drv_cipher_klad_load_key(0, ca_type, HI_CIPHER_KLAD_TARGET_RSA, d, klen);
+        if ( ret != HI_SUCCESS ) {
+            HI_LOG_ERROR("drv_cipher_klad_load_key, error!\n");
+            return ret;
+        }
+    } else {
+        for (i = 0; i < klen; i += WORD_WIDTH) {
+            crypto_memcpy(&val, sizeof(hi_u32), d + i, WORD_WIDTH);
+            val ^= random[id];
+            IFEP_RSA_WRITE(REG_SEC_RSA_WSEC_REG, val);
+
+            /* switch between even and odd */
+            id ^= 0x01;
+        }
+    }
+    return HI_SUCCESS;
+}
+
+static void drv_rsa_set_input(hi_u8 *in, hi_u32 klen)
+{
+    hi_u32 i = 0;
+    hi_u32 val = 0x00;
+
+    for (i = 0; i < klen; i += WORD_WIDTH) {
+        crypto_memcpy(&val, sizeof(hi_u32), in + i, WORD_WIDTH);
+        IFEP_RSA_WRITE(REG_SEC_RSA_WDAT_REG, val);
+    }
+    return;
+}
+
+static void drv_rsa_get_output(hi_u8 *out, hi_u32 klen)
+{
+    hi_u32 i = 0;
+    hi_u32 val = 0x00;
+
+    for (i = 0; i < klen; i += 4) {
+        val = IFEP_RSA_READ(REG_SEC_RSA_RRSLT_REG);
+        crypto_memcpy(out + i, sizeof(hi_u32), &val, 4);
+    }
+    return;
+}
+
+static hi_u32 drv_rsa_get_klen(rsa_key_width width)
+{
+    hi_u32 klen = 0x00;
+
+    /* nonsupport rsa 3072, can compute it as 4096 */
+
+    switch (width) {
+        case RSA_KEY_WIDTH_1024: {
+            klen = RSA_KEY_LEN_1024;
+            break;
+        }
+        case RSA_KEY_WIDTH_2048: {
+            klen = RSA_KEY_LEN_2048;
+            break;
+        }
+        case RSA_KEY_WIDTH_4096: {
+            klen = RSA_KEY_LEN_4096;
+            break;
+        }
+        default: {
+            HI_LOG_ERROR("error, nonsupport RSA width %d\n", width);
+            klen = 0;
+            break;
+        }
+    }
+
+    return klen;
+}
+
+static void drv_rsa_start(void)
+{
+    sec_rsa_start_reg start;
+
+    HI_LOG_FUNC_ENTER();
+
+    rsainfo.done = HI_FALSE;
+
+    start.u32 = 0x00;
+
+    if (rsainfo.rsa_sub_ver == RSA_SUB_VER_RAND_MASK) {
+        start.bits.sec_rsa_start_reg = 0x05;
+    } else {
+        start.bits.sec_rsa_start_reg = 0x01;
+    }
+
+    IFEP_RSA_WRITE(REG_SEC_RSA_START_REG, start.u32);
+    HI_LOG_INFO("REG_SEC_RSA_START_REG 0x%x\n", start.u32);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+static hi_s32 drv_rsa_wait_done(void)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    hi_u32 i;
+    sec_rsa_busy_reg ready;
+    const char *name = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_IFEP_RSA, &int_valid, &int_num, &name);
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    /* interrupt support, wait irq*/
+    if ((rsainfo.rsa_sub_ver == RSA_SUB_VER_RAND_MASK) && (int_valid == HI_TRUE)) {
+        hi_s32 ret = HI_FAILURE;
+
+        /* wait interrupt */
+        ret = crypto_queue_wait_timeout(rsainfo.queue, &rsainfo.done, RSA_TIME_OUT);
+        if ((ret <= 0x00) && (ret != -ERESTARTSYS)) {
+            HI_LOG_ERROR("wait done timeout\n");
+            HI_LOG_PRINT_FUNC_ERR(crypto_queue_wait_timeout, ret);
+            return HI_ERR_CIPHER_TIMEOUT;
+        }
+    } else
+#endif
+    {
+        /* wait ready */
+        for (i = 0; i < RSA_TIME_OUT; i++) {
+            ready.u32 = IFEP_RSA_READ(REG_SEC_RSA_BUSY_REG);
+            if (!ready.bits.sec_rsa_busy_reg) {
+                break;
+            }
+            crypto_msleep(1);
+        }
+
+        if (i >= RSA_TIME_OUT) {
+            HI_LOG_ERROR("error, rsa wait free timeout\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_TIMEOUT);
+            return HI_ERR_CIPHER_TIMEOUT;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static void drv_rsa_randnum(hi_u8 *n, hi_u8 *k, hi_u32 klen, hi_u32 random[2])
+{
+    HI_LOG_FUNC_ENTER();
+
+#ifdef RSA_RAND_MASK
+    if (rsainfo.rsa_sub_ver == RSA_SUB_VER_RAND_MASK) {
+        u16 crc16 = 0;
+
+        random[0] = get_rand();
+        random[1] = get_rand();
+
+        crc16 = drv_rsa_key_crc(n, k, klen, random);
+        HI_LOG_INFO("random 0x%x 0x%x, CRC16: 0x%x\n", random[0], random[1], crc16);
+        IFEP_RSA_WRITE(REG_SEC_RSA_KEY_RANDOM_1, random[0]);
+        IFEP_RSA_WRITE(REG_SEC_RSA_KEY_RANDOM_2, random[1]);
+        IFEP_RSA_WRITE(REG_SEC_RSA_CRC16_REG, crc16);
+    } else
+#endif
+    {
+        random[0] = 0x00;
+        random[1] = 0x00;
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+static hi_s32 drv_rsa_clean_ram(void)
+{
+    hi_s32 ret = HI_FAILURE;
+    sec_rsa_mod_reg ctrl;
+
+    ctrl.u32 = IFEP_RSA_READ(REG_SEC_RSA_MOD_REG);
+    ctrl.bits.sec_rsa_mod_sel = RSA_MODE_CLEAR_RAM;
+    ctrl.bits.sec_rsa_data0_clr = 1;
+    ctrl.bits.sec_rsa_data1_clr = 1;
+    ctrl.bits.sec_rsa_data2_clr = 1;
+    IFEP_RSA_WRITE(REG_SEC_RSA_MOD_REG, ctrl.u32);
+
+    /* start */
+    drv_rsa_start();
+
+    /* wait done */
+    ret = drv_rsa_wait_done();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_rsa_wait_done, ret);
+        return ret;
+    }
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 drv_rsa_error_code(void)
+{
+    hi_u32 code = 0;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (rsainfo.rsa_sub_ver == RSA_SUB_VER_RAND_MASK) {
+        code = IFEP_RSA_READ(REG_SEC_RSA_ERROR_REG);
+    }
+
+    if (code == 0x00) {
+        ret = HI_SUCCESS;
+    } else {
+        HI_LOG_ERROR("rsa error code: 0x%x\n", code);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_HARD_STATUS);
+        return HI_ERR_CIPHER_HARD_STATUS;
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+hi_s32 drv_ifep_rsa_exp_mod(hi_u32 ca_type, hi_u8 *n, hi_u8 *k, hi_u8 *in, hi_u8 *out, rsa_key_width width)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 klen = 0;
+    hi_u32 random[2] = {0, 0};
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(rsa_initialize);
+
+    klen = drv_rsa_get_klen(width);
+    if (klen == 0) {
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    drv_rsa_resume();
+
+    /* set rsa width */
+    drv_rsa_set_width(width);
+
+    /* config randnum */
+    drv_rsa_randnum(n, k, klen, random);
+
+    /* set rsa key */
+    ret = drv_rsa_set_key(ca_type, n, k, klen, random);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_rsa_set_key, ret);
+        ret = HI_ERR_CIPHER_ILLEGAL_KEY;
+        goto exit;
+    }
+
+    /* set input data */
+    drv_rsa_set_input(in, klen);
+
+    /* start */
+    drv_rsa_start();
+
+    /* wait done */
+    ret = drv_rsa_wait_done();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_rsa_wait_done, ret);
+        ret = HI_ERR_CIPHER_TIMEOUT;
+        goto exit;
+    }
+
+    /* get input data */
+    drv_rsa_get_output(out, klen);
+
+    ret = drv_rsa_error_code();
+exit:
+    /* clean key and data */
+    (void)drv_rsa_clean_ram();
+    drv_rsa_suspend();
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+void drv_ifep_rsa_get_capacity(rsa_capacity *capacity)
+{
+    crypto_memset(capacity, sizeof(rsa_capacity), 0,  sizeof(rsa_capacity));
+
+    capacity->rsa = CRYPTO_CAPACITY_SUPPORT;
+
+    return;
+}
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+
+#endif //End of CHIP_RSA_VER_V100

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_ifep_rsa_v100.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_ifep_rsa_v100.h
@@ -1,0 +1,126 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_ifep_rsa_v100.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef _DRV_RSA_V1_H_
+#define _DRV_RSA_V1_H_
+
+#include "drv_osal_lib.h"
+
+/*************************** Internal Structure Definition ****************************/
+/** \addtogroup      rsa drivers*/
+/** @{*/  /** <!-- [rsa]*/
+
+/*! \Define the offset of reg */
+#define REG_SEC_RSA_BUSY_REG                          (0x50)
+#define REG_SEC_RSA_MOD_REG                           (0x54)
+#define REG_SEC_RSA_WSEC_REG                          (0x58)
+#define REG_SEC_RSA_WDAT_REG                          (0x5c)
+#define REG_SEC_RSA_RPKT_REG                          (0x60)
+#define REG_SEC_RSA_RRSLT_REG                         (0x64)
+#define REG_SEC_RSA_START_REG                         (0x68)
+#define REG_SEC_RSA_ADDR_REG                          (0x6C)
+#define REG_SEC_RSA_ERROR_REG                         (0x70)
+#define REG_SEC_RSA_CRC16_REG                         (0x74)
+#define REG_SEC_RSA_KEY_RANDOM_1                      (0x7c)
+#define REG_SEC_RSA_INT_EN                            (0x80)
+#define REG_SEC_RSA_INT_STATUS                        (0x84)
+#define REG_SEC_RSA_INT_RAW                           (0x88)
+#define REG_SEC_RSA_INT_ERR_CLR                       (0x8c)
+#define REG_SEC_RSA_VERSION_ID                        (0x90)
+#define REG_SEC_RSA_KEY_RANDOM_2                      (0x94)
+
+/*! \Define the union sec_rsa_busy_reg */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    sec_rsa_busy_reg  : 1   ; /* [0]  */
+        hi_u32    reserved_1        : 31  ; /* [31..1]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+
+} sec_rsa_busy_reg;
+
+/*! \Define the union sec_rsa_mod_reg */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    sec_rsa_mod_sel     : 2  ; /* [1..0]  */
+        hi_u32    sec_rsa_key_width   : 2  ; /* [3..2]  */
+        hi_u32    sec_rsa_data0_clr   : 1  ; /* [4]  */
+        hi_u32    sec_rsa_data1_clr   : 1  ; /* [5]  */
+        hi_u32    sec_rsa_data2_clr   : 1  ; /* [6]  */
+        hi_u32    reserved_1          : 25 ; /* [31..7]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+
+} sec_rsa_mod_reg;
+
+/*! \Define the union sec_rsa_start_reg */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    sec_rsa_start_reg     : 4   ; /* [3..0]  */
+        hi_u32    reserved_1            : 28  ; /* [31..4]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+
+} sec_rsa_start_reg;
+
+/* Define the union sec_rsa_int_en */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    rsa_int_en            : 1   ; /* [0]  */
+        unsigned int    reserved_0            : 30  ; /* [30..1]  */
+        unsigned int    int_en                : 1   ; /* [31]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} sec_rsa_int_en;
+
+/* Define the union sec_rsa_int_status */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    rsa_int_status        : 1   ; /* [0]  */
+        unsigned int    reserved_0            : 31  ; /* [31..1]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} sec_rsa_int_status;
+
+/* Define the union sec_rsa_int_raw */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    rsa_int_raw           : 1   ; /* [0]  */
+        unsigned int    reserved_0            : 31  ; /* [31..1]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} sec_rsa_int_raw;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_lib.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_lib.c
@@ -1,0 +1,674 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_lib.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "cryp_trng.h"
+
+/*********************** Internal Structure Definition ***********************/
+/** \addtogroup      base type*/
+/** @{*/  /** <!-- [base]*/
+
+/*crg register addr size*/
+#define CRG_REG_ADDR_SIZE        (0x100)
+
+/*set a bit within a word*/
+#undef  SET_BIT
+#define SET_BIT(src, bit)        ((src) |= (1 << (bit)))
+
+/*clear a bit within a word*/
+#undef  CLEAR_BIT
+#define CLEAR_BIT(src,bit)       ((src) &= ~(1 << (bit)))
+
+/*! module already initialize or not */
+static hi_u32 module_initialize = HI_FALSE;
+
+/*! \struct resource_channel
+ * the tbale of base info of module, such as addr/reset/clk/ver.
+*/
+struct sys_arch_hardware_info {
+    /*the name of module, used for debug print and request interrupt*/
+    const char *name;
+
+    /*smoe field may be needn't to used*/
+    hi_u32 reset_valid: 1; /*bis[0], reset availability, 0-valid, 1-invalid*/
+    hi_u32 clk_valid: 1;   /*bis[1], clock availability, 0-valid, 1-invalid*/
+    hi_u32 phy_valid: 1;   /*bis[2], system address availability, 0-valid, 1-invalid*/
+    hi_u32 crg_valid: 1;   /*bis[3], CRG availability, 0-valid, 1-invalid*/
+    hi_u32 ver_valid: 1;   /*bis[4], version reg availability, 0-valid, 1-invalid*/
+    hi_u32 int_valid: 1;   /*bis[5], interrupt availability, 0-valid, 1-invalid*/
+    hi_u32 res_valid: 25;  /*bis[6..31]*/
+
+    /*module base addr*/
+    hi_u32 reg_addr_phy;
+
+    /*base logic addr size*/
+    hi_u32 reg_addr_size;
+
+    /*crg register addr, which provide the switch of reset and clock*/
+    hi_u32 crg_addr_phy;
+
+    /*the clk switch bit index within the crg register,
+     *if the switch bis is provided by second crg register, you need to add 32*/
+    hi_u32 clk_bit: 8;
+
+    /*the reset switch bit index within the crg register,
+     * if the switch bis is provided by second crg register, you need to add 32*/
+    hi_u32 reset_bit: 8;
+
+    /*the interrupt number*/
+    hi_u32 int_num: 8;
+
+    /*the reserve bits*/
+    hi_u32 res: 8;
+
+    /*the offset of version register*/
+    hi_u32 version_reg;
+
+    /*the value of version register, you can used it to check the active module*/
+    hi_u32 version_val;
+
+    /*cpu address of module register*/
+    void *reg_addr_via;
+
+    /*cpu address of crg register*/
+    void *crg_addr_via;
+};
+
+static struct sys_arch_hardware_info hard_info_table[CRYPTO_MODULE_ID_CNT] = {
+    HARD_INFO_CIPHER,
+    HARD_INFO_CIPHER_KEY,
+    HARD_INFO_HASH,
+    HARD_INFO_IFEP_RSA,
+    HARD_INFO_SIC_RSA,
+    HARD_INFO_TRNG,
+    HARD_INFO_SM2,
+    HARD_INFO_SM4,
+    HARD_INFO_SMMU,
+};
+
+#ifdef CRYPTO_SWITCH_CPU
+static struct sys_arch_hardware_info nsec_hard_info_table[CRYPTO_MODULE_ID_CNT] = {
+    NSEC_HARD_INFO_CIPHER,
+    NSEC_HARD_INFO_CIPHER_KEY,
+    NSEC_HARD_INFO_HASH,
+    NSEC_HARD_INFO_IFEP_RSA,
+    NSEC_HARD_INFO_SIC_RSA,
+    NSEC_HARD_INFO_TRNG,
+    NSEC_HARD_INFO_SM2,
+    NSEC_HARD_INFO_SM4,
+    NSEC_HARD_INFO_SMMU,
+};
+
+static hi_u32 s_secure_cpu = HI_FALSE;
+#endif
+
+compat_addr compat_addr_zero = {.phy = 0};
+
+extern hi_u32 drv_symc_is_secure(void);
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      base*/
+/** @{*/  /** <!--[base]*/
+
+static hi_s32 module_addr_map_reg(void)
+{
+    hi_u32 i;
+    hi_s32 ret = HI_SUCCESS;
+    struct sys_arch_hardware_info *table = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (module_initialize == HI_TRUE) {
+        return HI_SUCCESS;
+    }
+
+    for (i = 0; i < CRYPTO_MODULE_ID_CNT; i++) {
+        table = &hard_info_table[i];
+
+        HI_LOG_INFO("[%d] %s\n", i, table->name);
+
+        /*io remap crg register*/
+        if (table->crg_valid) {
+            table->crg_addr_via = crypto_ioremap_nocache(table->crg_addr_phy, CRG_REG_ADDR_SIZE);
+            if (table->crg_addr_via == HI_NULL) {
+                HI_LOG_ERROR("iomap reg of module failed\n");
+                module_addr_unmap();
+                ret = HI_FAILURE;
+                break;
+            }
+            HI_LOG_INFO("crg phy 0x%x, via 0x%p\n", table->crg_addr_phy, table->crg_addr_via);
+        }
+
+        /*io remap module register*/
+        if (table->phy_valid) {
+            table->reg_addr_via = crypto_ioremap_nocache(table->reg_addr_phy,
+                                                         table->reg_addr_size);
+            if (table->reg_addr_via == HI_NULL) {
+                HI_LOG_ERROR("iomap reg of module failed\n");
+                module_addr_unmap();
+                ret = HI_FAILURE;
+                break;
+            }
+            HI_LOG_INFO("reg phy 0x%x, via 0x%p, size 0x%x\n", table->reg_addr_phy,
+                table->reg_addr_via, table->reg_addr_size);
+        }
+    }
+
+    module_initialize = HI_TRUE;
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+/**
+\brief  unmap the physics addr to cpu within the base table, contains the base addr and crg addr.
+*/
+hi_s32 module_addr_unmap(void)
+{
+    hi_u32 i;
+    struct sys_arch_hardware_info *table = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (module_initialize == HI_FALSE) {
+        return HI_SUCCESS;
+    }
+
+    for (i = 0; i < CRYPTO_MODULE_ID_CNT; i++) {
+        table = &hard_info_table[i];
+
+        HI_LOG_INFO("[%d] %s\n", i, table->name);
+
+        /*io unmap crg register*/
+        if (table->crg_valid && table->crg_addr_via) {
+            HI_LOG_INFO("crg via addr 0x%p\n", table->crg_addr_via);
+            crypto_iounmap(table->crg_addr_via, CRG_REG_ADDR_SIZE);
+            table->crg_addr_via = HI_NULL;
+        }
+
+        /*io unmap module register*/
+        if (table->phy_valid && table->reg_addr_via) {
+            HI_LOG_INFO("reg via addr 0x%p\n", table->reg_addr_via);
+            crypto_iounmap(table->reg_addr_via, table->reg_addr_size);
+            table->reg_addr_via = HI_NULL;
+        }
+    }
+
+    module_initialize = HI_FALSE;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+\brief  map the physics addr to cpu within the base table, contains the base addr and crg addr.
+*/
+hi_s32 module_addr_map(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = module_addr_map_reg();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(module_addr_map_reg, ret);
+        return ret;
+    }
+
+#ifdef CRYPTO_SWITCH_CPU
+    s_secure_cpu = drv_symc_is_secure();
+    if (s_secure_cpu == HI_TRUE) {
+        /* default secure cpu, do nothing */
+        return HI_SUCCESS;
+    }
+
+    HI_LOG_INFO("non-secure CPU need to remap reg addr\n");
+
+    /* use non-secure info */
+    crypto_memcpy(&hard_info_table, sizeof(hard_info_table),
+                  &nsec_hard_info_table, sizeof(nsec_hard_info_table));
+
+    /* remap module addr */
+    ret = module_addr_unmap();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(module_addr_unmap, ret);
+        return ret;
+    }
+    ret = module_addr_map_reg();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(module_addr_map, ret);
+        return ret;
+    }
+#endif
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+\brief  get secure cpu type.
+*/
+hi_u32 module_get_secure(void)
+{
+#ifdef CRYPTO_SEC_CPU
+    return HI_TRUE;
+#elif defined(CRYPTO_SWITCH_CPU)
+    return s_secure_cpu;
+#else
+    return HI_FALSE;
+#endif
+}
+
+/**
+\brief  open clock.
+*/
+static void module_clock(module_id id, hi_u32 open)
+{
+    hi_u32 val = 0;
+    hi_u32 *addr = HI_NULL;
+    struct sys_arch_hardware_info *table = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    table = &hard_info_table[id];
+
+    if (table->clk_valid) {
+        if (table->crg_addr_via == HI_NULL) {
+            HI_LOG_ERROR("\033[0;1;31m""%s clock failed, crg addr is null\n""\033[0m", table->name);
+            return;
+        }
+
+        /*open clk, the addr may be need to add 1*/
+        addr = table->crg_addr_via;
+        addr += table->clk_bit / WORD_BIT_WIDTH;
+
+        val = crypto_read(addr);
+
+        if (open) {
+            SET_BIT(val, table->clk_bit % WORD_BIT_WIDTH);
+        } else {
+            CLEAR_BIT(val, table->clk_bit % WORD_BIT_WIDTH);
+        }
+
+        crypto_write(addr, val);
+
+        /*wait hardware clock active*/
+        crypto_msleep(1);
+
+        HI_LOG_INFO("%s clock, open   %d, bit %d, phy 0x%x, via 0x%p\n",
+                    table->name, open, table->clk_bit,
+                    table->crg_addr_phy, table->crg_addr_via);
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+static void module_reset(module_id id, hi_u32 enable)
+{
+    hi_u32 val = 0;
+    hi_u32 *addr = HI_NULL;
+    hi_u32 expect = 0;
+    struct sys_arch_hardware_info *table = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    table = &hard_info_table[id];
+
+    if (table->reset_valid) {
+        if (table->crg_addr_via == HI_NULL) {
+            HI_LOG_ERROR("\033[0;1;31m""%s reset failed, crg addr is null\n""\033[0m", table->name);
+            return;
+        }
+
+        /*the addr may be need to add 1*/
+        addr = table->crg_addr_via;
+        addr += table->reset_bit / WORD_BIT_WIDTH;
+
+        val = crypto_read(addr);
+
+        if (enable) {
+            SET_BIT(val, table->reset_bit % WORD_BIT_WIDTH);
+            expect = 0;
+        } else {
+            CLEAR_BIT(val, table->reset_bit % WORD_BIT_WIDTH);
+            expect = table->version_val;
+        }
+
+        crypto_write(addr, val);
+
+        /*wait hardware reset finish*/
+        crypto_msleep(1);
+
+        HI_LOG_INFO("%s reset, enable %d, bit %d, phy 0x%x, via 0x%p\n",
+                    table->name, enable, table->reset_bit,
+                    table->crg_addr_phy, table->crg_addr_via);
+
+        /*check the value of version reg to make sure reset success*/
+        if (table->ver_valid && table->reg_addr_via) {
+            val = crypto_read((hi_u8 *)table->reg_addr_via + table->version_reg);
+            if (val != expect) {
+                HI_LOG_ERROR("\033[0;1;31m""%s reset failed, version reg should be 0x%x but 0x%x\n""\033[0m",
+                             table->name, expect, val);
+                return;
+            }
+
+            HI_LOG_INFO("%s version reg, offset 0x%x, expect val 0x%x, real val 0x%x\n",
+                        table->name, table->version_reg, expect, val);
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+/**
+\brief  enable a module, open clock  and remove reset signal.
+*/
+void module_enable(module_id id)
+{
+    module_clock(id, HI_TRUE);
+    module_reset(id, HI_FALSE);
+    return;
+}
+
+/**
+\brief  disable a module, close clock and set reset signal.
+*/
+void module_disable(module_id id)
+{
+    module_reset(id, HI_TRUE);
+    module_clock(id, HI_FALSE);
+    return;
+}
+
+/**
+\brief  get attribute of module.
+*/
+void module_get_attr(module_id id, hi_u32 *int_valid, hi_u32 *int_num, const char **name)
+{
+    *int_valid = hard_info_table[id].int_valid;
+    *int_num = hard_info_table[id].int_num;
+    if (name) {
+        *name = hard_info_table[id].name;
+    }
+
+    return;
+}
+
+/**
+\brief  get base address of module.
+*/
+void module_set_irq(module_id id, hi_u32 irq)
+{
+    hard_info_table[id].int_num = irq;
+    HI_LOG_INFO("%s set irq number 0x%x\n", hard_info_table[id].name, irq);
+}
+
+/**
+\brief  read a register.
+*/
+hi_u32 module_reg_read(module_id id, hi_u32 offset)
+{
+    hi_u32 val = 0;
+    void *addr = HI_NULL;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_CHECK_PARAM(id >= CRYPTO_MODULE_ID_CNT);
+    HI_LOG_CHECK_PARAM(offset >= hard_info_table[id].reg_addr_size);
+
+    /* tee may be read trng before cipher module init */
+    if (hard_info_table[id].reg_addr_via == HI_NULL) {
+        ret = module_addr_map();
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(module_addr_map, ret);
+            return 0;
+        }
+    }
+
+    /*get the absolute address of reg*/
+    addr = (hi_u8 *)(hard_info_table[id].reg_addr_via) + offset;
+    val = crypto_read(addr);
+
+    return val;
+}
+
+/**
+\brief  write a register.
+*/
+void module_reg_write(module_id id, hi_u32 offset, hi_u32 val)
+{
+    void *addr = HI_NULL;
+    hi_s32 ret = HI_FAILURE;
+
+    /*check if module is valid*/
+    if (id >= CRYPTO_MODULE_ID_CNT) {
+        HI_LOG_ERROR("error, invalid module id %d\n", id);
+        return;
+    }
+
+    /*check if offset is valid*/
+    if (offset >= hard_info_table[id].reg_addr_size) {
+        HI_LOG_ERROR("error, reg offset overflow 0x%x\n", offset);
+        return;
+    }
+
+    /* tee may be read trng before cipher module init */
+    if (hard_info_table[id].reg_addr_via == HI_NULL) {
+        ret = module_addr_map();
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(module_addr_map, ret);
+            return;
+        }
+    }
+
+    /*get the absolute address of reg*/
+    addr = (hi_u8 *)hard_info_table[id].reg_addr_via + offset;
+    crypto_write(addr, val);
+
+    return;
+}
+
+/**
+\brief  Initialize the channel list.
+*/
+hi_s32 crypto_channel_init(channel_context *ctx, hi_u32 num, hi_u32 ctx_size)
+{
+    hi_u32 size = 0;
+    hi_u32 i = 0;
+    hi_u8 *buf = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+
+    /* clear context */
+    size = sizeof(channel_context) * num;
+    crypto_memset(ctx, size, 0, size);
+
+    /* set context buffer */
+    if (ctx_size > 0) {
+        buf = (hi_u8 *)crypto_malloc(ctx_size * num);
+        if (buf == HI_NULL) {
+            return HI_ERR_CIPHER_FAILED_MEM;
+        }
+        crypto_memset(buf, ctx_size * num, 0, ctx_size * num);
+
+        /* the buffer addresss is stored at ctx[0].ctx*/
+        for (i = 0; i < num; i++) {
+            ctx[i].ctx = buf;
+            buf += ctx_size;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+\brief  denit the channel list.
+*/
+hi_s32 crypto_channel_deinit(channel_context *ctx, hi_u32 num)
+{
+    hi_u32 size = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+
+    /* the buffer addresss is stored at ctx[0].ctx*/
+    if (ctx[0].ctx != HI_NULL) {
+        crypto_free(ctx[0].ctx);
+        ctx[0].ctx = HI_NULL;
+    }
+
+    /* clear context */
+    size = sizeof(channel_context) * num;
+    crypto_memset(ctx, size, 0, size);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+\brief  allocate a channel.
+*/
+hi_s32 crypto_channel_alloc(channel_context *ctx, hi_u32 num, hi_u32 mask, hi_u32 *id)
+{
+    hi_s32 ret = HI_ERR_CIPHER_BUSY;
+    hi_u32 i = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+    HI_LOG_CHECK_PARAM(id == HI_NULL);
+
+    for (i = 0; i < num; i++) {
+        /* check the valid channel */
+        if (mask & (0x01 << i)) {
+            if (!ctx[i].open) { /* found a free channel */
+                ret = HI_SUCCESS;
+                ctx[i].open = HI_TRUE; /* alloc channel */
+                *id = i;
+                break;
+            }
+        }
+    }
+
+    if (i == num) {
+        HI_LOG_ERROR("error, all channels are busy.\n");
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+/**
+\brief  free a  channel.
+*/
+void crypto_channel_free(channel_context *ctx, hi_u32 num, hi_u32 id)
+{
+    HI_LOG_FUNC_ENTER();
+
+    /*free channel*/
+    ctx[id].open = HI_FALSE;
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+/**
+\brief  get the private data of channel.
+*/
+void *crypto_channel_get_context(channel_context *ctx, hi_u32 num, hi_u32 id)
+{
+    if (ctx == HI_NULL) {
+        HI_LOG_ERROR("crypto_channel_get_context() ctx is HI_NULL\n");
+        HI_LOG_PRINT_ERR_CODE(0);
+        return HI_NULL;
+    }
+
+    if ((id >= num) || (!ctx[id].open)) {
+        HI_LOG_ERROR("crypto_channel_get_context()- error, id %d, open %d, num %d\n",
+                     id, ctx[id].open, num);
+        HI_LOG_PRINT_ERR_CODE(0);
+        return HI_NULL;
+    }
+
+    return ctx[id].ctx;
+}
+
+void hex2str(char buf[2], hi_u8 val)
+{
+    hi_u8 high, low;
+
+    high = (val >> 4) & 0x0F;
+    low =  val & 0x0F;
+
+    if (high <= 9) {
+        buf[0] = high + '0';
+    } else {
+        buf[0] = (high - 0x0A) + 'A';
+    }
+
+    if (low <= 9) {
+        buf[1] = low + '0';
+    } else {
+        buf[1] = (low - 0x0A) + 'A';
+    }
+
+}
+
+/* Implementation that should never be optimized out by the compiler */
+void crypto_zeroize( void *buf, hi_u32 len )
+{
+    volatile unsigned char *p = (unsigned char *)buf;
+
+    if (buf == HI_NULL) {
+        return;
+    }
+
+    while (len--) {
+        *p++ = 0;
+    }
+}
+
+void *crypto_calloc(size_t n, size_t size)
+{
+    void *ptr = HI_NULL;
+
+    ptr = crypto_malloc(n * size);
+
+    if (ptr != HI_NULL) {
+        crypto_memset(ptr, n * size, 0, n * size);
+    }
+
+    return ptr;
+}
+
+hi_u32 get_rand(void)
+{
+    hi_u32 randnum = 0;
+
+    cryp_trng_get_random(&randnum, -1);
+
+    return randnum;
+}
+
+/** @}*/  /** <!-- ==== API Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_symc_v100.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_symc_v100.c
@@ -1,0 +1,1724 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_symc_v100.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_symc_v100.h"
+#include "drv_symc.h"
+
+#ifdef CHIP_SYMC_VER_V100
+
+#define MAX_NODE_SIZE                (0x100000 - 16)
+
+/*************************** Internal Structure Definition ****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+/*! Define the struct of node */
+typedef struct {
+    hi_u32 phy_addr;  /*!<  physics address of buffer */
+    hi_u32 flags;     /*!<  flag */
+    hi_u32 length;    /*!<  length of buffer */
+    hi_u32 iv_addr;   /*!<  physics address of iv */
+} symc_entry;
+
+/*! Define the struct of iv in node */
+typedef struct {
+    hi_u32 iv[SYMC_IV_MAX_SIZE_IN_WORD];  /*!<  iv data */
+} symc_entry_iv;
+
+/*! Define the context of cipher */
+typedef struct {
+    symc_entry *entry_in;     /*!<  in node list */
+    symc_entry *entry_out;    /*!<  out node list */
+    symc_entry_iv *entry_iv;  /*!<  buffer to store the IV */
+    hi_u32 iv[SYMC_IV_MAX_SIZE_IN_WORD];/*!<  iv data from user*/
+
+    /* iv usage flag, should be CIPHER_IV_CHANGE_ONE_PKG
+     * or CIPHER_IV_CHANGE_ALL_PKG.
+     */
+    hi_u32 iv_flag;
+    hi_u32 id_in;                       /*!<  current in nodes index */
+    hi_u32 id_out;                      /*!<  current out nodes index */
+    hi_u32 cnt;                         /*!<  total count nodes to be computed */
+    hi_u32 done;                        /*!<  calculation finish flag*/
+    crypto_queue_head  queue;        /*!<  quene list */
+    callback_symc_isr callback;      /*!<  isr callback functon */
+    callback_symc_destory destory;   /*!<  destory callback functon */
+    void *ctx;                       /*!<  params for isr callback functon */
+} symc_hard_context;
+
+/*! Channel of cipher */
+static channel_context symc_hard_channel[CRYPTO_HARD_CHANNEL_MAX];
+
+/*! dma memory of cipher node list*/
+static crypto_mem   symc_dma;
+
+/*! symc already initialize or not */
+static hi_u32 symc_initialize = HI_FALSE;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+
+static hi_u32 drv_symc_done_try(hi_u32 chn_num)
+{
+    int_raw status;
+    symc_hard_context *ctx = HI_NULL;
+    hi_u32 process = 0;
+
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    status.u32 = SYMC_READ(REG_INT_RAW);
+    status.bits.chn_obuf_raw &= 0x01 << chn_num; /* check interception */
+
+    /*clear interception*/
+    SYMC_WRITE(REG_INT_RAW, status.u32);
+
+    if (status.bits.chn_obuf_raw) {
+        ctx = crypto_channel_get_context(symc_hard_channel, CRYPTO_HARD_CHANNEL_MAX, chn_num);
+        if (ctx == HI_NULL) {
+            HI_LOG_ERROR("crypto channel get context failed,ctx is null!\n");
+            return HI_ERR_CIPHER_INVALID_POINT;
+        }
+
+        process = SYMC_READ(REG_CHANn_OFULL_CNT(chn_num));
+        SYMC_WRITE(REG_CHANn_IEMPTY_CNT(chn_num), process);
+        SYMC_WRITE(REG_CHANn_OFULL_CNT(chn_num),  process);
+        ctx->cnt -= process;
+    }
+
+    return status.bits.chn_obuf_raw ? HI_TRUE : HI_FALSE;
+}
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+static hi_u32 drv_symc_done_notify(void)
+{
+    symc_hard_context *ctx = HI_NULL;
+    int_raw status;
+    hi_u32 process = 0;
+    hi_u32 i;
+
+    status.u32 = SYMC_READ(REG_INT_RAW);
+
+    /*must clear interception before any operation */
+    SYMC_WRITE(REG_INT_RAW, status.u32);
+
+    /*just process the valid channel*/
+    status.bits.chn_obuf_raw &= CIPHER_HARD_CHANNEL_MASK;
+
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        if ((status.bits.chn_obuf_raw >> i) & 0x01) {
+            /* received interception, tell hardware that
+             * we already process the output node
+             */
+            ctx = crypto_channel_get_context(symc_hard_channel, CRYPTO_HARD_CHANNEL_MAX, i);
+            if (ctx == HI_NULL) {
+                HI_LOG_ERROR("crypto channel get context failed,ctx is null!\n");
+                return HI_ERR_CIPHER_INVALID_POINT;
+            }
+
+            process = SYMC_READ(REG_CHANn_OFULL_CNT(i));
+            SYMC_WRITE(REG_CHANn_IEMPTY_CNT(i), process);
+            SYMC_WRITE(REG_CHANn_OFULL_CNT(i),  process);
+            ctx->cnt -= process;
+        }
+    }
+
+    return status.bits.chn_obuf_raw; /* mask */
+
+}
+
+/*! symc interrupt process function */
+static irqreturn_t drv_symc_interrupt_isr(hi_s32 irq, void *devId)
+{
+    hi_u32 mask, i;
+    symc_hard_context *ctx = HI_NULL;
+
+    HI_LOG_DEBUG("symc irq: %d\n", irq);
+
+    /* get channel context*/
+    mask = drv_symc_done_notify();
+
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        if ((mask >> i) & 0x01) {
+            ctx = crypto_channel_get_context(symc_hard_channel, CRYPTO_HARD_CHANNEL_MAX, i);
+            if (ctx == HI_NULL) {
+                HI_LOG_ERROR("Ctx get context failed.\n");
+                return IRQ_NONE;
+            }
+
+            /*make sure all the loaded nodes are finished before start next compute*/
+            if (0x00 != ctx->cnt) {
+                continue;
+            }
+
+            /* continue to load other nodes */
+            if ((ctx->callback) && (ctx->callback(ctx->ctx) == HI_FALSE)) {
+                HI_LOG_DEBUG("contiue to compute chn %d\n", i);
+                drv_symc_start(i);
+            } else { /* finished, no more nodes need to be load */
+                ctx->done = HI_TRUE;
+                HI_LOG_DEBUG("chn %d wake up\n", i);
+                crypto_queue_wait_up(&ctx->queue);
+            }
+        }
+    }
+
+    return IRQ_HANDLED;
+}
+
+/*! symc register interrupt process function */
+static hi_s32 drv_symc_register_interrupt(void)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 int_valid = 0, int_num = 0;
+    hi_u32 i;
+    const char *name;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_SYMC, &int_valid, &int_num, &name);
+
+    if (int_valid == HI_FALSE) {
+        return HI_SUCCESS;
+    }
+
+    /* request irq */
+    HI_LOG_DEBUG("symc request irq, num %d, name %s\n", int_num, name);
+    ret = crypto_request_irq(int_num, drv_symc_interrupt_isr, name);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("Irq request failure, ret=%d, irq = %d", ret, int_num);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_REGISTER_IRQ);
+        return ret;
+    }
+
+    /* initialize queue list*/
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        crypto_queue_init(&((symc_hard_context *)symc_hard_channel[i].ctx)->queue);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/*! symc unregister interrupt process function */
+static void drv_symc_unregister_interrupt(void)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    const char *name = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_SYMC, &int_valid, &int_num, &name);
+
+    if (int_valid == HI_FALSE) {
+        return;
+    }
+
+    /* free irq */
+    HI_LOG_DEBUG("symc free irq, num %d, name %s\n", int_num, name);
+    crypto_free_irq(int_num, name);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+/*! set interrupt */
+static void drv_symc_set_interrupt(void)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    int_en  int_en;
+    int_raw int_raw;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_SYMC, &int_valid, &int_num, HI_NULL);
+
+    if (int_valid == HI_FALSE) {
+        int_en.u32 = SYMC_READ(REG_INT_EN);
+
+        /*The top interrupt switch only can be enable/disable by secure CPU*/
+        int_en.bits.sec_int_en = 0;
+        int_en.bits.int_en = 0;
+        int_en.bits.chn_obuf_en &= ~CIPHER_HARD_CHANNEL_MASK;
+        SYMC_WRITE(REG_INT_EN, int_en.u32);
+        HI_LOG_INFO("REG_INT_EN 0x%x\n", int_en.u32);
+    } else {
+        int_en.u32 = SYMC_READ(REG_INT_EN);
+
+        /*The top interrupt switch only can be enable/disable by secure CPU*/
+        int_en.bits.sec_int_en = 1;
+        int_en.bits.int_en = 1;
+        int_en.bits.chn_obuf_en = CIPHER_HARD_CHANNEL_MASK;
+        SYMC_WRITE(REG_INT_EN, int_en.u32);
+        HI_LOG_INFO("REG_INT_EN 0x%x\n", int_en.u32);
+    }
+
+    /* clear interception
+     * the history of interception may trigge the system to
+     * call the irq function before initialization
+     * when register interrupt, this will cause a system abort.
+     */
+    int_raw.u32 = SYMC_READ(REG_INT_RAW);
+    int_raw.bits.chn_obuf_raw &= CIPHER_HARD_CHANNEL_MASK; /* clear valid channel */
+    SYMC_WRITE(REG_INT_RAW, int_raw.u32);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+#endif
+
+/*! set symc entry */
+static void drv_symc_set_entry(hi_u32 chn, hi_u32 dma_addr, hi_u32 mmz_addr, void *cpu_addr)
+{
+    hi_u32 i;
+    symc_hard_context *ctx = (symc_hard_context *)symc_hard_channel[chn].ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    /*set first in node addr*/
+    HI_LOG_INFO("chn %d, entry in  dma addr 0x%x, mmz addr 0x%x, cpu addr 0x%p\n",
+                chn, dma_addr, mmz_addr, cpu_addr);
+    SYMC_WRITE(REG_CHANn_SRC_LST_SADDR(chn), mmz_addr);   /*node list must be mmz*/
+    ctx->entry_in = cpu_addr;
+    dma_addr += ENTRY_NODE_SIZE * SYMC_MAX_LIST_NUM;
+    mmz_addr += ENTRY_NODE_SIZE * SYMC_MAX_LIST_NUM;
+    cpu_addr = (hi_u8 *)cpu_addr + ENTRY_NODE_SIZE * SYMC_MAX_LIST_NUM;
+
+    /*set first out node addr*/
+    HI_LOG_INFO("chn %d, entry out dma addr 0x%x, mmz addr 0x%x, cpu addr 0x%p\n",
+                chn, dma_addr, mmz_addr, cpu_addr);
+    SYMC_WRITE(REG_CHANn_DEST_LST_SADDR(chn), mmz_addr);   /*node list must be mmz*/
+    ctx->entry_out = cpu_addr;
+    dma_addr += ENTRY_NODE_SIZE * SYMC_MAX_LIST_NUM;
+    mmz_addr += ENTRY_NODE_SIZE * SYMC_MAX_LIST_NUM;
+    cpu_addr = (hi_u8 *)cpu_addr + ENTRY_NODE_SIZE * SYMC_MAX_LIST_NUM;
+
+    /*set iv addr of in node*/
+    HI_LOG_INFO("chn %d,        IV dma addr 0x%x, cpu addr 0x%p\n", chn, dma_addr, cpu_addr);
+    for (i = 0; i < SYMC_MAX_LIST_NUM; i++) {
+        /*set iv dma addr to each in node, IV dma addr may be mmz or mmu*/
+        ctx->entry_in[i].iv_addr = dma_addr;
+        dma_addr += SYMC_IV_MAX_SIZE;
+    }
+    ctx->entry_iv = cpu_addr;
+    cpu_addr = (hi_u8 *)cpu_addr + SYMC_IV_MAX_SIZE * SYMC_MAX_LIST_NUM;
+
+    /*the symc module may be running at setup period,
+     *Here, we must continue running immediately after the last node*/
+    ctx->id_in = SYMC_READ(REG_CHANn_SRC_LST_RADDR(chn));
+    ctx->id_out = SYMC_READ(REG_CHANn_DEST_LST_RADDR(chn));
+    ctx->cnt = 0x00;
+    HI_LOG_INFO("chn %d, id in %d, out %d\n\n", chn, ctx->id_in, ctx->id_out);
+
+    /*set total node list Num */
+    HI_LOG_DEBUG("set total node list Num\n");
+    SYMC_WRITE(REG_CHANn_IBUF_NUM(chn), SYMC_MAX_LIST_NUM);
+    SYMC_WRITE(REG_CHANn_OBUF_NUM(chn), SYMC_MAX_LIST_NUM);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+#ifdef CRYPTO_SMMU_SUPPORT
+
+/*! set smmu */
+static void drv_symc_smmu_bypass(void)
+{
+    chann_rd_dat_addr_smmu_bypass rd_mmu;
+    chann_wr_dat_addr_smmu_bypass wr_mmu;
+
+    HI_LOG_FUNC_ENTER();
+
+    rd_mmu.u32 = SYMC_READ(CHANn_RD_DAT_ADDR_SMMU_BYPASS);
+    wr_mmu.u32 = SYMC_READ(CHANn_WR_DAT_ADDR_SMMU_BYPASS);
+
+    /*bypass: 1-use mmz, 0-use mmu*/
+    rd_mmu.bits.chann_rd_dat_addr_smmu_bypass &= ~(CIPHER_HARD_CHANNEL_MASK >> 1);
+    wr_mmu.bits.chann_wr_dat_addr_smmu_bypass &= ~(CIPHER_HARD_CHANNEL_MASK >> 1);
+
+    SYMC_WRITE(CHANn_RD_DAT_ADDR_SMMU_BYPASS, rd_mmu.u32);
+    SYMC_WRITE(CHANn_WR_DAT_ADDR_SMMU_BYPASS, wr_mmu.u32);
+
+    HI_LOG_INFO("CHANn_RD_DAT_ADDR_SMMU_BYPASS 0x%x\n", rd_mmu.u32);
+    HI_LOG_INFO("CHANn_WR_DAT_ADDR_SMMU_BYPASS 0x%x\n", wr_mmu.u32);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+/*! smmu int enable */
+static void drv_symc_smmint_enable(void)
+{
+    smmu_scr scr;
+    smmu_int int_en;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* enable smmu interception and disable bypass*/
+    scr.u32 = SMMU_READ(REG_MMU_GLOBAL_CTR_ADDR);
+    scr.bits.glb_bypass = 0;
+    scr.bits.int_en = 1;
+    SMMU_WRITE(REG_MMU_GLOBAL_CTR_ADDR, scr.u32);
+    HI_LOG_INFO("REG_MMU_GLOBAL_CTR_ADDR 0x%x\n", scr.u32);
+
+    /*enable interception*/
+    if (crypto_is_sec_cpu()) {
+        int_en.u32 = SMMU_READ(REG_MMU_INTMAS_S);
+        int_en.bits.ints_tlbmiss = 0;
+        int_en.bits.ints_ptw_trans = 0;
+        int_en.bits.ints_tlbinvalid = 0;
+        SMMU_WRITE(REG_MMU_INTMAS_S, int_en.u32);
+        HI_LOG_INFO("REG_MMU_INTMAS_S 0x%x\n", int_en.u32);
+    } else {
+        int_en.u32 = SMMU_READ(REG_MMU_INTMASK_NS);
+        int_en.bits.ints_tlbmiss = 0;
+        int_en.bits.ints_ptw_trans = 0;
+        int_en.bits.ints_tlbinvalid = 0;
+        SMMU_WRITE(REG_MMU_INTMASK_NS, int_en.u32);
+        HI_LOG_INFO("REG_MMU_INTMASK_NS 0x%x\n", int_en.u32);
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+#endif
+
+/*! smmu int disable */
+static void drv_symc_smmu_int_disable(void)
+{
+    smmu_scr scr;
+    smmu_int int_en;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* enable smmu interception and disable bypass*/
+    scr.u32 = SMMU_READ(REG_MMU_GLOBAL_CTR_ADDR);
+    scr.bits.glb_bypass = 0;
+    scr.bits.int_en = 0;
+    SMMU_WRITE(REG_MMU_GLOBAL_CTR_ADDR, scr.u32);
+    HI_LOG_INFO("REG_MMU_GLOBAL_CTR_ADDR 0x%x\n", scr.u32);
+
+    /* disable secure interception */
+    int_en.u32 = SMMU_READ(REG_MMU_INTMAS_S);
+    int_en.bits.ints_tlbmiss = 1;
+    int_en.bits.ints_ptw_trans = 1;
+    int_en.bits.ints_tlbinvalid = 1;
+    SMMU_WRITE(REG_MMU_INTMAS_S, int_en.u32);
+    HI_LOG_INFO("REG_MMU_INTMAS_S 0x%x\n", int_en.u32);
+
+    /* disable non-secure interception */
+    int_en.u32 = SMMU_READ(REG_MMU_INTMASK_NS);
+    int_en.bits.ints_tlbmiss = 1;
+    int_en.bits.ints_ptw_trans = 1;
+    int_en.bits.ints_tlbinvalid = 1;
+    SMMU_WRITE(REG_MMU_INTMASK_NS, int_en.u32);
+    HI_LOG_INFO("REG_MMU_INTMASK_NS 0x%x\n", int_en.u32);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+/*! smmu set base address */
+static hi_s32 drv_symc_smmu_base_addr(void)
+{
+    hi_u64 err_raddr = 0;
+    hi_u64 err_waddr = 0;
+    hi_u64 table_addr = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* get table base addr from system api */
+    smmu_get_table_addr(&err_raddr, &err_waddr, &table_addr);
+
+    if (crypto_is_sec_cpu()) {
+#ifdef CHIP_SMMU_VER_V200
+        SMMU_WRITE(REG_MMU_ERR_RDADDR_H_S, 0x00); /*default error read high addr*/
+        SMMU_WRITE(REG_MMU_ERR_WRADDR_H_S, 0x00); /*default error write high addr*/
+        SMMU_WRITE(REG_MMU_SCB_TTBR_H,     0x00); /*smmu page table high addr*/
+#endif
+        SMMU_WRITE(REG_MMU_ERR_RDADDR_S, (hi_u32)err_raddr); /*default error read addr*/
+        SMMU_WRITE(REG_MMU_ERR_WRADDR_S, (hi_u32)err_waddr); /*default error write addr*/
+        SMMU_WRITE(REG_MMU_SCB_TTBR, (hi_u32)table_addr);    /*smmu page table addr*/
+
+    } else {
+#ifdef CHIP_SMMU_VER_V200
+        SMMU_WRITE(REG_MMU_ERR_RDADDR_H_NS, 0x00);  /*default error read high addr*/
+        SMMU_WRITE(REG_MMU_ERR_WRADDR_H_NS, 0x00);  /*default error write high addr*/
+        SMMU_WRITE(REG_MMU_CB_TTBR_H,       0x00);  /*smmu page table high addr*/
+#endif
+        SMMU_WRITE(REG_MMU_ERR_RDADDR_NS, (hi_u32)err_raddr);/*default error read addr*/
+        SMMU_WRITE(REG_MMU_ERR_WRADDR_NS, (hi_u32)err_waddr);/*default error write addr*/
+        SMMU_WRITE(REG_MMU_CB_TTBR, (hi_u32)table_addr);     /*smmu page table addr*/
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+#endif
+
+/*! set secure channel,
+ *  non-secure CPU can't change the value of SEC_CHN_CFG,
+ *  so non-secure CPU call this function will do nothing.
+ */
+static void drv_symc_enable_secure(void)
+{
+    sec_chn_cfg sec;
+
+    HI_LOG_FUNC_ENTER();
+
+    /*The REG_SEC_CHN_CFG only can be set by secure CPU*/
+    sec.u32 = SYMC_READ(REG_SEC_CHN_CFG);
+    sec.bits.sec_chn_cfg = CIPHER_HARD_CHANNEL_MASK;
+    SYMC_WRITE(REG_SEC_CHN_CFG, sec.u32);
+    HI_LOG_INFO("REG_SEC_CHN_CFG 0x%x\n", sec.u32);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+static void drv_symc_print_last_node(hi_u32 chn_num)
+{
+    symc_entry *in = HI_NULL, *out = HI_NULL;
+    symc_hard_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx = (symc_hard_context *)symc_hard_channel[chn_num].ctx;
+
+    /* get last in node info*/
+    if (ctx->id_in == 0x00) {
+        in = &ctx->entry_in[SYMC_NODE_LIST_SIZE];
+    } else {
+        in = &ctx->entry_in[ctx->id_in - 1];
+    }
+
+    /* get last out node info*/
+    if (ctx->id_out == 0x00) {
+        out = &ctx->entry_out[SYMC_NODE_LIST_SIZE];
+    } else {
+        out = &ctx->entry_out[ctx->id_out - 1];
+    }
+
+    HI_LOG_ERROR("chn %d, src addr 0x%x, size 0x%x, dest addr 0x%x, size 0x%x\n",
+                 chn_num, in->phy_addr, in->length, out->phy_addr, out->length);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+static void drv_symc_print_status(hi_u32 chn_num)
+{
+    int_raw    raw;
+    int_status status;
+    int_en     enable;
+    sec_chn_cfg cfg;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_ERROR("REG_CHANn_SRC_LST_SADDR         : 0x%x\n", SYMC_READ(REG_CHANn_SRC_LST_SADDR(chn_num)));
+    HI_LOG_ERROR("REG_CHANn_SRC_LST_RADDR         : 0x%x\n", SYMC_READ(REG_CHANn_SRC_LST_RADDR(chn_num)));
+    HI_LOG_ERROR("REG_CHANn_IBUF_NUM              : 0x%x\n", SYMC_READ(REG_CHANn_IBUF_NUM(chn_num)));
+    HI_LOG_ERROR("CHANn_SRC_ADDR                  : 0x%x\n", SYMC_READ(CHANn_SRC_ADDR(chn_num)));
+    HI_LOG_ERROR("REG_CHANn_DEST_LST_SADDR        : 0x%x\n", SYMC_READ(REG_CHANn_DEST_LST_SADDR(chn_num)));
+    HI_LOG_ERROR("REG_CHANn_DEST_LST_RADDR        : 0x%x\n", SYMC_READ(REG_CHANn_DEST_LST_RADDR(chn_num)));
+    HI_LOG_ERROR("REG_CHANn_OBUF_NUM              : 0x%x\n", SYMC_READ(REG_CHANn_OBUF_NUM(chn_num)));
+    HI_LOG_ERROR("REG_CHANn_DEST_ADDR             : 0x%x\n", SYMC_READ(REG_CHANn_DEST_ADDR(chn_num)));
+    HI_LOG_ERROR("CHANn_CIPHER_CTRL               : 0x%x\n", SYMC_READ(REG_CHANn_CIPHER_CTRL(chn_num)));
+
+    raw.u32    = SYMC_READ(REG_INT_RAW);
+    status.u32 = SYMC_READ(REG_INT_STATUS);
+    enable.u32 = SYMC_READ(REG_INT_EN);
+    cfg.u32    = SYMC_READ(REG_SEC_CHN_CFG);
+
+    HI_LOG_ERROR("\nsec_chn_cfg 0x%x, chn %d, nsec_int_en 0x%x, sec_int_en 0x%x, chn_obuf_en 0x%x, status 0x%x, raw 0x%x\n",
+                 (cfg.bits.sec_chn_cfg >> chn_num) & 0x01,
+                 chn_num, enable.bits.int_en, enable.bits.sec_int_en,
+                 (enable.bits.chn_obuf_en >> chn_num) & 0x01,
+                 (status.bits.chn_obuf_int >> chn_num) & 0x01,
+                 (raw.bits.chn_obuf_raw >> chn_num) & 0x01);
+
+    HI_LOG_ERROR("\nThe cause of time out may be:\n"
+                 "\t1. SMMU address invalid\n"
+                 "\t2. interrupt number or name incorrect\n"
+                 "\t3. CPU type mismatching, request CPU and channel: %s\n",
+                 crypto_is_sec_cpu() ? "secure" : "non-secure");
+
+    /* avoid compile error when HI_LOG_ERROR be defined to empty */
+    CRYPTO_UNUSED(raw);
+    CRYPTO_UNUSED(status);
+    CRYPTO_UNUSED(enable);
+    CRYPTO_UNUSED(cfg);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+static void drv_symc_get_err_code(hi_u32 chn_num)
+{
+    HI_LOG_FUNC_ENTER();
+
+#ifdef CRYPTO_SMMU_SUPPORT
+    {
+        /* check error code
+         * bit0: TLB miss
+         * bit1: PTW transaciont error
+         * bit2: TLB read invalid
+         * bit3: TLB Write invalid
+         */
+        hi_u32 code = 0;
+
+        /*read error code*/
+        if (crypto_is_sec_cpu()) {
+            code = SMMU_READ(REG_MMU_INTRAW_S);
+            SMMU_WRITE(REG_MMU_INTRAW_S, code);
+        } else {
+            code = SMMU_READ(REG_MMU_INTRAW_NS);
+            SMMU_WRITE(REG_MMU_INTRAW_NS, code);
+        }
+        HI_LOG_INFO("symc done, hardware error code 0x%x\n", code);
+
+        if ((code >> 3) & 0x01) {
+            HI_LOG_ERROR("MMU Error, there is a TLB Write invalid generated during the translation process.\n");
+        }
+        if ((code >> 2) & 0x01) {
+            HI_LOG_ERROR("MMU Error, there is a TLB read invalid generated during the translation process.\n");
+        }
+        if ((code >> 1) & 0x01) {
+            HI_LOG_ERROR("MMU Error, the PTW transaciont receive an error response.\n");
+        }
+        if ((code) & 0x01) {
+            HI_LOG_ERROR("MMU Error, there is a TLB miss generated during the translation process.\n");
+        }
+    }
+#endif
+
+    /*print the inout buffer address*/
+    drv_symc_print_last_node(chn_num);
+    drv_symc_print_status(chn_num);
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+void drv_symc_enrty_init(crypto_mem mem)
+{
+    hi_u32 i;
+    hi_u32 dma_addr = 0;
+    hi_u32 mmz_addr = 0;
+    void *cpu_addr = HI_NULL;
+
+    HI_LOG_INFO("symc entry list configure\n");
+    dma_addr = ADDR_L32(mem.dma_addr);
+    mmz_addr = ADDR_L32(mem.mmz_addr);
+    cpu_addr = mem.dma_virt;
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        if ((CIPHER_HARD_CHANNEL_MASK >> i) & 0x01) { /*valid channel*/
+            drv_symc_set_entry(i, dma_addr, mmz_addr, cpu_addr);
+            dma_addr += CHN_LIST_SIZE; /* move to next channel */
+            mmz_addr += CHN_LIST_SIZE; /* move to next channel */
+            cpu_addr = (hi_u8 *)cpu_addr + CHN_LIST_SIZE; /* move to next channel */
+        }
+    }
+    return;
+}
+
+/* encrypt data using special chn*/
+hi_s32 drv_cipher_aes_test(hi_void)
+{
+    hi_s32 ret = HI_SUCCESS;
+    crypto_mem mem;
+    hi_u32 chn = 0;
+    hi_u32 last = 0, first = 0;
+    hi_u32 key[SYMC_KEY_MAX_SIZE_IN_WORD] = {0};
+    const char *gold_enc = "\x66\xE9\x4B\xD4\xEF\x8A\x2C\x3B\x88\x4C\xFA\x59\xCA\x34\x2B\x2E";
+    hi_s32 i;
+
+    ret = crypto_mem_create(&mem, SEC_MMZ, "symc_data", AES_BLOCK_SIZE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, malloc ddr for symc test data failed\n");
+        HI_LOG_PRINT_FUNC_ERR(crypto_mem_create, ret);
+        return ret;
+    }
+
+    /* read last used channel */
+    last = SYMC_READ(REG_HL_APP_LEN) & 0xFF;
+
+    /* read the max valid channel */
+    for (i = CRYPTO_HARD_CHANNEL_MAX - 1; i > 0; i--) {
+        if (CIPHER_HARD_CHANNEL_MASK & (0x1 << i)) {
+            first = i;
+            break;
+        }
+    }
+
+    /* select a channel dfferent with last used channel*/
+    if ( last == first) {
+        chn = first - 1;
+    } else {
+        chn = first;
+    }
+    HI_LOG_INFO("drv cipher aes test, first %d, last chn %d, use chn %d\n", first, last, chn);
+
+    symc_hard_channel[chn].open = HI_TRUE;
+    drv_symc_set_key(chn, key, HI_FALSE);
+
+    ret = drv_symc_config(chn, SYMC_ALG_AES, SYMC_MODE_ECB, SYMC_DAT_WIDTH_128,
+                          HI_FALSE, 0, SYMC_KEY_DEFAULT, HI_FALSE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_config, ret);
+        goto exit;
+    }
+    crypto_memset(mem.dma_virt, AES_BLOCK_SIZE, 0, AES_BLOCK_SIZE);
+
+    ret = drv_symc_add_inbuf(chn, mem.dma_addr, AES_BLOCK_SIZE, SYMC_NODE_USAGE_NORMAL);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_add_inbuf, ret);
+        goto exit;
+    }
+
+    ret = drv_symc_add_outbuf(chn, mem.dma_addr, AES_BLOCK_SIZE, SYMC_NODE_USAGE_NORMAL);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_add_outbuf, ret);
+        goto exit;
+    }
+
+    /* start running */
+    drv_symc_start(chn);
+
+    /* wait done */
+    ret = drv_symc_wait_done(chn, CRYPTO_TIME_OUT);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_wait_done, ret);
+        goto exit;
+    }
+
+    if (0 != memcmp(mem.dma_virt, gold_enc, AES_BLOCK_SIZE)) {
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_INIT);
+        ret = HI_ERR_CIPHER_FAILED_INIT;
+        goto exit;
+    }
+
+exit:
+    crypto_mem_destory(&mem);
+    symc_hard_channel[chn].open = HI_FALSE;
+
+    return ret;
+}
+
+#ifdef CRYPTO_SWITCH_CPU
+hi_u32 drv_symc_is_secure(void)
+{
+    sec_chn_cfg sec;
+    sec_chn_cfg tmp;
+    hi_u32 secure = HI_FALSE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_INFO("Change the secure type of the chn0 to get cpu type\n");
+    module_enable(CRYPTO_MODULE_ID_SYMC);
+
+    sec.u32 = SYMC_READ(REG_SEC_CHN_CFG);
+
+    /* change the secure type of chn0 */
+    sec.bits.sec_chn_cfg ^= 0x01;
+    SYMC_WRITE(REG_SEC_CHN_CFG, sec.u32);
+
+    /* read the secure type of chn0 */
+    tmp.u32 = SYMC_READ(REG_SEC_CHN_CFG);
+
+    if (tmp.bits.sec_chn_cfg == sec.bits.sec_chn_cfg) {
+        /* The REG_SEC_CHN_CFG only can be set by secure CPU
+         * can write the cfg, must be secure CPU
+         */
+        secure =  HI_TRUE;
+
+        /* recovery the secure type of chn0 */
+        sec.bits.sec_chn_cfg ^= 0x01;
+        SYMC_WRITE(REG_SEC_CHN_CFG, sec.u32);
+    }
+
+    HI_LOG_INFO("secure type: 0x%x\n", secure);
+
+    HI_LOG_FUNC_EXIT();
+    return secure;
+}
+#endif
+
+hi_s32 drv_symc_init(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (symc_initialize == HI_TRUE) {
+        return HI_SUCCESS;
+    }
+
+    crypto_memset(&symc_dma, sizeof(symc_dma), 0, sizeof(symc_dma));
+
+    ret = crypto_channel_init(symc_hard_channel, CRYPTO_HARD_CHANNEL_MAX, sizeof(symc_hard_context));
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, symc channel list init failed\n");
+        HI_LOG_PRINT_FUNC_ERR(crypto_channel_init, ret);
+        return ret;
+    }
+
+    HI_LOG_INFO("disable symc\n");
+    module_disable(CRYPTO_MODULE_ID_SYMC);
+
+    HI_LOG_INFO("enable symc\n");
+    module_enable(CRYPTO_MODULE_ID_SYMC);
+
+    HI_LOG_INFO("enable smmu\n");
+    module_enable(CRYPTO_MODULE_ID_SMMU);
+
+    HI_LOG_INFO("alloc memory for nodes list\n");
+    ret = crypto_mem_create(&symc_dma, SEC_MMZ, "symc_node_list", SYMC_NODE_LIST_SIZE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, malloc ddr for symc nodes list failed\n");
+        HI_LOG_PRINT_FUNC_ERR(crypto_mem_create, ret);
+        goto __error1;
+    }
+
+    HI_LOG_INFO("symc secure channel configure\n");
+    drv_symc_enable_secure();
+
+    HI_LOG_INFO("symc entry list configure\n");
+    drv_symc_enrty_init(symc_dma);
+
+#ifdef CRYPTO_SMMU_SUPPORT
+    HI_LOG_INFO("symc SMMU configure\n");
+    drv_symc_smmu_int_disable();
+    drv_symc_smmu_bypass();
+    drv_symc_smmu_base_addr();
+#endif
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+
+#ifdef CRYPTO_SMMU_SUPPORT
+    drv_symc_smmint_enable();
+#endif
+
+    HI_LOG_INFO("symc interrupt configure\n");
+    drv_symc_set_interrupt();
+
+    HI_LOG_INFO("symc register interrupt function\n");
+    ret = drv_symc_register_interrupt();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, register interrupt failed\n");
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_register_interrupt, ret);
+        crypto_mem_destory(&symc_dma);
+        goto __error1;
+    }
+#endif
+
+    symc_initialize = HI_TRUE;
+
+    /* because can't reset hardware under tee environment
+     * the low channel(1 or 2) may be used by boot or loader,
+     * DRV_CIPHER_Init() will change the address of first node list,
+     * this may occur a hardware error to analyse address,
+     * so here need to start anther channel to computing once,
+     * it will force the hardware re-read the address of first node list
+     */
+    ret = drv_cipher_aes_test();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_cipher_aes_test, ret);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+__error1:
+    module_disable(CRYPTO_MODULE_ID_SMMU);
+    module_disable(CRYPTO_MODULE_ID_SYMC);
+    crypto_channel_deinit(symc_hard_channel, CRYPTO_HARD_CHANNEL_MAX);
+
+    symc_initialize = HI_FALSE;
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+hi_s32 drv_symc_deinit(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+
+    crypto_mem_destory(&symc_dma);
+
+    module_disable(CRYPTO_MODULE_ID_SYMC);
+    module_disable(CRYPTO_MODULE_ID_SMMU);
+
+    crypto_channel_deinit(symc_hard_channel, CRYPTO_HARD_CHANNEL_MAX);
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    drv_symc_unregister_interrupt();
+#endif
+
+    symc_initialize = HI_FALSE;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_resume(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_INFO("enable symc\n");
+    module_enable(CRYPTO_MODULE_ID_SYMC);
+    module_enable(CRYPTO_MODULE_ID_SMMU);
+    module_disable(CRYPTO_MODULE_ID_SM4);
+
+    /* must be called before set register of
+     - interrupt
+     - channel
+     */
+    drv_symc_enable_secure();
+
+#ifdef CRYPTO_SMMU_SUPPORT
+    drv_symc_smmu_int_disable();
+    drv_symc_smmu_bypass();
+    drv_symc_smmu_base_addr();
+#endif
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+#ifdef CRYPTO_SMMU_SUPPORT
+    drv_symc_smmint_enable();
+#endif
+    drv_symc_set_interrupt();
+#endif
+
+    drv_symc_enrty_init(symc_dma);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+}
+
+void drv_symc_suspend(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    module_disable(CRYPTO_MODULE_ID_SYMC);
+    module_disable(CRYPTO_MODULE_ID_SMMU);
+
+    HI_LOG_FUNC_EXIT();
+    return ;
+}
+
+hi_s32 drv_symc_alloc_chn(hi_u32 *chn_num)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 list = 0;
+    hi_u32 chn = 0;
+    hi_u32 resume = HI_FALSE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+
+    ret = crypto_channel_alloc(symc_hard_channel, CRYPTO_HARD_CHANNEL_MAX,
+                               CIPHER_HARD_CHANNEL_MASK, &chn);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(crypto_channel_alloc, ret);
+        return ret;
+    }
+
+    /* hardware may be unexpected reset by other module or platform,
+     * such as unexpected reset by fastboot after load tee image,
+     * in this case, the hardware configuration will be reset,
+     * here try to re-config the hardware.
+     */
+    list = SYMC_READ(REG_CHANn_SRC_LST_SADDR(chn));
+
+#ifdef CRYPTO_SMMU_SUPPORT
+    {
+        hi_u32 base = 0;
+
+        if (crypto_is_sec_cpu()) {
+            base = SMMU_READ(REG_MMU_SCB_TTBR);
+        } else {
+            base = SMMU_READ(REG_MMU_CB_TTBR);
+        }
+        if ((list == 0) || (base == 0)) {
+            resume = HI_TRUE;
+        }
+    }
+#else
+    if (list == 0) {
+        resume = HI_TRUE;
+    }
+#endif
+
+    if (resume == HI_TRUE) {
+        /* smmu base address or node list address is zero
+         * means hardware be unexpected reset
+         */
+        HI_LOG_WARN("cipher module is not ready, try to resume it now...\n");
+        ret = drv_symc_resume();
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_symc_resume, ret);
+            return ret;
+        }
+    }
+
+    *chn_num = chn;
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_symc_free_chn(hi_u32 chn_num)
+{
+    symc_hard_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx = crypto_channel_get_context(symc_hard_channel,
+                                     CRYPTO_HARD_CHANNEL_MAX, chn_num);
+
+    if (ctx->destory != HI_NULL) {
+        ctx->destory();
+        ctx->destory = HI_NULL;
+    }
+
+    crypto_channel_free(symc_hard_channel, CRYPTO_HARD_CHANNEL_MAX, chn_num);
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+hi_s32 drv_symc_set_iv(hi_u32 chn_num, hi_u32 iv[SYMC_IV_MAX_SIZE_IN_WORD], hi_u32 ivlen, hi_u32 flag)
+{
+    hi_u32 i;
+    symc_hard_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    CRYPTO_UNUSED(ivlen);
+
+    ctx = crypto_channel_get_context(symc_hard_channel,
+                                     CRYPTO_HARD_CHANNEL_MAX, chn_num);
+    if (ctx == HI_NULL) {
+        HI_LOG_ERROR("crypto channel get context failed,ctx is null!\n");
+        return HI_ERR_CIPHER_INVALID_POINT;
+    }
+
+    /*copy iv data into channel context*/
+    for (i = 0; i < SYMC_IV_MAX_SIZE_IN_WORD; i++) {
+        ctx->iv[i] = iv[i];
+        HI_LOG_INFO("IV[%d] 0x%x\n", i, iv[i]);
+    }
+    ctx->iv_flag = flag;
+
+    HI_LOG_INFO("iv_flag 0x%x\n", flag);
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+void drv_symc_get_iv(hi_u32 chn_num, hi_u32 iv[SYMC_IV_MAX_SIZE_IN_WORD])
+{
+    hi_u32 i;
+
+    HI_LOG_FUNC_ENTER();
+
+    for (i = 0; i < SYMC_IV_MAX_SIZE_IN_WORD; i++) {
+        iv[i] = SYMC_READ(REG_CHAN_CIPHER_IVOUT(chn_num) + i * 4);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+void drv_symc_set_key(hi_u32 chn_num, hi_u32 key[SYMC_KEY_MAX_SIZE_IN_WORD], hi_u32 odd)
+{
+    hi_u32 i;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* unsupport odd key */
+    if (odd) {
+        return;
+    }
+
+    for (i = 0; i < SYMC_KEY_MAX_SIZE_IN_WORD; i++) {
+        SYMC_WRITE(REG_CIPHER_KEY(chn_num) + i * 4, key[i]);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+void drv_symc_set_sm1_sk(hi_u32 chn_num, hi_u32 key[SYMC_SM1_SK_SIZE_IN_WORD])
+{
+    CRYPTO_UNUSED(chn_num);
+    CRYPTO_UNUSED(key);
+    return;
+}
+
+hi_s32 drv_symc_add_inbuf(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size, symc_node_usage usage)
+{
+    symc_entry *entry = HI_NULL;
+    hi_u32 *node_iv = HI_NULL;
+    symc_hard_context *ctx = HI_NULL;
+    hi_u32 iv_flag = HI_FALSE;
+    hi_u32 length = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+    HI_LOG_CHECK_PARAM(0 == buf_size);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    ctx = crypto_channel_get_context(symc_hard_channel,
+                                     CRYPTO_HARD_CHANNEL_MAX, chn_num);
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+    HI_LOG_CHECK_PARAM(ctx->cnt >= SYMC_MAX_LIST_NUM);
+    HI_LOG_CHECK_PARAM(ctx->id_in >= SYMC_MAX_LIST_NUM);
+    HI_LOG_CHECK_PARAM(ctx->id_out >= SYMC_MAX_LIST_NUM);
+
+    /* split the buf to mutlit node, as the max length of one node is 1M-16*/
+    while (buf_size > 0) {
+        if (ctx->cnt > SYMC_MAX_LIST_NUM) {
+            HI_LOG_ERROR("node count %d overflow, max %d\n",  ctx->cnt, SYMC_MAX_LIST_NUM);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_OVERFLOW);
+            return HI_ERR_CIPHER_OVERFLOW;
+        }
+
+        if (buf_size > MAX_NODE_SIZE) {
+            length = MAX_NODE_SIZE;
+        } else {
+            length = buf_size;
+        }
+        entry = &ctx->entry_in[ctx->id_in];
+        node_iv = ctx->entry_iv[ctx->id_in].iv;
+        iv_flag = HI_FALSE;
+
+        /*set dma addr and size, only support 32bit ddr*/
+        entry->phy_addr = ADDR_L32(buf_phy);
+        entry->length = length;
+
+        /*set flag*/
+        entry->flags = SYMC_BUF_LIST_FLAG_DUMM | SYMC_BUF_LIST_FLAG_EOL;
+
+        HI_LOG_INFO("add inbuf, chn %d, id %d, addr 0x%x, length 0x%x, iv_flag %d\n",
+                    chn_num, ctx->id_in, entry->phy_addr, entry->length, ctx->iv_flag);
+
+        /*first node must set iv except ecb mode*/
+        if (ctx->iv_flag == CIPHER_IV_CHANGE_ONE_PKG) {
+            iv_flag = HI_TRUE;
+
+            /* don't set iv any more*/
+            ctx->iv_flag = 0;
+        } else if (ctx->iv_flag == CIPHER_IV_CHANGE_ALL_PKG) {
+            iv_flag = HI_TRUE;
+        }
+
+        /* set iv to node */
+        if (iv_flag) {
+            entry->flags |= SYMC_BUF_LIST_FLAG_IVSET;
+            node_iv[0] = ctx->iv[0];
+            node_iv[1] = ctx->iv[1];
+            node_iv[2] = ctx->iv[2];
+            node_iv[3] = ctx->iv[3];
+            HI_LOG_DEBUG("iv[0] 0x%x\n", node_iv[0]);
+            HI_LOG_DEBUG("iv[1] 0x%x\n", node_iv[1]);
+            HI_LOG_DEBUG("iv[2] 0x%x\n", node_iv[2]);
+            HI_LOG_DEBUG("iv[3] 0x%x\n", node_iv[3]);
+        }
+
+        /* move to next node, reset to zero if overflow*/
+        ctx->id_in++;
+        if (ctx->id_in == SYMC_MAX_LIST_NUM) {
+            ctx->id_in = 0;
+        }
+
+        /* total count of computed nodes add 1*/
+        ctx->cnt++;
+
+        ADDR_L32(buf_phy) += length;
+        buf_size -= length;
+    }
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_add_outbuf(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size, symc_node_usage usage)
+{
+    symc_entry *entry = HI_NULL;
+    symc_hard_context *ctx = HI_NULL;
+    hi_u32 length = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+    HI_LOG_CHECK_PARAM(buf_size == 0);
+
+    CRYPTO_UNUSED(usage);
+
+    ctx = crypto_channel_get_context(symc_hard_channel,
+                                     CRYPTO_HARD_CHANNEL_MAX, chn_num);
+    if (ctx == HI_NULL) {
+        HI_LOG_ERROR("crypto channel get context failed,ctx is null!\n");
+        return HI_ERR_CIPHER_INVALID_POINT;
+    }
+
+    /* split the buf to mutlit node, as the max length of one node is 1M-16*/
+    while (buf_size > 0) {
+        if ( buf_size > MAX_NODE_SIZE) {
+            length = MAX_NODE_SIZE;
+        } else {
+            length = buf_size;
+        }
+        entry = &ctx->entry_out[ctx->id_out];
+
+        /*set dma addr and size, only support 32bit ddr*/
+        entry->phy_addr = ADDR_L32(buf_phy);
+        entry->length = length;
+
+        HI_LOG_INFO("add outbuf, chn %d, id %d, addr 0x%x, length 0x%x\n",
+                    chn_num, ctx->id_out, entry->phy_addr, entry->length);
+
+        /*set flag*/
+        entry->flags = SYMC_BUF_LIST_FLAG_DUMM | SYMC_BUF_LIST_FLAG_EOL;
+
+        /*move to next node, reset to zero if overflow*/
+        ctx->id_out++;
+        if (ctx->id_out == SYMC_MAX_LIST_NUM) {
+            ctx->id_out = 0;
+        }
+
+        ADDR_L32(buf_phy) += length;
+        buf_size -= length;
+    }
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_aead_ccm_add_n(hi_u32 chn_num,  hi_u8 *n)
+{
+    HI_LOG_CHECK_INITED(symc_initialize);
+    CRYPTO_UNUSED(chn_num);
+    CRYPTO_UNUSED(n);
+
+    return HI_ERR_CIPHER_UNSUPPORTED;
+}
+
+hi_s32 drv_aead_ccm_add_a(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size)
+{
+    HI_LOG_CHECK_INITED(symc_initialize);
+    CRYPTO_UNUSED(chn_num);
+    CRYPTO_UNUSED(buf_phy);
+    CRYPTO_UNUSED(buf_size);
+
+    return HI_ERR_CIPHER_UNSUPPORTED;
+}
+
+hi_s32 drv_aead_gcm_add_a(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size)
+{
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+    CRYPTO_UNUSED(chn_num);
+    CRYPTO_UNUSED(buf_phy);
+    CRYPTO_UNUSED(buf_size);
+
+    return HI_ERR_CIPHER_UNSUPPORTED;
+}
+
+hi_s32 drv_aead_get_tag(hi_u32 chn_num, hi_u32 *tag)
+{
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+    CRYPTO_UNUSED(chn_num);
+    CRYPTO_UNUSED(tag);
+
+    return HI_FAILURE;
+}
+
+hi_s32 drv_aead_gcm_add_clen(hi_u32 chn_num, hi_u8 *clen)
+{
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+    CRYPTO_UNUSED(chn_num);
+    CRYPTO_UNUSED(clen);
+
+    return HI_ERR_CIPHER_UNSUPPORTED;
+}
+
+void drv_symc_add_buf_usage(hi_u32 chn_num, hi_u32 in, symc_node_usage usage)
+{
+    CRYPTO_UNUSED(chn_num);
+    CRYPTO_UNUSED(in);
+    CRYPTO_UNUSED(usage);
+}
+
+hi_s32 drv_symc_node_check(symc_alg alg, symc_mode mode,
+                        hi_u32 klen, hi_u32 block_size,
+                        compat_addr input[],
+                        compat_addr output[],
+                        hi_u32 length[],
+                        symc_node_usage usage_list[],
+                        hi_u32 pkg_num)
+{
+    hi_u32 i;
+    hi_u32 tail = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(block_size == 0);
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+    CRYPTO_UNUSED(alg);
+    CRYPTO_UNUSED(mode);
+    CRYPTO_UNUSED(klen);
+    CRYPTO_UNUSED(input);
+    CRYPTO_UNUSED(output);
+    CRYPTO_UNUSED(usage_list);
+
+    for (i = 0; i < pkg_num; i++) {
+        HI_LOG_DEBUG("node %d, length 0x%x\n", i, length[i]);
+        if (0 != (length[i] % block_size)) {
+            /* The last block of CTR mode don't need align with block size,
+             * but the hardware require the data size must align with block size,
+             * as the MMZ/MMU size is align with page size(4K) by system,
+             * here we can increase the last block size to align with block size.
+             */
+            if ((mode == SYMC_MODE_CTR) && (i == pkg_num - 1)) {
+                tail = length[i] % block_size;
+                if ( 0x00 != tail) {
+                    length[i] += block_size - tail;
+                }
+            } else {
+                HI_LOG_ERROR("error, node length must be multiple of block size %d.\n", block_size);
+                HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_LENGTH);
+                return HI_ERR_CIPHER_INVALID_LENGTH;
+            }
+        }
+
+        /* each node length can't be zero*/
+        if (length[i] == 0) {
+            HI_LOG_ERROR("PKG len must large than 0.\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_LENGTH);
+            return HI_ERR_CIPHER_INVALID_LENGTH;
+        }
+
+        /* check overflow */
+        if (length[i] > ADDR_L32(input[i]) + length[i]) {
+            HI_LOG_ERROR("PKG len overflow.\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_LENGTH);
+            return HI_ERR_CIPHER_INVALID_LENGTH;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_config(hi_u32 chn_num, symc_alg alg, symc_mode mode, symc_width width,
+                    hi_u32 decrypt, hi_u32 sm1_round_num, symc_klen klen, hi_u32 hard_key)
+{
+    chann_chipher_ctrl ctrl;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+    HI_LOG_CHECK_PARAM(alg > SYMC_ALG_AES);
+    HI_LOG_CHECK_PARAM(mode > SYMC_MODE_CTR);
+    HI_LOG_CHECK_PARAM(klen >= SYMC_KEY_LEN_COUNT);
+
+    CRYPTO_UNUSED(sm1_round_num);
+
+    ctrl.u32 = SYMC_READ(REG_CHANn_CIPHER_CTRL(chn_num));
+
+    ctrl.bits.decrypt = decrypt;
+    ctrl.bits.mode = mode;
+    ctrl.bits.alg_sel = alg;
+    ctrl.bits.width = width;
+    ctrl.bits.key_length = klen;
+    ctrl.bits.key_sel = hard_key;
+    ctrl.bits.key_adder = chn_num;
+    ctrl.bits.weight = 1;
+
+    SYMC_WRITE(REG_CHANn_CIPHER_CTRL(chn_num), ctrl.u32);
+    HI_LOG_INFO("REG_CHANn_CIPHER_CTRL[%d] 0x%x\n", chn_num, ctrl.u32);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_set_isr_callback(hi_u32 chn_num, callback_symc_isr callback, void *ctx)
+{
+    symc_hard_context *hisi_ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    hisi_ctx = crypto_channel_get_context(symc_hard_channel,
+                                          CRYPTO_HARD_CHANNEL_MAX, chn_num);
+    if (hisi_ctx == HI_NULL) {
+        HI_LOG_ERROR("crypto channel get context failed,hisi_ctx is null!\n");
+        return HI_ERR_CIPHER_INVALID_POINT;
+    }
+
+    hisi_ctx->callback = callback;
+    hisi_ctx->ctx = ctx;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_start(hi_u32 chn_num)
+{
+    symc_hard_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+    ctx = crypto_channel_get_context(symc_hard_channel,
+                                     CRYPTO_HARD_CHANNEL_MAX, chn_num);
+    HI_LOG_CHECK_PARAM(ctx->cnt < 0x01);
+
+    HI_LOG_INFO("symc start, chn %d, cnt %d\n", chn_num, ctx->cnt);
+
+    ctx->done = HI_FALSE;
+
+    /* read last used channel */
+    SYMC_WRITE(REG_HL_APP_LEN, chn_num);
+
+    /*start work, the count of nodes to be computed is ctx->cnt*/
+    SYMC_WRITE(REG_CHANn_INT_OCNTCFG(chn_num), ctx->cnt);
+    SYMC_WRITE(REG_CHANn_OBUF_CNT(chn_num), ctx->cnt);
+    SYMC_WRITE(REG_CHANn_IBUF_CNT(chn_num), ctx->cnt);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_wait_done(hi_u32 chn_num, hi_u32 timeout)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    hi_u32 i;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_INITED(symc_initialize);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    module_get_attr(CRYPTO_MODULE_ID_SYMC, &int_valid, &int_num, HI_NULL);
+
+    HI_LOG_INFO("symc wait done, chn %d\n", chn_num);
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    /* interrupt support, wait irq*/
+    if (int_valid) {
+        hi_s32 ret = HI_FAILURE;
+        symc_hard_context *ctx = HI_NULL;
+
+        ctx = crypto_channel_get_context(symc_hard_channel, CRYPTO_HARD_CHANNEL_MAX, chn_num);
+        if (ctx == HI_NULL) {
+            HI_LOG_ERROR("crypto channel get context failed, ctx is null, chn=%d\n", chn_num);
+            HI_LOG_PRINT_FUNC_ERR(crypto_channel_get_context, HI_ERR_CIPHER_INVALID_POINT);
+            return HI_ERR_CIPHER_INVALID_POINT;
+        }
+
+        /* wait interrupt */
+        ret = crypto_queue_wait_timeout(ctx->queue, &ctx->done, timeout);
+        if ((ret <= 0) && (ret != -ERESTARTSYS)) {
+            HI_LOG_ERROR("wait done timeout, chn=%d\n", chn_num);
+            HI_LOG_PRINT_FUNC_ERR(crypto_queue_wait_timeout, HI_ERR_CIPHER_TIMEOUT);
+            drv_symc_get_err_code(chn_num);
+            return HI_ERR_CIPHER_TIMEOUT;
+        }
+    } else /* interrupt unsupport, query the raw interrupt flag*/
+#endif
+    {
+        for (i = 0; i < timeout; i++) {
+            if (drv_symc_done_try(chn_num)) {
+                break;
+            }
+            if (i <= MS_TO_US) {
+                crypto_udelay(1);  /* short waitting for 1000 us */
+            } else {
+                crypto_msleep(1);  /* long waitting for 5000 ms*/
+            }
+        }
+        if (timeout <= i) {
+            HI_LOG_ERROR("symc wait done timeout, chn=%d\n", chn_num);
+            HI_LOG_PRINT_FUNC_ERR(crypto_queue_wait_timeout, HI_ERR_CIPHER_TIMEOUT);
+            drv_symc_get_err_code(chn_num);
+            return HI_ERR_CIPHER_TIMEOUT;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_set_destory_callbcak(hi_u32 chn_num, callback_symc_destory destory)
+{
+    symc_hard_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx = crypto_channel_get_context(symc_hard_channel,
+                                     CRYPTO_HARD_CHANNEL_MAX, chn_num);
+    if (ctx == HI_NULL) {
+        HI_LOG_ERROR("crypto channel get context failed,ctx is null!\n");
+        return HI_ERR_CIPHER_INVALID_POINT;
+    }
+
+    ctx->destory = destory;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/******* proc function begin ********/
+#if (1 == HI_PROC_SUPPORT)
+void drv_symc_proc_ctrl(symc_chn_status *status, chann_chipher_ctrl ctrl)
+{
+    status->decrypt = ctrl.bits.decrypt;
+    switch (ctrl.bits.alg_sel) {
+        case HI_CIPHER_ALG_DES: {
+            status->alg = "DES ";
+            break;
+        }
+        case HI_CIPHER_ALG_3DES: {
+            status->alg = "3DES";
+            break;
+        }
+        case HI_CIPHER_ALG_AES: {
+            status->alg = "AES ";
+            break;
+        }
+        default: {
+            status->alg = "BUTT";
+            break;
+        }
+    }
+
+    switch (ctrl.bits.mode) {
+        case HI_CIPHER_WORK_MODE_ECB: {
+            status->mode = "ECB ";
+            break;
+        }
+        case HI_CIPHER_WORK_MODE_CBC: {
+            status->mode = "CBC ";
+            break;
+        }
+        case HI_CIPHER_WORK_MODE_CFB: {
+            status->mode = "CFB ";
+            break;
+        }
+        case HI_CIPHER_WORK_MODE_OFB: {
+            status->mode = "OFB ";
+            break;
+        }
+        case HI_CIPHER_WORK_MODE_CTR: {
+            status->mode = "CTR ";
+            break;
+        }
+        case HI_CIPHER_WORK_MODE_CCM: {
+            status->mode = "CCM ";
+            break;
+        }
+        case HI_CIPHER_WORK_MODE_GCM: {
+            status->mode = "GCM ";
+            break;
+        }
+        default: {
+            status->mode = "BUTT";
+            break;
+        }
+    }
+
+    if (ctrl.bits.alg_sel == HI_CIPHER_ALG_AES) {
+        switch (ctrl.bits.key_length) {
+            case HI_CIPHER_KEY_AES_128BIT: {
+                status->klen = AES_KEY_128BIT;
+                break;
+            }
+            case HI_CIPHER_KEY_AES_192BIT: {
+                status->klen = AES_KEY_192BIT;
+                break;
+            }
+            case HI_CIPHER_KEY_AES_256BIT: {
+                status->klen = AES_KEY_256BIT;
+                break;
+            }
+            default: {
+                status->klen = 0;
+                break;
+            }
+        }
+    } else if (ctrl.bits.alg_sel == HI_CIPHER_ALG_DES) {
+        status->klen = DES_KEY_SIZE;
+    } else if (ctrl.bits.alg_sel == HI_CIPHER_ALG_3DES) {
+        switch (ctrl.bits.key_length) {
+            case HI_CIPHER_KEY_DES_3KEY: {
+                status->klen = TDES_KEY_192BIT;
+                break;
+            }
+            case HI_CIPHER_KEY_DES_2KEY: {
+                status->klen = TDES_KEY_128BIT;
+                break;
+            }
+            default: {
+                status->klen = 0;
+                break;
+            }
+        }
+    } else {
+        status->klen = 0;
+    }
+
+    if (ctrl.bits.key_sel) {
+        status->ksrc = "HW";
+    } else {
+        status->ksrc = "SW";
+    }
+
+    return;
+}
+
+hi_s32 drv_symc_proc_status(symc_chn_status *status)
+{
+    hi_u32 addr = 0;
+    chann_chipher_ctrl ctrl;
+    int_raw stIntRaw;
+    int_en stIntEn;
+    hi_u32 val;
+    hi_u32 i, j;
+
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        if (symc_hard_channel[i].open == HI_TRUE) {
+            status[i].open = "open ";
+        } else {
+            status[i].open = "close";
+        }
+
+        /* get cipher ctrl */
+        if (i != 0) {
+            addr = REG_CHANn_CIPHER_CTRL(i);
+        } else {
+            addr = REG_CHAN0_CIPHER_CTRL;
+        }
+        ctrl.u32 = SYMC_READ(addr);
+        drv_symc_proc_ctrl(&status[i], ctrl);
+
+        /* get data in */
+        if (i != 0) {
+            addr = REG_CHANn_SRC_LST_SADDR(i);
+            status[i].inaddr = SYMC_READ(addr);
+        } else {
+            status[i].inaddr = REG_CHAN0_CIPHER_DIN;
+        }
+
+        /* get data out */
+        if (i != 0) {
+            addr = REG_CHANn_DEST_LST_SADDR(i);
+            status[i].outaddr = SYMC_READ(addr);
+        } else {
+            status[0].outaddr = REG_CHAN0_CIPHER_DOUT;
+        }
+
+        for (j = 0; j < 4; j++) {
+            val = SYMC_READ(REG_CHAN_CIPHER_IVOUT(i) + j * 4);
+            hex2str(status[i].iv + j * 8, (hi_u8)(val & 0xFF));
+            hex2str(status[i].iv + j * 8 + 2, (hi_u8)((val >> 8) & 0xFF));
+            hex2str(status[i].iv + j * 8 + 4, (hi_u8)((val >> 16) & 0xFF));
+            hex2str(status[i].iv + j * 8 + 6, (hi_u8)((val >> 24) & 0xFF));
+        }
+
+        /* get INT RAW status */
+        stIntRaw.u32 = SYMC_READ(REG_INT_RAW);
+        status[i].inraw = (stIntRaw.bits.chn_ibuf_raw >> i) & 0x1;
+        status[i].outraw = (stIntRaw.bits.chn_obuf_raw >> i) & 0x1;
+
+        /* get INT EN status */
+        stIntEn.u32 = SYMC_READ(REG_INT_EN);
+        status[i].intswitch = stIntEn.bits.sec_int_en;
+        status[i].inten = (stIntEn.bits.chn_ibuf_en >> i) & 0x1;
+        status[i].outen = (stIntEn.bits.chn_obuf_en >> i) & 0x1;
+
+        /* get INT_OINTCFG */
+        addr = REG_CHANn_INT_OCNTCFG(i);
+        status[i].outintcnt = SYMC_READ(addr);
+    }
+
+    return HI_SUCCESS;
+}
+#endif
+/******* proc function end ********/
+
+void drv_symc_get_capacity(symc_capacity *capacity)
+{
+    HI_LOG_FUNC_ENTER();
+
+    crypto_memset(capacity, sizeof(symc_capacity), 0,  sizeof(symc_capacity));
+
+    /* AES */
+    capacity->aes_ecb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->aes_cbc = CRYPTO_CAPACITY_SUPPORT;
+    capacity->aes_ofb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->aes_cfb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->aes_ctr = CRYPTO_CAPACITY_SUPPORT;
+    capacity->aes_cts = CRYPTO_CAPACITY_NONSUPPORT;
+
+    /* TDES */
+    capacity->tdes_ecb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->tdes_cbc = CRYPTO_CAPACITY_SUPPORT;
+    capacity->tdes_ofb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->tdes_cfb = CRYPTO_CAPACITY_SUPPORT;
+
+    /* DES */
+    capacity->des_ecb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->des_cbc = CRYPTO_CAPACITY_SUPPORT;
+    capacity->des_ofb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->des_cfb = CRYPTO_CAPACITY_SUPPORT;
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+/** @}*/  /** <!-- ==== API Code end ====*/
+
+#endif //End of CHIP_SYMC_VER_V100

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_symc_v100.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_symc_v100.h
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) Hisilicon Technologies Co., Ltd. 2012-2019. All rights reserved.
+ * Description:
+ * Author:
+ * Create:
+ */
+
+#ifndef _DRV_SYMC_V100_H_
+#define _DRV_SYMC_V100_H_
+
+#include "drv_osal_lib.h"
+
+/********************* Internal Structure Definition **********************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+/*! \Size of entry node */
+#define ENTRY_NODE_SIZE     (16)
+
+/*! \symmetric cipher max iv size*/
+#define SYMC_IV_MAX_SIZE        (SYMC_IV_MAX_SIZE_IN_WORD * 4)
+
+/*! \Size of nodes list */
+#define CHN_LIST_SIZE     \
+    ((ENTRY_NODE_SIZE  *2 + SYMC_IV_MAX_SIZE) * SYMC_MAX_LIST_NUM)
+
+/*! \Size of symc nodes list */
+#define SYMC_NODE_LIST_SIZE  (CHN_LIST_SIZE * CIPHER_HARD_CHANNEL_CNT)
+
+/*! \Dump flag of node buffer, if set to 1, the SMMU will dump the page cache*/
+#define SYMC_BUF_LIST_FLAG_DUMM   (0x01 << 20)
+
+/*! \IV set flag of node buffer, if set to 1, the IV will update to hardware*/
+#define SYMC_BUF_LIST_FLAG_IVSET  (0x01 << 21)
+
+/*! \EOL flag of node buffer, set to 1 at the last node*/
+#define SYMC_BUF_LIST_FLAG_EOL    (0x01 << 22)
+
+/*! \Define the offset of reg */
+#define  REG_CHAN0_CIPHER_DOUT           (0x0000)
+#define  REG_CHAN_CIPHER_IVOUT(id)       (0x0010 + (id)*16)
+#define  REG_CIPHER_KEY(id)              (0x0090 + (id)*32)
+#define  REG_SEC_CHN_CFG                 (0x0824)
+#define  REG_HL_APP_LEN                  (0x082C)
+#define  REG_CHAN0_CIPHER_CTRL           (0x1000)
+#define  REG_CHAN0_CIPHER_DIN            (0x1014)
+#define  REG_CHANn_IBUF_NUM(id)          (0x1000 + (id)*128)
+#define  REG_CHANn_IBUF_CNT(id)          (0x1000 + (id)*128 + 0x4)
+#define  REG_CHANn_IEMPTY_CNT(id)        (0x1000 + (id)*128 + 0x8)
+#define  REG_CHANn_CIPHER_CTRL(id)       (0x1000 + (id)*128 + 0x10)
+#define  REG_CHANn_SRC_LST_SADDR(id)     (0x1000 + (id)*128 + 0x14)
+#define  REG_CHANn_IAGE_CNT(id)          (0x1000 + (id)*128 + 0x1C)
+#define  REG_CHANn_SRC_LST_RADDR(id)     (0x1000 + (id)*128 + 0x20)
+#define  CHANn_SRC_ADDR(id)              (0x1000 + (id)*128 + 0x24)
+#define  REG_CHANn_OBUF_NUM(id)          (0x1000 + (id)*128 + 0x3C)
+#define  REG_CHANn_OBUF_CNT(id)          (0x1000 + (id)*128 + 0x40)
+#define  REG_CHANn_OFULL_CNT(id)         (0x1000 + (id)*128 + 0x44)
+#define  REG_CHANn_INT_OCNTCFG(id)       (0x1000 + (id)*128 + 0x48)
+#define  REG_CHANn_DEST_LST_SADDR(id)    (0x1000 + (id)*128 + 0x4C)
+#define  REG_CHANn_OAGE_CNT(id)          (0x1000 + (id)*128 + 0x54)
+#define  REG_CHANn_DEST_LST_RADDR(id)    (0x1000 + (id)*128 + 0x58)
+#define  REG_CHANn_DEST_ADDR(id)         (0x1000 + (id)*128 + 0x5C)
+#define  REG_INT_STATUS                  (0x1400)
+#define  REG_INT_EN                      (0x1404)
+#define  REG_INT_RAW                     (0x1408)
+#define  CHANn_RD_DAT_ADDR_SMMU_BYPASS   (0x1418)
+#define  CHANn_WR_DAT_ADDR_SMMU_BYPASS   (0x141C)
+
+#define  REG_MMU_GLOBAL_CTR_ADDR         (0x00)
+#define  REG_MMU_INTMAS_S                (0x10)
+#define  REG_MMU_INTRAW_S                (0x14)
+#define  REG_MMU_INTSTAT_S               (0x18)
+#define  REG_MMU_INTCLR_S                (0x1c)
+#define  REG_MMU_INTMASK_NS              (0x20)
+#define  REG_MMU_INTRAW_NS               (0x24)
+#define  REG_MMU_INTSTAT_NS              (0x28)
+#define  REG_MMU_INTCLR_NS               (0x2C)
+
+#ifdef CHIP_SMMU_VER_V200
+#define  REG_MMU_SCB_TTBR_H              (0x2e0)
+#define  REG_MMU_SCB_TTBR                (0x2e4)
+#define  REG_MMU_CB_TTBR_H               (0x2e8)
+#define  REG_MMU_CB_TTBR                 (0x2ec)
+#define  REG_MMU_ERR_RDADDR_H_S          (0x2f0)
+#define  REG_MMU_ERR_RDADDR_S            (0x2f4)
+#define  REG_MMU_ERR_WRADDR_H_S          (0x2f8)
+#define  REG_MMU_ERR_WRADDR_S            (0x2fc)
+#define  REG_MMU_ERR_RDADDR_H_NS         (0x300)
+#define  REG_MMU_ERR_RDADDR_NS           (0x304)
+#define  REG_MMU_ERR_WRADDR_H_NS         (0x308)
+#define  REG_MMU_ERR_WRADDR_NS           (0x30c)
+#else
+#define  REG_MMU_SCB_TTBR                (0x208)
+#define  REG_MMU_CB_TTBR                 (0x20C)
+#define  REG_MMU_ERR_RDADDR_S            (0x2f0)
+#define  REG_MMU_ERR_WRADDR_S            (0x2f4)
+#define  REG_MMU_ERR_RDADDR_NS           (0x304)
+#define  REG_MMU_ERR_WRADDR_NS           (0x308)
+#endif
+
+/*! \Define the union chann_chipher_ctrl */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    decrypt         : 1   ; /* [0]  */
+        hi_u32    mode            : 3   ; /* [3..1]  */
+        hi_u32    alg_sel         : 2   ; /* [5..4]  */
+        hi_u32    width           : 2   ; /* [7..6]  */
+        hi_u32    reserved_1      : 1   ; /* [8]  */
+        hi_u32    key_length      : 2   ; /* [10..9]  */
+        hi_u32    reserved_2      : 2   ; /* [12..11]  */
+        hi_u32    key_sel         : 1   ; /* [13]  */
+        hi_u32    key_adder       : 3   ; /* [16..14]  */
+        hi_u32    reserved_3      : 5   ; /* [21..17]  */
+        hi_u32    weight          : 10  ; /* [31..22]  */
+    } bits;
+
+    hi_u32    u32;                        /*! \Define an unsigned member */
+} chann_chipher_ctrl;
+
+/*! \Define the union sec_chn_cfg */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    sec_chn_cfg     : 8   ; /* [7..0]  */
+        hi_u32    sec_chn_cfg_lock : 1  ; /* [8]  */
+        hi_u32    reserved_1      : 23  ; /* [31..9]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+} sec_chn_cfg;
+
+/*! \Define the union chann_rd_dat_addr_smmu_bypass */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    chann_rd_dat_addr_smmu_bypass     : 7   ; /* [6..0]  */
+        hi_u32    reserved_1                        : 25  ; /* [31..7]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+} chann_rd_dat_addr_smmu_bypass;
+
+/*! \Define the union chann_wr_dat_addr_smmu_bypass */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    chann_wr_dat_addr_smmu_bypass     : 7  ; /* [6..0]  */
+        hi_u32    reserved_1                        : 25 ; /* [31..7]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+} chann_wr_dat_addr_smmu_bypass;
+
+/*! \Define the union int_status */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    chn_ibuf_int           : 8 ; /* [7..0]  */
+        hi_u32    chn_obuf_int           : 8 ; /* [15..8]  */
+        hi_u32    tdes_key_error_int     : 1 ; /* [16]  */
+        hi_u32    reserved_1             : 15; /* [31..17]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+} int_status;
+
+/*! \Define the union int_en */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    chn_ibuf_en           : 8 ; /* [7..0]  */
+        hi_u32    chn_obuf_en           : 8 ; /* [15..8]  */
+        hi_u32    tdes_key_error_en     : 1 ; /* [16]  */
+        hi_u32    reserved_1            : 13; /* [31..17]  */
+        hi_u32    sec_int_en            : 1 ; /* [30]  */
+        hi_u32    int_en                : 1 ; /* [31]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+} int_en;
+
+/*! \Define the union int_raw */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    chn_ibuf_raw           : 8 ; /* [7..0]  */
+        hi_u32    chn_obuf_raw           : 8 ; /* [15..8]  */
+        hi_u32    tdes_key_error_raw     : 1 ; /* [16]  */
+        hi_u32    reserved_1             : 15; /* [31..17]  */
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+} int_raw;
+
+/*! \Define the union smmu_scr */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    glb_bypass           : 1 ; /* [0]     */
+        hi_u32    reserved_1           : 2;  /* [2..1]  */
+        hi_u32    int_en               : 1 ; /* [3]     */
+        hi_u32    reserved_2           : 28; /* [31..4] */
+
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+} smmu_scr;
+
+/*! \Define the union smmu_int */
+typedef union {
+    /*! \Define the struct bits */
+    struct {
+        hi_u32    ints_tlbmiss         : 1 ; /* [0]  */
+        hi_u32    ints_ptw_trans       : 1;  /* [1]  */
+        hi_u32    ints_tlbinvalid      : 1 ; /* [2]  */
+        hi_u32    reserved_2           : 29; /* [31..3]  */
+
+    } bits;
+
+    /*! \Define an unsigned member */
+    hi_u32    u32;
+} smmu_int;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_symc_v200.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_symc_v200.c
@@ -1,0 +1,2005 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_symc_v200.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_symc_v200.h"
+#include "drv_symc.h"
+
+#ifdef CHIP_SYMC_VER_V200
+
+#define KLAD_KEY_USE_ERR         0x01
+#define ALG_LEN_ERR              0x02
+#define SMMU_PAGE_UNVLID         0x04
+#define OUT_SMMU_PAGE_NOT_VALID  0x08
+#define KLAD_KEY_WRITE_ERR       0x10
+
+/*************************** Internal Structure Definition ****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+/*! \Length of pading buffer */
+#define SYMC_PAD_BUFFER_LEN             (128)
+
+/*! \Length of aes ccm/gcm key */
+#define AES_CCM_GCM_KEY_LEN             (16)
+
+/*! \Total Length of pading buffer */
+#define SYMC_PAD_BUFFER_TOTAL_LEN       (SYMC_PAD_BUFFER_LEN * CIPHER_HARD_CHANNEL_CNT)
+
+/*! spacc symc int entry struct which is defined by hardware, you can't change it */
+typedef struct {
+    hi_u32     spacc_cmd: 2;            /*!<  reserve */
+    hi_u32     rev1: 6;                 /*!<  reserve */
+    hi_u32     sym_ctrl: 7;             /*!<  symc control flag*/
+    hi_u32     rev2: 1;                 /*!<  reserve */
+    hi_u32     gcm_iv_len: 4;           /*!<  gcm iv length */
+    hi_u32     rev3: 12;                /*!<  reserve */
+    hi_u32     sym_start_high;          /*!<  syma start high addr */
+    hi_u32     sym_start_addr;          /*!<  syma start low addr */
+    hi_u32     sym_alg_length;          /*!<  syma data length */
+    hi_u32     iv[4];                   /*!<  symc IV */
+} symc_entry_in;
+
+/*! spacc symc out entry struct which is defined by hardware, you can't change it */
+typedef struct {
+    hi_u32    rev1: 8;                  /*!<  reserve */
+    hi_u32    aes_ctrl: 4;              /*!<  aes contrl */
+    hi_u32    rev2: 20;                 /*!<  reserve */
+    hi_u32    sym_start_addr;           /*!<  syma start high addr */
+    hi_u32    sym_alg_length;           /*!<  syma data length */
+    hi_u32    hash_rslt_start_addr;     /*!<  syma data length */
+    hi_u32    tag[AEAD_TAG_SIZE_IN_WORD];  /*!<  CCM/GCM tag */
+} symc_entry_out;
+
+/*! Define the context of cipher */
+typedef struct {
+    hi_u32 open;                        /*!<  open or close */
+    symc_entry_in  *entry_in;           /*!<  in node list */
+    symc_entry_out *entry_out;          /*!<  out node list */
+    compat_addr    dma_entry;           /*!<  dma addr of node */
+    compat_addr    dma_pad;             /*!<  dma addr of padding buffer, for CCM/GCM */
+    hi_u8          *via_pad;            /*!<  via addr of padding buffer, for CCM/GCM */
+    hi_u32         offset_pad;          /*!<  offset of padding buffer, for CCM/GCM */
+    hi_u32 iv[SYMC_IV_MAX_SIZE_IN_WORD];/*!<  iv data from user*/
+
+    /* iv usage flag, should be CIPHER_IV_CHANGE_ONE_PKG
+     * or CIPHER_IV_CHANGE_ALL_PKG.
+     */
+    hi_u32 iv_flag;                     /*!<  iv flag */
+    hi_u32 iv_len;                      /*!<  iv length */
+    symc_alg alg;                       /*!<  The alg of Symmetric cipher */
+    symc_mode mode;                     /*!<  mode */
+    hi_u32 id_in;                       /*!<  current in nodes index */
+    hi_u32 id_out;                      /*!<  current out nodes index */
+    hi_u32 cnt_in;                      /*!<  total count in nodes to be computed */
+    hi_u32 cnt_out;                     /*!<  total count out nodes to be computed */
+    hi_u32 done;                        /*!<  calculation finish flag*/
+    crypto_queue_head  queue;           /*!<  quene list */
+    callback_symc_isr callback;         /*!<  isr callback functon */
+    callback_symc_destory destory;      /*!<  destory callback functon */
+    void *ctx;                          /*!<  params for isr callback functon */
+} symc_hard_context;
+
+/*! spacc symc_chn_who_used struct which is defined by hardware, you can't change it */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    non_sec_chn_who_used : 16   ; /* [15..0]  */
+        unsigned int    sec_chn1_who_used     : 2   ; /* [17..16]  */
+        unsigned int    reserved              : 22  ; /* [31..18]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int        u32;
+} symc_chn_who_used;
+
+/*! Channel of cipher */
+static symc_hard_context hard_context[CRYPTO_HARD_CHANNEL_MAX];
+
+/*! dma memory of cipher node list*/
+static crypto_mem   symc_dma;
+
+/*! symc already initialize or not */
+static hi_u32 symc_initialize = HI_FALSE;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+#ifndef HI_ADVCA_FUNCTION_RELEASE
+extern int dump_mem(void);
+#endif
+
+static hi_u32 drv_symc_done_try(hi_u32 chn_num)
+{
+    cipher_int_raw status;
+
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    status.u32 = SYMC_READ(CIPHER_INT_RAW);
+    status.bits.cipher_chn_obuf_raw &= 0x01 << chn_num; /* check interception */
+
+    /*clear interception*/
+    SYMC_WRITE(CIPHER_INT_RAW, status.u32);
+
+    return (hi_u32)(status.bits.cipher_chn_obuf_raw ? HI_TRUE : HI_FALSE);
+}
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+static hi_u32 drv_symc_done_notify(void)
+{
+    cipher_int_status status;
+    cipher_int_raw    raw;
+
+    status.u32 = SYMC_READ(CIPHER_INT_STATUS);
+    raw.u32 = 0;
+
+    /*just process the valid channel*/
+    status.bits.cipher_chn_obuf_int &= CIPHER_HARD_CHANNEL_MASK;
+    raw.bits.cipher_chn_obuf_raw = status.bits.cipher_chn_obuf_int;
+
+    /*clear interception*/
+    SYMC_WRITE(CIPHER_INT_RAW, raw.u32);
+
+    return status.bits.cipher_chn_obuf_int; /* mask */
+}
+
+static hi_u32 drv_hash_done_test(void)
+{
+    hash_int_status int_st;
+    hi_u32 chn_mask = 0;
+
+    int_st.u32 = SYMC_READ(HASH_INT_STATUS);
+
+    /*just process the valid channel*/
+    int_st.bits.hash_chn_oram_int &= HASH_HARD_CHANNEL_MASK;
+    chn_mask = int_st.bits.hash_chn_oram_int;
+
+    return chn_mask;
+}
+
+/*! symc interrupt process function */
+static irqreturn_t drv_symc_interrupt_isr(hi_s32 irq, void *devId)
+{
+    hi_u32 mask, i;
+    symc_hard_context *ctx = HI_NULL;
+    irqreturn_t ret = IRQ_HANDLED;
+
+    /* get channel context*/
+    mask = drv_symc_done_notify();
+    HI_LOG_DEBUG("symc irq: %d, mask 0x%x\n", irq, mask);
+
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        if ((mask >> i) & 0x01) {
+            ctx = &hard_context[i];
+            if ((ctx->callback) && (ctx->callback(ctx->ctx) == HI_FALSE)) {
+                /* contiue to compute */
+                HI_LOG_DEBUG("contiue to compute chn %d\n", i);
+                drv_symc_start(i);
+            } else {
+                /* finish */
+                ctx->done = HI_TRUE;
+                HI_LOG_DEBUG("chn %d wake up\n", i);
+                crypto_queue_wait_up(&ctx->queue);
+            }
+        }
+    }
+
+    /* symc and hash use the sample interrupt number
+     * so if hash has occur interrupt, we should return IRQ_NONE
+     * to tell system continue to process the hash interrupt.
+     */
+    if (drv_hash_done_test() != 0) {
+        ret = IRQ_NONE;
+    }
+
+    return ret;
+}
+
+/*! symc register interrupt process function */
+static hi_s32 drv_symc_register_interrupt(void)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 int_valid = 0, int_num = 0;
+    hi_u32 i;
+    const char *name;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_SYMC, &int_valid, &int_num, &name);
+
+    if (int_valid == HI_FALSE) {
+        return HI_SUCCESS;
+    }
+
+    /* request irq */
+    HI_LOG_DEBUG("symc request irq, num %d, name %s\n", int_num, name);
+    ret = crypto_request_irq(int_num, drv_symc_interrupt_isr, name);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("Irq request failure, irq = %d\n", int_num);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_REGISTER_IRQ);
+        return ret;
+    }
+
+    /* initialize queue list*/
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        crypto_queue_init(&hard_context[i].queue);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/*! symc unregister interrupt process function */
+static void drv_symc_unregister_interrupt(void)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    const char *name;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_SYMC, &int_valid, &int_num, &name);
+
+    if (int_valid == HI_FALSE) {
+        return;
+    }
+
+    /* free irq */
+    HI_LOG_DEBUG("symc free irq, num %d, name %s\n", int_num, name);
+    crypto_free_irq(int_num, name);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+/*! set interrupt */
+static void drv_symc_set_interrupt(void)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    cipher_int_en cipher_int_en;
+    cipher_int_raw    raw;
+
+    HI_LOG_FUNC_ENTER();
+
+    module_get_attr(CRYPTO_MODULE_ID_SYMC, &int_valid, &int_num, HI_NULL);
+
+    if (int_valid) {
+        /* Enable interrupt */
+        cipher_int_en.u32 = SYMC_READ(CIPHER_INT_EN);
+
+        if (crypto_is_sec_cpu()) {
+            cipher_int_en.bits.cipher_sec_int_en = 1;
+        } else {
+            cipher_int_en.bits.cipher_nsec_int_en = 1;
+        }
+        cipher_int_en.bits.cipher_chn_obuf_en |= CIPHER_HARD_CHANNEL_MASK;
+
+        SYMC_WRITE(CIPHER_INT_EN, cipher_int_en.u32);
+        HI_LOG_INFO("CIPHER_INT_EN: 0x%x\n", cipher_int_en.u32);
+    } else {
+        /* Disable interrupt */
+        cipher_int_en.u32 = SYMC_READ(CIPHER_INT_EN);
+
+        if (crypto_is_sec_cpu()) {
+            cipher_int_en.bits.cipher_sec_int_en = 0;
+        } else {
+            cipher_int_en.bits.cipher_nsec_int_en = 0;
+        }
+        SYMC_WRITE(CIPHER_INT_EN, cipher_int_en.u32);
+        HI_LOG_INFO("CIPHER_INT_EN: 0x%x\n", cipher_int_en.u32);
+    }
+
+    /* clear interception
+     * the history of interception may trigge the system to
+     * call the irq function before initialization
+     * when register interrupt, this will cause a system abort.
+     */
+    raw.u32 = SYMC_READ(CIPHER_INT_RAW);
+    raw.bits.cipher_chn_obuf_raw &= CIPHER_HARD_CHANNEL_MASK; /* clear valid channel */
+    SYMC_WRITE(CIPHER_INT_RAW, raw.u32);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+#endif
+
+/*! set reduceing power disspation */
+static void drv_symc_core_auto_cken_bypass(void)
+{
+#ifdef CRYPTO_CORE_AUTO_CKEN_SUPPORT
+    cal_crg_cfg core_auto_cken_bypass;
+
+    HI_LOG_FUNC_ENTER();
+
+    core_auto_cken_bypass.u32 = SYMC_READ(SPACC_CALC_CRG_CFG);
+
+    core_auto_cken_bypass.bits.spacc_core_auto_cken_bypass = 0x0;
+    core_auto_cken_bypass.bits.spacc_rft_mem_wr_clk_gt_en = 0x1;
+    core_auto_cken_bypass.bits.spacc_rft_mem_rd_clk_gt_en = 0x1;
+    core_auto_cken_bypass.bits.spacc_rfs_mem_clk_gt_en = 0x1;
+
+    SYMC_WRITE(SPACC_CALC_CRG_CFG, core_auto_cken_bypass.u32);
+
+    HI_LOG_INFO("SPACC_CALC_CRG_CFG[0x%x]: 0x%x\n", SPACC_CALC_CRG_CFG, core_auto_cken_bypass.u32);
+
+    HI_LOG_FUNC_EXIT();
+#endif
+}
+
+/*! set symc entry */
+static hi_s32 drv_symc_recover_entry(hi_u32 chn)
+{
+    chann_cipher_in_node_cfg cipher_in_cfg;
+    chann_cipher_out_node_cfg cipher_out_cfg;
+    symc_hard_context *ctx = &hard_context[chn];
+    compat_addr out_addr;
+    hi_u32 entry = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* set total num and start addr for cipher in node
+     * On ree, the chn may be seized by tee,
+     * so we must check it, that is check we can write the reg of chn or not.
+     */
+    SYMC_WRITE(CHANn_CIPHER_IN_NODE_START_ADDR(chn), ADDR_L32(ctx->dma_entry));
+    SYMC_WRITE(CHANN_CIPHER_IN_NODE_START_HIGH(chn), ADDR_H32(ctx->dma_entry));
+    entry =  SYMC_READ(CHANn_CIPHER_IN_NODE_START_ADDR(chn));
+    if (entry != ADDR_L32(ctx->dma_entry)) {
+        HI_LOG_INFO("the ree chn be seized by tee\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_UNAVAILABLE);
+        return HI_ERR_CIPHER_UNAVAILABLE;
+    }
+    cipher_in_cfg.u32  = SYMC_READ(CHANn_CIPHER_IN_NODE_CFG(chn));
+    ctx->id_in = cipher_in_cfg.bits.cipher_in_node_wptr;
+    HI_LOG_INFO("symc chn %d recover, id in  0x%x, IN_NODE_START_ADDR  0x%x, VIA %p\n",
+                chn, ctx->id_in, ADDR_L32(ctx->dma_entry), ctx->entry_in);
+
+    /*set total num and start addr for cipher out node*/
+    cipher_out_cfg.u32 = SYMC_READ(CHANn_CIPHER_OUT_NODE_CFG(chn));
+    ADDR_U64(out_addr) = ADDR_U64(ctx->dma_entry) + SYMC_NODE_SIZE;
+    SYMC_WRITE(CHANn_CIPHER_OUT_NODE_START_ADDR(chn), ADDR_L32(out_addr));
+    SYMC_WRITE(CHANN_CIPHER_OUT_NODE_START_HIGH(chn), ADDR_H32(out_addr));
+    ctx->id_out = cipher_out_cfg.bits.cipher_out_node_wptr;
+    HI_LOG_INFO("symc chn %d recover, id out 0x%x, OUT_NODE_START_ADDR 0x%x, VIA %p\n",
+                chn, ctx->id_out, ADDR_L32(ctx->dma_entry) + SYMC_NODE_SIZE,
+                ctx->entry_out);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/*! set symc entry */
+static void drv_symc_set_entry(hi_u32 chn, compat_addr dma_addr, void *cpu_addr)
+{
+    chann_cipher_in_node_cfg cipher_in_cfg;
+    chann_cipher_out_node_cfg cipher_out_cfg;
+    symc_hard_context *ctx = &hard_context[chn];
+
+    HI_LOG_FUNC_ENTER();
+
+    /*set total num and start addr for cipher in node*/
+    cipher_in_cfg.u32  = SYMC_READ(CHANn_CIPHER_IN_NODE_CFG(chn));
+    cipher_in_cfg.bits.cipher_in_node_total_num = SYMC_MAX_LIST_NUM;
+    SYMC_WRITE(CHANn_CIPHER_IN_NODE_CFG(chn), cipher_in_cfg.u32);
+    HI_LOG_INFO("CHANn_CIPHER_IN_NODE_CFG[0x%x]: \t0x%x, PHY: 0x%x, VIA %p\n",
+                CHANn_CIPHER_IN_NODE_CFG(chn), cipher_in_cfg.u32, ADDR_L32(dma_addr), cpu_addr);
+    ctx->entry_in = (symc_entry_in *)cpu_addr;
+    ctx->cnt_in = 0;
+    ADDR_U64(dma_addr) += SYMC_NODE_SIZE;
+    cpu_addr = (hi_u8 *)cpu_addr + SYMC_NODE_SIZE;
+
+    /*set total num and start addr for cipher out node*/
+    cipher_out_cfg.u32 = SYMC_READ(CHANn_CIPHER_OUT_NODE_CFG(chn));
+    cipher_out_cfg.bits.cipher_out_node_total_num = SYMC_MAX_LIST_NUM;
+    SYMC_WRITE(CHANn_CIPHER_OUT_NODE_CFG(chn), cipher_out_cfg.u32);
+    HI_LOG_INFO("CHANn_CIPHER_OUT_NODE_CFG[0x%x]: \t0x%x, PHY: 0x%x, VIA %p\n",
+                CHANn_CIPHER_OUT_NODE_CFG(chn), cipher_out_cfg.u32, ADDR_L32(dma_addr), cpu_addr);
+    ctx->entry_out = (symc_entry_out *)cpu_addr;
+    ctx->cnt_out = 0;
+    ADDR_U64(dma_addr) += SYMC_NODE_SIZE;
+
+    HI_LOG_FUNC_EXIT();
+}
+
+/*! set symc pad buffer */
+static void drv_symc_set_pad_buffer(hi_u32 chn, compat_addr dma_addr, void *cpu_addr)
+{
+    symc_hard_context *ctx = &hard_context[chn];
+
+    ctx->dma_pad = dma_addr;
+    ctx->via_pad = cpu_addr;
+    ctx->offset_pad = 0x00;
+}
+
+/*! set smmu */
+static void drv_symc_smmu_bypass(void)
+{
+#ifdef CRYPTO_SMMU_SUPPORT
+    cipher_in_smmu_en cipher_in_smmu_en;
+    out_smmu_en out_smmu_en;
+
+    HI_LOG_FUNC_ENTER();
+
+    cipher_in_smmu_en.u32 = SYMC_READ(CIPHER_IN_SMMU_EN);
+    out_smmu_en.u32 = SYMC_READ(OUT_SMMU_EN);
+
+    cipher_in_smmu_en.bits.cipher_in_chan_rd_dat_smmu_en  |= CIPHER_HARD_CHANNEL_MASK >> 1;
+    cipher_in_smmu_en.bits.cipher_in_chan_rd_node_smmu_en &= ~(CIPHER_HARD_CHANNEL_MASK >> 1);
+
+    out_smmu_en.bits.out_chan_wr_dat_smmu_en  |= CIPHER_HARD_CHANNEL_MASK >> 1;
+    out_smmu_en.bits.out_chan_rd_node_smmu_en &= ~(CIPHER_HARD_CHANNEL_MASK >> 1);
+
+    SYMC_WRITE(CIPHER_IN_SMMU_EN, cipher_in_smmu_en.u32);
+    SYMC_WRITE(OUT_SMMU_EN, out_smmu_en.u32);
+
+    HI_LOG_INFO("CIPHER_IN_SMMU_EN[0x%x]: 0x%x\n", CIPHER_IN_SMMU_EN, cipher_in_smmu_en.u32);
+    HI_LOG_INFO("OUT_SMMU_EN[0x%x]      : 0x%x\n", OUT_SMMU_EN, out_smmu_en.u32);
+
+    HI_LOG_FUNC_EXIT();
+#endif
+}
+
+/*! smmu set base address */
+static void drv_symc_smmu_base_addr(void)
+{
+#ifdef CRYPTO_SMMU_SUPPORT
+    hi_u64 err_raddr = 0;
+    hi_u64 err_waddr = 0;
+    hi_u64 table_addr = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* get table base addr from system api */
+    smmu_get_table_addr(&err_raddr, &err_waddr, &table_addr);
+
+    if (crypto_is_sec_cpu()) {
+        SYMC_WRITE(SEC_SMMU_START_ADDR, (hi_u32)table_addr);
+        HI_LOG_INFO("SEC_SMMU_START_ADDR[0x%x]  : 0x%x\n", SEC_SMMU_START_ADDR, (hi_u32)table_addr);
+    } else {
+        SYMC_WRITE(NORM_SMMU_START_ADDR, (hi_u32)table_addr);
+        HI_LOG_INFO("NORM_SMMU_START_ADDR[0x%x]  : 0x%x\n", NORM_SMMU_START_ADDR, (hi_u32)table_addr);
+    }
+#endif
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+/*! set secure channel,
+ *  non-secure CPU can't change the value of SEC_CHN_CFG,
+ *  so non-secure CPU call this function will do nothing.
+ */
+static void drv_symc_enable_secure(hi_u32 chn, hi_u32 enable)
+{
+    sec_chn_cfg sec_chn_cfg;
+
+    HI_LOG_FUNC_ENTER();
+
+    /*The SEC_CHN_CFG only can be set by secure CPU*/
+    sec_chn_cfg.u32 = SYMC_READ(SEC_CHN_CFG);
+    if (enable == HI_TRUE) {
+        sec_chn_cfg.bits.cipher_sec_chn_cfg |= 0x01 << chn;
+    } else {
+        sec_chn_cfg.bits.cipher_sec_chn_cfg &= ~(0x01 << chn);
+    }
+    SYMC_WRITE(SEC_CHN_CFG, sec_chn_cfg.u32);
+    HI_LOG_INFO("SEC_CHN_CFG[0x%x]: 0x%x\n", SEC_CHN_CFG, sec_chn_cfg.u32);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+static void drv_symc_print_last_node(hi_u32 chn_num)
+{
+    symc_entry_in *in = HI_NULL;
+    symc_entry_out *out = HI_NULL;
+    symc_hard_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx = &hard_context[chn_num];
+
+    /* get last in node info*/
+    if (ctx->id_in == 0x00) {
+        in = &ctx->entry_in[SYMC_NODE_LIST_SIZE];
+    } else {
+        in = &ctx->entry_in[ctx->id_in - 1];
+    }
+
+    /* get last out node info*/
+    if (ctx->id_out == 0x00) {
+        out = &ctx->entry_out[SYMC_NODE_LIST_SIZE];
+    } else {
+        out = &ctx->entry_out[ctx->id_out - 1];
+    }
+
+    HI_LOG_ERROR("chn %d, src addr 0x%x, size 0x%x, dest addr 0x%x, size 0x%x\n",
+                 chn_num, in->sym_start_addr, in->sym_alg_length,
+                 out->sym_start_addr, out->sym_alg_length);
+    CRYPTO_UNUSED(in);
+    CRYPTO_UNUSED(out);
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+static void drv_symc_print_status(hi_u32 chn_num)
+{
+    cipher_int_raw    raw;
+    cipher_int_status status;
+    cipher_int_en     enable;
+    sec_chn_cfg       cfg;
+    chann_cipher_in_node_cfg in_node_cfg;
+    chann_cipher_out_node_cfg out_node_cfg;
+
+    HI_LOG_FUNC_ENTER();
+
+    in_node_cfg.u32  = SYMC_READ(CHANn_CIPHER_IN_NODE_CFG(chn_num));
+    out_node_cfg.u32 = SYMC_READ(CHANn_CIPHER_OUT_NODE_CFG(chn_num));
+    HI_LOG_ERROR("CHANn_CIPHER_IN_NODE_CFG        : 0x%x\n", in_node_cfg.u32);
+    HI_LOG_ERROR("CHANn_CIPHER_IN_NODE_START_ADDR : 0x%x\n", SYMC_READ(CHANn_CIPHER_IN_NODE_START_ADDR(chn_num)));
+    HI_LOG_ERROR("CHANn_CIPHER_IN_BUF_RPTR        : 0x%x\n", SYMC_READ(CHANn_CIPHER_IN_BUF_RPTR(chn_num)));
+    HI_LOG_ERROR("CHANn_CIPHER_OUT_NODE_CFG       : 0x%x\n", out_node_cfg.u32);
+    HI_LOG_ERROR("CHANn_CIPHER_OUT_NODE_START_ADDR: 0x%x\n", SYMC_READ(CHANn_CIPHER_OUT_NODE_START_ADDR(chn_num)));
+    HI_LOG_ERROR("CHANn_CIPHER_OUT_BUF_RPTR       : 0x%x\n", SYMC_READ(CHANn_CIPHER_OUT_BUF_RPTR(chn_num)));
+    HI_LOG_ERROR("CHANn_CIPHER_CTRL               : 0x%x\n", SYMC_READ(CHANn_CIPHER_CTRL(chn_num)));
+
+    raw.u32    = SYMC_READ(CIPHER_INT_RAW);
+    status.u32 = SYMC_READ(CIPHER_INT_STATUS);
+    enable.u32 = SYMC_READ(CIPHER_INT_EN);
+    cfg.u32    = SYMC_READ(SEC_CHN_CFG);
+    HI_LOG_ERROR("\nsec_chn_cfg 0x%x, chn %d, nsec_int_en 0x%x, sec_int_en 0x%x, chn_obuf_en 0x%x, status 0x%x, raw 0x%x\n",
+                 (cfg.bits.cipher_sec_chn_cfg >> chn_num) & 0x01,
+                 chn_num, enable.bits.cipher_nsec_int_en, enable.bits.cipher_sec_int_en,
+                 (enable.bits.cipher_chn_obuf_en >> chn_num) & 0x01,
+                 (status.bits.cipher_chn_obuf_int >> chn_num) & 0x01,
+                 (raw.bits.cipher_chn_obuf_raw >> chn_num) & 0x01);
+
+    HI_LOG_ERROR("\nThe cause of time out may be:\n"
+                 "\t1. SMMU address invalid\n"
+                 "\t2. interrupt number or name incorrect\n"
+                 "\t3. CPU type mismatching, request CPU and channel: %s\n",
+                 crypto_is_sec_cpu() ? "secure" : "non-secure");
+
+    /* avoid compile error when HI_LOG_ERROR be defined to empty */
+    CRYPTO_UNUSED(raw);
+    CRYPTO_UNUSED(status);
+    CRYPTO_UNUSED(enable);
+    CRYPTO_UNUSED(cfg);
+    CRYPTO_UNUSED(in_node_cfg);
+    CRYPTO_UNUSED(out_node_cfg);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+static hi_s32 drv_symc_get_err_code(hi_u32 chn_num)
+{
+    hi_u32 code = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* check error code
+     * bit0: klad_key_use_err
+     * bit1: alg_len_err
+     * bit2: smmu_page_unvlid
+     * bit3: out_smmu_page_not_valid
+     * bit4: klad_key_write_err
+     */
+
+    /*read error code*/
+    code = SYMC_READ(CALC_ERR);
+
+    if (code & KLAD_KEY_USE_ERR) {
+        HI_LOG_ERROR("symc error: klad_key_use_err, chn %d !!!\n", chn_num);
+    }
+    if (code & ALG_LEN_ERR) {
+        HI_LOG_ERROR("symc error: alg_len_err, chn %d !!!\n", chn_num);
+    }
+    if (code & SMMU_PAGE_UNVLID) {
+        HI_LOG_ERROR("symc error: smmu_page_unvlid, chn %d !!!\n", chn_num);
+    }
+    if (code & OUT_SMMU_PAGE_NOT_VALID) {
+        HI_LOG_ERROR("symc error: out_smmu_page_not_valid, chn %d !!!\n", chn_num);
+    }
+    if (code & KLAD_KEY_WRITE_ERR) {
+        HI_LOG_ERROR("symc error: klad_key_write_err, chn %d !!!\n", chn_num);
+    }
+
+    /*print the inout buffer address*/
+    drv_symc_print_last_node(chn_num);
+    drv_symc_print_status(chn_num);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static void drv_symc_entry_init(crypto_mem  mem)
+{
+    hi_u32 i = 0;
+    void *cpu_addr = HI_NULL;
+    compat_addr dma_pad;
+    hi_u8    *via_pad = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* set in node and out node dma buffer */
+    HI_LOG_INFO("symc entry list configure\n");
+    cpu_addr = mem.dma_virt;
+
+    /* skip the in node and out node dma buffer */
+    ADDR_U64(dma_pad) = ADDR_U64(mem.dma_addr) + SYMC_NODE_LIST_SIZE;
+    via_pad = (hi_u8 *)mem.dma_virt + SYMC_NODE_LIST_SIZE;
+
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        if ((CIPHER_HARD_CHANNEL_MASK >> i) & 0x01) { /*valid channel*/
+            /* in node and out node */
+            drv_symc_set_entry(i, mem.mmz_addr, cpu_addr);
+            ADDR_U64(hard_context[i].dma_entry) = ADDR_U64(mem.mmz_addr);
+            ADDR_U64(mem.mmz_addr) += SYMC_NODE_SIZE * 2; /* move to next channel */
+            cpu_addr = (hi_u8 *)cpu_addr + SYMC_NODE_SIZE * 2; /* move to next channel */
+
+            /* padding */
+            drv_symc_set_pad_buffer(i, dma_pad, via_pad);
+            ADDR_U64(dma_pad) += SYMC_PAD_BUFFER_LEN;
+            via_pad += SYMC_PAD_BUFFER_LEN;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+static hi_s32 drv_symc_mem_init(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    /** dma buffer struct
+      * ((in_node || out_node) * chn_num) || (pad_buffer * chn_num)
+      */
+    HI_LOG_INFO("alloc memory for nodes list\n");
+    ret = crypto_mem_create(&symc_dma, SEC_MMZ, "symc_node_list",
+                            SYMC_NODE_LIST_SIZE + SYMC_PAD_BUFFER_TOTAL_LEN);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, malloc ddr for symc nodes list failed\n");
+        HI_LOG_PRINT_FUNC_ERR(crypto_mem_create, ret);
+        return ret;
+    }
+
+    drv_symc_entry_init(symc_dma);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 drv_symc_mem_deinit(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    ret = crypto_mem_destory(&symc_dma);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(crypto_mem_destory, ret);
+        return ret;
+    }
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 drv_symc_chn_resume(hi_u32 chn_num)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 base = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (crypto_is_sec_cpu()) {
+        base = SYMC_READ(SEC_SMMU_START_ADDR);
+    } else {
+        base = SYMC_READ(NORM_SMMU_START_ADDR);
+    }
+
+    if (base == 0) {
+        /* smmu base address is zero means hardware be unexpected reset */
+        HI_LOG_WARN("cipher module is not ready, try to resume it now...\n");
+        ret = drv_symc_resume();
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_symc_resume, ret);
+            return ret;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_alloc_chn(hi_u32 *chn_num)
+{
+    hi_s32 ret = HI_ERR_CIPHER_BUSY;
+    symc_chn_who_used tee, ree;
+    hi_u32 i = 0;
+    hi_u32 ree_use = 0, tee_use = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        /* check the valid channel */
+        if ((CIPHER_HARD_CHANNEL_MASK & (0x1 << i)) && (hard_context[i].open == HI_FALSE)) {
+            /*get every chanel status occupied with REE/TEE */
+            tee.u32 = SYMC_READ(CHN_WHO_USED_TEE);
+            ree.u32 = SYMC_READ(CHN_WHO_USED_REE);
+            tee_use  = tee.bits.non_sec_chn_who_used & SYMC_CHN_MASK(i);
+            ree_use  = ree.bits.non_sec_chn_who_used & SYMC_CHN_MASK(i);
+
+            /* 0x00 is not used */
+            if (tee_use == 0x00 && ree_use == 0x00) {
+                if (crypto_is_sec_cpu() == HI_TRUE) {
+                    tee.bits.non_sec_chn_who_used |= SYMC_CHN_MASK(i);
+                    SYMC_WRITE(CHN_WHO_USED_TEE, tee.u32);
+
+                    /* check if the channal aleardy be useded by other cpu
+                     * if other cpu break-in when write the CIPHER_NON_SEC_CHN_WHO_USED
+                     * the value of CIPHER_NON_SEC_CHN_WHO_USED will be channged
+                     */
+                    ree.u32 = SYMC_READ(CHN_WHO_USED_REE);
+                    ree_use  = ree.bits.non_sec_chn_who_used & SYMC_CHN_MASK(i);
+                    if (ree_use) {
+                        /* chn aleardy be used by ree */
+                        tee.bits.non_sec_chn_who_used &= ~ SYMC_CHN_MASK(i);
+                        SYMC_WRITE(CHN_WHO_USED_TEE, tee.u32);
+                        continue;
+                    }
+
+                    drv_symc_enable_secure(i, HI_TRUE);
+                    ret = drv_symc_recover_entry(i);
+                    if (ret != HI_SUCCESS) {
+                        /* chn aleardy be used by ree */
+                        tee.bits.non_sec_chn_who_used &= ~ SYMC_CHN_MASK(i);
+                        SYMC_WRITE(CHN_WHO_USED_TEE, tee.u32);
+                        continue;
+                    }
+                } else {
+                    ree.bits.non_sec_chn_who_used |= SYMC_CHN_MASK(i);
+                    SYMC_WRITE(CHN_WHO_USED_REE, ree.u32);
+
+                    /* check if the channal aleardy be useded by other cpu
+                     * if other cpu break-in when write the CIPHER_NON_SEC_CHN_WHO_USED
+                     * the value of CIPHER_NON_SEC_CHN_WHO_USED will be channged
+                     */
+                    tee.u32 = SYMC_READ(CHN_WHO_USED_TEE);
+                    tee_use  = tee.bits.non_sec_chn_who_used & SYMC_CHN_MASK(i);
+                    if (tee_use) {
+                        /* chn aleardy be used by tee */
+                        ree.bits.non_sec_chn_who_used &= ~ SYMC_CHN_MASK(i);
+                        SYMC_WRITE(CHN_WHO_USED_REE, ree.u32);
+                        continue;
+                    }
+
+                    drv_symc_enable_secure(i, HI_TRUE);
+                    ret = drv_symc_recover_entry(i);
+                    if (ret != HI_SUCCESS) {
+                        /* chn aleardy be used by tee */
+                        ree.bits.non_sec_chn_who_used &= ~ SYMC_CHN_MASK(i);
+                        SYMC_WRITE(CHN_WHO_USED_REE, ree.u32);
+                        continue;
+                    }
+                }
+
+                /* alloc channel */
+                hard_context[i].open = HI_TRUE;
+                *chn_num = i;
+                HI_LOG_INFO("alloc symc chn %d.\n", i);
+                break;
+            }
+        }
+    }
+
+    if (i >= CRYPTO_HARD_CHANNEL_MAX) {
+        HI_LOG_ERROR("symc alloc channel failed\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_BUSY);
+        return HI_ERR_CIPHER_BUSY;
+    }
+
+    /* hardware may be unexpected reset by other module or platform,
+     * such as unexpected reset by fastboot after load tee image,
+     * in this case, the hardware configuration will be reset,
+     * here try to re-config the hardware.
+     */
+    ret = drv_symc_chn_resume(*chn_num);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_chn_resume, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_symc_free_chn(hi_u32 chn_num)
+{
+    symc_chn_who_used used;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (hard_context[chn_num].open == HI_FALSE) {
+        HI_LOG_FUNC_EXIT();
+        return;
+    }
+
+    /* clean tee and ree mask */
+    if (crypto_is_sec_cpu() == HI_TRUE) {
+        used.u32 = SYMC_READ(CHN_WHO_USED_TEE);
+        used.bits.non_sec_chn_who_used &= ~ SYMC_CHN_MASK(chn_num);
+        SYMC_WRITE(CHN_WHO_USED_TEE, used.u32);
+    } else {
+        used.u32 = SYMC_READ(CHN_WHO_USED_REE);
+        used.bits.non_sec_chn_who_used &= ~ SYMC_CHN_MASK(chn_num);
+        SYMC_WRITE(CHN_WHO_USED_REE, used.u32);
+    }
+
+    drv_symc_enable_secure(chn_num, HI_FALSE);
+    if (hard_context[chn_num].destory != HI_NULL) {
+        hard_context[chn_num].destory();
+        hard_context[chn_num].destory = HI_NULL;
+    }
+
+    /*free channel*/
+    hard_context[chn_num].open = HI_FALSE;
+
+    HI_LOG_INFO("free symc chn %d.\n", chn_num);
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+#ifdef CRYPTO_SWITCH_CPU
+hi_u32 drv_symc_is_secure(void)
+{
+    sec_chn_cfg sec;
+    sec_chn_cfg tmp;
+    hi_u32 secure = HI_FALSE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_INFO("Change the secure type of the chn0 to get cpu type\n");
+    module_enable(CRYPTO_MODULE_ID_SYMC);
+
+    sec.u32 = SYMC_READ(SEC_CHN_CFG);
+
+    /* change the secure type of chn0 */
+    sec.bits.cipher_sec_chn_cfg ^= 0x01;
+    SYMC_WRITE(SEC_CHN_CFG, sec.u32);
+
+    /* read the secure type of chn0 */
+    tmp.u32 = SYMC_READ(SEC_CHN_CFG);
+
+    if (tmp.bits.cipher_sec_chn_cfg == sec.bits.cipher_sec_chn_cfg) {
+        /* The REG_SEC_CHN_CFG only can be set by secure CPU
+         * can write the cfg, must be secure CPU
+         */
+        secure =  HI_TRUE;
+
+        /* recovery the secure type of chn0 */
+        sec.bits.cipher_sec_chn_cfg ^= 0x01;
+        SYMC_WRITE(SEC_CHN_CFG, sec.u32);
+    }
+
+    HI_LOG_INFO("secure type: 0x%x\n", secure);
+
+    HI_LOG_FUNC_EXIT();
+    return secure;
+}
+#endif
+
+hi_s32 drv_symc_init(void)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 i = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (symc_initialize == HI_TRUE) {
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    crypto_memset(&symc_dma, sizeof(symc_dma), 0, sizeof(symc_dma));
+    crypto_memset(hard_context, sizeof(hard_context), 0, sizeof(hard_context));
+
+    HI_LOG_INFO("enable symc\n");
+    module_enable(CRYPTO_MODULE_ID_SYMC);
+
+    module_disable(CRYPTO_MODULE_ID_SM4);
+
+    ret = drv_symc_mem_init();
+    if (ret != HI_SUCCESS) {
+        goto __error;
+    }
+    HI_LOG_INFO("SYMC DMA buffer, MMU 0x%x, MMZ 0x%x, VIA %p, size 0x%x\n",
+                ADDR_L32(symc_dma.dma_addr), ADDR_L32(symc_dma.mmz_addr),
+                symc_dma.dma_virt, symc_dma.dma_size);
+
+    HI_LOG_INFO("symc SMMU configure\n");
+    drv_symc_smmu_bypass();
+    drv_symc_smmu_base_addr();
+
+    HI_LOG_INFO("symc core_auto_cken_bypass configure\n");
+    drv_symc_core_auto_cken_bypass();
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    HI_LOG_INFO("symc interrupt configure\n");
+    drv_symc_set_interrupt();
+
+    HI_LOG_INFO("symc register interrupt function\n");
+    ret = drv_symc_register_interrupt();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_register_interrupt, ret);
+        drv_symc_mem_deinit();
+        goto __error;
+    }
+#endif
+
+    /*  set all channel as non-secure channel,
+     *  may be set it to secure channel when alloc handle.
+     */
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        /* check the valid channel */
+        if (CIPHER_HARD_CHANNEL_MASK & (0x1 << i)) {
+            drv_symc_enable_secure(i, HI_FALSE);
+        }
+    }
+
+    symc_initialize = HI_TRUE;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+__error:
+    module_disable(CRYPTO_MODULE_ID_SYMC);
+
+    return ret;
+}
+
+hi_s32 drv_symc_resume(void)
+{
+    hi_u32 i;
+    symc_chn_who_used used;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_INFO("enable symc\n");
+    module_enable(CRYPTO_MODULE_ID_SYMC);
+    module_disable(CRYPTO_MODULE_ID_SM4);
+
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        if (hard_context[i].open) {
+            if (crypto_is_sec_cpu() == HI_TRUE) {
+                used.u32 = SYMC_READ(CHN_WHO_USED_TEE);
+                used.bits.non_sec_chn_who_used |= SYMC_CHN_MASK(i);
+                SYMC_WRITE(CHN_WHO_USED_TEE, used.u32);
+            } else {
+                used.u32 = SYMC_READ(CHN_WHO_USED_REE);
+                used.bits.non_sec_chn_who_used |= SYMC_CHN_MASK(i);
+                SYMC_WRITE(CHN_WHO_USED_REE, used.u32);
+            }
+
+            drv_symc_enable_secure(i, HI_TRUE);
+            ret = drv_symc_recover_entry(i);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_PRINT_FUNC_ERR(drv_symc_recover_entry, ret);
+                return ret;
+            }
+        }
+    }
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    drv_symc_set_interrupt();
+#endif
+
+    drv_symc_entry_init(symc_dma);
+    drv_symc_smmu_bypass();
+    drv_symc_smmu_base_addr();
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_symc_suspend(void)
+{
+    return;
+}
+
+hi_s32 drv_symc_deinit(void)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 i;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+
+    ret = drv_symc_mem_deinit();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_mem_deinit, ret);
+        return ret;
+    }
+    module_disable(CRYPTO_MODULE_ID_SYMC);
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    drv_symc_unregister_interrupt();
+#endif
+
+    /* free all channel */
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        if (CIPHER_HARD_CHANNEL_MASK & (0x1 << i)) {
+            drv_symc_free_chn(i);
+        }
+    }
+
+    symc_initialize = HI_FALSE;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_symc_add_buf_usage(hi_u32 chn_num, hi_u32 in, symc_node_usage usage)
+{
+    symc_hard_context *ctx = HI_NULL;
+    hi_u32 id = 0;
+
+    ctx = &hard_context[chn_num];
+
+    if (in == HI_TRUE) {
+        /* get last node */
+        id = (ctx->id_in == 0) ? SYMC_MAX_LIST_NUM - 1 : ctx->id_in - 1;
+
+        ctx->entry_in[id].sym_ctrl = ctx->entry_in[id].sym_ctrl | (hi_u32)usage;
+        HI_LOG_INFO("chn %d, add symc in ctrl: id %d, ctrl 0x%x\n", chn_num, id, ctx->entry_in[id].sym_ctrl);
+    } else {
+        /* get last node */
+        id = (ctx->id_out == 0) ? SYMC_MAX_LIST_NUM - 1 : ctx->id_out - 1;
+
+        ctx->entry_out[id].aes_ctrl = ctx->entry_out[id].aes_ctrl | (hi_u32)usage;
+        HI_LOG_INFO("chn %d, add symc out ctrl: id %d, ctrl 0x%x\n", chn_num, id, ctx->entry_out[id].aes_ctrl);
+    }
+
+    return;
+}
+
+hi_s32 drv_symc_set_iv(hi_u32 chn_num, hi_u32 iv[SYMC_IV_MAX_SIZE_IN_WORD], hi_u32 ivlen, hi_u32 flag)
+{
+    hi_u32 i;
+    symc_hard_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx = &hard_context[chn_num];
+
+    /*copy iv data into channel context*/
+    for (i = 0; i < SYMC_IV_MAX_SIZE_IN_WORD; i++) {
+        ctx->iv[i] = iv[i];
+    }
+    ctx->iv_flag = flag;
+    ctx->iv_len = ivlen;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_symc_get_iv(hi_u32 chn_num, hi_u32 iv[SYMC_IV_MAX_SIZE_IN_WORD])
+{
+    hi_u32 i;
+
+    HI_LOG_FUNC_ENTER();
+
+    for (i = 0; i < SYMC_IV_MAX_SIZE_IN_WORD; i++) {
+        iv[i] = SYMC_READ(CHANn_CIPHER_IVOUT(chn_num) + i * 4);
+        HI_LOG_INFO("IV[%d]: 0x%x\n", i, iv[i]);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+void drv_symc_set_key(hi_u32 chn_num, hi_u32 key[SYMC_KEY_MAX_SIZE_IN_WORD], hi_u32 odd)
+{
+    hi_u32 i = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /*Set key, odd key only valid for aes ecb/cbc/ofb/cfb/ctr*/
+    SYMC_WRITE(ODD_EVEN_KEY_SEL, odd);
+    for (i = 0; i < SYMC_KEY_MAX_SIZE_IN_WORD; i++) {
+        SYMC_WRITE(CIPHER_KEY(chn_num) + i * 4, key[i]);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+void drv_symc_set_sm1_sk(hi_u32 chn_num, hi_u32 key[SYMC_SM1_SK_SIZE_IN_WORD])
+{
+    hi_u32 i = 0;
+
+    for (i = 0; i < SYMC_SM1_SK_SIZE_IN_WORD; i++) {
+        SYMC_WRITE(SM1_SK(chn_num) + i * 4, key[i]);
+    }
+    return;
+}
+
+hi_s32 drv_symc_add_inbuf(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size, symc_node_usage usage)
+{
+    symc_hard_context *ctx = HI_NULL;
+    hi_u32 id = 0, size = 0;
+    hi_u32 i = 0;
+    void *addr = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    ctx = &hard_context[chn_num];
+
+    id = ctx->id_in;
+    addr = &ctx->entry_in[id];
+    size = sizeof(symc_entry_in);
+    crypto_memset(addr, size, 0, size);
+    ctx->entry_in[id].spacc_cmd = 0x00;
+    ctx->entry_in[id].sym_start_addr = ADDR_L32(buf_phy);
+    ctx->entry_in[id].sym_start_high = ADDR_H32(buf_phy);
+    ctx->entry_in[id].sym_alg_length = buf_size;
+    ctx->entry_in[id].sym_ctrl =  usage;
+
+    if (ctx->mode == SYMC_MODE_GCM) {
+        ctx->entry_in[id].gcm_iv_len = ctx->iv_len - 1;
+    }
+
+    /* set IV to every node, but the hardware only update th IV
+     * from node when first flag is 1
+     */
+    for (i = 0; i < SYMC_IV_MAX_SIZE_IN_WORD; i++) {
+        ctx->entry_in[id].iv[i] = ctx->iv[i];
+        HI_LOG_DEBUG("IV[%d]: 0x%x\n", i, ctx->iv[i]);
+    }
+
+    if (ctx->iv_flag == CIPHER_IV_CHANGE_ONE_PKG) {
+        /* update iv for first node */
+        ctx->iv_flag = 0x00;
+
+        /* don't update iv any more */
+        ctx->entry_in[id].sym_ctrl |= SYMC_NODE_USAGE_FIRST;
+    } else if (ctx->iv_flag == CIPHER_IV_CHANGE_ALL_PKG) {
+        /* update iv for all node */
+        ctx->entry_in[id].sym_ctrl |= SYMC_NODE_USAGE_FIRST | SYMC_NODE_USAGE_LAST;
+    }
+
+    /* move to next node */
+    ctx->id_in++;
+    ctx->id_in %= SYMC_MAX_LIST_NUM;
+    HI_LOG_INFO("chn %d, add symc in buf[%p]: id %d, addr 0x%x, len 0x%x, ctrl 0x%x\n",
+                chn_num, &ctx->entry_in[id], id, ADDR_L32(buf_phy), buf_size, ctx->entry_in[id].sym_ctrl);
+
+    /* total count of computed nodes add 1*/
+    ctx->cnt_in++;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_add_outbuf(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size, symc_node_usage usage)
+{
+    symc_hard_context *ctx = HI_NULL;
+    hi_u32 id = 0, size = 0;
+    void *addr = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    ctx = &hard_context[chn_num];
+
+    id = ctx->id_out;
+    addr = &ctx->entry_out[id];
+    size = sizeof(symc_entry_out);
+    crypto_memset(addr, size, 0, size);
+    ctx->entry_out[id].sym_start_addr = ADDR_L32(buf_phy);
+    ctx->entry_out[id].tag[0] = ADDR_H32(buf_phy);
+    ctx->entry_out[id].sym_alg_length = buf_size;
+    ctx->entry_out[id].aes_ctrl =  usage;
+
+    /* move to next node */
+    ctx->id_out++;
+    ctx->id_out %= SYMC_MAX_LIST_NUM;
+    HI_LOG_INFO("chn %d, add symc out buf[%p]: id %d, addr 0x%x, len 0x%x, ctrl 0x%x\n",
+                chn_num, &ctx->entry_out[id], id, ADDR_L32(buf_phy), buf_size, usage);
+
+    /* total count of computed nodes add 1*/
+    ctx->cnt_out++;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_aead_ccm_add_n(hi_u32 chn_num, hi_u8 *n)
+{
+    hi_s32 ret = HI_FAILURE;
+    symc_hard_context *ctx = HI_NULL;
+    symc_node_usage usage = 0x00;
+    compat_addr dma_pad;
+    hi_u8 *via_pad = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    ctx = &hard_context[chn_num];
+
+    HI_LOG_DEBUG("PAD buffer, PHY: 0x%x, VIA %p\n", ADDR_L32(ctx->dma_pad), ctx->via_pad);
+
+    ADDR_U64(dma_pad) = ADDR_U64(ctx->dma_pad) + ctx->offset_pad;
+    via_pad = ctx->via_pad + ctx->offset_pad;
+
+    usage = SYMC_NODE_USAGE_IN_CCM_N | SYMC_NODE_USAGE_LAST;
+    crypto_memcpy(via_pad, SYMC_CCM_N_LEN, n, SYMC_CCM_N_LEN);
+    ctx->offset_pad += SYMC_CCM_N_LEN;
+    ret = drv_symc_add_inbuf(chn_num, dma_pad, SYMC_CCM_N_LEN, usage);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_add_inbuf, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_u32 drv_aead_ccm_a_head(hi_u8 *buf, hi_u32 alen)
+{
+    hi_u32 idx = 0;
+
+    /* Formatting of the Associated Data in B1, the length of A denotes as a*/
+    /* The value a is encoded according to the following three cases:
+     * If 0 < a < 2^16 - 2^8, then a  is encoded as a[0..15], i.e., two octets.
+     * If 2^16 - 2^8 <= a < 2^32, then a  is encoded as 0xff || 0xfe || a[0..31], i.e., six octets.
+     * If 2^32 <= a < 2^64, then  a is encoded as 0xff || 0xff || a[0..63], i.e., ten octets.
+     * For example, if a=2^16, the encoding of a  is
+     * 11111111 11111110 00000000 00000001 00000000 00000000.
+     */
+    if (alen < SYMC_CCM_A_SMALL_LEN) {
+        buf[idx++] = (hi_u8)(alen >> 8);
+        buf[idx++] = (hi_u8)(alen);
+    } else {
+        buf[idx++] = 0xFF;
+        buf[idx++] = 0xFE;
+        buf[idx++] = (hi_u8)(alen >> 24);
+        buf[idx++] = (hi_u8)(alen >> 16);
+        buf[idx++] = (hi_u8)(alen >> 8);
+        buf[idx++] = (hi_u8)alen;
+    }
+
+    return idx;
+}
+
+hi_s32 drv_aead_ccm_add_a(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size)
+{
+    symc_hard_context *ctx = HI_NULL;
+    compat_addr dma_pad;
+    hi_u8 *via_pad = HI_NULL;
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 count = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+    ctx = &hard_context[chn_num];
+    HI_LOG_CHECK_PARAM((ctx->offset_pad + SYMC_CCM_A_HEAD_LEN) >= SYMC_PAD_BUFFER_LEN);
+
+    /* return success when alen is zero*/
+    if (buf_size == 0x00) {
+        return HI_SUCCESS;
+    }
+
+    ADDR_U64(dma_pad) = ADDR_U64(ctx->dma_pad) + ctx->offset_pad;
+    via_pad = ctx->via_pad + ctx->offset_pad;
+    crypto_memset(via_pad, AES_BLOCK_SIZE * 2, 0, AES_BLOCK_SIZE * 2);
+
+    /* add ccm a head */
+    count = drv_aead_ccm_a_head(via_pad, buf_size);
+    ret = drv_symc_add_inbuf(chn_num, dma_pad, count, SYMC_NODE_USAGE_IN_CCM_A);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_add_inbuf, ret);
+        return ret;
+    }
+
+    /* move buffer addr */
+    ctx->offset_pad += count;
+    ADDR_U64(dma_pad) += count;
+    via_pad += count;
+
+    /*  add the phy of A into node list*/
+    ret = drv_symc_add_inbuf(chn_num, buf_phy, buf_size, SYMC_NODE_USAGE_IN_CCM_A);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_add_inbuf, ret);
+        return ret;
+    }
+
+    /*if idx + Alen do not aligned with 16, padding 0 to the tail*/
+    count = (buf_size + count) % AES_BLOCK_SIZE;
+    if (count > 0) {
+        /* add the padding phy of A into node list*/
+        ret = drv_symc_add_inbuf(chn_num, dma_pad, AES_BLOCK_SIZE - count,
+                                 SYMC_NODE_USAGE_IN_CCM_A);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_symc_add_inbuf, ret);
+            return ret;
+        }
+        ctx->offset_pad += AES_BLOCK_SIZE - count;
+    }
+
+    /* add ccm a last flag */
+    drv_symc_add_buf_usage(chn_num, HI_TRUE, SYMC_NODE_USAGE_LAST);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_aead_gcm_add_a(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size)
+{
+    symc_hard_context *ctx = HI_NULL;
+    compat_addr dma_pad;
+    hi_u8 *via_pad = HI_NULL;
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 count = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+    ctx = &hard_context[chn_num];
+    HI_LOG_CHECK_PARAM((ctx->offset_pad + AES_BLOCK_SIZE) >= SYMC_PAD_BUFFER_LEN);
+
+    /* return success when alen is zero*/
+    if (buf_size == 0x00) {
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    ADDR_U64(dma_pad) = ADDR_U64(ctx->dma_pad) + ctx->offset_pad;
+    via_pad = ctx->via_pad + ctx->offset_pad;
+    crypto_memset(via_pad, AES_BLOCK_SIZE, 0, AES_BLOCK_SIZE);
+
+    /*Add phy of A into node list*/
+    ret = drv_symc_add_inbuf(chn_num, buf_phy, buf_size, SYMC_NODE_USAGE_IN_GCM_A);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_add_inbuf, ret);
+        return ret;
+    }
+
+    /*if Alen do not aligned with 16, padding 0 to the tail*/
+    count = (buf_size + count) % AES_BLOCK_SIZE;
+    if (count > 0) {
+        /* add the padding phy of A into node list*/
+        ret = drv_symc_add_inbuf(chn_num, dma_pad, AES_BLOCK_SIZE - count,
+                                 SYMC_NODE_USAGE_IN_GCM_A);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_symc_add_inbuf, ret);
+            return ret;
+        }
+        ctx->offset_pad += AES_BLOCK_SIZE - count;
+    }
+
+    /* add gcm a last flag */
+    drv_symc_add_buf_usage(chn_num, HI_TRUE, SYMC_NODE_USAGE_LAST);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_aead_gcm_add_clen(hi_u32 chn_num, hi_u8 *clen)
+{
+    hi_s32 ret = HI_FAILURE;
+    symc_hard_context *ctx = HI_NULL;
+    symc_node_usage usage = 0x00;
+    compat_addr dma_pad;
+    hi_u8 *via_pad = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+    ctx = &hard_context[chn_num];
+    HI_LOG_CHECK_PARAM((ctx->offset_pad + SYMC_CCM_N_LEN) >= SYMC_PAD_BUFFER_LEN);
+
+    /* add Clen */
+    ADDR_U64(dma_pad) = ADDR_U64(ctx->dma_pad) + ctx->offset_pad;
+    via_pad = ctx->via_pad + ctx->offset_pad;
+
+    usage = SYMC_NODE_USAGE_IN_GCM_LEN | SYMC_NODE_USAGE_LAST;
+
+    crypto_memcpy(via_pad, SYMC_GCM_CLEN_LEN, clen, SYMC_GCM_CLEN_LEN);
+    ctx->offset_pad += SYMC_GCM_CLEN_LEN;
+
+    ret = drv_symc_add_inbuf(chn_num, dma_pad, SYMC_GCM_CLEN_LEN, usage);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_add_inbuf, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_aead_get_tag(hi_u32 chn_num, hi_u32 *tag)
+{
+    symc_hard_context *ctx = HI_NULL;
+    chann_cipher_out_node_cfg out_node_cfg;
+    hi_u32 last;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    ctx = &hard_context[chn_num];
+
+    out_node_cfg.u32 = SYMC_READ(CHANn_CIPHER_OUT_NODE_CFG(chn_num));
+    last = out_node_cfg.bits.cipher_out_node_wptr;
+    last = (last == 0) ? (SYMC_MAX_LIST_NUM - 1) : (last - 1);
+
+    crypto_memcpy(tag, AEAD_TAG_SIZE_IN_WORD * 4, ctx->entry_out[last].tag,
+                  AEAD_TAG_SIZE_IN_WORD * 4);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_node_check(symc_alg alg, symc_mode mode,
+                        hi_u32 klen, hi_u32 block_size,
+                        compat_addr input[],
+                        compat_addr output[],
+                        hi_u32 length[],
+                        symc_node_usage usage_list[],
+                        hi_u32 pkg_num)
+{
+    hi_u32 i = 0;
+    hi_u32 total = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(block_size == 0);
+
+    CRYPTO_UNUSED(input);
+    CRYPTO_UNUSED(output);
+
+    for (i = 0; i < pkg_num; i++) {
+        /* Used the odd key must accord with conditions as follows:*/
+        if ((hi_u32)usage_list[i] & SYMC_NODE_USAGE_ODD_KEY) {
+            /* 1. Only support aes ecb/cbc/cfb/ofb/ctr */
+            if ((alg != SYMC_ALG_AES)
+                || ((mode != SYMC_MODE_ECB)
+                    && (mode != SYMC_MODE_CBC)
+                    && (mode != SYMC_MODE_CFB)
+                    && (mode != SYMC_MODE_OFB)
+                    && (mode != SYMC_MODE_CTR))) {
+                HI_LOG_ERROR("Odd key only support aes ecb/cbc/cfb/ofb/ctr.");
+                HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+                return HI_ERR_CIPHER_INVALID_PARA;
+            }
+
+            /* 2. Only support aes128 */
+            if (klen != AES_CCM_GCM_KEY_LEN) {
+                HI_LOG_ERROR("Odd key only support aes128, klen %d\n", klen);
+                HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+                return HI_ERR_CIPHER_INVALID_PARA;
+            }
+
+            /* 3. each node length must be a multiple of 64*/
+            if ((length[i] % (AES_BLOCK_SIZE * 4)) != 0) {
+                HI_LOG_ERROR("Odd key only supported when each node length is a multiple of 64.");
+                HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_LENGTH);
+                return HI_ERR_CIPHER_INVALID_LENGTH;
+            }
+        }
+
+        /* each node length can't be zero*/
+        if (length[i] == 0) {
+            HI_LOG_ERROR("PKG len must large than 0.\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_LENGTH);
+            return HI_ERR_CIPHER_INVALID_LENGTH;
+        }
+
+        /* check overflow */
+        if (length[i] > ADDR_L32(input[i]) + length[i]) {
+            HI_LOG_ERROR("PKG len overflow.\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_LENGTH);
+            return HI_ERR_CIPHER_INVALID_LENGTH;
+        }
+        total += length[i];
+    }
+
+    if ((SYMC_ALG_NULL_CIPHER != alg) &&
+        ((SYMC_MODE_ECB == mode)
+         || (mode == SYMC_MODE_CBC)
+         || (mode == SYMC_MODE_CFB)
+         || (mode == SYMC_MODE_OFB))) {
+        /* The length of data depend on alg and mode, which limit to hardware
+         * for ecb/cbc/ofb/cfb, the total data length must aligned with block size.
+         * for ctr/ccm/gcm, support any data length.
+         */
+        if (total % block_size != 0) {
+            HI_LOG_ERROR("PKG len must align with 0x%x.\n", block_size);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_LENGTH);
+            return HI_ERR_CIPHER_INVALID_LENGTH;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_config(hi_u32 chn_num, symc_alg alg, symc_mode mode, symc_width width, hi_u32 decrypt,
+                    hi_u32 sm1_round_num, symc_klen klen, hi_u32 hard_key)
+{
+    symc_hard_context *ctx = HI_NULL;
+    chann_chipher_ctrl cipher_ctrl;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+    HI_LOG_CHECK_PARAM(alg >= SYMC_ALG_COUNT);
+    HI_LOG_CHECK_PARAM(mode > SYMC_MODE_GCM);
+    HI_LOG_CHECK_PARAM(klen >= SYMC_KEY_LEN_COUNT);
+
+    ctx = &hard_context[chn_num];
+
+    /* record alg */
+    ctx->alg = alg;
+    CRYPTO_UNUSED(sm1_round_num);
+
+    HI_LOG_INFO("symc configure, chn %d, alg %d, mode %d, dec %d, hard %d\n",
+                chn_num, alg, mode, decrypt, hard_key);
+
+    cipher_ctrl.u32 = SYMC_READ(CHANn_CIPHER_CTRL(chn_num));
+    cipher_ctrl.bits.sym_chn_sm1_round_num = sm1_round_num;
+    cipher_ctrl.bits.sym_chn_key_sel = hard_key;
+    cipher_ctrl.bits.sym_chn_key_length = klen;
+    cipher_ctrl.bits.sym_chn_dat_width = width;
+    cipher_ctrl.bits.sym_chn_decrypt = decrypt;
+    cipher_ctrl.bits.sym_chn_alg_sel = alg;
+    cipher_ctrl.bits.sym_chn_alg_mode = mode;
+    ctx->mode = mode;
+    SYMC_WRITE(CHANn_CIPHER_CTRL(chn_num), cipher_ctrl.u32);
+    HI_LOG_INFO("CHANn_CIPHER_CTRL(%d): 0x%x\n", chn_num, cipher_ctrl.u32);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_set_isr_callback(hi_u32 chn_num, callback_symc_isr callback, void *ctx)
+{
+    symc_hard_context *hisi_ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    hisi_ctx = &hard_context[chn_num];
+
+    hisi_ctx->callback = callback;
+    hisi_ctx->ctx = ctx;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_start(hi_u32 chn_num)
+{
+    symc_hard_context *ctx = HI_NULL;
+    chann_cipher_in_node_cfg in_node_cfg;
+    chann_cipher_out_node_cfg out_node_cfg;
+    hi_u32 ptr = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    ctx = &hard_context[chn_num];
+
+    HI_LOG_INFO("symc start, chn %d\n", chn_num);
+
+    ctx->done = HI_FALSE;
+
+    /*configure out nodes*/
+    out_node_cfg.u32 = SYMC_READ(CHANn_CIPHER_OUT_NODE_CFG(chn_num));
+    if (out_node_cfg.bits.cipher_out_node_wptr != out_node_cfg.bits.cipher_out_node_rptr) {
+        HI_LOG_ERROR("Error, chn %d is busy.\n", chn_num);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_BUSY);
+        return HI_ERR_CIPHER_BUSY;
+    }
+    ptr = out_node_cfg.bits.cipher_out_node_wptr + ctx->cnt_out;
+    out_node_cfg.bits.cipher_out_node_wptr = ptr % SYMC_MAX_LIST_NUM;
+    out_node_cfg.bits.cipher_out_node_mpackage_int_level = ctx->cnt_out;
+    SYMC_WRITE(CHANn_CIPHER_OUT_NODE_CFG(chn_num), out_node_cfg.u32);
+    HI_LOG_INFO("CHANn_CIPHER_OUT_NODE_CFG: 0x%x\n", out_node_cfg.u32);
+
+    /*configure in nodes*/
+    in_node_cfg.u32 = SYMC_READ(CHANn_CIPHER_IN_NODE_CFG(chn_num));
+    if (in_node_cfg.bits.cipher_in_node_wptr != in_node_cfg.bits.cipher_in_node_rptr) {
+        HI_LOG_ERROR("Error, chn %d is busy.\n", chn_num);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_BUSY);
+        return HI_ERR_CIPHER_BUSY;
+    }
+    ptr = in_node_cfg.bits.cipher_in_node_wptr + ctx->cnt_in;
+    in_node_cfg.bits.cipher_in_node_wptr = ptr % SYMC_MAX_LIST_NUM;
+    in_node_cfg.bits.cipher_in_node_mpackage_int_level = ctx->cnt_in;
+
+    /* SM4 may be disable independent from spacc */
+    if (ctx->alg == SYMC_ALG_SM4) {
+        module_enable(CRYPTO_MODULE_ID_SM4);
+    }
+
+    /* start */
+    SYMC_WRITE(CHANn_CIPHER_IN_NODE_CFG(chn_num), in_node_cfg.u32);
+    HI_LOG_INFO("CHANn_CIPHER_IN_NODE_CFG: 0x%x\n", in_node_cfg.u32);
+
+    /*all the nodes are processed, retset the cnount to zero */
+    ctx->cnt_in = 0;
+    ctx->cnt_out = 0;
+    ctx->offset_pad = 0;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_wait_done(hi_u32 chn_num, hi_u32 timeout)
+{
+    hi_u32 int_valid = 0, int_num = 0;
+    hi_u32 i;
+    symc_hard_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc_initialize != HI_TRUE);
+    HI_LOG_CHECK_PARAM(chn_num >= CRYPTO_HARD_CHANNEL_MAX);
+
+    ctx = &hard_context[chn_num];
+    module_get_attr(CRYPTO_MODULE_ID_SYMC, &int_valid, &int_num, HI_NULL);
+
+#ifdef CRYPTO_OS_INT_SUPPORT
+    /* interrupt support, wait irq*/
+    if (int_valid) {
+        hi_s32 ret = HI_FAILURE;
+
+        /* wait interrupt */
+        ret = crypto_queue_wait_timeout(ctx->queue, &ctx->done, timeout);
+
+        /* Disable SM4 independent from spacc */
+        if (ctx->alg == SYMC_ALG_SM4) {
+            module_disable(CRYPTO_MODULE_ID_SM4);
+        }
+
+        if ((ret <= 0x00) && (ret != -ERESTARTSYS)) {
+            HI_LOG_ERROR("wait done timeout, chn=%d\n", chn_num);
+            HI_LOG_PRINT_FUNC_ERR(crypto_queue_wait_timeout, ret);
+            drv_symc_get_err_code(chn_num);
+            return HI_ERR_CIPHER_TIMEOUT;
+        }
+    } else /* interrupt unsupport, query the raw interrupt flag*/
+#endif
+    {
+        for (i = 0; i < timeout; i++) {
+            if (drv_symc_done_try(chn_num)) {
+                break;
+            }
+            if (MS_TO_US >= i) {
+                crypto_udelay(1);  /* short waitting for 1000 us */
+            } else {
+                crypto_msleep(1);  /* long waitting for 5000 ms*/
+            }
+        }
+
+        /* Disable SM4 independent from spacc */
+        if (ctx->alg == SYMC_ALG_SM4) {
+            module_disable(CRYPTO_MODULE_ID_SM4);
+        }
+
+        if (timeout <= i) {
+            HI_LOG_ERROR("symc wait done timeout, chn=%d\n", chn_num);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_TIMEOUT);
+            drv_symc_get_err_code(chn_num);
+            return HI_ERR_CIPHER_TIMEOUT;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 drv_symc_set_destory_callbcak(hi_u32 chn_num, callback_symc_destory destory)
+{
+    symc_hard_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx = &hard_context[chn_num];
+    ctx->destory = destory;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/******* proc function begin ********/
+#if (1 == HI_PROC_SUPPORT)
+hi_s32 drv_symc_proc_status(symc_chn_status *status)
+{
+    hi_u32 addr = 0;
+    chann_chipher_ctrl ctrl;
+    cipher_int_raw stIntRaw;
+    cipher_int_en  stIntEn;
+    chann_cipher_in_node_cfg stInNode;
+    hi_u32 val;
+    hi_u32 i, j;
+
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        if (hard_context[i].open == HI_TRUE) {
+            status[i].open = "open ";
+        } else {
+            status[i].open = "close";
+        }
+        /* get cipher ctrl */
+        if (0 != i) {
+            addr = CHANn_CIPHER_CTRL(i);
+        } else {
+            addr = CHAN0_CIPHER_CTRL;
+        }
+
+        ctrl.u32 = SYMC_READ(addr);
+        status[i].decrypt = ctrl.bits.sym_chn_decrypt;
+        switch (ctrl.bits.sym_chn_alg_sel) {
+            case HI_CIPHER_ALG_DES: {
+                status[i].alg = "DES ";
+                break;
+            }
+            case HI_CIPHER_ALG_3DES: {
+                status[i].alg = "3DES";
+                break;
+            }
+            case HI_CIPHER_ALG_AES: {
+                status[i].alg = "AES ";
+                break;
+            }
+            case HI_CIPHER_ALG_SM1: {
+                status[i].alg = "SM1 ";
+                break;
+            }
+            case HI_CIPHER_ALG_SM4: {
+                status[i].alg = "SM4 ";
+                break;
+            }
+            case HI_CIPHER_ALG_DMA: {
+                status[i].alg = "DMA ";
+                break;
+            }
+            default: {
+                status[i].alg = "BUTT";
+                break;
+            }
+        }
+
+        switch (ctrl.bits.sym_chn_alg_mode) {
+            case HI_CIPHER_WORK_MODE_ECB: {
+                status[i].mode = "ECB ";
+                break;
+            }
+            case HI_CIPHER_WORK_MODE_CBC: {
+                status[i].mode = "CBC ";
+                break;
+            }
+            case HI_CIPHER_WORK_MODE_CFB: {
+                status[i].mode = "CFB ";
+                break;
+            }
+            case HI_CIPHER_WORK_MODE_OFB: {
+                status[i].mode = "OFB ";
+                break;
+            }
+            case HI_CIPHER_WORK_MODE_CTR: {
+                status[i].mode = "CTR ";
+                break;
+            }
+            case HI_CIPHER_WORK_MODE_CCM: {
+                status[i].mode = "CCM ";
+                break;
+            }
+            case HI_CIPHER_WORK_MODE_GCM: {
+                status[i].mode = "GCM ";
+                break;
+            }
+            default: {
+                status[i].mode = "BUTT";
+                break;
+            }
+        }
+
+        if (ctrl.bits.sym_chn_alg_sel == HI_CIPHER_ALG_AES) {
+            switch (ctrl.bits.sym_chn_key_length) {
+                case HI_CIPHER_KEY_AES_128BIT: {
+                    status[i].klen = AES_KEY_128BIT;
+                    break;
+                }
+                case HI_CIPHER_KEY_AES_192BIT: {
+                    status[i].klen = AES_KEY_192BIT;
+                    break;
+                }
+                case HI_CIPHER_KEY_AES_256BIT: {
+                    status[i].klen = AES_KEY_256BIT;
+                    break;
+                }
+                default: {
+                    status[i].klen = 0;
+                    break;
+                }
+            }
+        } else if (ctrl.bits.sym_chn_alg_sel == HI_CIPHER_ALG_DES) {
+            status[i].klen = DES_KEY_SIZE;
+        } else if (ctrl.bits.sym_chn_alg_sel == HI_CIPHER_ALG_3DES) {
+            switch (ctrl.bits.sym_chn_key_length) {
+                case HI_CIPHER_KEY_DES_3KEY: {
+                    status[i].klen = TDES_KEY_192BIT;
+                    break;
+                }
+                case HI_CIPHER_KEY_DES_2KEY: {
+                    status[i].klen = TDES_KEY_128BIT;
+                    break;
+                }
+                default: {
+                    status[i].klen = 0;
+                    break;
+                }
+            }
+        } else if (ctrl.bits.sym_chn_alg_sel == HI_CIPHER_ALG_SM1) {
+            status[i].klen = SM1_AK_EK_SIZE + SM1_SK_SIZE;
+        } else if (ctrl.bits.sym_chn_alg_sel == HI_CIPHER_ALG_SM4) {
+            status[i].klen = SM4_KEY_SIZE;
+        } else {
+            status[i].klen = 0;
+        }
+
+        if (ctrl.bits.sym_chn_key_sel) {
+            status[i].ksrc = "HW";
+        } else {
+            status[i].ksrc = "SW";
+        }
+
+        /* get data in */
+        if (0 != i) {
+            addr = CHANn_CIPHER_IN_BUF_RPTR(i);
+            status[i].inaddr = SYMC_READ(addr);
+        } else {
+            status[0].inaddr = CHAN0_CIPHER_DIN;
+        }
+
+        /* get data out */
+        if (0 != i) {
+            addr = CHANn_CIPHER_OUT_BUF_RPTR(i);
+            status[i].outaddr = SYMC_READ(addr);
+        } else {
+            status[0].outaddr = CHAN0_CIPHER_DOUT;
+        }
+
+        for (j = 0; j < 4; j++) {
+            val = SYMC_READ(CHANn_CIPHER_IVOUT(i) + j * 4);
+            hex2str(status[i].iv + j * 8, (hi_u8)(val & 0xFF));
+            hex2str(status[i].iv + j * 8 + 2, (hi_u8)((val >> 8) & 0xFF));
+            hex2str(status[i].iv + j * 8 + 4, (hi_u8)((val >> 16) & 0xFF));
+            hex2str(status[i].iv + j * 8 + 6, (hi_u8)((val >> 24) & 0xFF));
+        }
+
+        /* get INT RAW status */
+        stIntRaw.u32 = SYMC_READ(CIPHER_INT_RAW);
+        status[i].inraw = (stIntRaw.bits.cipher_chn_ibuf_raw >> i) & 0x1;
+        status[i].outraw = (stIntRaw.bits.cipher_chn_obuf_raw >> i) & 0x1;
+
+        /* get INT EN status */
+        stIntEn.u32 = SYMC_READ(CIPHER_INT_EN);
+        status[i].intswitch = stIntEn.bits.cipher_nsec_int_en;
+        status[i].inten = (stIntEn.bits.cipher_chn_ibuf_en >> i) & 0x1;
+        status[i].outen = (stIntEn.bits.cipher_chn_obuf_en >> i) & 0x1;
+
+        /* get INT_OINTCFG */
+        addr = CHANn_CIPHER_IN_NODE_CFG(i);
+        stInNode.u32 = SYMC_READ(addr);
+        status[i].outintcnt = stInNode.bits.cipher_in_node_mpackage_int_level;
+
+    }
+
+    return HI_SUCCESS;
+}
+#endif
+/******* proc function end ********/
+
+void drv_symc_get_capacity(symc_capacity *capacity)
+{
+    HI_LOG_FUNC_ENTER();
+
+    /* the mode depend on alg, which limit to hardware
+     * des/3des support ecb/cbc/cfb/ofb
+     * aes support ecb/cbc/cfb/ofb/ctr/ccm/gcm
+     * sm1 support ecb/cbc/cfb/ofb
+     * sm4 support ecb/cbc/ctr
+     */
+
+    crypto_memset(capacity, sizeof(symc_capacity), 0,  sizeof(symc_capacity));
+
+    /* AES */
+    capacity->aes_ecb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->aes_cbc = CRYPTO_CAPACITY_SUPPORT;
+    capacity->aes_ofb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->aes_cfb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->aes_ctr = CRYPTO_CAPACITY_SUPPORT;
+#ifdef CHIP_AES_CCM_GCM_SUPPORT
+    capacity->aes_ccm = CRYPTO_CAPACITY_SUPPORT;
+    capacity->aes_gcm = CRYPTO_CAPACITY_SUPPORT;
+#endif
+
+    /* TDES */
+    capacity->tdes_ecb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->tdes_cbc = CRYPTO_CAPACITY_SUPPORT;
+    capacity->tdes_ofb = CRYPTO_CAPACITY_SUPPORT;
+    capacity->tdes_cfb = CRYPTO_CAPACITY_SUPPORT;
+
+    /* DES */
+    capacity->des_ecb  = CRYPTO_CAPACITY_SUPPORT;
+    capacity->des_cbc  = CRYPTO_CAPACITY_SUPPORT;
+    capacity->des_ofb  = CRYPTO_CAPACITY_SUPPORT;
+    capacity->des_cfb  = CRYPTO_CAPACITY_SUPPORT;
+
+    /* SM1 */
+#ifdef CHIP_SYMC_SM1_SUPPORT
+    capacity->sm1_ecb  = CRYPTO_CAPACITY_SUPPORT;
+    capacity->sm1_cbc  = CRYPTO_CAPACITY_SUPPORT;
+    capacity->sm1_ofb  = CRYPTO_CAPACITY_SUPPORT;
+    capacity->sm1_cfb  = CRYPTO_CAPACITY_SUPPORT;
+#endif
+
+    /* SM4 */
+    capacity->sm4_ecb  = CRYPTO_CAPACITY_SUPPORT;
+    capacity->sm4_cbc  = CRYPTO_CAPACITY_SUPPORT;
+    capacity->sm4_ctr  = CRYPTO_CAPACITY_SUPPORT;
+
+    /* DMA */
+    capacity->dma = CRYPTO_CAPACITY_SUPPORT;
+
+    return;
+}
+
+/** @}*/  /** <!-- ==== API Code end ====*/
+
+#endif //End of CHIP_SYMC_VER_V200

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_symc_v200.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_symc_v200.c
@@ -1705,7 +1705,17 @@ hi_s32 drv_symc_wait_done(hi_u32 chn_num, hi_u32 timeout)
             module_disable(CRYPTO_MODULE_ID_SM4);
         }
 
-        if ((ret <= 0x00) && (ret != -ERESTARTSYS)) {
+        /*
+         * -ERESTARTSYS was excluded here, which let a wait cut short by a
+         * signal fall through to HI_SUCCESS below. crypto_queue_wait_timeout
+         * is wait_event_interruptible_timeout, so that is reachable whenever
+         * the calling thread takes a signal -- and the caller then copies out
+         * a buffer the engine may not have finished writing, with no error
+         * anywhere. Ciphertext is meant to look like noise, so nothing
+         * downstream can tell. Report it instead and let the caller retry or
+         * fall back.
+         */
+        if (ret <= 0x00) {
             HI_LOG_ERROR("wait done timeout, chn=%d\n", chn_num);
             HI_LOG_PRINT_FUNC_ERR(crypto_queue_wait_timeout, ret);
             drv_symc_get_err_code(chn_num);

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_symc_v200.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_symc_v200.h
@@ -1,0 +1,252 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_symc_v200.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef _DRV_SYMC_V200_H_
+#define _DRV_SYMC_V200_H_
+
+#include "drv_osal_lib.h"
+
+/*************************** Internal Structure Definition ****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+/*! hash in entry list size */
+#define SYMC_NODE_SIZE             (SYMC_MAX_LIST_NUM * 32)
+
+/*! hash in entry list size */
+#define SYMC_NODE_LIST_SIZE        (SYMC_NODE_SIZE * 2 * CIPHER_HARD_CHANNEL_CNT)
+
+/*! \Define the offset of reg */
+#define CHANn_CIPHER_IVOUT(id)                  (0x0000 + (id)*0x10)
+#define CHAN0_CIPHER_DOUT                       (0x0080)
+#define CIPHER_KEY(id)                          (0x0100 + (id)*0x20)
+#define SM1_SK(id)                              (0x0200 + (id)*0x10)
+#define ODD_EVEN_KEY_SEL                        (0x0290)
+#define HDCP_MODE_CTRL                          (0x0300)
+#define SEC_CHN_CFG                             (0x0304)
+#define CALC_ERR                                (0x0320)
+#define CHAN0_CIPHER_CTRL                       (0x0400)
+#define CIPHER_INT_STATUS                       (0x0404)
+#define CIPHER_INT_EN                           (0x0408)
+#define CIPHER_INT_RAW                          (0x040c)
+#define CIPHER_IN_SMMU_EN                       (0x0410)
+#define OUT_SMMU_EN                             (0x0414)
+#define CHAN0_CIPHER_DIN                        (0x0420)
+#define NORM_SMMU_START_ADDR                    (0x0440)
+#define SEC_SMMU_START_ADDR                     (0x0444)
+#define CHANn_CIPHER_CTRL(id)                   (0x0400 + (id)*0x80)
+#define CHANn_CIPHER_IN_NODE_CFG(id)            (0x0404 + (id)*0x80)
+#define CHANn_CIPHER_IN_NODE_START_ADDR(id)     (0x0408 + (id)*0x80)
+#define CHANn_CIPHER_IN_BUF_RPTR(id)            (0x040C + (id)*0x80)
+#define CHANn_CIPHER_OUT_NODE_CFG(id)           (0x0430 + (id)*0x80)
+#define CHANn_CIPHER_OUT_NODE_START_ADDR(id)    (0x0434 + (id)*0x80)
+#define CHANn_CIPHER_OUT_BUF_RPTR(id)           (0x0438 + (id)*0x80)
+#define CHANN_CIPHER_IN_NODE_START_HIGH(id)     (0x0460 + (id)*0x80)
+#define CHANN_CIPHER_OUT_NODE_START_HIGH(id)    (0x0470 + (id)*0x80)
+#define HASH_INT_STATUS                         (0x0804)
+#define CHN_WHO_USED_REE                        (0x0390)
+#define CHN_WHO_USED_TEE                        (0x0394)
+#define SYMC_CHN_MASK(id)                       (0x01 << (id))
+
+/* reducing power dissipation */
+#define SPACC_CALC_CRG_CFG                      (0x039C)
+
+/* Define the union cal_crg_cfg */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    reserved_0                   : 28   ; /* [27..0] */
+        hi_u32    spacc_core_auto_cken_bypass  : 1    ; /* [28]  */
+        hi_u32    spacc_rft_mem_wr_clk_gt_en   : 1    ; /* [29]  */
+        hi_u32    spacc_rft_mem_rd_clk_gt_en   : 1    ; /* [30]  */
+        hi_u32    spacc_rfs_mem_clk_gt_en      : 1    ; /* [31]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} cal_crg_cfg;
+
+/* Define the union sec_chn_cfg */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    cipher_sec_chn_cfg    : 8   ; /* [7..0]  */
+        hi_u32    cipher_sec_chn_cfg_lock : 1   ; /* [8]  */
+        hi_u32    reserved_0            : 7   ; /* [15..9]  */
+        hi_u32    hash_sec_chn_cfg      : 8   ; /* [23..16]  */
+        hi_u32    hash_sec_chn_cfg_lock : 1   ; /* [24]  */
+        hi_u32    reserved_1            : 7   ; /* [31..25]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} sec_chn_cfg;
+
+/* Define the union cipher_int_status */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    reserved_0            : 1   ; /* [0]  */
+        hi_u32    cipher_chn_ibuf_int   : 7   ; /* [7..1]  */
+        hi_u32    cipher_chn_obuf_int   : 8   ; /* [15..8]  */
+        hi_u32    reserved_1            : 16  ; /* [31..16]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} cipher_int_status;
+
+/* Define the union cipher_int_en */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    reserved_0            : 1   ; /* [0]  */
+        hi_u32    cipher_chn_ibuf_en    : 7   ; /* [7..1]  */
+        hi_u32    cipher_chn_obuf_en    : 8   ; /* [15..8]  */
+        hi_u32    reserved_1            : 14  ; /* [29..16]  */
+        hi_u32    cipher_sec_int_en     : 1   ; /* [30]  */
+        hi_u32    cipher_nsec_int_en    : 1   ; /* [31]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} cipher_int_en;
+
+/* Define the union cipher_int_raw */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    reserved_0            : 1   ; /* [0]  */
+        hi_u32    cipher_chn_ibuf_raw   : 7   ; /* [7..1]  */
+        hi_u32    cipher_chn_obuf_raw   : 8   ; /* [15..8]  */
+        hi_u32    reserved_1            : 16  ; /* [31..16]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} cipher_int_raw;
+
+/* Define the union hash_int_status */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        unsigned int    reserved_0            : 18  ; /* [17..0]  */
+        unsigned int    hash_chn_oram_int     : 8   ; /* [25..18]  */
+        unsigned int    reserved_1            : 6   ; /* [31..26]  */
+    } bits;
+
+    /* Define an unsigned member */
+    unsigned int    u32;
+
+} hash_int_status;
+
+/* Define the union cipher_in_smmu_en */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    cipher_in_chan_rd_dat_smmu_en : 7   ; /* [6..0]  */
+        hi_u32    reserved_0            : 9   ; /* [15..7]  */
+        hi_u32    cipher_in_chan_rd_node_smmu_en : 7   ; /* [22..16]  */
+        hi_u32    reserved_1            : 9   ; /* [31..23]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} cipher_in_smmu_en;
+
+/* Define the union out_smmu_en */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    out_chan_wr_dat_smmu_en : 7   ; /* [6..0]  */
+        hi_u32    reserved_0            : 9   ; /* [15..7]  */
+        hi_u32    out_chan_rd_node_smmu_en : 7   ; /* [22..16]  */
+        hi_u32    reserved_1            : 9   ; /* [31..23]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} out_smmu_en;
+
+/* Define the union chann_chipher_ctrl */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    reserved_0            : 1   ; /* [0]  */
+        hi_u32    sym_chn_alg_mode      : 3   ; /* [3..1]  */
+        hi_u32    sym_chn_alg_sel       : 3   ; /* [6..4]  */
+        hi_u32    sym_chn_decrypt       : 1   ; /* [7]  */
+        hi_u32    sym_chn_dat_width     : 2   ; /* [9..8]  */
+        hi_u32    sym_chn_key_length    : 2   ; /* [11..10]  */
+        hi_u32    reserved_1            : 2   ; /* [13..12]  */
+        hi_u32    sym_chn_key_sel       : 1   ; /* [14]  */
+        hi_u32    reserved_2            : 1   ; /* [15]  */
+        hi_u32    sym_chn_dout_byte_swap_en : 1   ; /* [16]  */
+        hi_u32    sym_chn_din_byte_swap_en : 1   ; /* [17]  */
+        hi_u32    sym_chn_sm1_round_num : 2   ; /* [19..18]  */
+        hi_u32    reserved_3            : 2   ; /* [21..20]  */
+        hi_u32    weight                : 10  ; /* [31..22]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} chann_chipher_ctrl;
+
+/* Define the union chann_cipher_in_node_cfg */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    cipher_in_node_mpackage_int_level : 7   ; /* [6..0]  */
+        hi_u32    reserved_0            : 1   ; /* [7]  */
+        hi_u32    cipher_in_node_rptr   : 7   ; /* [14..8]  */
+        hi_u32    reserved_1            : 1   ; /* [15]  */
+        hi_u32    cipher_in_node_wptr   : 7   ; /* [22..16]  */
+        hi_u32    reserved_2            : 1   ; /* [23]  */
+        hi_u32    cipher_in_node_total_num : 7   ; /* [30..24]  */
+        hi_u32    reserved_3            : 1   ; /* [31]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} chann_cipher_in_node_cfg;
+
+/* Define the union chann_cipher_out_node_cfg */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    cipher_out_node_mpackage_int_level : 7   ; /* [6..0]  */
+        hi_u32    reserved_0            : 1   ; /* [7]  */
+        hi_u32    cipher_out_node_rptr  : 7   ; /* [14..8]  */
+        hi_u32    reserved_1            : 1   ; /* [15]  */
+        hi_u32    cipher_out_node_wptr  : 7   ; /* [22..16]  */
+        hi_u32    reserved_2            : 1   ; /* [23]  */
+        hi_u32    cipher_out_node_total_num : 7   ; /* [30..24]  */
+        hi_u32    reserved_3            : 1   ; /* [31]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} chann_cipher_out_node_cfg;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_trng_v100.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_trng_v100.c
@@ -1,0 +1,103 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_trng_v100.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_trng_v100.h"
+#include "drv_trng.h"
+
+#ifdef CHIP_TRNG_VER_V100
+
+/*************************** Internal Structure Definition ****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+/*! Define the post process depth */
+#define TRNG_POST_PROCESS_DEPTH     0x10
+
+/*! Define the osc sel */
+#define TRNG_OSC_SEL                0x02
+
+/** @} */  /** <!-- ==== Structure Definition end ==== */
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      hdcp */
+/** @{ */  /** <!--[hdcp]*/
+
+hi_s32 drv_trng_randnum(hi_u32 *randnum, hi_u32 timeout)
+{
+    rng_stat stat;
+    rng_ctrl ctrl;
+    hi_u32 times = 0;
+    static hi_u32 last = 0x1082;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(randnum == HI_NULL);
+
+    if (ctrl.u32 != last) {
+        module_enable(CRYPTO_MODULE_ID_TRNG);
+
+        ctrl.u32 = TRNG_READ(RNG_CTRL);
+        ctrl.bits.filter_enable = 0x00;
+        ctrl.bits.mix_en = 0x00;
+        ctrl.bits.drop_enable = 0x00;
+        ctrl.bits.post_process_enable = 0x01;
+        ctrl.bits.post_process_depth = TRNG_POST_PROCESS_DEPTH;
+        ctrl.bits.osc_sel = TRNG_OSC_SEL;
+        TRNG_WRITE(RNG_CTRL, ctrl.u32);
+    }
+
+#if defined(HI_PLATFORM_TYPE_LINUX)
+    if (timeout == 0) { /* unblock */
+        /* trng number is valid ? */
+        stat.u32 = TRNG_READ(RNG_STAT);
+        if (stat.bits.rng_data_count == 0x00) {
+            return HI_ERR_CIPHER_NO_AVAILABLE_RNG;
+        }
+    } else /* block */
+#endif
+    {
+        while (times++ < TRNG_TIMEOUT) {
+            /* trng number is valid ? */
+            stat.u32 = TRNG_READ(RNG_STAT);
+            if (stat.bits.rng_data_count > 0x00) {
+                break;
+            }
+        }
+
+        /* time out */
+        if (times >= TRNG_TIMEOUT) {
+            return HI_ERR_CIPHER_NO_AVAILABLE_RNG;
+        }
+    }
+
+    /* read valid randnum */
+    *randnum = TRNG_READ(RNG_FIFO_DATA);
+
+    HI_LOG_INFO("randnum: 0x%x\n", *randnum);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_trng_get_capacity(trng_capacity *capacity)
+{
+    crypto_memset(capacity, sizeof(trng_capacity), 0,  sizeof(trng_capacity));
+
+    capacity->trng = CRYPTO_CAPACITY_SUPPORT;
+
+    return;
+}
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+
+#endif //End of CHIP_TRNG_VER_V100

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_trng_v100.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_trng_v100.h
@@ -1,0 +1,68 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_trng_v100.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef _DRV_HDCP_V100_H_
+#define _DRV_HDCP_V100_H_
+
+#include "drv_osal_lib.h"
+
+/*************************** Internal Structure Definition ****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+/*! \Define the offset of reg */
+#define RNG_CTRL                   (0x0000)
+#define RNG_FIFO_DATA              (0x0004)
+#define RNG_STAT                   (0x0008)
+
+#define TRNG_TIMEOUT               (0x10000000)
+
+/* Define the union rng_ctrl */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    osc_sel               : 2   ; /* [1..0]  */
+        hi_u32    cleardata             : 1   ; /* [2]  */
+        hi_u32    mix_en                : 1   ; /* [3]  */
+        hi_u32    filter_enable         : 1   ; /* [4]  */
+        hi_u32    drop_enable           : 1   ; /* [5]  */
+        hi_u32    reserved0             : 1   ; /* [6]  */
+        hi_u32    post_process_enable   : 1   ; /* [7]  */
+        hi_u32    post_process_depth    : 8   ; /* [15..8]  */
+        hi_u32    reserved1             : 13  ; /* [28..16]  */
+        hi_u32    low_osc_st0           : 1   ; /* [29]  */
+        hi_u32    low_osc_st1           : 1   ; /* [30]  */
+        hi_u32    reserved2             : 1   ; /* [31]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} rng_ctrl;
+
+/* Define the union rng_stat */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    rng_data_count        : 3   ; /* [2..0]  */
+        hi_u32    reserved_0            : 28  ; /* [30..2]  */
+        hi_u32    rn_dat_rdy            : 1   ; /* [31]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} rng_stat;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_trng_v200.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_trng_v200.c
@@ -1,0 +1,98 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_trng_v200.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_trng_v200.h"
+#include "drv_trng.h"
+
+#ifdef CHIP_TRNG_VER_V200
+
+/*************************** Internal Structure Definition ****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+/*! Define the osc sel */
+#define TRNG_OSC_SEL                0x02
+
+/** @} */  /** <!-- ==== Structure Definition end ==== */
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      trng */
+/** @{ */  /** <!--[trng]*/
+
+hi_s32 drv_trng_randnum(hi_u32 *randnum, hi_u32 timeout)
+{
+    hisec_com_trng_data_st stat;
+    hisec_com_trng_ctrl ctrl;
+    static hi_u32 last = 0x0A;
+    hi_u32 times = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(randnum == HI_NULL);
+
+    ctrl.u32 = TRNG_READ(HISEC_COM_TRNG_CTRL);
+    if (ctrl.u32 != last) {
+        module_enable(CRYPTO_MODULE_ID_TRNG);
+
+        ctrl.bits.mix_enable = 0x00;
+        ctrl.bits.drop_enable = 0x00;
+        ctrl.bits.pre_process_enable = 0x00;
+        ctrl.bits.post_process_enable = 0x00;
+        ctrl.bits.post_process_depth = 0x00;
+        ctrl.bits.drbg_enable = 0x01;
+        ctrl.bits.osc_sel = TRNG_OSC_SEL;
+        TRNG_WRITE(HISEC_COM_TRNG_CTRL, ctrl.u32);
+        last = ctrl.u32;
+    }
+
+    if (timeout == 0) { /* unblock */
+        /* trng number is valid ? */
+        stat.u32 = TRNG_READ(HISEC_COM_TRNG_DATA_ST);
+        if (0x00 == stat.bits.trng_fifo_data_cnt) {
+            return HI_ERR_CIPHER_NO_AVAILABLE_RNG;
+        }
+    } else { /* block */
+        while (times++ < timeout) {
+            /* trng number is valid ? */
+            stat.u32 = TRNG_READ(HISEC_COM_TRNG_DATA_ST);
+            if (0x00 < stat.bits.trng_fifo_data_cnt) {
+                break;
+            }
+        }
+
+        /* time out */
+        if (times >= timeout) {
+            return HI_ERR_CIPHER_NO_AVAILABLE_RNG;
+        }
+    }
+
+    /* read valid randnum */
+    *randnum = TRNG_READ(HISEC_COM_TRNG_FIFO_DATA);
+    HI_LOG_INFO("randnum: 0x%x\n", *randnum);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void drv_trng_get_capacity(trng_capacity *capacity)
+{
+    crypto_memset(capacity, sizeof(trng_capacity), 0,  sizeof(trng_capacity));
+
+    capacity->trng = CRYPTO_CAPACITY_SUPPORT;
+
+    return;
+}
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+
+#endif //End of CHIP_TRNG_VER_V200

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_trng_v200.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/drv_trng_v200.h
@@ -1,0 +1,74 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_trng_v200.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef _DRV_TRNG_V200_H_
+#define _DRV_TRNG_V200_H_
+
+#include "drv_osal_lib.h"
+
+/*************************** Internal Structure Definition ****************************/
+/** \addtogroup      trng drivers*/
+/** @{*/  /** <!-- [trng]*/
+
+/*! \Define the offset of reg */
+#define  HISEC_COM_TRNG_CTRL            (0x00)
+#define  HISEC_COM_TRNG_FIFO_DATA       (0x04)
+#define  HISEC_COM_TRNG_DATA_ST         (0x08)
+
+/* Define the union hisec_com_trng_ctrl */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32   osc_sel            :  2;   /* [1..0]  */
+        hi_u32   cleardata          :  1;   /* [2]  */
+        hi_u32   drbg_enable        :  1;   /* [3]  */
+        hi_u32   pre_process_enable :  1;   /* [4]  */
+        hi_u32   drop_enable        :  1;   /* [5]  */
+        hi_u32   mix_enable         :  1;   /* [6]  */
+        hi_u32   post_process_enable:  1;   /* [7]  */
+        hi_u32   post_process_depth :  8;   /* [15..8]  */
+        hi_u32   reserved0          :  1;   /* [16]  */
+        hi_u32   trng_sel           :  2;   /* [18..17]  */
+        hi_u32   pos_self_test_en   :  1;   /* [19]  */
+        hi_u32   pre_self_test_en     :  1;   /* [20]  */
+        hi_u32   reserved1          :  11;  /* [31..21]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} hisec_com_trng_ctrl;
+
+/* Define the union hisec_com_trng_data_st */
+typedef union {
+    /* Define the struct bits */
+    struct {
+        hi_u32    low_osc_st0        :    1; /* [0]  */
+        hi_u32    low_osc_st1        :    1; /* [1]  */
+        hi_u32    low_ro_st0         :    1; /* [2]  */
+        hi_u32    low_ro_st1         :    1; /* [3]  */
+        hi_u32    otp_trng_sel       :    1; /* [4]  */
+        hi_u32    reserved0          :    3; /* [7..5]  */
+        hi_u32    trng_fifo_data_cnt :    8; /* [15..8]  */
+        hi_u32    sic_trng_alarm     :    6; /* [21..16]  */
+        hi_u32    sic_trng_bist_alarm:    1; /* [22]  */
+        hi_u32    reserved1          :    9; /* [31..23]  */
+    } bits;
+
+    /* Define an unsigned member */
+    hi_u32    u32;
+
+} hisec_com_trng_data_st;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/include/drv_hash.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/include/drv_hash.h
@@ -1,0 +1,128 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_hash.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __DRV_HASH_H__
+#define __DRV_HASH_H__
+
+/*************************** Structure Definition ****************************/
+/** \addtogroup     hash */
+/** @{ */  /** <!-- [hash] */
+
+/*! \hash block size */
+#define HASH_BLOCK_SIZE_64         (64)   /* SHA1, SHA224, SHA256 */
+#define HASH_BLOCK_SIZE_128        (128)  /* SHA384, SHA512 */
+
+/*! \hash capacity, 0-nonsupport, 1-support */
+typedef struct {
+    hi_u32 sha1        : 1 ;    /*!<  Support SHA1  */
+    hi_u32 sha224      : 1 ;    /*!<  Support SHA224  */
+    hi_u32 sha256      : 1 ;    /*!<  Support SHA256  */
+    hi_u32 sha384      : 1 ;    /*!<  Support SHA384  */
+    hi_u32 sha512      : 1 ;    /*!<  Support SHA512  */
+    hi_u32 sm3         : 1 ;    /*!<  Support SM3  */
+} hash_capacity;
+
+/*! \hash mode */
+typedef enum {
+    HASH_MODE_SHA1,      /*!<  SHA1  */
+    HASH_MODE_SHA224,    /*!<  SHA2 224  */
+    HASH_MODE_SHA256,    /*!<  SHA2 256  */
+    HASH_MODE_SHA384,    /*!<  SHA2 384  */
+    HASH_MODE_SHA512,    /*!<  SHA2 512  */
+    HASH_MODE_SM3,       /*!<  SM3  */
+    HASH_MODE_COUNT,
+} hash_mode;
+
+/** @} */  /** <!-- ==== Structure Definition end ==== */
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      hash */
+/** @{ */  /** <!--[hash]*/
+
+
+/**
+\brief  Initialize the hash module.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_hash_init(void);
+
+/**
+\brief  Deinitialize the hash module.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_hash_deinit(void);
+
+/**
+\brief  suspend the hash module.
+\retval     NA.
+*/
+void drv_hash_suspend(void);
+
+/**
+\brief  resume the hash module.
+\retval     NA.
+*/
+void drv_hash_resume(void);
+
+/**
+\brief  set work params.
+\param[in]  chn_num The channel number.
+\param[in]  mode The hash mode.
+\param[in] state The hash initial result.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_hash_config(hi_u32 chn_num, hash_mode mode, hi_u32 state[HASH_RESULT_MAX_SIZE_IN_WORD]);
+
+/**
+\brief  start hash calculation.
+\param[in]  chn_num The channel number.
+\param[in]  buf_phy The MMZ/SMMU address of in buffer.
+\param[in]  buf_size The MMZ/SMMU siae of in buffer.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_hash_start(hi_u32 chn_num, crypto_mem *mem, hi_u32 buf_size);
+
+/**
+\brief  wait running finished.
+\param[in]  chn_num The channel number.
+\param[out] state The hash result.
+\param[in]  hashLen The length of hash result.
+\retval     On received interception, HI_TRUE is returned  otherwise HI_FALSE is returned.
+*/
+hi_s32 drv_hash_wait_done(hi_u32 chn_num, hi_u32 *state);
+
+/**
+\brief  reset hash after hash finished.
+\param[in]  chn_num The channel number.
+\retval     NA.
+*/
+void drv_hash_reset(hi_u32 chn_num);
+
+/**
+\brief  compute a block hmac.
+\param[in]  din block data.
+\param[out] hamc The output.
+\retval     On received interception, HI_TRUE is returned  otherwise HI_FALSE is returned.
+*/
+hi_s32 drv_hmac256_block(hi_u32 *din, hi_u32 *hamc);
+
+/**
+\brief  get the hash capacity.
+\param[out] capacity The hash capacity.
+\retval     NA.
+*/
+void drv_hash_get_capacity(hash_capacity *capacity);
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/include/drv_osal_chip.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/include/drv_osal_chip.h
@@ -1,0 +1,47 @@
+#ifndef __DRV_OSAL_CHIP_H__
+#define __DRV_OSAL_CHIP_H__
+
+#if defined(CHIP_TYPE_hi3559av100es)
+#include "drv_osal_hi3559aes.h"
+
+#elif defined(CHIP_TYPE_hi3559av100)
+#include "drv_osal_hi3559.h"
+
+#elif defined(CHIP_TYPE_hi3519av100)
+#include "drv_osal_hi3519av100.h"
+
+#elif defined(CHIP_TYPE_hi3516cv500)
+#include "drv_osal_hi3516cv500.h"
+
+#elif defined(CHIP_TYPE_hi3516ev200)
+#include "drv_osal_hi3516ev200.h"
+
+#else
+#error You need to define a configuration file for chip !
+#endif
+
+#if defined(CHIP_HASH_VER_V100) || defined(CHIP_HASH_VER_V200)
+#define CHIP_HASH_SUPPORT
+#endif
+
+#if defined(CHIP_SYMC_VER_V100) || defined(CHIP_SYMC_VER_V200)
+#define CHIP_SYMC_SUPPORT
+#endif
+
+#if defined(CHIP_TRNG_VER_V100) || defined(CHIP_TRNG_VER_V200)
+#define CHIP_TRNG_SUPPORT
+#endif
+
+#if defined(CHIP_IFEP_RSA_VER_V100) || defined(CHIP_SIC_RSA_VER_V100)
+#define CHIP_RSA_SUPPORT
+#endif
+
+#if defined(CHIP_HDCP_VER_V100) || defined(CHIP_HDCP_VER_V200)
+#define CHIP_HDCP_SUPPORT
+#endif
+
+#if defined(CHIP_SM2_VER_V100)
+#define CHIP_SM2_SUPPORT
+#endif
+
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/include/drv_srsa.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/include/drv_srsa.h
@@ -1,0 +1,92 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_srsa.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __DRV_RSA_H__
+#define __DRV_RSA_H__
+
+/*************************** Structure Definition ****************************/
+/** \addtogroup     rsa */
+/** @{ */  /** <!-- [rsa] */
+
+/*! Define RSA 1024 key length */
+#define RSA_KEY_LEN_1024             128
+
+/*! Define RSA 2048 key length */
+#define RSA_KEY_LEN_2048             256
+
+/*! Define RSA 3072 key length */
+#define RSA_KEY_LEN_3072             384
+
+/*! Define RSA 4096 key length */
+#define RSA_KEY_LEN_4096             512
+
+/*! \rsa capacity, 0-nonsupport, 1-support */
+typedef struct {
+    hi_u32 rsa         : 1 ;    /*!<  Support RSA */
+} rsa_capacity;
+
+/*! \rsa key width */
+typedef enum {
+    RSA_KEY_WIDTH_1024 = 0x00, /*!<  RSA 1024  */
+    RSA_KEY_WIDTH_2048,        /*!<  RSA 2048  */
+    RSA_KEY_WIDTH_4096,        /*!<  RSA 4096  */
+    RSA_KEY_WIDTH_3072,        /*!<  RSA 3072  */
+    RSA_KEY_WIDTH_COUNT,
+} rsa_key_width;
+
+/** @} */  /** <!-- ==== Structure Definition end ==== */
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      rsa */
+/** @{ */  /** <!--[rsa]*/
+
+
+/**
+\brief  Initialize the rsa module.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_rsa_init(void);
+
+/**
+\brief  Deinitialize the rsa module.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_rsa_deinit(void);
+
+/**
+\brief  RSA encrypt/decrypt use rsa exponent-modular arithmetic.
+\param[in]  n The N of rsa key.
+\param[in]  k The d/e of rsa key.
+\param[in]  in The input data.
+\param[out] out The input data.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_ifep_rsa_exp_mod(hi_u32 ca_type, hi_u8 *n, hi_u8 *k, hi_u8 *in, hi_u8 *out, rsa_key_width width);
+
+/**
+\brief  get the hash capacity.
+\param[out] capacity The hash capacity.
+\retval     NA.
+*/
+void drv_ifep_rsa_get_capacity(rsa_capacity *capacity);
+
+/**
+\brief  get the hash capacity.
+\param[out] capacity The hash capacity.
+\retval     NA.
+*/
+void drv_sic_rsa_get_capacity(rsa_capacity *capacity);
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/include/drv_symc.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/include/drv_symc.h
@@ -1,0 +1,443 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_symc.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __DRV_CIPHER_H__
+#define __DRV_CIPHER_H__
+
+/*************************** Structure Definition ****************************/
+/** \addtogroup     symmetric cipher */
+/** @{ */  /** <!-- [symc] */
+
+/*! \symmetric cipher max key size in words */
+#define SYMC_KEY_MAX_SIZE_IN_WORD      (8)
+
+/*! \symmetric cipher max iv size in word */
+#define SYMC_IV_MAX_SIZE_IN_WORD       (4)
+
+/*! \symmetric sm1 sk size in words */
+#define SYMC_SM1_SK_SIZE_IN_WORD       (4)
+
+/*! \DES BLOCK size */
+#define DES_BLOCK_SIZE                 (8)
+
+/*! \Numbers of nodes list */
+#define SYMC_MAX_LIST_NUM              (16)
+
+/*! \Length of CCM N */
+#define SYMC_CCM_N_LEN                 (16)
+
+/*! \Length of CCM A head */
+#define SYMC_CCM_A_HEAD_LEN            (16)
+
+/*! \Length of GCM CLEN */
+#define SYMC_GCM_CLEN_LEN              (16)
+
+/*! \Small length of CCM A  */
+#define SYMC_CCM_A_SMALL_LEN           (0x10000 - 0x100)
+
+/*! \AES KEY size 128bit*/
+#define AES_KEY_128BIT                 (16)
+
+/*! \AES KEY size 192bit*/
+#define AES_KEY_192BIT                 (24)
+
+/*! \AES KEY size 256bit*/
+#define AES_KEY_256BIT                 (32)
+
+/*! \DES KEY size 128bit*/
+#define DES_KEY_SIZE                   (8)
+
+/*! \TDES KEY size 128bit*/
+#define TDES_KEY_128BIT                (16)
+
+/*! \TDES KEY size 192bit*/
+#define TDES_KEY_192BIT                (24)
+
+/*! \DES block size*/
+#define DES_BLOCK_SIZE                 (8)
+
+/*! \SM1 KEY size */
+#define SM1_AK_EK_SIZE                 (32)
+#define SM1_SK_SIZE                    (16)
+
+/*! \SM4 KEY size */
+#define SM4_KEY_SIZE                   (16)
+
+/*! \symmetric cipher width */
+typedef enum {
+    SYMC_DAT_WIDTH_128 = 0,
+    SYMC_DAT_WIDTH_8,
+    SYMC_DAT_WIDTH_1,
+    SYMC_DAT_WIDTH_64 = 3,
+    SYMC_DAT_WIDTH_COUNT,
+} symc_width;
+
+/*! \symmetric cipher algorithm */
+typedef enum {
+    SYMC_ALG_DES,         /*!<  Data Encryption Standard  */
+    SYMC_ALG_TDES,        /*!<  Triple Data Encryption Standard  */
+    SYMC_ALG_AES,         /*!<  Advanced Encryption Standard  */
+    SYMC_ALG_SM4,         /*!<  SM4 Algorithm  */
+    SYMC_ALG_SM1,         /*!<  SM1 Algorithm  */
+    SYMC_ALG_NULL_CIPHER, /*!<  null cipher, dma copy  */
+    SYMC_ALG_COUNT,
+} symc_alg;
+
+/*! \symmetric cipher key length */
+typedef enum {
+    SYMC_KEY_DEFAULT = 0,   /*!<  Default, aes-128, 3des-192, sm1-256, sm4-128 */
+    SYMC_KEY_AES_192BIT,        /*!<  AES 192 bit key */
+    SYMC_KEY_AES_256BIT,        /*!<  AES 256 bit key */
+    SYMC_KEY_TDES_2KEY,         /*!<  3DES 128 bit key */
+    SYMC_KEY_LEN_COUNT,
+} symc_klen;
+
+/*! \symmetric cipher mode */
+typedef enum {
+    SYMC_MODE_ECB = 0, /*!<  Electronic Codebook Mode */
+    SYMC_MODE_CBC,     /*!<  Cipher Block Chaining */
+    SYMC_MODE_CFB,     /*!<  Cipher Feedback Mode */
+    SYMC_MODE_OFB,     /*!<  Output Feedback Mode */
+    SYMC_MODE_CTR,     /*!<  Counter Mode */
+    SYMC_MODE_CCM,     /*!<  Counter with Cipher Block Chaining-Message Authentication Code */
+    SYMC_MODE_GCM,     /*!<  Galois/Counter Mode */
+    SYMC_MODE_CTS,     /*!<  CTS Mode */
+    SYMC_MODE_COUNT,
+} symc_mode;
+
+/*! \locational of buffer under symmetric cipher */
+typedef enum {
+    SYMC_NODE_USAGE_NORMAL = 0x00,  /*!<  The normal buffer, don't update the iv */
+    SYMC_NODE_USAGE_FIRST = 0x01,   /*!<  The first buffer, the usage of iv is expired */
+    SYMC_NODE_USAGE_LAST  = 0x02,   /*!<  The last buffer, must update the iv */
+    SYMC_NODE_USAGE_ODD_KEY = 0x40, /*!<  Use the odd key to encrypt/decrypt this buffer*/
+    SYMC_NODE_USAGE_EVEN_KEY = 0x00,/*!<  Use the even key to encrypt/decrypt this buffer*/
+    SYMC_NODE_USAGE_IN_GCM_A    = 0x00, /*!<  The buffer of GCM A */
+    SYMC_NODE_USAGE_IN_GCM_P    = 0x08, /*!<  The buffer of GCM P */
+    SYMC_NODE_USAGE_IN_GCM_LEN  = 0x10, /*!<  The buffer of GCM LEN */
+    SYMC_NODE_USAGE_IN_CCM_N    = 0x00, /*!<  The buffer of CCM N */
+    SYMC_NODE_USAGE_IN_CCM_A    = 0x08, /*!<  The buffer of CCM A */
+    SYMC_NODE_USAGE_IN_CCM_P    = 0x10, /*!<  The buffer of CCM P */
+    SYMC_NODE_USAGE_CCM_LAST    = 0x20, /*!<  The buffer of CCM LAST */
+} symc_node_usage;
+
+/*! \symc error code */
+enum symc_error_code {
+    HI_SYMC_ERR_ALG_INVALID = HI_BASE_ERR_BASE_SYMC, /*!<  invalid algorithm */
+    HI_SYMC_ERR_MODE_INVALID,       /*!<  invalid mode */
+    HI_SYMC_ERR_LEN_INVALID,        /*!<  data length invalid */
+    HI_SYMC_ERR_IV_LEN_INVALID,     /*!<  IV length invalid */
+    HI_SYMC_ERR_TAG_LEN_INVALID,    /*!<  TAG length invalid */
+    HI_SYMC_ERR_KEY_LEN_INVALID,    /*!<  key length invalid */
+    HI_SYMC_ERR_KEY_INVALID,        /*!<  key invalid */
+    HI_SYMC_ERR_ID_INVALID,         /*!<  channel id invalid */
+    HI_SYMC_ERR_SMMU_INVALID,       /*!<  SMMU invalid */
+    HI_SYMC_ERR_TIME_OUT,           /*!<  encrypt/decrypt timeout */
+    HI_SYMC_ERR_BUSY,               /*!<  busy */
+};
+
+typedef struct {
+    hi_u32 id;
+    char *open;
+    char *alg;
+    char *mode;
+    hi_u32 klen;
+    char *ksrc;
+    hi_u8 decrypt;
+    hi_u32 inlen;
+    hi_u32 inaddr;
+    hi_u32 outlen;
+    hi_u32 outaddr;
+    hi_u8 intswitch;
+    hi_u8 inten;
+    hi_u8 inraw;
+    hi_u8 outen;
+    hi_u8 outraw;
+    hi_u32 outintcnt;
+    char  iv[AES_IV_SIZE * 2 + 1];
+} symc_chn_status;
+
+/*! \symc capacity, 0-nonsupport, 1-support */
+typedef struct {
+    hi_u32 aes_ecb     : 1 ;    /*!<  Support AES ECB  */
+    hi_u32 aes_cbc     : 1 ;    /*!<  Support AES CBC  */
+    hi_u32 aes_cfb     : 1 ;    /*!<  Support AES CFB  */
+    hi_u32 aes_ofb     : 1 ;    /*!<  Support AES OFB  */
+    hi_u32 aes_ctr     : 1 ;    /*!<  Support AES CTR  */
+    hi_u32 aes_ccm     : 1 ;    /*!<  Support AES CCM  */
+    hi_u32 aes_gcm     : 1 ;    /*!<  Support AES GCM  */
+    hi_u32 aes_cts     : 1 ;    /*!<  Support AES CTS  */
+    hi_u32 tdes_ecb    : 1 ;    /*!<  Support TDES ECB */
+    hi_u32 tdes_cbc    : 1 ;    /*!<  Support TDES CBC */
+    hi_u32 tdes_cfb    : 1 ;    /*!<  Support TDES CFB */
+    hi_u32 tdes_ofb    : 1 ;    /*!<  Support TDES OFB */
+    hi_u32 tdes_ctr    : 1 ;    /*!<  Support TDES CTR */
+    hi_u32 des_ecb     : 1 ;    /*!<  Support DES ECB */
+    hi_u32 des_cbc     : 1 ;    /*!<  Support DES CBC */
+    hi_u32 des_cfb     : 1 ;    /*!<  Support DES CFB */
+    hi_u32 des_ofb     : 1 ;    /*!<  Support DES OFB */
+    hi_u32 des_ctr     : 1 ;    /*!<  Support DES CTR */
+    hi_u32 sm1_ecb     : 1 ;    /*!<  Support SM1 ECB  */
+    hi_u32 sm1_cbc     : 1 ;    /*!<  Support SM1 CBC  */
+    hi_u32 sm1_cfb     : 1 ;    /*!<  Support SM1 CFB  */
+    hi_u32 sm1_ofb     : 1 ;    /*!<  Support SM1 OFB  */
+    hi_u32 sm1_ctr     : 1 ;    /*!<  Support SM1 CTR  */
+    hi_u32 sm4_ecb     : 1 ;    /*!<  Support SM4 ECB  */
+    hi_u32 sm4_cbc     : 1 ;    /*!<  Support SM4 CBC  */
+    hi_u32 sm4_cfb     : 1 ;    /*!<  Support SM4 CFB  */
+    hi_u32 sm4_ofb     : 1 ;    /*!<  Support SM4 OFB  */
+    hi_u32 sm4_ctr     : 1 ;    /*!<  Support SM4 CTR  */
+    hi_u32 dma         : 1 ;    /*!<  Support DMA  */
+} symc_capacity;
+
+typedef hi_s32 (*callback_symc_isr)(void *ctx);
+typedef void (*callback_symc_destory)(void);
+
+/** @} */  /** <!-- ==== Structure Definition end ==== */
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      symc */
+/** @{ */  /** <!--[symc]*/
+
+
+/**
+\brief  Initialize the symc module.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_symc_init(void);
+
+/**
+\brief  Deinitialize the symc module.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_symc_deinit(void);
+
+/**
+\brief  suspend the symc module.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+void drv_symc_suspend(void);
+
+/**
+\brief  resume the symc module.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_symc_resume(void);
+
+/**
+\brief  allocate a hard symc channel.
+\param[out]  chn_num The channel number.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_symc_alloc_chn(hi_u32 *chn_num);
+
+/**
+\brief  free a hard symc channel.
+\param[in]  chn_num The channel number.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+void drv_symc_free_chn(hi_u32 chn_num);
+
+/**
+\brief  set the iv to the symc module.
+\param[in]  chn_num The channel number.
+\retval     NA.
+*/
+hi_s32 drv_symc_reset(hi_u32 chn_num);
+
+/**
+\brief  check the length of nodes list.
+\param[in]  alg The symmetric cipher algorithm.
+\param[in]  mode The symmetric cipher mode.
+\param[in]  block_size The block size.
+\param[in]  input The MMZ/SMMU address of in buffer.
+\param[in]  output The MMZ/SMMU address of out buffer.
+\param[in]  length The MMZ/SMMU siae of in buffer.
+\param[in]  klen The key length.
+\param[in]  usage_list The usage of node.
+\param[in]  pkg_num The numbers of node.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_symc_node_check(symc_alg alg, symc_mode mode,
+                        symc_klen klen, hi_u32 block_size,
+                        compat_addr input[],
+                        compat_addr output[],
+                        hi_u32 length[],
+                        symc_node_usage usage_list[],
+                        hi_u32 pkg_num);
+
+/**
+\brief  set work params.
+\param[in]  chn_num The channel number.
+\param[in]  alg The symmetric cipher algorithm.
+\param[in]  mode The symmetric cipher mode.
+\param[in]  decrypt Decrypt or encrypt.
+\param[in]  sm1_round_num The round number of sm1.
+\param[in]  klen The key length.
+\param[in]  hard_key whether use the hard key or not.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_symc_config(hi_u32 chn_num, symc_alg alg, symc_mode mode, symc_width width, hi_u32 decrypt,
+                    hi_u32 sm1_round_num, symc_klen klen, hi_u32 hard_key);
+
+/**
+\brief  set the iv to the symc module.
+\param[in]  chn_num The channel number.
+\param[in]  iv The IV data, hardware use the valid bytes according to the alg.
+\param[in]  flag The IV flag, should be CIPHER_IV_CHANGE_ONE_PKG or CIPHER_IV_CHANGE_ALL_PKG.
+\retval     NA.
+*/
+hi_s32 drv_symc_set_iv(hi_u32 chn_num, hi_u32 iv[SYMC_IV_MAX_SIZE_IN_WORD], hi_u32 ivlen, hi_u32 flag);
+
+/**
+\brief  get the iv to the symc module.
+\param[in]  chn_num The channel number.
+\param[out] iv The IV data, the length is 16.
+\retval     NA.
+*/
+void drv_symc_get_iv(hi_u32 chn_num, hi_u32 iv[SYMC_IV_MAX_SIZE_IN_WORD]);
+
+/**
+\brief  set the key to the symc module.
+\param[in]  chn_num The channel number.
+\param[in]  key The key data, hardware use the valid bytes according to the alg.
+\param[in]  odd This id odd key or not .
+\retval     NA.
+*/
+void drv_symc_set_key(hi_u32 chn_num, hi_u32 key[SYMC_KEY_MAX_SIZE_IN_WORD], hi_u32 odd);
+
+/**
+\brief  set the sm1 sk to the symc module.
+\param[in]  chn_num The channel number.
+\param[in]  key The sk data, the length is 16.
+\retval     NA.
+*/
+void drv_symc_set_sm1_sk(hi_u32 chn_num, hi_u32 key[SYMC_SM1_SK_SIZE_IN_WORD]);
+
+/**
+\brief  add a in buffer to the nodes list.
+\param[in]  chn_num The channel number.
+\param[in]  buf_phy The MMZ/SMMU address of in buffer.
+\param[in]  buf_size The MMZ/SMMU siae of in buffer.
+\param[in]  local The locational of in buffer under a symmetric cipher.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_symc_add_inbuf(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size, symc_node_usage usage);
+
+/**
+\brief  add a out buffer to the nodes list.
+\param[in]  chn_num The channel number.
+\param[in]  buf_phy The MMZ/SMMU address of out buffer.
+\param[in]  buf_size The MMZ/SMMU siae of out buffer.
+\param[in]  local The locational of in buffer under a symmetric cipher.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_symc_add_outbuf(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size, symc_node_usage usage);
+
+/**
+\brief  add a buffer usage to the nodes list.
+\param[in]  chn_num The channel number.
+\param[in]  in in or out.
+\param[in]  usage uasge.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+void drv_symc_add_buf_usage(hi_u32 chn_num, hi_u32 in, symc_node_usage usage);
+
+/**
+\brief  add N of CCM to the nodes list.
+\param[in]  chn_num The channel number.
+\param[in]  n The buffer of n, the size is 16.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_aead_ccm_add_n(hi_u32 chn_num, hi_u8 *n);
+
+/**
+\brief  add A of CCM to the nodes list.
+\param[in]  chn_num The channel number.
+\param[in]  buf_phy The MMZ/SMMU address of A.
+\param[in]  buf_size The MMZ/SMMU size of A.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_aead_ccm_add_a(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size);
+
+/**
+\brief  add A of GCM to the nodes list.
+\param[in]  chn_num The channel number.
+\param[in]  buf_phy The MMZ/SMMU address of A.
+\param[in]  buf_size The MMZ/SMMU size of A.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_aead_gcm_add_a(hi_u32 chn_num, compat_addr buf_phy, hi_u32 buf_size);
+
+/**
+\brief  add length field of GCM to the nodes list.
+\param[in]  chn_num The channel number.
+\param[in]  buf_phy The MMZ/SMMU address of length field, the size is 16.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_aead_gcm_add_clen(hi_u32 chn_num, hi_u8 *clen);
+
+/**
+\brief  get ccm/gcm tag.
+\param[in]   chn_num The channel number.
+\param[out]  tag The tag value.
+\retval     On received interception, HI_TRUE is returned  otherwise HI_FALSE is returned.
+*/
+hi_s32 drv_aead_get_tag(hi_u32 chn_num, hi_u32 *tag);
+
+/**
+\brief  start symmetric cipher calculation.
+\param[in]  chn_num The channel number.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_symc_start(hi_u32 chn_num);
+
+/**
+\brief  wait running finished.
+\param[in]  chn_num The channel number.
+\retval     On received interception, HI_TRUE is returned  otherwise HI_FALSE is returned.
+*/
+hi_s32 drv_symc_wait_done(hi_u32 chn_num, hi_u32 timeout);
+
+/**
+\brief  set isr callback function.
+\param[in]  chn_num The channel number.
+\retval     On finished, HI_TRUE is returned otherwise HI_FALSE is returned.
+*/
+hi_s32 drv_symc_set_isr_callback(hi_u32 chn_num, callback_symc_isr callback, void *ctx);
+
+/**
+\brief  set destory callback function.
+\param[in]  chn_num The channel number.
+\retval     On finished, HI_TRUE is returned otherwise HI_FALSE is returned.
+*/
+hi_s32 drv_symc_set_destory_callbcak(hi_u32 chn_num, callback_symc_destory destory);
+
+/**
+\brief  proc status.
+\param[in]  status The  proc status.
+\retval     On received interception, HI_TRUE is returned  otherwise HI_FALSE is returned.
+*/
+hi_s32 drv_symc_proc_status(symc_chn_status *status);
+
+/**
+\brief  get the symc capacity.
+\param[out] capacity The symc capacity.
+\retval     NA.
+*/
+void drv_symc_get_capacity(symc_capacity *capacity);
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/include/drv_trng.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/include/drv_trng.h
@@ -1,0 +1,50 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_trng.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __DRV_TRNG_H__
+#define __DRV_TRNG_H__
+
+/*************************** Structure Definition ****************************/
+/** \addtogroup     rsa */
+/** @{ */  /** <!-- [rsa] */
+
+/*! \rsa capacity, 0-nonsupport, 1-support */
+typedef struct {
+    hi_u32 trng         : 1 ;    /*!<  Support TRNG */
+} trng_capacity;
+
+/** @} */  /** <!-- ==== Structure Definition end ==== */
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      trng */
+/** @{ */  /** <!--[trng]*/
+
+
+/**
+\brief get rand number.
+\param[out]  randnum rand number.
+\param[in]   timeout time out.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 drv_trng_randnum(hi_u32 *randnum, hi_u32 timeout);
+
+/**
+\brief  get the trng capacity.
+\param[out] capacity The hash capacity.
+\retval     NA.
+*/
+void drv_trng_get_capacity(trng_capacity *capacity);
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_hash.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_hash.c
@@ -1,0 +1,779 @@
+/******************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : cryp_hash.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "drv_hash.h"
+#include "cryp_hash.h"
+#include "ext_alg.h"
+
+/*************************** Internal Structure Definition *******************/
+/** \addtogroup      rsa */
+/** @{*/  /** <!-- [rsa]*/
+
+/* size of hash physical memory */
+#define HASH_PHY_MEM_SIZE             (0x100000)/* 1M */
+
+/* try to create memory for HASH */
+#define HASH_PHY_MEM_CREATE_TRY_TIME  (10)
+
+/* block size */
+#define SHA1_BLOCK_SIZE            (64)   /* SHA1 */
+#define SHA224_BLOCK_SIZE          (64)   /* SHA224 */
+#define SHA256_BLOCK_SIZE          (64)   /* SHA256 */
+#define SHA384_BLOCK_SIZE          (128)  /* SHA384 */
+#define SHA512_BLOCK_SIZE          (128)  /* SHA512 */
+#define SM3_BLOCK_SIZE             (64)   /* SM3 */
+
+/* first byte of hash padding */
+#define HASH_PADDING_B0               (0x80)
+
+/* Pading size */
+#define HASH_BLOCK64_PAD_MIN       (9)    /* 0x80 || Len(64)  */
+#define HASH_BLOCK128_PAD_MIN      (17)   /* 0x80 || Len(128) */
+
+/* The max tab size of symc function */
+#define HASH_FUNC_TAB_SIZE          (16)
+
+/* SHA-1, the initial hash value, H(0)*/
+#define SHA1_H0     0x67452301
+#define SHA1_H1     0xefcdab89
+#define SHA1_H2     0x98badcfe
+#define SHA1_H3     0x10325476
+#define SHA1_H4     0xc3d2e1f0
+
+/* SHA-224, the initial hash value, H(0)*/
+#define SHA224_H0    0xc1059ed8
+#define SHA224_H1    0x367cd507
+#define SHA224_H2    0x3070dd17
+#define SHA224_H3    0xf70e5939
+#define SHA224_H4    0xffc00b31
+#define SHA224_H5    0x68581511
+#define SHA224_H6    0x64f98fa7
+#define SHA224_H7    0xbefa4fa4
+
+/* SHA-256, the initial hash value, H(0)*/
+#define SHA256_H0    0x6a09e667
+#define SHA256_H1    0xbb67ae85
+#define SHA256_H2    0x3c6ef372
+#define SHA256_H3    0xa54ff53a
+#define SHA256_H4    0x510e527f
+#define SHA256_H5    0x9b05688c
+#define SHA256_H6    0x1f83d9ab
+#define SHA256_H7    0x5be0cd19
+
+/* SHA-384, the initial hash value, H(0)*/
+#define SHA384_H0    0xcbbb9d5dc1059ed8ULL
+#define SHA384_H1    0x629a292a367cd507ULL
+#define SHA384_H2    0x9159015a3070dd17ULL
+#define SHA384_H3    0x152fecd8f70e5939ULL
+#define SHA384_H4    0x67332667ffc00b31ULL
+#define SHA384_H5    0x8eb44a8768581511ULL
+#define SHA384_H6    0xdb0c2e0d64f98fa7ULL
+#define SHA384_H7    0x47b5481dbefa4fa4ULL
+
+/* SHA-512, the initial hash value, H(0)*/
+#define SHA512_H0    0x6a09e667f3bcc908ULL
+#define SHA512_H1    0xbb67ae8584caa73bULL
+#define SHA512_H2    0x3c6ef372fe94f82bULL
+#define SHA512_H3    0xa54ff53a5f1d36f1ULL
+#define SHA512_H4    0x510e527fade682d1ULL
+#define SHA512_H5    0x9b05688c2b3e6c1fULL
+#define SHA512_H6    0x1f83d9abfb41bd6bULL
+#define SHA512_H7    0x5be0cd19137e2179ULL
+
+/* SM3, the initial hash value, H(0)*/
+#define SM3_H0    0x7380166F
+#define SM3_H1    0x4914B2B9
+#define SM3_H2    0x172442D7
+#define SM3_H3    0xDA8A0600
+#define SM3_H4    0xA96F30BC
+#define SM3_H5    0x163138AA
+#define SM3_H6    0xE38DEE4D
+#define SM3_H7    0xB0FB0E4E
+
+/* hash function list */
+static hash_func hash_descriptor[HASH_FUNC_TAB_SIZE];
+
+#ifdef CHIP_HASH_SUPPORT
+/**
+ * \brief          hash context structure
+ */
+typedef struct {
+    hash_mode mode;    /*!<  HASH mode */
+    hi_u32 block_size;    /*!<  HASH block size */
+    hi_u32 hash_size;     /*!<  HASH result size */
+    hi_u32 hard_chn;      /*!<  HASH hardware channel number */
+    hi_u8 tail[HASH_BLOCK_SIZE_128 * 2]; /*!<  buffer to store the tail and padding data */
+    hi_u32 tail_len;                  /*!<  length of the tail message */
+    hi_u32 total;                    /*!<  total length of the message */
+    hi_u32 hash[HASH_RESULT_MAX_SIZE_IN_WORD]; /*!<  buffer to store the result */
+    crypto_mem mem;    /*!<  DMA memory of hash message */
+}
+cryp_hash_context;
+
+/* hash dma memory */
+static crypto_mem hash_mem;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      hash drivers*/
+/** @{*/  /** <!-- [hash]*/
+
+static hi_s32 cryp_hash_initial(cryp_hash_context *hisi_ctx, hash_mode mode)
+{
+#ifndef CHIP_TYPE_hi3516ev200
+    hi_u64 H0;
+#endif
+
+    HI_LOG_FUNC_ENTER();
+
+    switch (mode) {
+        case HASH_MODE_SHA1: {
+            hisi_ctx->block_size = SHA1_BLOCK_SIZE;
+            hisi_ctx->hash_size = SHA1_RESULT_SIZE;
+            hisi_ctx->hash[0] = CPU_TO_BE32(SHA1_H0);
+            hisi_ctx->hash[1] = CPU_TO_BE32(SHA1_H1);
+            hisi_ctx->hash[2] = CPU_TO_BE32(SHA1_H2);
+            hisi_ctx->hash[3] = CPU_TO_BE32(SHA1_H3);
+            hisi_ctx->hash[4] = CPU_TO_BE32(SHA1_H4);
+            break;
+        }
+        case HASH_MODE_SHA224: {
+            hisi_ctx->hash_size = SHA224_RESULT_SIZE;
+            hisi_ctx->block_size = SHA224_BLOCK_SIZE;
+            hisi_ctx->hash[0] = CPU_TO_BE32(SHA224_H0);
+            hisi_ctx->hash[1] = CPU_TO_BE32(SHA224_H1);
+            hisi_ctx->hash[2] = CPU_TO_BE32(SHA224_H2);
+            hisi_ctx->hash[3] = CPU_TO_BE32(SHA224_H3);
+            hisi_ctx->hash[4] = CPU_TO_BE32(SHA224_H4);
+            hisi_ctx->hash[5] = CPU_TO_BE32(SHA224_H5);
+            hisi_ctx->hash[6] = CPU_TO_BE32(SHA224_H6);
+            hisi_ctx->hash[7] = CPU_TO_BE32(SHA224_H7);
+            break;
+        }
+        case HASH_MODE_SHA256: {
+            hisi_ctx->hash_size = SHA256_RESULT_SIZE;
+            hisi_ctx->block_size = SHA256_BLOCK_SIZE;
+            hisi_ctx->hash[0] = CPU_TO_BE32(SHA256_H0);
+            hisi_ctx->hash[1] = CPU_TO_BE32(SHA256_H1);
+            hisi_ctx->hash[2] = CPU_TO_BE32(SHA256_H2);
+            hisi_ctx->hash[3] = CPU_TO_BE32(SHA256_H3);
+            hisi_ctx->hash[4] = CPU_TO_BE32(SHA256_H4);
+            hisi_ctx->hash[5] = CPU_TO_BE32(SHA256_H5);
+            hisi_ctx->hash[6] = CPU_TO_BE32(SHA256_H6);
+            hisi_ctx->hash[7] = CPU_TO_BE32(SHA256_H7);
+            break;
+        }
+#ifndef CHIP_TYPE_hi3516ev200
+        case HASH_MODE_SHA384: {
+            hisi_ctx->hash_size = SHA384_RESULT_SIZE;
+            hisi_ctx->block_size = SHA384_BLOCK_SIZE;
+            H0 = CPU_TO_BE64(SHA384_H0);
+            crypto_memcpy(&hisi_ctx->hash[0], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA384_H1);
+            crypto_memcpy(&hisi_ctx->hash[2], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA384_H2);
+            crypto_memcpy(&hisi_ctx->hash[4], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA384_H3);
+            crypto_memcpy(&hisi_ctx->hash[6], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA384_H4);
+            crypto_memcpy(&hisi_ctx->hash[8], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA384_H5);
+            crypto_memcpy(&hisi_ctx->hash[10], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA384_H6);
+            crypto_memcpy(&hisi_ctx->hash[12], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA384_H7);
+            crypto_memcpy(&hisi_ctx->hash[14], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            break;
+        }
+        case HASH_MODE_SHA512: {
+            hisi_ctx->hash_size = SHA512_RESULT_SIZE;
+            hisi_ctx->block_size = SHA512_BLOCK_SIZE;
+            H0 = CPU_TO_BE64(SHA512_H0);
+            crypto_memcpy(&hisi_ctx->hash[0], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA512_H1);
+            crypto_memcpy(&hisi_ctx->hash[2], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA512_H2);
+            crypto_memcpy(&hisi_ctx->hash[4], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA512_H3);
+            crypto_memcpy(&hisi_ctx->hash[6], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA512_H4);
+            crypto_memcpy(&hisi_ctx->hash[8], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA512_H5);
+            crypto_memcpy(&hisi_ctx->hash[10], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA512_H6);
+            crypto_memcpy(&hisi_ctx->hash[12], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            H0 = CPU_TO_BE64(SHA512_H7);
+            crypto_memcpy(&hisi_ctx->hash[14], DOUBLE_WORD_WIDTH, &H0, sizeof(H0));
+            break;
+        }
+#endif
+        case HASH_MODE_SM3: {
+            hisi_ctx->hash_size = SM3_RESULT_SIZE;
+            hisi_ctx->block_size = SM3_BLOCK_SIZE;
+            hisi_ctx->hash[0] = CPU_TO_BE32(SM3_H0);
+            hisi_ctx->hash[1] = CPU_TO_BE32(SM3_H1);
+            hisi_ctx->hash[2] = CPU_TO_BE32(SM3_H2);
+            hisi_ctx->hash[3] = CPU_TO_BE32(SM3_H3);
+            hisi_ctx->hash[4] = CPU_TO_BE32(SM3_H4);
+            hisi_ctx->hash[5] = CPU_TO_BE32(SM3_H5);
+            hisi_ctx->hash[6] = CPU_TO_BE32(SM3_H6);
+            hisi_ctx->hash[7] = CPU_TO_BE32(SM3_H7);
+            break;
+        }
+        default: {
+            HI_LOG_ERROR("Invalid hash mode, mode = 0x%x.\n", mode);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+* \brief          Create DMA memory of HASH message
+*/
+static hi_s32 cryp_hash_create_mem(hi_void)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 i = 0;
+    hi_u32 length = HASH_PHY_MEM_SIZE;
+
+    HI_LOG_FUNC_ENTER();
+
+    crypto_memset(&hash_mem, sizeof(hash_mem), 0x00, sizeof(hash_mem));
+
+    /* Try to alloc memory, halve the length if failed */
+    for (i = 0; i < HASH_PHY_MEM_CREATE_TRY_TIME; i++) {
+        ret = hash_mem_create(&hash_mem, SEC_MMZ, "hash_msg_dma", length);
+        if (ret == HI_SUCCESS) {
+            return HI_SUCCESS;
+        } else {
+            /* halve the length */
+            length /= 0x02;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_ERR_CIPHER_FAILED_MEM;
+}
+
+static hi_s32 cryp_hash_destory_mem(hi_void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    ret = hash_mem_destory(&hash_mem);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(crypto_mem_destory, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_hash_chunk_copy(const hi_void *chunk, hi_void *dma, hi_u32 len, hash_chunk_src src)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* Don't process the empty message */
+    if (len == 0x00) {
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    HI_LOG_CHECK_PARAM(chunk == HI_NULL);
+    HI_LOG_CHECK_PARAM(dma   == HI_NULL);
+
+    if (src == HASH_CHUNCK_SRC_LOCAL) {
+        crypto_memcpy(dma, len, chunk, len);
+    } else {
+        ret = crypto_copy_from_user(dma, chunk, len);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(crypto_copy_from_user, ret);
+            return ret;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/* hash hardware computation */
+static hi_s32 cryp_hash_process(cryp_hash_context *hisi_ctx,
+                             hi_u8 *msg, hi_u32 length,
+                             hash_chunk_src src)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_void *buf = HI_NULL;
+    hi_u32 left = 0, size = 0, max = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* Don't process the empty message */
+    if (length == 0x00) {
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    HI_LOG_DEBUG("length 0x%x, dma_size 0x%x\n", length, hisi_ctx->mem.dma_size);
+
+    /* get dma buffer */
+    buf = crypto_mem_virt(&hisi_ctx->mem);
+    left = length;
+
+    /* align at block size */
+    max  = hisi_ctx->mem.dma_size / hisi_ctx->block_size;
+    max *= hisi_ctx->block_size;
+
+    while (left > 0) {
+        if (left <= max) {
+            /* left size less than dma buffer,
+             * can process all left mesaage
+             */
+            size = left;
+        } else {
+            /* left size large than dma buffer,
+             * just process mesaage with dma size
+             */
+            size = max;
+        }
+
+        HI_LOG_DEBUG("msg 0x%p, size 0x%x, left 0x%x, max 0x%x\n", msg, size, left, max);
+
+        /* copy message to dma buffer */
+        ret = cryp_hash_chunk_copy(msg, buf, size, src);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_hash_chunk_copy, ret);
+            goto exit;
+        }
+
+        /* configure mode */
+        ret = drv_hash_config(hisi_ctx->hard_chn, hisi_ctx->mode, hisi_ctx->hash);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_hash_config, ret);
+            goto exit;
+        }
+
+        /* start */
+        ret = drv_hash_start(hisi_ctx->hard_chn, &hisi_ctx->mem, size);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_hash_start, ret);
+            goto exit;
+        }
+
+        /* wait done */
+        ret = drv_hash_wait_done(hisi_ctx->hard_chn, hisi_ctx->hash);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_hash_wait_done, ret);
+            break;
+        }
+
+        /* re-compute left length */
+        left -= size;
+        msg += size;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+exit:
+    return ret;
+}
+
+/* hash message paading to align at block size */
+static hi_u32 cryp_hash_pading(hi_u32 block_size, hi_u8 *msg, hi_u32 tail_size, hi_u32 total)
+{
+    hi_u32 pad_len = 0, min = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* get min padding size */
+    if (block_size == HASH_BLOCK_SIZE_64) {
+        min = HASH_BLOCK64_PAD_MIN;
+    } else {
+        min = HASH_BLOCK128_PAD_MIN;
+    }
+
+    pad_len = block_size - (total % block_size);
+
+    /* if pad len less than min value, add a block */
+    if (pad_len < min) {
+        pad_len += block_size;
+    }
+
+    /* Format(binary): {data|| 0x80 || 00 00 ... || Len(64)} */
+    crypto_memset(&msg[tail_size], HASH_BLOCK_SIZE_128 * 2 - tail_size, 0, pad_len);
+    msg[tail_size] = HASH_PADDING_B0;
+    tail_size += pad_len - 8;
+
+    /* write 8 bytes fix data length * 8 */
+    msg[tail_size++] = 0x00;
+    msg[tail_size++] = 0x00;
+    msg[tail_size++] = 0x00;
+    msg[tail_size++] = (hi_u8)((total >> 29) & 0x07);
+    msg[tail_size++] = (hi_u8)((total >> 21) & 0xff);
+    msg[tail_size++] = (hi_u8)((total >> 13) & 0xff);
+    msg[tail_size++] = (hi_u8)((total >> 5)  & 0xff);
+    msg[tail_size++] = (hi_u8)((total << 3)  & 0xff);
+
+    HI_LOG_FUNC_EXIT();
+
+    return tail_size;
+}
+
+static hi_void *cryp_hash_create(hash_mode mode)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_hash_context *hisi_ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    hisi_ctx = crypto_calloc(1, sizeof(cryp_hash_context));
+    if (hisi_ctx == HI_NULL) {
+        HI_LOG_ERROR("malloc hash context buffer failed!");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+        return HI_NULL;
+    }
+
+    hisi_ctx->mode = mode;
+    hisi_ctx->hard_chn = HASH_HARD_CHANNEL;
+
+    ret = cryp_hash_initial(hisi_ctx, mode);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_hash_initial, ret);
+        goto error1;
+    }
+
+    crypto_memcpy(&hisi_ctx->mem, sizeof(crypto_mem), &hash_mem, sizeof(crypto_mem));
+
+    HI_LOG_FUNC_EXIT();
+
+    return hisi_ctx;
+
+error1:
+    crypto_free(hisi_ctx);
+    hisi_ctx = HI_NULL;
+
+    return HI_NULL;
+}
+
+static hi_s32 cryp_hash_destory(hi_void *ctx)
+{
+    cryp_hash_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+    if (hisi_ctx == HI_NULL) {
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    drv_hash_reset(hisi_ctx->hard_chn);
+    crypto_free(ctx);
+    ctx = HI_NULL;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_hash_update(hi_void *ctx, hi_u8 *chunk, hi_u32 chunkLen, hash_chunk_src src)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_hash_context *hisi_ctx = ctx;
+    hi_u32 inverse_len = 0;
+
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+
+    HI_LOG_DEBUG("last: total 0x%x, block size %d, tail_len %d, chunkLen 0x%x, src %d\n", hisi_ctx->total,
+                 hisi_ctx->block_size, hisi_ctx->tail_len, chunkLen, src);
+
+    /* total len */
+    hisi_ctx->total += chunkLen;
+
+    /* left tail len to make up a block */
+    inverse_len = hisi_ctx->block_size - hisi_ctx->tail_len;
+
+    if (chunkLen  < inverse_len) {
+        /* can't make up a block */
+        inverse_len = chunkLen;
+    }
+
+    /* try to make up the tail data to be a block */
+    ret = cryp_hash_chunk_copy(chunk,
+                               hisi_ctx->tail + hisi_ctx->tail_len,
+                               inverse_len,
+                               src);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_hash_chunk_copy, ret);
+        return ret;
+    }
+    hisi_ctx->tail_len += inverse_len;
+    chunk += inverse_len;
+    chunkLen -= inverse_len;  /* the chunkLen may be zero */
+
+    HI_LOG_DEBUG("new: total 0x%x, tail_len %d, chunkLen 0x%x\n", hisi_ctx->total,
+                 hisi_ctx->tail_len, chunkLen);
+
+    /* process tail block */
+    if (hisi_ctx->tail_len == hisi_ctx->block_size) {
+        ret = cryp_hash_process(hisi_ctx,
+                                hisi_ctx->tail,
+                                hisi_ctx->tail_len,
+                                HASH_CHUNCK_SRC_LOCAL);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_hash_process, ret);
+            return ret;
+        }
+        /* new tail len */
+        hisi_ctx->tail_len = chunkLen % hisi_ctx->block_size;
+
+        /* new chunk len align at block size */
+        chunkLen -= hisi_ctx->tail_len;
+
+        /* save new tail */
+        ret = cryp_hash_chunk_copy(chunk + chunkLen,
+                                   hisi_ctx->tail,
+                                   hisi_ctx->tail_len,
+                                   src);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_hash_chunk_copy, ret);
+            return ret;
+        }
+    }
+
+    HI_LOG_DEBUG("new: total 0x%x, tail_len %d, chunkLen 0x%x\n", hisi_ctx->total,
+                 hisi_ctx->tail_len, chunkLen);
+
+    /* process left block, just resurn HI_SUCCESS if the chunkLen is zero */
+    ret = cryp_hash_process(hisi_ctx, chunk, chunkLen, src);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_hash_process, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_hash_finish(hi_void *ctx,  hi_void *hash, hi_u32 *hashlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_hash_context *hisi_ctx = ctx;
+    hi_u32 left = 0;
+
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+
+    /* padding message */
+    left = cryp_hash_pading(hisi_ctx->block_size,
+                            hisi_ctx->tail,
+                            hisi_ctx->tail_len,
+                            hisi_ctx->total);
+
+    ret = cryp_hash_process(hisi_ctx, hisi_ctx->tail, left, HASH_CHUNCK_SRC_LOCAL);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_hash_process, ret);
+        return ret;
+    }
+
+    crypto_memcpy(hash,
+                  HASH_RESULT_MAX_SIZE,
+                  hisi_ctx->hash,
+                  hisi_ctx->hash_size);
+    *hashlen = hisi_ctx->hash_size;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+#endif
+
+static hi_s32 func_register_hash(hash_func *func)
+{
+    hi_u32 i = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* check availability */
+    if ((func->create  == HI_NULL)
+        || (func->destroy == HI_NULL)
+        || (func->update == HI_NULL)
+        || (func->finish == HI_NULL)) {
+        HI_LOG_ERROR("hash function is null.\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    HI_LOG_DEBUG("register hash mode %d\n", func->mode);
+
+    /* is it already registered? */
+    for (i = 0; i < HASH_FUNC_TAB_SIZE; i++) {
+        if (hash_descriptor[i].valid && hash_descriptor[i].mode == func->mode) {
+            HI_LOG_FUNC_EXIT();
+            return HI_SUCCESS;
+        }
+    }
+
+    /* find a blank spot */
+    for (i = 0; i < HASH_FUNC_TAB_SIZE; i++) {
+        if (!hash_descriptor[i].valid) {
+            hash_descriptor[i] = *func;
+            hash_descriptor[i].valid = HI_TRUE;
+            HI_LOG_FUNC_EXIT();
+            return HI_SUCCESS;
+        }
+    }
+
+    return HI_ERR_CIPHER_INVALID_PARA;
+}
+
+/* hash function register */
+static hi_void cryp_register_hash_default(hi_u32 capacity, hash_mode mode, hi_u32 blocksize, hi_u32 hashlen)
+{
+    hash_func func;
+
+    crypto_memset(&func, sizeof(func), 0 , sizeof(func));
+
+    /* register the hash function if supported */
+    if (capacity) {
+#ifdef CHIP_HASH_SUPPORT
+        func.mode = mode;
+        func.block_size = blocksize;
+        func.size = hashlen;
+        func.create = cryp_hash_create;
+        func.destroy = cryp_hash_destory;
+        func.update = cryp_hash_update;
+        func.finish = cryp_hash_finish;
+        func_register_hash(&func);
+#endif
+    } else if (mode == HASH_MODE_SM3) {
+#if defined(SOFT_SM3_SUPPORT)
+        func.mode = mode;
+        func.block_size = blocksize;
+        func.size = hashlen;
+        func.create = ext_sm3_create;
+        func.destroy = ext_sm3_destory;
+        func.update = ext_sm3_update;
+        func.finish = ext_sm3_finish;
+        func_register_hash(&func);
+#endif
+    } else {
+#if defined(SOFT_SHA1_SUPPORT) \
+    || defined(SOFT_SHA256_SUPPORT) \
+    || defined(SOFT_SHA512_SUPPORT)
+        func.mode = mode;
+        func.block_size = blocksize;
+        func.size = hashlen;
+        func.create = mbedtls_hash_create;
+        func.destroy = mbedtls_hash_destory;
+        func.update = mbedtls_hash_update;
+        func.finish = mbedtls_hash_finish;
+        func_register_hash(&func);
+#endif
+    }
+    return;
+}
+
+/* hash function register */
+static hi_void cryp_register_all_hash(hi_void)
+{
+    hash_capacity capacity;
+
+    crypto_memset(&capacity, sizeof(capacity), 0, sizeof(capacity));
+
+#ifdef CHIP_HASH_SUPPORT
+    /* get hash capacity */
+    drv_hash_get_capacity(&capacity);
+#endif
+
+    cryp_register_hash_default(capacity.sha1, HASH_MODE_SHA1, SHA1_BLOCK_SIZE, SHA1_RESULT_SIZE);
+    cryp_register_hash_default(capacity.sha224, HASH_MODE_SHA224, SHA224_BLOCK_SIZE, SHA224_RESULT_SIZE);
+    cryp_register_hash_default(capacity.sha256, HASH_MODE_SHA256, SHA256_BLOCK_SIZE, SHA256_RESULT_SIZE);
+    cryp_register_hash_default(capacity.sha384, HASH_MODE_SHA384, SHA384_BLOCK_SIZE, SHA384_RESULT_SIZE);
+    cryp_register_hash_default(capacity.sha512, HASH_MODE_SHA512, SHA512_BLOCK_SIZE, SHA512_RESULT_SIZE);
+    cryp_register_hash_default(capacity.sm3, HASH_MODE_SM3, SM3_BLOCK_SIZE, SM3_RESULT_SIZE);
+
+    return;
+}
+
+hash_func *cryp_get_hash(hi_u32 mode)
+{
+    hi_u32 i = 0;
+    hash_func *template = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* find the valid function */
+    for (i = 0; i < HASH_FUNC_TAB_SIZE; i++) {
+        if (hash_descriptor[i].valid) {
+            if (hash_descriptor[i].mode == mode) {
+                template = &hash_descriptor[i];
+                break;
+            }
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return template;
+}
+
+hi_s32 cryp_hash_init(hi_void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    crypto_memset(hash_descriptor, sizeof(hash_descriptor), 0, sizeof(hash_descriptor));
+
+#ifdef CHIP_HASH_SUPPORT
+    {
+        hi_s32 ret = HI_FAILURE;
+
+        ret = drv_hash_init();
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_hash_init, ret);
+            return ret;
+        }
+
+        ret = cryp_hash_create_mem();
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_hash_create_mem, ret);
+            drv_hash_deinit();
+            return ret;
+        }
+    }
+#endif
+
+    /* hash function register */
+    cryp_register_all_hash();
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_void cryp_hash_deinit(hi_void)
+{
+    HI_LOG_FUNC_ENTER();
+
+#ifdef CHIP_HASH_SUPPORT
+    drv_hash_deinit();
+    cryp_hash_destory_mem();
+#endif
+
+    HI_LOG_FUNC_EXIT();
+}
+
+/** @}*/  /** <!-- ==== API Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_rsa.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_rsa.c
@@ -1,0 +1,1038 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : cryp_rsa.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "drv_srsa.h"
+#include "cryp_rsa.h"
+#include "cryp_trng.h"
+#include "mbedtls/rsa.h"
+
+/********************** Internal Structure Definition ************************/
+/** \addtogroup      rsa */
+/** @{*/  /** <!-- [rsa]*/
+
+#define RSA_PKCS1_TYPE_MIN_PAD_LEN               (11)
+#define RSA_BITS_1024                            1024
+#define RSA_BITS_2048                            2048
+#define RSA_BITS_3072                            3072
+#define RSA_BITS_4096                            4096
+
+/*! rsa mutex */
+static crypto_mutex rsa_mutex;
+static hi_u32 rsa_key_ca_type = HI_UNF_CIPHER_KEY_SRC_USER;
+
+#define KAPI_RSA_LOCK()   \
+    ret = crypto_mutex_lock(&rsa_mutex);  \
+    if (ret != HI_SUCCESS)        \
+    {\
+        HI_LOG_ERROR("error, rsa lock failed\n");\
+        HI_LOG_FUNC_EXIT();\
+        return ret;\
+    }
+
+#define KAPI_RSA_UNLOCK()   crypto_mutex_unlock(&rsa_mutex)
+
+/*! \rsa rsa soft function */
+extern int mbedtls_mpi_exp_mod_sw(mbedtls_mpi *X, const mbedtls_mpi *A,
+                                  const mbedtls_mpi *E, const mbedtls_mpi *N,
+                                  mbedtls_mpi *_RR);
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      rsa drivers*/
+/** @{*/  /** <!-- [rsa]*/
+
+void mbedtls_mpi_print(const mbedtls_mpi *X, const char *name)
+{
+#ifdef CIPHER_DEBUG_SUPPORT
+    int ret;
+    size_t n;
+    hi_u8 buf[512] = {0};
+
+    n = mbedtls_mpi_size(X);
+    MBEDTLS_MPI_CHK(mbedtls_mpi_write_binary(X, buf, n));
+    HI_PRINT_HEX(name, (hi_u8 *)buf, n);
+
+cleanup:
+    return;
+#endif
+}
+
+#ifdef CHIP_RSA_SUPPORT
+static hi_s32 rsa_get_klen(unsigned long module_len, hi_u32 *keylen, rsa_key_width *width)
+{
+    if (module_len <= RSA_KEY_LEN_1024) {
+        *keylen = 128;
+        *width = RSA_KEY_WIDTH_1024;
+    } else if (module_len <= RSA_KEY_LEN_2048) {
+        *keylen = 256;
+        *width = RSA_KEY_WIDTH_2048;
+    } else if (module_len <= RSA_KEY_LEN_4096) {
+        *keylen = 512;
+        *width = RSA_KEY_WIDTH_4096;
+    } else {
+        HI_LOG_ERROR("error, invalid key len %ld\n", module_len);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_check_data(hi_u8 *N, hi_u8 *E, hi_u8 *MC, hi_u32 len)
+{
+    hi_u32 i;
+
+    /*MC > 0*/
+    for (i = 0; i < len; i++) {
+        if (0 < MC[i]) {
+            break;
+        }
+    }
+    if (i >= len) {
+        HI_LOG_ERROR("RSA M/C is zero, error!\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    /*MC < N*/
+    for (i = 0; i < len; i++) {
+        if (MC[i] < N[i]) {
+            break;
+        }
+    }
+    if (i >= len) {
+        HI_LOG_ERROR("RSA M/C is larger than N, error!\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    /*E >= 1*/
+    for (i = 0; i < len; i++) {
+        if (E[i] > 0) {
+            break;
+        }
+    }
+    if (i >= len) {
+        HI_LOG_ERROR("RSA D/E is zero, error!\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    return HI_SUCCESS;
+}
+
+static int cryp_ifep_rsa_exp_mod(hi_u32 ca_type, mbedtls_mpi *X, const mbedtls_mpi *A,
+                                 const mbedtls_mpi *E, const mbedtls_mpi *N,
+                                 mbedtls_mpi *_RR)
+{
+    hi_u32 module_len = 0;
+    hi_u8 *buf = HI_NULL;
+    hi_u8 *n = HI_NULL, *k = HI_NULL;
+    hi_u8 *in = HI_NULL, *out = HI_NULL;
+    hi_u32 keylen = 0;
+    rsa_key_width width = 0;
+    mbedtls_mpi _A;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* computes valid bits of N */
+    module_len = MAX(mbedtls_mpi_size(N), mbedtls_mpi_size(E));
+
+    ret = rsa_get_klen(module_len, &keylen, &width);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(rsa_get_klen, ret);
+        return ret;
+    }
+
+    /* mallc buf to store n || k(e or d) || in || out */
+    buf = crypto_malloc(keylen * 4);
+    if (buf == HI_NULL) {
+        HI_LOG_PRINT_FUNC_ERR(crypto_malloc, HI_ERR_CIPHER_FAILED_MEM);
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    /* zero */
+    crypto_memset(buf, keylen * 4, 0, keylen * 4);
+
+    n = buf;
+    k = n + keylen;
+    in = k + keylen;
+    out = in + keylen;
+
+    mbedtls_mpi_init(&_A);
+    CHECK_EXIT(mbedtls_mpi_mod_mpi(&_A, A, N));
+
+    /* read A, E, N */
+    CHECK_EXIT(mbedtls_mpi_write_binary(&_A, in, keylen));
+    CHECK_EXIT(mbedtls_mpi_write_binary(E, k, keylen));
+    CHECK_EXIT(mbedtls_mpi_write_binary(N, n, keylen));
+
+    /* key and data valid ?*/
+    CHECK_EXIT(cryp_check_data(n, k, in, keylen));
+
+    /* out = in ^ k mod n */
+    ret = drv_ifep_rsa_exp_mod(ca_type, n, k, in, out, width);
+    if (ret == HI_SUCCESS) {
+        /* write d */
+        mbedtls_mpi_read_binary(X, out, keylen);
+    }
+
+exit__:
+
+    mbedtls_mpi_free(&_A);
+    crypto_free(buf);
+    buf = HI_NULL;
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+#endif
+
+int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
+                        const mbedtls_mpi *E,
+                        const mbedtls_mpi *N,
+                        mbedtls_mpi *_RR)
+{
+    hi_s32 ret = HI_FAILURE;
+#if defined(CHIP_IFEP_RSA_VER_V100)
+    hi_u32 elen = 0;
+#endif
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(X == HI_NULL);
+    HI_LOG_CHECK_PARAM(A == HI_NULL);
+    HI_LOG_CHECK_PARAM(E == HI_NULL);
+    HI_LOG_CHECK_PARAM(N == HI_NULL);
+
+    mbedtls_mpi_print(A, "M");
+    mbedtls_mpi_print(E, "E");
+    mbedtls_mpi_print(N, "N");
+
+#if defined(CHIP_IFEP_RSA_VER_V100)
+    elen = mbedtls_mpi_size(E);
+    if (elen <= RSA_KEY_LEN_4096) {
+        /* The private key may be not from user when generate rsa key pare
+         * in this case use klad key will failed.
+         */
+        ret = cryp_ifep_rsa_exp_mod(rsa_key_ca_type, X, A, E, N, _RR);
+    } else
+#endif
+    {
+        if (rsa_key_ca_type != HI_UNF_CIPHER_KEY_SRC_USER) {
+            HI_LOG_ERROR("sofrware rsa nonsupport klad key\n");
+            return HI_ERR_CIPHER_ILLEGAL_KEY;
+        }
+
+        ret = mbedtls_mpi_exp_mod_sw(X, A, E, N, _RR);
+    }
+
+    mbedtls_mpi_print(X, "X");
+
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("rsa mpi_exp_mod failed, ret = 0x%x\n", ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+int cryp_rsa_init(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    crypto_mutex_init(&rsa_mutex);
+
+#if defined(CHIP_IFEP_RSA_VER_V100)
+    {
+        hi_s32 ret = HI_FAILURE;
+
+        ret = drv_rsa_init();
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_rsa_init, ret);
+            return ret;
+        }
+    }
+#endif
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void cryp_rsa_deinit(void)
+{
+#if defined(CHIP_IFEP_RSA_VER_V100)
+    rsa_capacity capacity;
+
+    drv_ifep_rsa_get_capacity(&capacity);
+
+    /* recovery the rsa function of mbedtls */
+    if (capacity.rsa) {
+        drv_rsa_deinit();
+    }
+#endif
+
+    crypto_mutex_destroy(&rsa_mutex);
+}
+
+int mbedtls_get_random(void *param, hi_u8 *rand, size_t size)
+{
+    hi_u32 i;
+    hi_u32 randnum = 0;
+
+    for (i = 0; i < size; i += 4) {
+        cryp_trng_get_random(&randnum, -1);
+        rand[i + 3] = (hi_u8)(randnum >> 24) & 0xFF;
+        rand[i + 2] = (hi_u8)(randnum >> 16) & 0xFF;
+        rand[i + 1] = (hi_u8)(randnum >> 8) & 0xFF;
+        rand[i + 0] = (hi_u8)(randnum) & 0xFF;
+    }
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_rsa_init_key(cryp_rsa_key *key, hi_u32 *mode, mbedtls_rsa_context *rsa)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    mbedtls_mpi_init(&rsa->N);
+    mbedtls_mpi_init(&rsa->E);
+    mbedtls_mpi_init(&rsa->D);
+    mbedtls_mpi_init(&rsa->P);
+    mbedtls_mpi_init(&rsa->Q);
+    mbedtls_mpi_init(&rsa->DP);
+    mbedtls_mpi_init(&rsa->DQ);
+    mbedtls_mpi_init(&rsa->QP);
+
+    CHECK_EXIT(mbedtls_mpi_read_binary(&rsa->N, key->n, key->klen));
+    rsa->len = key->klen;
+    if ((rsa->len < RSA_MIN_KEY_LEN) || (rsa->len > RSA_MAX_KEY_LEN)) {
+        HI_LOG_ERROR("RSA invalid keylen: 0x%x!\n", (hi_u32)rsa->len);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        ret = HI_ERR_CIPHER_INVALID_PARA;
+        goto exit__;
+    }
+
+    if (key->public) {
+        CHECK_EXIT(mbedtls_mpi_read_binary(&rsa->E, (hi_u8 *)&key->e, WORD_WIDTH));
+        *mode = MBEDTLS_RSA_PUBLIC;
+    } else {
+        if (key->d != HI_NULL) { /* Non CRT */
+            CHECK_EXIT(mbedtls_mpi_read_binary(&rsa->D, key->d, key->klen));
+            *mode = MBEDTLS_RSA_PRIVATE;
+        } else { /* CRT */
+            CHECK_EXIT(mbedtls_mpi_read_binary(&rsa->P, key->p, key->klen / 2));
+            CHECK_EXIT(mbedtls_mpi_read_binary(&rsa->Q, key->q, key->klen / 2));
+            CHECK_EXIT(mbedtls_mpi_read_binary(&rsa->DP, key->dp, key->klen / 2));
+            CHECK_EXIT(mbedtls_mpi_read_binary(&rsa->DQ, key->dq, key->klen / 2));
+            CHECK_EXIT(mbedtls_mpi_read_binary(&rsa->QP, key->qp, key->klen / 2));
+            *mode = MBEDTLS_RSA_PRIVATE;
+        }
+    }
+
+    rsa_key_ca_type = key->ca_type;
+
+    HI_LOG_DEBUG("mode %d, e 0x%x\n", *mode, key->e);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+exit__:
+
+    mbedtls_mpi_free(&rsa->N);
+    mbedtls_mpi_free(&rsa->E);
+    mbedtls_mpi_free(&rsa->D);
+    mbedtls_mpi_free(&rsa->P);
+    mbedtls_mpi_free(&rsa->Q);
+    mbedtls_mpi_free(&rsa->DP);
+    mbedtls_mpi_free(&rsa->DQ);
+    mbedtls_mpi_free(&rsa->QP);
+
+    return ret;
+}
+
+static void cryp_rsa_deinit_key(mbedtls_rsa_context *rsa)
+{
+    HI_LOG_FUNC_ENTER();
+
+    mbedtls_mpi_free(&rsa->N);
+    mbedtls_mpi_free(&rsa->E);
+    mbedtls_mpi_free(&rsa->D);
+    mbedtls_mpi_free(&rsa->P);
+    mbedtls_mpi_free(&rsa->Q);
+    mbedtls_mpi_free(&rsa->DP);
+    mbedtls_mpi_free(&rsa->DQ);
+    mbedtls_mpi_free(&rsa->QP);
+
+    HI_LOG_FUNC_EXIT();
+}
+
+static hi_s32 cryp_rsa_get_alg(hi_u32 scheme, int *padding, int *hash_id, int *hashlen)
+{
+    switch (scheme) {
+        case HI_CIPHER_RSA_ENC_SCHEME_NO_PADDING:
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_0:
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_1:
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_2: {
+            *padding = 0x00;
+            *hash_id = 0;
+            *hashlen = 0;
+            break;
+        }
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_PKCS1_V1_5: {
+            *padding = MBEDTLS_RSA_PKCS_V15;
+            *hash_id = 0;
+            *hashlen = 0;
+            break;
+        }
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA1: {
+            *padding = MBEDTLS_RSA_PKCS_V15;
+            *hash_id = MBEDTLS_MD_SHA1;
+            *hashlen = SHA1_RESULT_SIZE;
+            break;
+        }
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA224: {
+            *padding = MBEDTLS_RSA_PKCS_V15;
+            *hash_id = MBEDTLS_MD_SHA224;
+            *hashlen = SHA224_RESULT_SIZE;
+            break;
+        }
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA256: {
+            *padding = MBEDTLS_RSA_PKCS_V15;
+            *hash_id = MBEDTLS_MD_SHA256;
+            *hashlen = SHA256_RESULT_SIZE;
+            break;
+        }
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA384: {
+            *padding = MBEDTLS_RSA_PKCS_V15;
+            *hash_id = MBEDTLS_MD_SHA384;
+            *hashlen = SHA384_RESULT_SIZE;
+            break;
+        }
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_V15_SHA512: {
+            *padding = MBEDTLS_RSA_PKCS_V15;
+            *hash_id = MBEDTLS_MD_SHA512;
+            *hashlen = SHA512_RESULT_SIZE;
+            break;
+        }
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA1:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA1: {
+            *padding = MBEDTLS_RSA_PKCS_V21;
+            *hash_id = MBEDTLS_MD_SHA1;
+            *hashlen = SHA1_RESULT_SIZE;
+            break;
+        }
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA224:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA224: {
+            *padding = MBEDTLS_RSA_PKCS_V21;
+            *hash_id = MBEDTLS_MD_SHA224;
+            *hashlen = SHA224_RESULT_SIZE;
+            break;
+        }
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA256:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA256: {
+            *padding = MBEDTLS_RSA_PKCS_V21;
+            *hash_id = MBEDTLS_MD_SHA256;
+            *hashlen = SHA256_RESULT_SIZE;
+            break;
+        }
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA384:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA384: {
+            *padding = MBEDTLS_RSA_PKCS_V21;
+            *hash_id = MBEDTLS_MD_SHA384;
+            *hashlen = SHA384_RESULT_SIZE;
+            break;
+        }
+        case HI_CIPHER_RSA_SIGN_SCHEME_RSASSA_PKCS1_PSS_SHA512:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA512: {
+            *padding = MBEDTLS_RSA_PKCS_V21;
+            *hash_id = MBEDTLS_MD_SHA512;
+            *hashlen = SHA512_RESULT_SIZE;
+            break;
+        }
+        default: {
+            HI_LOG_ERROR("RSA padding mode error, mode = 0x%x.\n", scheme);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+
+    HI_LOG_DEBUG("padding %d, hash_id %d, hashlen %d\n", *padding, *hash_id, *hashlen);
+
+    return HI_SUCCESS;
+}
+
+/*PKCS #1: block type 0,1,2 message padding*/
+/*************************************************
+EB = 00 || BT || PS || 00 || D
+
+PS_LEN >= 8, mlen < key_len - 11
+*************************************************/
+static hi_s32 rsa_padding_add_pkcs1_type(mbedtls_rsa_context *rsa, hi_u32 mode, hi_u32 klen,
+                                      hi_u8  bt, hi_u8 *in, hi_u8 inlen, hi_u8 *out)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 plen = 0;
+    hi_u8 *peb = HI_NULL;
+    hi_u32 i = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (inlen > klen - RSA_PKCS1_TYPE_MIN_PAD_LEN) {
+        HI_LOG_ERROR("klen is invalid.\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    peb = out;
+
+    /* first byte is 0x00 */
+    *(peb++) = 0;
+
+    /* Private Key BT (Block Type) */
+    *(peb++) = bt;
+
+    /* The padding string PS shall consist of k-3-||D|| octets */
+    plen = klen - 3 - inlen;
+    switch (bt) {
+        case 0x00: {
+            /* For block type 00, the octets shall have value 00 */
+            crypto_memset(peb, plen, 0x00, plen);
+            break;
+        }
+        case 0x01: {
+            /* for block type 01, they shall have value FF */
+            crypto_memset(peb, plen, 0xFF, plen);
+            break;
+        }
+        case 0x02: {
+            /* for block type 02, they shall be pseudorandomly generated and nonzero. */
+            (hi_void)mbedtls_get_random(HI_NULL, peb, plen);
+
+            /* make sure nonzero */
+            for (i = 0; i < plen; i++) {
+                if (0x00 == peb[i]) {
+                    peb[i] = 0x01;
+                }
+            }
+            break;
+        }
+        default: {
+            HI_LOG_ERROR("BT(0x%x) is invalid.\n", plen);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+
+    /* skip the padding string */
+    peb += plen;
+
+    /* set 0x00 follow PS */
+    *(peb++) = 0x00;
+
+    /* input data */
+    crypto_memcpy(peb, inlen, in, inlen);
+
+    if (mode == MBEDTLS_RSA_PUBLIC) {
+        ret = mbedtls_rsa_public(rsa, out, out);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("rsa public failed.\n");
+            HI_LOG_PRINT_FUNC_ERR(mbedtls_rsa_public, ret);
+            return HI_ERR_CIPHER_RSA_CRYPT_FAILED;
+        }
+    } else {
+        ret = mbedtls_rsa_private(rsa, HI_NULL, 0, out, out);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("rsa private failed.\n");
+            HI_LOG_PRINT_FUNC_ERR(mbedtls_rsa_private, ret);
+            return HI_ERR_CIPHER_RSA_CRYPT_FAILED;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/*PKCS #1: block type 0,1,2 message padding*/
+/*************************************************
+EB = 00 || BT || PS || 00 || D
+
+PS_LEN >= 8, mlen < key_len - 11
+*************************************************/
+static hi_s32 rsa_padding_check_pkcs1_type(mbedtls_rsa_context *rsa, hi_u32 klen, hi_u32 mode,
+                                        hi_u8  bt, hi_u8 *in, hi_u32 inlen,
+                                        hi_u8 *out, hi_u32 *outlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u8 *peb = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (mode == MBEDTLS_RSA_PUBLIC) {
+        ret = mbedtls_rsa_public(rsa, in, in);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("rsa public failed.\n");
+            HI_LOG_PRINT_FUNC_ERR(mbedtls_rsa_public, ret);
+            return HI_ERR_CIPHER_RSA_CRYPT_FAILED;
+        }
+    } else {
+        ret = mbedtls_rsa_private(rsa, HI_NULL, 0, in, in);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("rsa private failed.\n");
+            HI_LOG_PRINT_FUNC_ERR(mbedtls_rsa_private, ret);
+            return HI_ERR_CIPHER_RSA_CRYPT_FAILED;
+        }
+    }
+
+    *outlen = 0x00;
+    peb = in;
+
+    /* first byte must be 0x00 */
+    if (*peb != 0x00) {
+        HI_LOG_ERROR("EB[0] != 0x00.\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+    peb++;
+
+    /* Private Key BT (Block Type) */
+    if (*peb != bt) {
+        HI_LOG_ERROR("EB[1] != BT(0x%x).\n", bt);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+    peb++;
+
+    switch (bt) {
+        case 0x00:
+            /* For block type 00, the octets shall have value 00 */
+            for (; peb < in + inlen - 1; peb++) {
+                if ((*peb == 0x00) && (*(peb + 1) != 0)) {
+                    break;
+                }
+            }
+            break;
+        case 0x01:
+            /* For block type 0x01 the octets shall have value 0xFF */
+            for (; peb < in + inlen - 1; peb++) {
+                if (*peb == 0xFF) {
+                    continue;
+                } else if (*peb == 0x00) {
+                    break;
+                } else {
+                    peb = in + inlen - 1;
+                    break;
+                }
+            }
+            break;
+        case 0x02:
+            /* for block type 02, they shall be pseudorandomly generated and nonzero. */
+            for (; peb < in + inlen - 1; peb++) {
+                if (0x00 == *peb) {
+                    break;
+                }
+            }
+            break;
+        default:
+            HI_LOG_ERROR("BT(0x%x) is invalid.\n", bt);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    if (peb >= (in + inlen - 1)) {
+        HI_LOG_ERROR("PS Error.\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    /* skip 0x00 after PS */
+    peb++;
+
+    /* get payload data */
+    *outlen = in + klen - peb;
+    crypto_memcpy(out, klen, peb, *outlen);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 rsa_no_padding(mbedtls_rsa_context *rsa, hi_u32 klen, hi_u32 mode,
+                          hi_u8 *in, hi_u32 inlen, hi_u8 *out)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u8 *data = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (inlen > klen) {
+        HI_LOG_ERROR("input length %d invalid.\n", inlen);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    /* mallc data buf */
+    data = crypto_malloc(RSA_MAX_KEY_LEN);
+    if (data == HI_NULL) {
+        HI_LOG_PRINT_FUNC_ERR(crypto_malloc, HI_ERR_CIPHER_FAILED_MEM);
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    crypto_memset(data, RSA_MAX_KEY_LEN, 0, RSA_MAX_KEY_LEN);
+    crypto_memcpy(data + klen - inlen, RSA_MAX_KEY_LEN, in, inlen);
+
+    if (mode == MBEDTLS_RSA_PUBLIC) {
+        ret = mbedtls_rsa_public(rsa, data, out);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("rsa public failed.\n");
+            HI_LOG_PRINT_FUNC_ERR(mbedtls_rsa_public, ret);
+            crypto_free(data);
+            data = HI_NULL;
+            return HI_ERR_CIPHER_RSA_CRYPT_FAILED;
+        }
+    } else {
+        ret = mbedtls_rsa_private(rsa, HI_NULL, 0, data, out);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("rsa private failed, ret = %d.\n", ret);
+            HI_LOG_PRINT_FUNC_ERR(mbedtls_rsa_private, ret);
+            crypto_free(data);
+            data = HI_NULL;
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+
+    crypto_free(data);
+    data = HI_NULL;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 cryp_rsa_encrypt(cryp_rsa_key *key, hi_cipher_rsa_enc_scheme scheme,
+                     hi_u8 *in, hi_u32 inlen, hi_u8 *out, hi_u32 *outlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 mode = 0;
+    int padding = 0;
+    int hash_id = 0;
+    int hashlen = 0;
+    hi_u32 bt = 0;
+    mbedtls_rsa_context rsa;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(key    == HI_NULL);
+    HI_LOG_CHECK_PARAM(in     == HI_NULL);
+    HI_LOG_CHECK_PARAM(out    == HI_NULL);
+    HI_LOG_CHECK_PARAM(outlen == HI_NULL);
+    HI_LOG_CHECK_PARAM(key->klen > RSA_KEY_LEN_4096);
+    HI_LOG_CHECK_PARAM(inlen > key->klen);
+    HI_LOG_CHECK_PARAM(key->ca_type >= HI_CIPHER_KEY_SRC_BUTT);
+
+    ret = cryp_rsa_get_alg(scheme, &padding, &hash_id, &hashlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, cryp_rsa_get_alg failed");
+        HI_LOG_PRINT_ERR_CODE(ret);
+        return ret;
+    }
+
+    KAPI_RSA_LOCK();
+
+    mbedtls_rsa_init(&rsa, padding, hash_id);
+
+    ret = cryp_rsa_init_key(key, &mode, &rsa);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, cryp_rsa_init_key failed");
+        HI_LOG_PRINT_ERR_CODE(ret);
+        KAPI_RSA_UNLOCK();
+        return ret;
+    }
+
+    switch (scheme) {
+        case HI_CIPHER_RSA_ENC_SCHEME_NO_PADDING: {
+            ret = rsa_no_padding(&rsa, key->klen, mode, in, inlen, out);
+            break;
+        }
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_0:
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_1:
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_2: {
+            bt = scheme - HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_0;
+            ret = rsa_padding_add_pkcs1_type(&rsa, mode, key->klen, bt, in, inlen, out);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_ERROR("error, rsa add pkcs1_type failed, ret = 0x%x", ret);
+                HI_LOG_PRINT_FUNC_ERR(rsa_padding_add_pkcs1_type, ret);
+                ret = HI_ERR_CIPHER_FAILED_ENCRYPT;
+            }
+            break;
+        }
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA1:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA224:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA256:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA384:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA512:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_PKCS1_V1_5: {
+            ret = mbedtls_rsa_pkcs1_encrypt(&rsa, mbedtls_get_random,
+                                            HI_NULL, mode, inlen, in, out);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_ERROR("error, rsa pkcs1 encrypt failed, ret = %d", ret);
+                HI_LOG_PRINT_FUNC_ERR(rsa_padding_add_pkcs1_type, ret);
+                ret = HI_ERR_CIPHER_FAILED_ENCRYPT;
+            }
+            break;
+        }
+        default: {
+            HI_LOG_ERROR("RSA padding mode error, mode = 0x%x.\n", scheme);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            ret = HI_ERR_CIPHER_INVALID_PARA;
+            break;
+        }
+    }
+
+    if (ret == HI_SUCCESS) {
+        *outlen = key->klen;
+    }
+
+    cryp_rsa_deinit_key(&rsa);
+
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("rsa encrypt failed, scheme %d, ret = 0x%x\n", scheme, ret);
+        KAPI_RSA_UNLOCK();
+        return ret;
+    }
+
+    KAPI_RSA_UNLOCK();
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+hi_s32 cryp_rsa_decrypt(cryp_rsa_key *key, hi_cipher_rsa_enc_scheme scheme,
+                     hi_u8 *in, hi_u32 inlen, hi_u8 *out, hi_u32 *outlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 mode = 0;
+    int padding = 0;
+    int hash_id = 0;
+    int hashlen = 0;
+    hi_u32 bt = 0;
+    size_t outsize = 0;
+    mbedtls_rsa_context rsa;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(key    == HI_NULL);
+    HI_LOG_CHECK_PARAM(in     == HI_NULL);
+    HI_LOG_CHECK_PARAM(out    == HI_NULL);
+    HI_LOG_CHECK_PARAM(outlen == HI_NULL);
+    HI_LOG_CHECK_PARAM(key->klen > RSA_KEY_LEN_4096);
+    HI_LOG_CHECK_PARAM(inlen != key->klen);
+    HI_LOG_CHECK_PARAM(key->ca_type >= HI_CIPHER_KEY_SRC_BUTT);
+
+    ret = cryp_rsa_get_alg(scheme, &padding, &hash_id, &hashlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, cryp_rsa_sign_get_alg failed");
+        HI_LOG_PRINT_FUNC_ERR(cryp_rsa_get_alg, ret);
+        return ret;
+    }
+
+    KAPI_RSA_LOCK();
+
+    mbedtls_rsa_init(&rsa, padding, hash_id);
+
+    ret = cryp_rsa_init_key(key, &mode, &rsa);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, cryp_rsa_init_key failed");
+        HI_LOG_PRINT_FUNC_ERR(cryp_rsa_init_key, ret);
+        KAPI_RSA_UNLOCK();
+        return ret;
+    }
+
+    switch (scheme) {
+        case HI_CIPHER_RSA_ENC_SCHEME_NO_PADDING: {
+            ret = rsa_no_padding(&rsa, key->klen, mode, in, inlen, out);
+            *outlen = key->klen;
+            if (ret != HI_SUCCESS) {
+                HI_LOG_PRINT_FUNC_ERR(rsa_no_padding, ret);
+            }
+            break;
+        }
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_0:
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_1:
+        case HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_2: {
+            bt = scheme - HI_CIPHER_RSA_ENC_SCHEME_BLOCK_TYPE_0;
+            ret = rsa_padding_check_pkcs1_type(&rsa, key->klen, mode, bt, in, inlen, out, outlen);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_ERROR("error, rsa check pkcs1 type failed, ret = %d", ret);
+                HI_LOG_PRINT_FUNC_ERR(rsa_padding_check_pkcs1_type, ret);
+                ret = HI_ERR_CIPHER_FAILED_DECRYPT;
+            }
+            break;
+        }
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA1:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA224:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA256:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA384:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_OAEP_SHA512:
+        case HI_CIPHER_RSA_ENC_SCHEME_RSAES_PKCS1_V1_5: {
+            ret = mbedtls_rsa_pkcs1_decrypt(&rsa, mbedtls_get_random,
+                                            HI_NULL, mode, &outsize, in, out, key->klen);
+            *outlen = (hi_u32)outsize;
+            if (ret != HI_SUCCESS) {
+                HI_LOG_ERROR("error, rsa pkcs1 decrypt failed, ret = %d", ret);
+                HI_LOG_PRINT_FUNC_ERR(mbedtls_rsa_pkcs1_decrypt, ret);
+                ret = HI_ERR_CIPHER_FAILED_DECRYPT;
+            }
+            break;
+        }
+        default: {
+            HI_LOG_ERROR("RSA padding mode error, mode = 0x%x.\n", scheme);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            ret = HI_ERR_CIPHER_INVALID_PARA;
+            break;
+        }
+    }
+
+    cryp_rsa_deinit_key(&rsa);
+
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("rsa decrypt failed, scheme %d, ret = 0x%x\n", scheme, ret);
+        KAPI_RSA_UNLOCK();
+        return ret;
+    }
+
+    KAPI_RSA_UNLOCK();
+    HI_LOG_FUNC_EXIT();
+
+    return HI_SUCCESS;
+}
+
+hi_s32 cryp_rsa_sign_hash(cryp_rsa_key *key, hi_cipher_rsa_sign_scheme scheme,
+                       hi_u8 *in, hi_u32 inlen, hi_u8 *out, hi_u32 *outlen, hi_u32 saltlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 mode = 0;
+    int padding = 0;
+    int hash_id = 0;
+    int hashlen = 0;
+    mbedtls_rsa_context rsa;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(key    == HI_NULL);
+    HI_LOG_CHECK_PARAM(in     == HI_NULL);
+    HI_LOG_CHECK_PARAM(out    == HI_NULL);
+    HI_LOG_CHECK_PARAM(outlen == HI_NULL);
+    HI_LOG_CHECK_PARAM(key->klen > RSA_KEY_LEN_4096);
+    HI_LOG_CHECK_PARAM(inlen > key->klen);
+
+    ret = cryp_rsa_get_alg(scheme, &padding, &hash_id, &hashlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, cryp_rsa_sign_get_alg failed");
+        HI_LOG_PRINT_FUNC_ERR(cryp_rsa_get_alg, ret);
+        return ret;
+    }
+
+    KAPI_RSA_LOCK();
+
+    mbedtls_rsa_init(&rsa, padding, hash_id);
+
+    ret = cryp_rsa_init_key(key, &mode, &rsa);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, cryp_rsa_init_key failed");
+        HI_LOG_PRINT_FUNC_ERR(cryp_rsa_init_key, ret);
+        KAPI_RSA_UNLOCK();
+        return ret;
+    }
+
+    ret = mbedtls_rsa_pkcs1_sign(&rsa, mbedtls_get_random, HI_NULL,
+                                 mode, hash_id, hashlen, in, out);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, rsa_pkcs1 sign failed, ret = 0x%x\n", ret);
+        HI_LOG_PRINT_FUNC_ERR(mbedtls_rsa_pkcs1_sign, ret);
+        ret = HI_ERR_CIPHER_RSA_SIGN;
+        cryp_rsa_deinit_key(&rsa);
+        KAPI_RSA_UNLOCK();
+        return ret;
+    }
+
+    *outlen = key->klen;
+
+    cryp_rsa_deinit_key(&rsa);
+
+    KAPI_RSA_UNLOCK();
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 cryp_rsa_verify_hash(cryp_rsa_key *key, hi_cipher_rsa_sign_scheme scheme,
+                         hi_u8 *hash, hi_u32 hlen, hi_u8 *sign, hi_u32 signlen, hi_u32 saltlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    int padding = 0;
+    int hash_id = 0;
+    int hashlen = 0;
+    hi_u32 mode = 0;
+    mbedtls_rsa_context rsa;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(key  == HI_NULL);
+    HI_LOG_CHECK_PARAM(hash == HI_NULL);
+    HI_LOG_CHECK_PARAM(sign == HI_NULL);
+    HI_LOG_CHECK_PARAM(key->klen > RSA_KEY_LEN_4096);
+    HI_LOG_CHECK_PARAM(signlen > key->klen);
+    HI_LOG_CHECK_PARAM(key->ca_type != HI_CIPHER_KEY_SRC_USER);
+
+    ret = cryp_rsa_get_alg(scheme, &padding, &hash_id, &hashlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, cryp_rsa_sign_get_alg failed");
+        HI_LOG_PRINT_FUNC_ERR(cryp_rsa_get_alg, ret);
+        return ret;
+    }
+
+    KAPI_RSA_LOCK();
+
+    mbedtls_rsa_init(&rsa, padding, hash_id);
+
+    ret = cryp_rsa_init_key(key, &mode, &rsa);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, cryp_rsa_init_key failed, ret = %d\n", ret);
+        HI_LOG_PRINT_FUNC_ERR(cryp_rsa_init_key, ret);
+        KAPI_RSA_UNLOCK();
+        return ret;
+    }
+
+    ret = mbedtls_rsa_pkcs1_verify(&rsa, mbedtls_get_random, HI_NULL,
+                                   mode, hash_id, hashlen, hash, sign);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error,  rsa pkcs1 verify failed, ret = 0x%x\n", ret);
+        HI_LOG_PRINT_FUNC_ERR(mbedtls_rsa_pkcs1_verify, ret);
+        ret = HI_ERR_CIPHER_RSA_VERIFY;
+        cryp_rsa_deinit_key(&rsa);
+        KAPI_RSA_UNLOCK();
+        return ret;
+    }
+
+    cryp_rsa_deinit_key(&rsa);
+    KAPI_RSA_UNLOCK();
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/** @}*/  /** <!-- ==== API Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_symc.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_symc.c
@@ -1,0 +1,2001 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : cryp_symc.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "drv_symc.h"
+#include "cryp_symc.h"
+#include "ext_alg.h"
+
+/*************************** Internal Structure Definition *******************/
+/** \addtogroup      aes */
+/** @{*/  /** <!-- [aes]*/
+
+/* AES set IV for first package */
+#define SYMC_IV_USAGE_ONE_PKG        (1)
+
+/* AES set IV for first package */
+#define SYMC_IV_USAGE_ALL_PKG        (2)
+
+/* SYMC interrupt level */
+#define SYMC_INT_LEVEL               (SYMC_MAX_LIST_NUM - 15) /* (1UL) */
+
+/* Length of SYMC ccm q  */
+#define SYMC_CCM_Q_LEN_2B        (2)
+#define SYMC_CCM_Q_LEN_3B        (3)
+#define SYMC_CCM_Q_LEN_4B        (4)
+
+/* Length of SYMC ccm P  */
+#define SYMC_CCM_P_LEN_2B        (0xFFFF)
+#define SYMC_CCM_P_LEN_3B        (0xFFFFFF)
+
+/* length range of aead */
+#define AES_CCM_MIN_IV_LEN      (7)
+#define AES_CCM_MAX_IV_LEN      (13)
+#define AES_CCM_NQ_LEN          (14)
+#define AES_CCM_MIN_TAG_LEN     (4)
+#define AES_CCM_MAX_TAG_LEN     (16)
+#define AES_GCM_MIN_IV_LEN      (1)
+#define AES_GCM_MAX_IV_LEN      (16)
+#define AES_GCM_MIN_TAG_LEN     (1)
+#define AES_GCM_MAX_TAG_LEN     (16)
+
+/* Multi nodes added status, finished or finished */
+#define SYMC_NODES_ADD_FINISHED    (0x0a0a0a0a)
+#define SYMC_NODES_ADD_NOTFINISHED (0X05050505)
+
+/**
+ * \brief          symc context structure
+ *
+ * \note           if the aes key derived from klad, the context msut
+ *                 attached with a independent hard key channel,
+ *                 otherwise the context can attached with a fixed common channel.
+ */
+typedef struct {
+    hi_u32 even_key[SYMC_KEY_SIZE / 4]; /*!<  SYMC even round keys, default */
+    hi_u32 odd_key[SYMC_KEY_SIZE / 4];  /*!<  SYMC odd round keys, default */
+    hi_u32 sk[SYMC_SM1_SK_SIZE / 4];    /*!<  sm1 sk */
+    hi_u32 iv[AES_IV_SIZE / 4];         /*!<  symc IV */
+    hi_u32 tag[AEAD_TAG_SIZE / 4];      /*!<  aead tag */
+    hi_u32 ivlen;                       /*!<  symc IV length */
+    hi_u32 iv_usage;                    /*!<  symc IV usage */
+
+    hi_u32 hard_chn;             /*!<  hard channel number */
+    hi_u32 hard_key;             /*!<  Key derived from klad or CPU */
+
+    symc_alg alg;                /*!<  Symmetric cipher algorithm */
+    symc_width width;            /*!<  Symmetric cipher width */
+    hi_u32 klen;                 /*!<  Symmetric cipher key length */
+
+    compat_addr aad;             /*!<  Associated Data */
+    hi_u32 alen;                 /*!<  Associated Data length */
+    hi_u32 tlen;                 /*!<  Tag length */
+
+    symc_mode mode;              /*!<  Symmetric cipher mode */
+
+    hi_u32 sm1_round;            /*!<  SM1 round number */
+    hi_u32 enclen;               /*!<  encrypt length */
+
+    hi_u32 block_size;           /*!<  Block size */
+
+    hi_u32 cur_nodes;            /*!<  current nodes id  */
+    hi_u32 total_nodes;          /*!<  total number of nodes */
+
+    compat_addr *input_list;     /*!<  input node list */
+    compat_addr *output_list;    /*!<  output node list */
+    hi_u32 *length_list;         /*!<  length of node list */
+    symc_node_usage *usage_list; /*!<  usage of node list */
+    hi_bool tdes2dma;            /*!<  3des with invalid key turns to dma */
+}
+cryp_symc_context;
+
+/* The max tab size of symc function */
+#define SYMC_FUNC_TAB_SIZE          (SYMC_ALG_COUNT * SYMC_MODE_COUNT)
+
+/* symc function list */
+static symc_func symc_descriptor[SYMC_FUNC_TAB_SIZE];
+
+/* symc context */
+static cryp_symc_context symc_context[CRYPTO_HARD_CHANNEL_MAX];
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+/* symc function register */
+static void cryp_register_all_symc(void);
+
+#ifdef CHIP_AES_CCM_GCM_SUPPORT
+static hi_u32 cyp_aead_gcm_clen(hi_u8 *buf, hi_u32 alen, hi_u32 enclen);
+#endif
+
+hi_s32 cryp_symc_init(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    crypto_memset(symc_descriptor, sizeof(symc_descriptor), 0, sizeof(symc_descriptor));
+
+    ret = drv_symc_init();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_init, ret);
+        return ret;
+    }
+
+    cryp_register_all_symc();
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void cryp_symc_deinit(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    drv_symc_deinit();
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+hi_s32 cryp_symc_alloc_chn(hi_u32 *hard_chn)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 key[SYMC_KEY_MAX_SIZE_IN_WORD] = {0, 1, 2, 3, 4, 5, 6, 7};
+    hi_u32 sm1_key[SYMC_SM1_SK_SIZE_IN_WORD] = {0, 1, 2, 3};
+
+    HI_LOG_FUNC_ENTER();
+
+    /* allocate a aes hard key channel */
+    ret = drv_symc_alloc_chn(hard_chn);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_alloc_chn, ret);
+        return ret;
+    }
+
+    /* Set a fake key to clear the true key. */
+    drv_symc_set_key(*hard_chn, key, HI_FALSE);
+    drv_symc_set_sm1_sk(*hard_chn, sm1_key);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void cryp_symc_free_chn(hi_u32 hard_chn)
+{
+    HI_LOG_FUNC_ENTER();
+
+    drv_symc_free_chn(hard_chn);
+
+    HI_LOG_FUNC_EXIT();
+}
+
+static void *cryp_symc_create(hi_u32 hard_chn)
+{
+    cryp_symc_context *hisi_ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    hisi_ctx = &symc_context[hard_chn];
+    crypto_memset(hisi_ctx, sizeof(cryp_symc_context), 0, sizeof(cryp_symc_context));
+    hisi_ctx->hard_key = HI_FALSE;
+    hisi_ctx->hard_chn = hard_chn;
+
+    HI_LOG_FUNC_EXIT();
+    return hisi_ctx;
+}
+
+static void cryp_symc_setkey(void *ctx, const hi_u8 *key, hi_u32 keylen, hi_u32 odd)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (hisi_ctx == HI_NULL) {
+        HI_LOG_ERROR("Invalid point.\n");
+        return;
+    }
+
+    if (odd) {
+        crypto_memcpy(hisi_ctx->odd_key, SYMC_KEY_SIZE, key, keylen);
+    } else {
+        crypto_memcpy(hisi_ctx->even_key, SYMC_KEY_SIZE, key, keylen);
+    }
+    hisi_ctx->klen = keylen;
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+static void cryp_symc_setiv(void *ctx, const hi_u8 *iv, hi_u32 ivlen, hi_u32 usage)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (hisi_ctx == HI_NULL) {
+        HI_LOG_ERROR("Invalid point.\n");
+        return;
+    }
+
+    if (iv == HI_NULL) {
+        if (ivlen != 0) {
+            HI_LOG_ERROR("Invalid iv len(%u), iv is null.\n", ivlen);
+        }
+        return;
+    }
+
+    crypto_memcpy(hisi_ctx->iv, AES_IV_SIZE, iv, ivlen);
+    hisi_ctx->iv_usage = usage;
+    hisi_ctx->ivlen = ivlen;
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+static void cryp_symc_getiv(void *ctx, hi_u8 *iv, hi_u32 *ivlen)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (hisi_ctx == HI_NULL) {
+        HI_LOG_ERROR("Invalid point.\n");
+        return;
+    }
+    crypto_memcpy(iv, AES_IV_SIZE, hisi_ctx->iv, hisi_ctx->ivlen);
+    *ivlen = hisi_ctx->ivlen;
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+static void cryp_symc_setmode(void *ctx, symc_alg alg, symc_mode mode, symc_width width)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (hisi_ctx == HI_NULL) {
+        HI_LOG_ERROR("Invalid point.\n");
+        return;
+    }
+    hisi_ctx->mode = mode;
+    hisi_ctx->alg = alg;
+    hisi_ctx->width = width;
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+static void cryp_3des2dma_setmode(void *ctx, symc_alg alg, symc_mode mode, symc_width width)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (hisi_ctx == HI_NULL) {
+        HI_LOG_ERROR("Invalid point.\n");
+        return;
+    }
+
+    CRYPTO_UNUSED(alg);
+    CRYPTO_UNUSED(mode);
+    CRYPTO_UNUSED(width);
+
+    hisi_ctx->mode = SYMC_MODE_ECB;
+    hisi_ctx->alg = SYMC_ALG_TDES;
+    hisi_ctx->width = SYMC_DAT_WIDTH_64;
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+static hi_s32 cryp_symc_sm1_setsk(void *ctx, const hi_u8 *key)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+
+    crypto_memcpy(hisi_ctx->sk, SYMC_SM1_SK_SIZE, key, SYMC_SM1_SK_SIZE);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_symc_sm1_setround(void *ctx, hi_u32 round)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+
+    hisi_ctx->sm1_round = round;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 symc_add_buf(cryp_symc_context *ctx, symc_node_usage out_uasge)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 cur = ctx->cur_nodes;
+
+    HI_LOG_FUNC_ENTER();
+
+    /*Add P in*/
+    ret = drv_symc_add_inbuf(ctx->hard_chn,
+                             ctx->input_list[cur],
+                             ctx->length_list[cur],
+                             ctx->usage_list[cur]);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_add_inbuf, ret);
+        return ret;
+    }
+
+    /*Add P out, only need the last flag*/
+    ret = drv_symc_add_outbuf(ctx->hard_chn,
+                              ctx->output_list[cur],
+                              ctx->length_list[cur],
+                              out_uasge);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_add_outbuf, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+static symc_node_usage symc_get_out_usage(symc_mode mode, hi_u32 cur_node, hi_u32 total_node)
+{
+    symc_node_usage usage = SYMC_NODE_USAGE_NORMAL;
+
+    if ((mode != SYMC_MODE_GCM) && ((cur_node + 1) == total_node)) {
+        usage = SYMC_NODE_USAGE_LAST;
+    }
+
+    return usage;
+}
+
+static hi_s32 symc_add_buf_list(void *ctx)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 i = 0;
+    hi_u32 nodes = 0;
+    hi_u32 cur = 0;
+    hi_u32 total_len = 0;
+    cryp_symc_context *hisi_ctx = ctx;
+    symc_node_usage usage = SYMC_NODE_USAGE_NORMAL;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* compute finished*/
+    if (hisi_ctx->cur_nodes == hisi_ctx->total_nodes) {
+        HI_LOG_FUNC_EXIT();
+        return SYMC_NODES_ADD_FINISHED;
+    }
+
+    /* compute not finished*/
+    /* select the minimum numbers of nodes to calculate*/
+    nodes = MIN(SYMC_INT_LEVEL, hisi_ctx->total_nodes - hisi_ctx->cur_nodes);
+    total_len = 0;
+
+    for (i = 0; i < nodes; i++) {
+        cur = hisi_ctx->cur_nodes;
+        usage = symc_get_out_usage(hisi_ctx->mode, cur, hisi_ctx->total_nodes);
+
+        /*Add one node*/
+        ret = symc_add_buf(hisi_ctx, usage);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(symc_add_buf, ret);
+            return ret;
+        }
+
+        total_len += hisi_ctx->length_list[cur];
+        hisi_ctx->cur_nodes++;
+    }
+
+    /* For each compute, the total length of valid nodes list
+     * must aligned with block size, otherwise can't recv interrupt,
+     * which limit to hardware devising.
+     */
+
+    /* Compute the tail length*/
+    total_len %= hisi_ctx->block_size;
+    if (total_len > 0) {
+        total_len = hisi_ctx->block_size - total_len;
+    }
+
+    /*if the total length don't aligned with block size, split joint the follow nodes*/
+    while ((total_len > 0) && (hisi_ctx->cur_nodes < hisi_ctx->total_nodes)) {
+        cur = hisi_ctx->cur_nodes;
+
+        /*The next node large than tail size, just split it to 2 nodes */
+        if (hisi_ctx->length_list[cur] > total_len) {
+            /*Add P in*/
+            ret = drv_symc_add_inbuf(hisi_ctx->hard_chn, hisi_ctx->input_list[cur],
+                                     total_len, hisi_ctx->usage_list[cur]);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_PRINT_FUNC_ERR(drv_symc_add_inbuf, ret);
+                return ret;
+            }
+
+            /*Add P out*/
+            usage = symc_get_out_usage(hisi_ctx->mode, cur, hisi_ctx->total_nodes);
+            ret = drv_symc_add_outbuf(hisi_ctx->hard_chn, hisi_ctx->output_list[cur],
+                                      total_len, usage);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_PRINT_FUNC_ERR(drv_symc_add_outbuf, ret);
+                return ret;
+            }
+
+            /*Let next node skip the tail size*/
+            ADDR_U64(hisi_ctx->input_list[cur]) += total_len;
+            ADDR_U64(hisi_ctx->output_list[cur]) += total_len;
+            hisi_ctx->length_list[cur] -= total_len;
+            total_len = 0;
+        } else {
+            /*The next node less than tail size, add it to nodes list */
+
+            /*Add one node*/
+            usage = symc_get_out_usage(hisi_ctx->mode, cur, hisi_ctx->total_nodes);
+            ret = symc_add_buf(hisi_ctx, usage);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_PRINT_FUNC_ERR(symc_add_buf, ret);
+                return ret;
+            }
+
+            /*re-compute the tail size*/
+            total_len -= hisi_ctx->length_list[cur];
+
+            /*Process next node*/
+            hisi_ctx->cur_nodes++;
+        }
+    }
+#ifdef CHIP_AES_CCM_GCM_SUPPORT
+    /* gcm add nodes finished ? */
+    if ((hisi_ctx->mode == SYMC_MODE_GCM)
+        && (hisi_ctx->cur_nodes == hisi_ctx->total_nodes)) {
+        hi_u8 clen[AES_BLOCK_SIZE];
+
+        /* At the and of GCM, must add a empty node to nodes list,
+        * limit to hardware devising
+        */
+        drv_symc_add_outbuf(hisi_ctx->hard_chn, ADDR_NULL, 0x00, SYMC_NODE_USAGE_LAST);
+        /*Format the length fields of C and add to nodes list*/
+        cyp_aead_gcm_clen(clen, hisi_ctx->alen, hisi_ctx->enclen);
+        drv_aead_gcm_add_clen(hisi_ctx->hard_chn, clen);
+    }
+#endif
+
+    HI_LOG_FUNC_EXIT();
+    return SYMC_NODES_ADD_NOTFINISHED;
+
+}
+
+static symc_klen cryp_symc_key_type(symc_alg alg, hi_u32 klen)
+{
+    symc_klen type;
+
+    if ((alg == SYMC_ALG_AES)
+        && (klen == AES_KEY_192BIT)) {
+        type = SYMC_KEY_AES_192BIT;
+    } else if ((alg == SYMC_ALG_AES)
+               && (klen == AES_KEY_256BIT)) {
+        type = SYMC_KEY_AES_256BIT;
+    } else if ((alg == SYMC_ALG_TDES)
+               && (klen == TDES_KEY_128BIT)) {
+        type = SYMC_KEY_TDES_2KEY;
+    } else {
+        type = SYMC_KEY_DEFAULT;
+    }
+
+    return type;
+}
+
+static hi_s32 cryp_symc_config(void *ctx, hi_u32 decrypt)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+    symc_klen type;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_INFO("symc configure, chn %d, alg %d, mode %d, dec %d, klen %d, hard %d, iv len %d, iv usage %d\n",
+                hisi_ctx->hard_chn, hisi_ctx->alg, hisi_ctx->mode,
+                decrypt, hisi_ctx->klen, hisi_ctx->hard_key,
+                hisi_ctx->ivlen, hisi_ctx->iv_usage);
+
+    type = cryp_symc_key_type(hisi_ctx->alg, hisi_ctx->klen);
+
+    /* configure */
+    ret = drv_symc_config(hisi_ctx->hard_chn, hisi_ctx->alg, hisi_ctx->mode, hisi_ctx->width,
+                          decrypt, hisi_ctx->sm1_round, type, hisi_ctx->hard_key);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_config, ret);
+        return ret;
+    }
+
+    if (hisi_ctx->hard_key != HI_TRUE) {
+        /* set odd key */
+        drv_symc_set_key(hisi_ctx->hard_chn, hisi_ctx->odd_key, HI_TRUE);
+
+        /* set even key */
+        drv_symc_set_key(hisi_ctx->hard_chn, hisi_ctx->even_key, HI_FALSE);
+    }
+
+    if (hisi_ctx->alg == SYMC_ALG_SM1) {
+        drv_symc_set_sm1_sk(hisi_ctx->hard_chn, hisi_ctx->sk);
+    }
+
+    /* set iv */
+    ret = drv_symc_set_iv(hisi_ctx->hard_chn, hisi_ctx->iv, hisi_ctx->ivlen, hisi_ctx->iv_usage);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_set_iv, ret);
+        return ret;
+    }
+
+    /*first node must set iv except ecb mode*/
+    if (hisi_ctx->iv_usage == CIPHER_IV_CHANGE_ONE_PKG) {
+        /* don't set iv any more*/
+        hisi_ctx->iv_usage = 0;
+    }
+
+    if (hisi_ctx->alg == SYMC_ALG_DES) {
+        hisi_ctx->block_size = DES_BLOCK_SIZE;
+    } else if (hisi_ctx->alg == SYMC_ALG_TDES) {
+        hisi_ctx->block_size = DES_BLOCK_SIZE;
+    } else {
+        hisi_ctx->block_size = AES_BLOCK_SIZE;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_symc_wait_done(void *ctx, hi_u32 timeout)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* wait done */
+    ret = drv_symc_wait_done(hisi_ctx->hard_chn, timeout);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_wait_done, ret);
+        return ret;
+    }
+
+    drv_symc_get_iv(hisi_ctx->hard_chn, hisi_ctx->iv);
+
+    if ((hisi_ctx->mode == SYMC_MODE_CCM)
+        || (hisi_ctx->mode == SYMC_MODE_GCM)) {
+        ret = drv_aead_get_tag(hisi_ctx->hard_chn, hisi_ctx->tag);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_aead_get_tag, ret);
+            return ret;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_symc_crypto_init(cryp_symc_context *hisi_ctx,
+                                 hi_u32 operation,
+                                 compat_addr input[],
+                                 compat_addr output[],
+                                 hi_u32 length[],
+                                 symc_node_usage usage_list[],
+                                 hi_u32 pkg_num, symc_node_usage usage)
+{
+    hi_u32 i = 0;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* length of pkage can't be zero */
+    hisi_ctx->enclen = 0;
+    if (pkg_num == 0x01) {
+        hisi_ctx->enclen += length[i];
+        usage_list[i] = usage_list[i] | (hi_u32)usage;
+    } else {
+        for (i = 0; i < pkg_num; i++) {
+            if (length[i] == 0x00) {
+                HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_OVERFLOW);
+                return HI_ERR_CIPHER_INVALID_LENGTH;
+            }
+
+            HI_LOG_CHECK_PARAM(hisi_ctx->enclen + length[i] < hisi_ctx->enclen);
+
+            hisi_ctx->enclen += length[i];
+            usage_list[i] = (hi_u32)usage_list[i] | (hi_u32)usage;
+        }
+    }
+
+    /* configuration parameter */
+    ret = cryp_symc_config(hisi_ctx, operation);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_symc_config, ret);
+        return ret;
+    }
+
+    hisi_ctx->input_list = input;
+    hisi_ctx->output_list = output;
+    hisi_ctx->length_list = length;
+    hisi_ctx->usage_list = usage_list;
+    hisi_ctx->total_nodes = pkg_num;
+    hisi_ctx->cur_nodes = 0;
+
+    /* set isr callback function */
+    ret = drv_symc_set_isr_callback(hisi_ctx->hard_chn, HI_NULL, HI_NULL);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_set_isr_callback, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_symc_crypto_process(cryp_symc_context *hisi_ctx, hi_u32 wait)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (wait == HI_TRUE) {
+        while (symc_add_buf_list(hisi_ctx) == SYMC_NODES_ADD_NOTFINISHED) {
+            /* start running */
+            drv_symc_start(hisi_ctx->hard_chn);
+
+            /* wait done */
+            ret = drv_symc_wait_done(hisi_ctx->hard_chn, CRYPTO_TIME_OUT);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_PRINT_FUNC_ERR(drv_symc_wait_done, ret);
+                return ret;
+            }
+        }
+    } else {
+        /* add buf list once */
+        ret = symc_add_buf_list(hisi_ctx);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(symc_add_buf_list, ret);
+            return ret;
+        }
+
+        /* set isr callback function */
+        ret = drv_symc_set_isr_callback(hisi_ctx->hard_chn, symc_add_buf_list, hisi_ctx);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_symc_set_isr_callback, ret);
+            return ret;
+        }
+
+        /* start running */
+        ret = drv_symc_start(hisi_ctx->hard_chn);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_symc_start, ret);
+            return ret;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_symc_crypto(void *ctx,
+                            hi_u32 operation,
+                            compat_addr input[],
+                            compat_addr output[],
+                            hi_u32 length[],
+                            symc_node_usage usage_list[],
+                            hi_u32 pkg_num,
+                            hi_u32 wait)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+
+    if (hisi_ctx->alg == SYMC_ALG_NULL_CIPHER) {
+        /* set last flag for each node when DMA copy */
+        hisi_ctx->iv_usage = CIPHER_IV_CHANGE_ALL_PKG;
+    }
+
+    ret = cryp_symc_crypto_init(hisi_ctx, operation, input, output, length,
+                                usage_list, pkg_num, SYMC_NODE_USAGE_NORMAL);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_symc_crypto_init, ret);
+        return ret;
+    }
+    usage_list[pkg_num - 1] = (hi_u32)usage_list[pkg_num - 1] | SYMC_NODE_USAGE_LAST;
+
+    /* tdes used as dma */
+    if (hisi_ctx->tdes2dma == HI_TRUE) {
+        if ((pkg_num != 0x01) && (length[0] < DES_BLOCK_SIZE)) {
+            HI_LOG_ERROR("Invalid 3des dma for pkg num (0x%x) or data lenth (0x%x).\n", pkg_num, length[0]);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    } else {
+        /* check the length of nodes list */
+        ret = drv_symc_node_check(hisi_ctx->alg,
+                                  hisi_ctx->mode,
+                                  hisi_ctx->klen,
+                                  hisi_ctx->block_size,
+                                  input,
+                                  output,
+                                  length,
+                                  usage_list,
+                                  pkg_num);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_symc_node_check, ret);
+            return ret;
+        }
+    }
+
+    ret = cryp_symc_crypto_process(hisi_ctx, wait);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_symc_crypto_process, ret);
+        return ret;
+    }
+
+    drv_symc_get_iv(hisi_ctx->hard_chn, hisi_ctx->iv);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+#ifdef CHIP_AES_CCM_GCM_SUPPORT
+static hi_s32 cryp_aead_ccm_setiv(void *ctx, const hi_u8 *iv, hi_u32 ivlen, hi_u32 usage)
+{
+    hi_u8 ccm_iv[AES_IV_SIZE] = {0};
+
+    /* The octet lengths of N are denoted  n,
+     * The octet length of the binary represen tation of the
+     * octet length of the payload denoted q,
+     * n is an element of {7, 8, 9, 10, 11, 12, 13}
+     * n + q = 15
+     * here the string of N  is pConfig->iv, and n is pConfig->ivLen.
+     */
+    if ((ivlen < AES_CCM_MIN_IV_LEN)
+        || (ivlen > AES_CCM_MAX_IV_LEN)) {
+        HI_LOG_ERROR("Invalid ccm iv len, ivlen = 0x%x.\n", ivlen);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    /* Formatting of the Counter Blocks(IV for CTR)
+     *
+     * According to the CCM spec, the counter is equivalent to
+     * a formatting of the counter index i into a complete data block.
+     * The counter blocks Ctri are formatted as shown below:
+     * | Octet number:  0    1 ... 15-q    16-q ... 15
+     * | Contents:     Flags     N             [i]
+     * Within each block Ctri, the N is get from pConfig->iv, n + q = 15,
+     * so the q equal to 15 - pConfig->ivLen.
+     * the [i] is the block conut start with 0,
+     * In the Flags field, Bits 0, 1, and 2 contain the encoding of q - 1,
+     * others bits shall be set to 0.
+     * so the first byte of IV shall be q -1, that is 15 - pConfig->ivLen - 1
+     */
+    crypto_memset(ccm_iv, sizeof(ccm_iv), 0, AES_IV_SIZE);
+    ccm_iv[0] = AES_CCM_NQ_LEN - ivlen; /*IV[0] = q - 1 = 15 - n -1*/
+    crypto_memcpy(&ccm_iv[1], sizeof(ccm_iv) - 1, iv, ivlen);
+    ivlen += 1;
+
+    cryp_symc_setiv(ctx, ccm_iv, ivlen, usage);
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_aead_gcm_setiv(void *ctx, const hi_u8 *iv, hi_u32 ivlen, hi_u32 usage)
+{
+    if ((ivlen < AES_GCM_MIN_IV_LEN)
+        || (ivlen > AES_GCM_MAX_IV_LEN)) {
+        HI_LOG_ERROR("Invalid gcm iv len, ivlen = 0x%x.\n", ivlen);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    cryp_symc_setiv(ctx, iv, ivlen, usage);
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 cyp_aead_ccm_n(hi_u8 *buf, hi_u8 *iv, hi_u32 ivlen,
+                          hi_u32 alen, hi_u32 enclen, hi_u32 tlen)
+{
+    hi_u32 idx = 0;
+    hi_u32 q = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* Format B0
+     * The leading octet of the first block of the formatting, B0,
+     * contains four flags for control information: two single bits,
+     * called  Reserved  and  Adata, and two strings of three bits,
+     * to encode the values t and q.  The encoding of t is [(t -2)/2],
+     * and the encoding of q is [ q-1].
+     * The ordering of the flags with in the octet is given:
+     *  _____________________________________________________
+     * |Bit number  7     |   6   | 5  4  3     |  2  1  0   |
+     * |Contents  Reserved  Adata   [(t -2)/2] |  [q-1]     |
+     *  -----------------------------------------------------
+     * The remaining 15 octets of the first block of  the formatting are
+     * devoted to the nonce and the binary representation of
+     * the message length in  q octets, as given:
+     *  _____________________________________________
+     * |Octet number  0   | 1 ... 15-q | 16-q ... 15 |
+     * |Contents    Flags |      N     |      Q      |
+     *  ---------------------------------------------
+    */
+    crypto_memset(buf, AES_BLOCK_SIZE, 0, AES_BLOCK_SIZE);
+    buf[idx]  = (alen > 0 ? 1 : 0) << 6; /* Adata */
+    buf[idx] |= ((tlen - 2) / 2) << 3;   /* (t -2)/2 */
+    buf[idx] |= (15 - ivlen);            /* q-1, n+q=15 */
+    idx++;
+
+    /* copy N, skip Flags in byte0*/
+    crypto_memcpy(&buf[idx], AES_BLOCK_SIZE - idx, &iv[1], ivlen - 1);
+    idx += ivlen - 1;
+
+    q = AES_BLOCK_SIZE - idx;
+
+    if (q >= SYMC_CCM_Q_LEN_4B) {
+        /* max payload len of 2^32, jump to the location of last word */
+        idx = AES_BLOCK_SIZE - SYMC_CCM_Q_LEN_4B;
+
+        buf[idx++] = (hi_u8)(enclen >> 24);
+        buf[idx++] = (hi_u8)(enclen >> 16);
+        buf[idx++] = (hi_u8)(enclen >> 8);
+        buf[idx++] = (hi_u8)(enclen);
+    } else if ((q == SYMC_CCM_Q_LEN_3B) && (enclen <= SYMC_CCM_P_LEN_3B)) {
+        /* max payload len of 2^24*/
+        buf[idx++] = (hi_u8)(enclen >> 16);
+        buf[idx++] = (hi_u8)(enclen >> 8);
+        buf[idx++] = (hi_u8)(enclen);
+    } else if ((q == SYMC_CCM_Q_LEN_2B) && (enclen <= SYMC_CCM_P_LEN_2B)) {
+        /* max payload len of 2^16*/
+        buf[idx++] = (hi_u8)(enclen >> 8);
+        buf[idx++] = (hi_u8)(enclen);
+    } else {
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_u32 cyp_aead_gcm_clen(hi_u8 *buf, hi_u32 alen, hi_u32 enclen)
+{
+    hi_u32 idx = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* Format len(C), 16 byets, coding in bits.
+     * Byet0~7:  bits number of Add
+     * Byet8~15: bits number of P
+     */
+
+    buf[idx++] = 0x00;
+    buf[idx++] = 0x00;
+    buf[idx++] = 0x00;
+    buf[idx++] = (hi_u8)((alen >> 29) & 0x07);
+    buf[idx++] = (hi_u8)((alen >> 21) & 0xff);
+    buf[idx++] = (hi_u8)((alen >> 13) & 0xff);
+    buf[idx++] = (hi_u8)((alen >> 5) & 0xff);
+    buf[idx++] = (hi_u8)((alen << 3) & 0xff);
+
+    buf[idx++] = 0x00;
+    buf[idx++] = 0x00;
+    buf[idx++] = 0x00;
+    buf[idx++] = (hi_u8)((enclen >> 29) & 0x07);
+    buf[idx++] = (hi_u8)((enclen >> 21) & 0xff);
+    buf[idx++] = (hi_u8)((enclen >> 13) & 0xff);
+    buf[idx++] = (hi_u8)((enclen >> 5) & 0xff);
+    buf[idx++] = (hi_u8)((enclen << 3) & 0xff);
+
+    return idx;
+}
+
+static hi_s32 cryp_aead_ccm_set_aad(void *ctx, compat_addr aad, hi_u32 alen, hi_u32 tlen)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* the parameter t denotes the octet length of T(tag)
+     * t is an element of  { 4, 6, 8, 10, 12, 14, 16}
+     * here t is pConfig->u32TagLen
+     */
+    if ((tlen & 0x01)
+        || (tlen < AES_CCM_MIN_TAG_LEN)
+        || (tlen > AES_CCM_MAX_TAG_LEN)) {
+        HI_LOG_ERROR("Invalid tag len, tlen = 0x%x.\n", tlen);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    hisi_ctx->aad = aad;
+    hisi_ctx->alen = alen;
+    hisi_ctx->tlen = tlen;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_aead_gcm_set_aad(void *ctx, compat_addr aad, hi_u32 alen, hi_u32 tlen)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    if ((tlen < AES_GCM_MIN_TAG_LEN)
+        || (tlen > AES_GCM_MAX_TAG_LEN)) {
+        HI_LOG_ERROR("Invalid tag len, tlen = 0x%x.\n", tlen);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    hisi_ctx->aad = aad;
+    hisi_ctx->alen = alen;
+    hisi_ctx->tlen = tlen;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_aead_crypto_zero(cryp_symc_context *hisi_ctx, hi_u32 wait)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* start running */
+    ret = drv_symc_start(hisi_ctx->hard_chn);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_symc_start, ret);
+        return ret;
+    }
+
+    /* wait done */
+    if (wait == HI_TRUE) {
+        ret = drv_symc_wait_done(hisi_ctx->hard_chn, CRYPTO_TIME_OUT);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_symc_wait_done, ret);
+            return ret;
+        }
+
+        ret = drv_aead_get_tag(hisi_ctx->hard_chn, hisi_ctx->tag);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_aead_get_tag, ret);
+            return ret;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_aead_ccm_crypto(void *ctx,
+                                hi_u32 operation,
+                                compat_addr input[],
+                                compat_addr output[],
+                                hi_u32 length[],
+                                symc_node_usage usage_list[],
+                                hi_u32 pkg_num, hi_u32 wait)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u8 n[AES_BLOCK_SIZE] = {0};
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = cryp_symc_crypto_init(hisi_ctx, operation, input, output, length,
+                                usage_list, pkg_num, SYMC_NODE_USAGE_IN_CCM_P);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_symc_crypto_init, ret);
+        return ret;
+    }
+
+    /***
+     * NIST Special Publication 800-38C
+     * The data that CCM protects consists of a message, i.e., a bit string,
+     * called the payload, denoted P, of bit length denoted Plen,
+     * and a bit string, called the associated data, denoted A.
+     * The associated data is optional, i.e., A may be the empty string.
+     * CCM provides assurance of the confidentiality of P and assurance of
+     * the authenticity of the origin of both A and P;
+     * confidentiality is not provided for A.
+     ***/
+
+    /* Compute N */
+    ret  = cyp_aead_ccm_n(n,
+                          (hi_u8 *)hisi_ctx->iv,
+                          hisi_ctx->ivlen,
+                          hisi_ctx->alen,
+                          hisi_ctx->enclen,
+                          hisi_ctx->tlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cyp_aead_ccm_n, ret);
+        return ret;
+    }
+
+    ret = drv_aead_ccm_add_n(hisi_ctx->hard_chn, n);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_aead_ccm_add_n, ret);
+        return ret;
+    }
+
+    /* Compute A */
+    ret = drv_aead_ccm_add_a(hisi_ctx->hard_chn, hisi_ctx->aad, hisi_ctx->alen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_aead_ccm_add_a, ret);
+        return ret;
+    }
+
+    if (0 == hisi_ctx->enclen) {
+        /*Set CCM last flag*/
+        drv_symc_add_buf_usage(hisi_ctx->hard_chn,
+                               HI_TRUE,
+                               SYMC_NODE_USAGE_CCM_LAST);
+
+        /* If P is HI_NULL, must add a empty node into node list, limit to hardware devising*/
+        ret = drv_symc_add_outbuf(hisi_ctx->hard_chn,
+                                  ADDR_NULL,
+                                  0x00,
+                                  SYMC_NODE_USAGE_LAST);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_symc_add_outbuf, ret);
+            return ret;
+        }
+
+        ret = cryp_aead_crypto_zero(hisi_ctx, wait);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_aead_crypto_zero, ret);
+            return ret;
+        }
+    } else {
+        /* for CCM, must set P last and ccm last flag */
+        usage_list[pkg_num - 1] = (hi_u32)usage_list[pkg_num - 1] | (SYMC_NODE_USAGE_CCM_LAST | SYMC_NODE_USAGE_LAST);
+        ret = cryp_symc_crypto_process(hisi_ctx, wait);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_symc_crypto_process, ret);
+            return ret;
+        }
+
+        ret = drv_aead_get_tag(hisi_ctx->hard_chn, hisi_ctx->tag);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_aead_get_tag, ret);
+            return ret;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_aead_gcm_crypto(void *ctx,
+                                hi_u32 operation,
+                                compat_addr input[],
+                                compat_addr output[],
+                                hi_u32 length[],
+                                symc_node_usage usage_list[],
+                                hi_u32 pkg_num, hi_u32 wait)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_symc_context *hisi_ctx = ctx;
+    hi_u8 clen[AES_BLOCK_SIZE] = {0};
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = cryp_symc_crypto_init(hisi_ctx, operation, input, output, length,
+                                usage_list, pkg_num, SYMC_NODE_USAGE_IN_GCM_P);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_symc_crypto_init, ret);
+        return ret;
+    }
+
+    /***
+     * NIST Special Publication 800-38D
+     * A || P || Clen.
+     ***/
+
+    /* Compute A */
+    ret = drv_aead_gcm_add_a(hisi_ctx->hard_chn, hisi_ctx->aad, hisi_ctx->alen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(drv_aead_gcm_add_a, ret);
+        return ret;
+    }
+
+    if (0 == hisi_ctx->enclen) {
+        /* At the and of GCM, must add a empty node to nodes list,
+         * limit to hardware devising
+         */
+        ret = drv_symc_add_outbuf(hisi_ctx->hard_chn, ADDR_NULL, 0x00, SYMC_NODE_USAGE_LAST);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_symc_add_outbuf, ret);
+            return ret;
+        }
+
+        /*Format the length fields of C and add to nodes list*/
+        cyp_aead_gcm_clen(clen, hisi_ctx->alen, 0x00);
+        ret = drv_aead_gcm_add_clen(hisi_ctx->hard_chn, clen);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_aead_gcm_add_clen, ret);
+            return ret;
+        }
+
+        ret = cryp_aead_crypto_zero(hisi_ctx, wait);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_aead_crypto_zero, ret);
+            return ret;
+        }
+    } else {
+        /* for GCM, must set P last and gcm last flag */
+        usage_list[pkg_num - 1] = (hi_u32)usage_list[pkg_num - 1] | SYMC_NODE_USAGE_LAST;
+        ret = cryp_symc_crypto_process(hisi_ctx, wait);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_symc_crypto_process, ret);
+            return ret;
+        }
+
+        ret = drv_aead_get_tag(hisi_ctx->hard_chn, hisi_ctx->tag);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_aead_get_tag, ret);
+            return ret;
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_aead_get_tag(void *ctx, hi_u32 tag[AEAD_TAG_SIZE_IN_WORD], hi_u32 *taglen)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(*taglen < hisi_ctx->tlen);
+
+    HI_LOG_DEBUG("tag buffer len %d, tag len %d\n", *taglen,  hisi_ctx->tlen);
+
+    *taglen = hisi_ctx->tlen;
+
+    crypto_memcpy(tag, AEAD_TAG_SIZE, hisi_ctx->tag, hisi_ctx->tlen);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+#endif
+
+static hi_s32 cryp_register_symc(symc_func *func)
+{
+    hi_u32 i = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* check availability */
+    if ((func->create == HI_NULL)
+        || (func->crypto == HI_NULL)) {
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    /* is it already registered? */
+    for (i = 0; i < SYMC_FUNC_TAB_SIZE; i++) {
+        if (symc_descriptor[i].valid
+            && symc_descriptor[i].alg == func->alg
+            && symc_descriptor[i].mode == func->mode) {
+            HI_LOG_FUNC_EXIT();
+            return HI_SUCCESS;
+        }
+    }
+
+    /* find a blank spot */
+    for (i = 0; i < SYMC_FUNC_TAB_SIZE; i++) {
+        if (!symc_descriptor[i].valid) {
+            crypto_memcpy(&symc_descriptor[i], sizeof(symc_func), func, sizeof(symc_func));
+            symc_descriptor[i].valid = HI_TRUE;
+            HI_LOG_DEBUG("symc_descriptor[%d], alg %d, mode %d\n", i,
+                         symc_descriptor[i].alg, symc_descriptor[i].mode);
+
+            HI_LOG_FUNC_EXIT();
+            return HI_SUCCESS;
+        }
+    }
+
+    /* Can't find a blank spot */
+    HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_OVERFLOW);
+    return HI_ERR_CIPHER_OVERFLOW;
+}
+
+static symc_func *cryp_get_symc(hi_u32 alg, hi_u32 mode)
+{
+    hi_u32 i = 0;
+    symc_func *template = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* find the valid function */
+    for (i = 0; i < SYMC_FUNC_TAB_SIZE; i++) {
+        HI_LOG_DEBUG("symc_descriptor[%d] valid %d, alg %d, mode %d \n",
+                     i, symc_descriptor[i].valid, symc_descriptor[i].alg, symc_descriptor[i].mode);
+
+        if (symc_descriptor[i].valid) {
+            if (symc_descriptor[i].alg == alg
+                && symc_descriptor[i].mode == mode) {
+                template = &symc_descriptor[i];
+                break;
+            }
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return template;
+}
+
+/***
+ * Defined the default template of Symmetric cipher function,
+ * the function can be replaced by other engine
+ */
+static hi_s32 cryp_aes_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen)
+{
+    hi_u32 klen = 0;
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* set the key length depend on alg
+     * des/3des support 2key and 3key
+     * aes support 128, 192, and 256
+     * sm1 support ak/ek/sk
+     * sm4 support 128
+     */
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+
+    hisi_ctx->tdes2dma = HI_FALSE;
+
+    switch (*hisi_klen) {
+        case HI_CIPHER_KEY_AES_128BIT: {
+            klen = AES_KEY_128BIT;
+            break;
+        }
+        case HI_CIPHER_KEY_AES_192BIT: {
+            klen = AES_KEY_192BIT;
+            break;
+        }
+        case HI_CIPHER_KEY_AES_256BIT: {
+            klen = AES_KEY_256BIT;
+            break;
+        }
+        default: {
+            HI_LOG_ERROR("aes with invalid keylen.\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+    HI_LOG_INFO("key len %d, type %d\n", klen, hisi_klen);
+
+    *hisi_klen = klen;
+
+    if (fkey == HI_NULL) {
+        hisi_ctx->hard_key = HI_TRUE;
+        hisi_ctx->klen = klen;
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    cryp_symc_setkey(ctx, fkey, klen, HI_FALSE);
+
+    if (skey) {
+        cryp_symc_setkey(ctx, skey, klen, HI_TRUE);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_tdes_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen)
+{
+    hi_u32 klen = 0;
+    cryp_symc_context *hisi_ctx = ctx;
+    symc_capacity capacity;
+    hi_u32 invalid = HI_FALSE;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* set the key length depend on alg
+     * des/3des support 2key and 3key
+     * aes support 128, 192, and 256
+     * sm1 support ak/ek/sk
+     * sm4 support 128
+     */
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+
+    CRYPTO_UNUSED(skey);
+
+    hisi_ctx->tdes2dma = HI_FALSE;
+
+    if (fkey == HI_NULL) {
+        if (HI_CIPHER_KEY_DES_2KEY != *hisi_klen) {
+            HI_LOG_ERROR("error, tdes hard key must be 2key.\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_ILLEGAL_KEY);
+            return HI_ERR_CIPHER_ILLEGAL_KEY;
+        }
+
+        hisi_ctx->hard_key = HI_TRUE;
+        hisi_ctx->klen = TDES_KEY_128BIT;
+        *hisi_klen = TDES_KEY_128BIT;
+
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    /* get symc capacity */
+    drv_symc_get_capacity(&capacity);
+
+    /*check k1 != k2*/
+    if (memcmp(&fkey[0], &fkey[8], DES_BLOCK_SIZE) == 0) {
+        invalid = HI_TRUE;
+    }
+
+    switch (*hisi_klen) {
+        case HI_CIPHER_KEY_DES_2KEY: {
+            klen = TDES_KEY_128BIT;
+            break;
+        }
+        case HI_CIPHER_KEY_DES_3KEY: {
+            klen = TDES_KEY_192BIT;
+
+            /*check k2 != k3*/
+            if (memcmp(&fkey[8], &fkey[16], DES_BLOCK_SIZE) == 0) {
+                invalid = HI_TRUE;
+            }
+            break;
+        }
+        default: {
+            HI_LOG_ERROR("3des with invalid keylen, keylen = 0x%x.\n", *hisi_klen);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+
+    if (invalid == HI_TRUE) {
+        if (capacity.dma == CRYPTO_CAPACITY_SUPPORT) {
+            HI_LOG_ERROR("3des with invalid key.\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_ILLEGAL_KEY;
+        }
+
+        /* if don't support dma, the tdes with invalid key can be used as dma*/
+        hisi_ctx->tdes2dma = HI_TRUE;
+    }
+
+    cryp_symc_setkey(ctx, fkey, klen, HI_FALSE);
+
+    *hisi_klen = klen;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_des_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+
+    CRYPTO_UNUSED(skey);
+
+    hisi_ctx->tdes2dma = HI_FALSE;
+
+    if (fkey == HI_NULL) {
+        HI_LOG_ERROR("error, des nonsupport hard key.\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_ILLEGAL_KEY);
+        return HI_ERR_CIPHER_ILLEGAL_KEY;
+    }
+
+    cryp_symc_setkey(ctx, fkey, DES_KEY_SIZE, HI_FALSE);
+
+    *hisi_klen = DES_KEY_SIZE;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_3des2dma_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen)
+{
+    hi_u8 key[TDES_KEY_128BIT] = {0};
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+
+    CRYPTO_UNUSED(fkey);
+    CRYPTO_UNUSED(skey);
+
+    cryp_symc_setkey(ctx, key, TDES_KEY_128BIT, HI_FALSE);
+
+    *hisi_klen = TDES_KEY_128BIT;
+    hisi_ctx->tdes2dma = HI_TRUE;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_sm1_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen)
+{
+    hi_s32 ret = HI_FAILURE;
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_CHECK_PARAM(hisi_klen == HI_NULL);
+    HI_LOG_CHECK_PARAM(*hisi_klen == HI_CIPHER_KEY_DEFAULT);
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+    CRYPTO_UNUSED(skey);
+
+    hisi_ctx->tdes2dma = HI_FALSE;
+
+    if (fkey == HI_NULL) {
+        hisi_ctx->hard_key = HI_TRUE;
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    cryp_symc_setkey(ctx, fkey, SM1_AK_EK_SIZE, HI_FALSE);
+
+    /* sm1 support ak/ek/sk */
+    ret = cryp_symc_sm1_setsk(ctx, skey);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_symc_sm1_setsk, ret);
+        return ret;
+    }
+
+    *hisi_klen = SM1_AK_EK_SIZE;
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_sm4_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_CHECK_PARAM(hisi_klen == HI_NULL);
+    HI_LOG_CHECK_PARAM(*hisi_klen != HI_CIPHER_KEY_DEFAULT);
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+    CRYPTO_UNUSED(skey);
+
+    hisi_ctx->tdes2dma = HI_FALSE;
+
+    if (fkey == HI_NULL) {
+        hisi_ctx->hard_key = HI_TRUE;
+
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+
+    /*  sm4 support 128 */
+    cryp_symc_setkey(ctx, fkey, SM4_KEY_SIZE, HI_FALSE);
+
+    *hisi_klen = SM4_KEY_SIZE;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_symc_setiv_default(void *ctx, const hi_u8 *iv, hi_u32 ivlen, hi_u32 usage)
+{
+    HI_LOG_FUNC_ENTER();
+
+    if (iv == HI_NULL) {
+        return HI_SUCCESS;
+    }
+
+    if (ivlen > AES_IV_SIZE) {
+        return HI_FAILURE;
+    }
+
+    cryp_symc_setiv(ctx, iv, ivlen, usage);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/* Default As AES */
+static void cryp_register_symc_default(symc_func *func, symc_alg alg, symc_mode mode)
+{
+    crypto_memset(func, sizeof(symc_func), 0, sizeof(symc_func));
+
+    func->mode = mode;
+    func->alg = alg;
+    func->create = cryp_symc_create;
+    func->setiv = cryp_symc_setiv_default;
+    func->getiv = cryp_symc_getiv;
+    func->crypto = cryp_symc_crypto;
+    func->setmode = cryp_symc_setmode;
+    func->setkey = cryp_aes_setkey;
+    func->waitdone = cryp_symc_wait_done;
+    return;
+}
+
+static void cryp_register_symc_aes(hi_u32 capacity, symc_mode mode)
+{
+    symc_func func;
+    hi_s32 ret = HI_FAILURE;
+
+    crypto_memset(&func, sizeof(symc_func), 0, sizeof(symc_func));
+
+    if (capacity == CRYPTO_CAPACITY_SUPPORT) {
+        cryp_register_symc_default(&func, SYMC_ALG_AES, mode);
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    }
+#ifdef SOFT_AES_SUPPORT
+    else {
+        cryp_register_symc_default(&func, SYMC_ALG_AES, mode);
+        func.create = ext_mbedtls_symc_create;
+        func.destroy = ext_mbedtls_symc_destory;
+        func.setiv = ext_mbedtls_symc_setiv;
+        func.getiv = ext_mbedtls_symc_getiv;
+        func.setkey = ext_mbedtls_symc_setkey;
+        func.setmode = ext_mbedtls_symc_setmode;
+        func.crypto = ext_mbedtls_symc_crypto;
+        func.waitdone = HI_NULL;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    }
+#endif
+
+    return;
+}
+
+static void cryp_register_symc_dma(hi_u32 dma_capacity, hi_u32 tdes_capacity)
+{
+    symc_func func;
+    hi_s32 ret = HI_FAILURE;
+
+    crypto_memset(&func, sizeof(func), 0, sizeof(func));
+
+    if (dma_capacity == CRYPTO_CAPACITY_SUPPORT) {
+        func.mode = SYMC_MODE_ECB;
+        func.alg = SYMC_ALG_NULL_CIPHER;
+        func.create = cryp_symc_create;
+        func.setmode = cryp_symc_setmode;
+        func.crypto = cryp_symc_crypto;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    } else if (tdes_capacity == CRYPTO_CAPACITY_SUPPORT) {
+        func.mode = SYMC_MODE_ECB;
+        func.alg = SYMC_ALG_NULL_CIPHER;
+        func.create = cryp_symc_create;
+        func.setmode = cryp_3des2dma_setmode;
+        func.setkey = cryp_3des2dma_setkey;
+        func.crypto = cryp_symc_crypto;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    }
+    return;
+}
+
+static void cryp_register_symc_aes_cts(hi_u32 capacity, symc_mode mode)
+{
+#ifdef SOFT_AES_CTS_SUPPORT
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_DEBUG("CTS crypto capacity %d, mode %d\n", capacity, mode);
+
+    if (capacity != CRYPTO_CAPACITY_SUPPORT) {
+        symc_func func;
+
+        crypto_memset(&func, sizeof(func), 0, sizeof(func));
+
+        cryp_register_symc_default(&func, SYMC_ALG_AES, mode);
+        func.crypto = cryp_aes_cbc_cts_crypto;
+        func.waitdone = HI_NULL;
+        HI_LOG_DEBUG("CTS crypto 0x%p, mode %d\n", func.crypto, mode);
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    }
+#endif
+    return;
+}
+
+static void cryp_register_aead_ccm(hi_u32 capacity, symc_mode mode)
+{
+    if (capacity == CRYPTO_CAPACITY_SUPPORT) {
+#ifdef CHIP_AES_CCM_GCM_SUPPORT
+        symc_func func;
+        hi_s32 ret = HI_FAILURE;
+
+        crypto_memset(&func, sizeof(func), 0, sizeof(func));
+
+        cryp_register_symc_default(&func, SYMC_ALG_AES, mode);
+        func.setadd = cryp_aead_ccm_set_aad;
+        func.gettag = cryp_aead_get_tag;
+        func.crypto = cryp_aead_ccm_crypto;
+        func.setiv = cryp_aead_ccm_setiv;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+#endif
+    } else {
+#ifdef SOFT_AES_CCM_GCM_SUPPORT
+        symc_func func;
+        hi_s32 ret = HI_FAILURE;
+
+        crypto_memset(&func, sizeof(func), 0, sizeof(func));
+
+        func.mode = mode;
+        func.alg = SYMC_ALG_AES;
+        func.create = ext_mbedtls_aead_create;
+        func.destroy = ext_mbedtls_aead_destory;
+        func.setiv = ext_mbedtls_aead_setiv;
+        func.getiv = HI_NULL;
+        func.crypto = ext_mbedtls_aead_ccm_crypto;
+        func.setmode = HI_NULL;
+        func.setkey = ext_mbedtls_aead_setkey;
+        func.setadd = ext_mbedtls_aead_set_aad;
+        func.gettag = ext_mbedtls_aead_get_tag;
+        func.waitdone = HI_NULL;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+#endif
+    }
+
+    return;
+}
+
+static void cryp_register_aead_gcm(hi_u32 capacity, symc_mode mode)
+{
+    if (capacity == CRYPTO_CAPACITY_SUPPORT) {
+#ifdef  CHIP_AES_CCM_GCM_SUPPORT
+        symc_func func;
+        hi_s32 ret = HI_FAILURE;
+
+        crypto_memset(&func, sizeof(symc_func), 0, sizeof(symc_func));
+
+        cryp_register_symc_default(&func, SYMC_ALG_AES, mode);
+        func.setadd = cryp_aead_gcm_set_aad;
+        func.gettag = cryp_aead_get_tag;
+        func.crypto = cryp_aead_gcm_crypto;
+        func.setiv = cryp_aead_gcm_setiv;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+#endif
+    } else {
+#ifdef SOFT_AES_CCM_GCM_SUPPORT
+        symc_func func;
+        hi_s32 ret = HI_FAILURE;
+
+        crypto_memset(&func, sizeof(symc_func), 0, sizeof(symc_func));
+
+        func.mode = mode;
+        func.alg = SYMC_ALG_AES;
+        func.create = ext_mbedtls_aead_create;
+        func.destroy = ext_mbedtls_aead_destory;
+        func.setiv = ext_mbedtls_aead_setiv;
+        func.getiv = HI_NULL;
+        func.crypto = ext_mbedtls_aead_gcm_crypto;
+        func.setmode = HI_NULL;
+        func.setkey = ext_mbedtls_aead_setkey;
+        func.setadd = ext_mbedtls_aead_set_aad;
+        func.gettag = ext_mbedtls_aead_get_tag;
+        func.waitdone = HI_NULL;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+#endif
+    }
+
+    return;
+}
+
+static void cryp_register_symc_tdes(hi_u32 capacity, symc_mode mode)
+{
+    symc_func func;
+    hi_s32 ret = HI_FAILURE;
+
+    crypto_memset(&func, sizeof(symc_func), 0, sizeof(symc_func));
+
+    if (capacity == CRYPTO_CAPACITY_SUPPORT) {
+        cryp_register_symc_default(&func, SYMC_ALG_TDES, mode);
+        func.setkey = cryp_tdes_setkey;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    }
+#ifdef SOFT_TDES_SUPPORT
+    else {
+        cryp_register_symc_default(&func, SYMC_ALG_TDES, mode);
+        func.create = ext_mbedtls_symc_create;
+        func.destroy = ext_mbedtls_symc_destory;
+        func.setiv = ext_mbedtls_symc_setiv;
+        func.getiv = ext_mbedtls_symc_getiv;
+        func.setkey = ext_mbedtls_symc_setkey;
+        func.setmode = ext_mbedtls_symc_setmode;
+        func.crypto = ext_mbedtls_symc_crypto;
+        func.waitdone = HI_NULL;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    }
+#endif
+    return;
+}
+
+static void cryp_register_symc_des(hi_u32 capacity, symc_mode mode)
+{
+    symc_func func;
+    hi_s32 ret = HI_FAILURE;
+
+    crypto_memset(&func, sizeof(symc_func), 0, sizeof(symc_func));
+
+    if (capacity == CRYPTO_CAPACITY_SUPPORT) {
+        cryp_register_symc_default(&func, SYMC_ALG_DES, mode);
+        func.setkey = cryp_des_setkey;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    }
+#ifdef SOFT_TDES_SUPPORT
+    else {
+        cryp_register_symc_default(&func, SYMC_ALG_DES, mode);
+        func.create = ext_mbedtls_symc_create;
+        func.destroy = ext_mbedtls_symc_destory;
+        func.setiv = ext_mbedtls_symc_setiv;
+        func.getiv = ext_mbedtls_symc_getiv;
+        func.setkey = ext_mbedtls_symc_setkey;
+        func.setmode = ext_mbedtls_symc_setmode;
+        func.crypto = ext_mbedtls_symc_crypto;
+        func.waitdone = HI_NULL;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    }
+#endif
+    return;
+}
+
+static void cryp_register_symc_sm1(hi_u32 capacity, symc_mode mode)
+{
+    symc_func func;
+    hi_s32 ret = HI_FAILURE;
+
+    crypto_memset(&func, sizeof(symc_func), 0, sizeof(symc_func));
+
+    if (capacity == CRYPTO_CAPACITY_SUPPORT) {
+        cryp_register_symc_default(&func, SYMC_ALG_SM1, mode);
+        func.setround = cryp_symc_sm1_setround;
+        func.setkey = cryp_sm1_setkey;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    }
+    return;
+}
+
+static void cryp_register_symc_sm4(hi_u32 capacity, symc_mode mode)
+{
+    symc_func func;
+    hi_s32 ret = HI_FAILURE;
+
+    crypto_memset(&func, sizeof(symc_func), 0, sizeof(symc_func));
+
+    if (capacity == CRYPTO_CAPACITY_SUPPORT) {
+        cryp_register_symc_default(&func, SYMC_ALG_SM4, mode);
+        func.setkey = cryp_sm4_setkey;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    }
+#ifdef SOFT_SM4_SUPPORT
+    else {
+        cryp_register_symc_default(&func, SYMC_ALG_SM4, mode);
+        func.create = ext_sm4_create;
+        func.destroy = ext_sm4_destory;
+        func.setiv = ext_sm4_setiv;
+        func.getiv = ext_sm4_getiv;
+        func.setkey = ext_sm4_setkey;
+        func.setmode = ext_sm4_setmode;
+        func.crypto = ext_sm4_crypto;
+        ret = cryp_register_symc(&func);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
+            return;
+        }
+    }
+#endif
+    return;
+}
+
+/* symc function register */
+static void cryp_register_all_symc(void)
+{
+    symc_capacity capacity;
+
+    HI_LOG_FUNC_ENTER();
+
+    crypto_memset(&capacity, sizeof(capacity), 0, sizeof(capacity));
+
+    /* get symc capacity */
+    drv_symc_get_capacity(&capacity);
+
+    /* register the symc function if supported */
+
+    /* AES */
+    cryp_register_symc_aes(capacity.aes_ecb, SYMC_MODE_ECB);
+    cryp_register_symc_aes(capacity.aes_cbc, SYMC_MODE_CBC);
+    cryp_register_symc_aes(capacity.aes_cfb, SYMC_MODE_CFB);
+    cryp_register_symc_aes(capacity.aes_ofb, SYMC_MODE_OFB);
+    cryp_register_symc_aes(capacity.aes_ctr, SYMC_MODE_CTR);
+    cryp_register_symc_dma(capacity.dma, capacity.tdes_ecb);
+    cryp_register_symc_aes_cts(capacity.aes_cts, SYMC_MODE_CTS);
+
+    /* AEAD */
+    cryp_register_aead_ccm(capacity.aes_ccm, SYMC_MODE_CCM);
+    cryp_register_aead_gcm(capacity.aes_gcm, SYMC_MODE_GCM);
+
+    /* TDES */
+    cryp_register_symc_tdes(capacity.tdes_ecb, SYMC_MODE_ECB);
+    cryp_register_symc_tdes(capacity.tdes_cbc, SYMC_MODE_CBC);
+    cryp_register_symc_tdes(capacity.tdes_cfb, SYMC_MODE_CFB);
+    cryp_register_symc_tdes(capacity.tdes_ofb, SYMC_MODE_OFB);
+    cryp_register_symc_tdes(capacity.tdes_ctr, SYMC_MODE_CTR);
+
+    /* DES */
+    cryp_register_symc_des(capacity.des_ecb, SYMC_MODE_ECB);
+    cryp_register_symc_des(capacity.des_cbc, SYMC_MODE_CBC);
+    cryp_register_symc_des(capacity.des_cfb, SYMC_MODE_CFB);
+    cryp_register_symc_des(capacity.des_ofb, SYMC_MODE_OFB);
+    cryp_register_symc_des(capacity.des_ctr, SYMC_MODE_CTR);
+
+    /* SM1 */
+    cryp_register_symc_sm1(capacity.sm1_ecb, SYMC_MODE_ECB);
+    cryp_register_symc_sm1(capacity.sm1_cbc, SYMC_MODE_CBC);
+    cryp_register_symc_sm1(capacity.sm1_cfb, SYMC_MODE_CFB);
+    cryp_register_symc_sm1(capacity.sm1_ofb, SYMC_MODE_OFB);
+    cryp_register_symc_sm1(capacity.sm1_ctr, SYMC_MODE_CTR);
+
+    /* SM4 */
+    cryp_register_symc_sm4(capacity.sm4_ecb, SYMC_MODE_ECB);
+    cryp_register_symc_sm4(capacity.sm4_cbc, SYMC_MODE_CBC);
+    cryp_register_symc_sm4(capacity.sm4_cfb, SYMC_MODE_CFB);
+    cryp_register_symc_sm4(capacity.sm4_ofb, SYMC_MODE_OFB);
+    cryp_register_symc_sm4(capacity.sm4_ctr, SYMC_MODE_CTR);
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+symc_func *cryp_get_symc_op(hi_cipher_alg alg, hi_cipher_work_mode mode)
+{
+    hi_u32 cryp_mode = 0;
+    symc_func *func = HI_NULL;
+    symc_alg cryp_alg;
+
+    HI_LOG_FUNC_ENTER();
+
+    switch (alg) {
+        case HI_CIPHER_ALG_DES:
+            cryp_alg = SYMC_ALG_DES;
+            break;
+        case HI_CIPHER_ALG_3DES:
+            cryp_alg = SYMC_ALG_TDES;
+            break;
+        case HI_CIPHER_ALG_AES:
+            cryp_alg = SYMC_ALG_AES;
+            break;
+        case HI_CIPHER_ALG_SM1:
+            cryp_alg = SYMC_ALG_SM1;
+            break;
+        case HI_CIPHER_ALG_SM4:
+            cryp_alg = SYMC_ALG_SM4;
+            break;
+        case HI_CIPHER_ALG_DMA:
+            cryp_alg = SYMC_ALG_NULL_CIPHER;
+            mode = HI_CIPHER_WORK_MODE_ECB;
+            break;
+        default:
+            HI_LOG_ERROR("Invalid alg, alg = 0x%x.\n", alg);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_NULL;
+    }
+
+    switch (mode) {
+        case HI_CIPHER_WORK_MODE_ECB:
+            cryp_mode = SYMC_MODE_ECB;
+            break;
+        case HI_CIPHER_WORK_MODE_CBC:
+            cryp_mode = SYMC_MODE_CBC;
+            break;
+        case HI_CIPHER_WORK_MODE_CFB:
+            cryp_mode = SYMC_MODE_CFB;
+            break;
+        case HI_CIPHER_WORK_MODE_OFB:
+            cryp_mode = SYMC_MODE_OFB;
+            break;
+        case HI_CIPHER_WORK_MODE_CTR:
+            cryp_mode = SYMC_MODE_CTR;
+            break;
+        case HI_CIPHER_WORK_MODE_CCM:
+            cryp_mode = SYMC_MODE_CCM;
+            break;
+        case HI_CIPHER_WORK_MODE_GCM:
+            cryp_mode = SYMC_MODE_GCM;
+            break;
+        default:
+            HI_LOG_ERROR("Invalid mode, mode = 0x%x.\n", mode);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_NULL;
+    }
+
+    func = cryp_get_symc(cryp_alg, cryp_mode);
+
+    HI_LOG_FUNC_EXIT();
+
+    return func;
+}
+
+/** @}*/  /** <!-- ==== API Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_trng.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_trng.c
@@ -1,0 +1,117 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : cryp_trng.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "drv_trng.h"
+#include "cryp_trng.h"
+
+/********************** Internal Structure Definition ************************/
+/** \addtogroup      trng */
+/** @{*/  /** <!-- [trng]*/
+
+/* the max continuous bits of randnum is allowed */
+#define CONTINUOUS_BITS_ALLOWD              0x08
+
+/* times try to read rang  */
+#define RANG_READ_TRY_TIME                  0x40
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      trng drivers*/
+/** @{*/  /** <!-- [trng]*/
+
+#ifdef CHIP_TRNG_SUPPORT
+static hi_s32 cryp_trng_check(hi_u32 randnum)
+{
+#ifdef CIPHER_CHECK_RNG_BY_BYTE
+    static hi_u32 lastrand = 0;
+    hi_u8 *byte = HI_NULL;
+    hi_u32 i;
+
+    /* compare with last rand number */
+    if (randnum == lastrand) {
+        return HI_FAILURE;
+    }
+
+    /* update last randnum */
+    lastrand = randnum;
+    byte = (hi_u8 *)&randnum;
+
+    /* continuous 8 bits0 or bit1 is prohibited */
+    for (i = 0; i < 4; i++) {
+        /* compare with 0x00 and 0xff */
+        if ((byte[i] == 0x00) || (byte[i] == 0xff)) {
+            return HI_FAILURE;
+        }
+    }
+#else
+    /* continuous 32 bits0 or bit1 is prohibited */
+    if ((randnum == 0x00000000) || (randnum == 0xffffffff)) {
+        return HI_ERR_CIPHER_NO_AVAILABLE_RNG;
+    }
+#endif
+    return HI_SUCCESS;
+}
+
+hi_s32 cryp_trng_get_random(hi_u32 *randnum, hi_u32 timeout)
+{
+    hi_u32 i = 0;
+    hi_s32 ret = HI_FAILURE;
+    trng_capacity capacity;
+
+    HI_LOG_FUNC_ENTER();
+
+    drv_trng_get_capacity(&capacity);
+    if (!capacity.trng) {
+        HI_LOG_ERROR("error, trng nonsupport\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_UNSUPPORTED);
+        return HI_ERR_CIPHER_UNSUPPORTED;
+    }
+
+    for (i = 0; i < RANG_READ_TRY_TIME; i++) {
+        ret = drv_trng_randnum(randnum, timeout);
+        if (ret != HI_SUCCESS) {
+            return ret;
+        }
+
+        ret = cryp_trng_check(*randnum);
+        if (ret == HI_SUCCESS) {
+            break;
+        }
+    }
+
+    if (i >= RANG_READ_TRY_TIME) {
+        HI_LOG_ERROR("error, trng randnum check failed\n");
+        return HI_ERR_CIPHER_NO_AVAILABLE_RNG;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+#else
+#include <linux/random.h>
+
+hi_s32 cryp_trng_get_random(hi_u32 *randnum, hi_u32 timeout)
+{
+    HI_LOG_FUNC_ENTER();
+
+    get_random_bytes((hi_u8 *)randnum, WORD_WIDTH);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+#endif
+
+/** @}*/  /** <!-- ==== API Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include/cryp_hash.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include/cryp_hash.h
@@ -1,0 +1,99 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : cryp_hash.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __CRYP_HASH_H_
+#define __CRYP_HASH_H_
+
+#include "drv_osal_lib.h"
+#include "drv_hash.h"
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      hash */
+/** @{ */  /** <!--[hash]*/
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+/**
+* \brief          Initialize crypto of hash *
+*/
+hi_s32 cryp_hash_init(hi_void);
+
+/**
+* \brief          Deinitialize crypto of hash
+*/
+hi_void cryp_hash_deinit(hi_void);
+
+/**
+ * \brief          Create hash handle
+ *
+ * \param mode     Hash mode
+ * \return         ctx if successful, or NULL
+ */
+typedef hi_void *(*func_hash_create)(hash_mode mode);
+
+/**
+ * \brief          Clear hash context
+ *
+ * \param ctx      symc handle to be destory
+ */
+typedef hi_s32 (*func_hash_destory)( hi_void *ctx);
+
+/**
+ * \brief          Hash message chunk calculation
+ *
+ * Note: the message must be write to the buffer
+ * which get from cryp_hash_get_cpu_addr, and the length of message chunk
+ * can't large than the length which get from cryp_hash_get_cpu_addr.
+ *
+ * \param ctx      hash handle to be destory
+ * \param chunk    hash message to update
+ * \param length   length of hash message
+ * \param src      source of hash message
+ */
+typedef hi_s32 (*func_hash_update)( hi_void *ctx, hi_u8 *chunk, hi_u32 chunkLen, hash_chunk_src src);
+
+/**
+ * \brief          HASH final digest
+ *
+ * \param ctx      Hash handle
+ * \param hash     HASH checksum result
+ * \param hashlen  Length of HASH checksum result
+ */
+typedef hi_s32 (*func_hash_finish)( hi_void *ctx,  hi_void *hash, hi_u32 *hashlen);
+
+/*! \struct of Hash function template */
+typedef struct {
+    hi_u32 valid;                  /*!<  vliad or not */
+    hi_u32 mode;                   /*!<  Mode of Hash */
+    hi_u32 block_size;             /*!<  block size */
+    hi_u32 size;                   /*!<  hash output size */
+    func_hash_create  create;      /*!<  Create function */
+    func_hash_destory destroy;     /*!<  destroy function */
+    func_hash_update  update;      /*!<  update function */
+    func_hash_finish  finish;      /*!<  finish function */
+} hash_func;
+
+/**
+\brief  Clone the function from template of hash engine.
+\param[out]  func The struct of function.
+\param[in]  mode The work mode.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hash_func *cryp_get_hash(hash_mode mode);
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include/cryp_rsa.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include/cryp_rsa.h
@@ -1,0 +1,131 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : cryp_rsa.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __CRYP_RSA_H_
+#define __CRYP_RSA_H_
+
+#include "drv_osal_lib.h"
+#include "drv_srsa.h"
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      rsa */
+/** @{ */  /** <!--[rsa]*/
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+/**
+* \brief          Initialize crypto of rsa *
+*/
+hi_s32 cryp_rsa_init(hi_void);
+
+/**
+* \brief          Deinitialize crypto of rsa *
+*/
+hi_void cryp_rsa_deinit(hi_void);
+
+/**
+\brief RSA encryption a plaintext with a RSA key.
+\param[in] key:         rsa key.
+\param[in] scheme:      rsa encrypt scheme.
+\param[in] in:          input data to be encryption
+\param[in] in:          input data to be encryption
+\param[out] inlen:      length of input data to be encryption
+\param[out] out:        output data to be encryption
+\param[out] outlen:     length of output data to be encryption
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\see \n
+N/A
+*/
+hi_s32 cryp_rsa_encrypt(cryp_rsa_key *key, hi_cipher_rsa_enc_scheme scheme,
+                        hi_u8 *in, hi_u32 inlen,
+                        hi_u8 *out, hi_u32 *outlen);
+
+/**
+\brief RSA decryption a plaintext with a RSA key.
+\param[in] key:         rsa key.
+\param[in] scheme:      rsa encrypt scheme.
+\param[in] in:          input data to be encryption
+\param[in] in:          input data to be encryption
+\param[out] inlen:      length of input data to be encryption
+\param[out] out:        output data to be encryption
+\param[out] outlen:     length of output data to be encryption
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\see \n
+N/A
+*/
+hi_s32 cryp_rsa_decrypt(cryp_rsa_key *key, hi_cipher_rsa_enc_scheme scheme,
+                        hi_u8 *in, hi_u32 inlen,
+                        hi_u8 *out, hi_u32 *outlen);
+
+/**
+\brief RSA sign a hash value with a RSA private key.
+\param[in] key:         rsa key.
+\param[in] scheme:      rsa sign scheme.
+\param[in] in:          input data to be encryption
+\param[in] in:          input data to be encryption
+\param[out] inlen:      length of input data to be encryption
+\param[out] out:        output data to be encryption
+\param[out] outlen:     length of output data to be encryption
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\see \n
+N/A
+*/
+hi_s32 cryp_rsa_sign_hash(cryp_rsa_key *key, hi_cipher_rsa_sign_scheme scheme,
+                          hi_u8 *in, hi_u32 inlen,
+                          hi_u8 *out, hi_u32 *outlen, hi_u32 saltlen);
+
+/**
+\brief RSA verify a hash value with a RSA public key.
+\param[in] key:         rsa key.
+\param[in] scheme:      rsa sign scheme.
+\param[in] in:          input data to be encryption
+\param[in] in:          input data to be encryption
+\param[out] inlen:      length of input data to be encryption
+\param[out] out:        output data to be encryption
+\param[out] outlen:     length of output data to be encryption
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\see \n
+N/A
+*/
+hi_s32 cryp_rsa_verify_hash(cryp_rsa_key *key, hi_cipher_rsa_sign_scheme scheme,
+                            hi_u8 *in, hi_u32 inlen,
+                            hi_u8 *sign, hi_u32 signlen, hi_u32 saltlen);
+
+/**
+\brief Generate a RSA private key.
+\param[in] numbits:     bit numbers of the integer public modulus.
+\param[in] exponent:    value of public exponent
+\param[out] key:        rsa key.
+\retval ::HI_SUCCESS  Call this API successful.
+\retval ::HI_FAILURE  Call this API fails.
+\see \n
+N/A
+*/
+hi_s32 cryp_rsa_gen_key(hi_u32 numbits, hi_u32 exponent, cryp_rsa_key *key);
+
+/**
+\brief Generate random.
+N/A
+*/
+int mbedtls_get_random(hi_void *param, hi_u8 *rand, size_t size);
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include/cryp_symc.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include/cryp_symc.h
@@ -1,0 +1,211 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : cryp_symc.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef CRYP_SYMC_H_
+#define CRYP_SYMC_H_
+
+#include "drv_osal_lib.h"
+#include "drv_symc.h"
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      aes */
+/** @{ */  /** <!--[aes]*/
+
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+
+/**
+* \brief          Initialize crypto of symc *
+*/
+hi_s32 cryp_symc_init(hi_void);
+
+/**
+* \brief          Deinitialize crypto of symc *
+*/
+hi_void cryp_symc_deinit(hi_void);
+
+/**
+ * \brief          Create symc handle
+ *
+ * \param handle   symc handle to be initialized
+ * \param chn      symc channel
+ */
+typedef hi_void *(*func_symc_create)( hi_u32 hard_chn );
+
+/**
+ * \brief          Clear symc context
+ *
+ * \param handle      symc handle to be destory
+ */
+typedef hi_s32 (*func_symc_destroy)( hi_void *ctx);
+
+/**
+ * \brief          symc key schedule
+ *
+ * \param handle   SYMC handle
+ * \param[in]  fkey first  key buffer, defualt
+ * \param[in]  skey second key buffer, expand
+ * \param hisi_klen input key type, output key length in bytes
+ *
+ * \return         0 if successful, or HI_SYMC_ERR_KEY_LEN_INVALID
+ */
+typedef hi_s32 (*func_symc_setkey)( hi_void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen);
+
+/**
+ * \brief          Symc iv schedule
+ *
+ * \param handle   symc handle
+ * \param IV       Symc IV
+ * \param ivlen    length of iv
+ *
+ * \return         0 if successful.
+ */
+typedef hi_s32 (*func_symc_setiv)( hi_void *ctx, const hi_u8 *iv, hi_u32 ivlen, hi_u32 usage);
+
+/**
+ * \brief          Symc iv schedule
+ *
+ * \param handle   symc handle
+ * \param IV       Symc IV
+ * \param ivlen    must be 128, 192 or 256
+ *
+ * \return         0 if successful.
+ */
+typedef hi_void (*func_symc_getiv)( hi_void *ctx, hi_u8 *iv, hi_u32 *ivlen);
+
+/**
+ * \brief          SYMC alg and mode
+ *
+ * \param handle   SYMC handle
+ * \param alg      Symmetric cipher alg
+ * \param mode     Symmetric cipher mode
+ * \param keybits  must be 128, 192 or 256
+ *
+ * \return         0 if successful.
+ */
+typedef hi_void (*func_symc_setmode)( hi_void *ctx, symc_alg alg, symc_mode mode, symc_width width);
+
+/**
+ * \brief          SYMC wait done
+ *
+ * \param ctx      SYMC handle
+ * \return         0 if successful.
+ */
+typedef hi_s32 (*func_symc_wait_done)(hi_void *ctx, hi_u32 timeout);
+
+/**
+ * \brief          SYMC alg and mode
+ *
+ * \param handle   SYMC handle
+ * \param round    SM1 round number
+ *
+ * \return         0 if successful.
+ */
+typedef hi_s32 (*func_symc_sm1_setround)( hi_void *ctx, hi_u32 round);
+
+/**
+ * \brief          symc  buffer encryption/decryption.
+ *
+ * Note: Due to the nature of aes you should use the same key schedule for
+ * both encryption and decryption.
+ *
+ * \param handle   symc handle
+ * \param operation  decrypt or encrypt
+ * \param mode     mode
+ * \param length   length of the input data
+ * \param input    buffer holding the input data
+ * \param output   buffer holding the output data
+ * \param usage_list usage of buffer
+ * \param pkg_num  numbers of buffer
+ * \param last     last or not
+ *
+ * \return         0 if successful
+ */
+typedef hi_s32 (*func_symc_crypto)(hi_void *ctx, hi_u32 operation,
+                                   compat_addr input[],
+                                   compat_addr output[],
+                                   hi_u32 length[],
+                                   symc_node_usage usage_list[],
+                                   hi_u32 pkg_num,
+                                   hi_u32 wait);
+
+/**
+ * \brief          CCM/GCM set Associated Data
+ *
+ * \param ctx      SYMC handle
+ * \param aad      Associated Data
+ * \param alen     Associated Data Length
+ * \param tlen     Tag length
+ *
+ * \return         0 if successful.
+ */
+typedef hi_s32 (*func_aead_set_aad)( hi_void *ctx, compat_addr aad, hi_u32 alen, hi_u32 tlen);
+
+/**
+ * \brief          SYMC multiple buffer encryption/decryption.
+ * \param[in]  id The channel number.
+ * \param[in]  tag tag data of CCM/GCM
+ * \param uuid uuid The user identification.
+ *
+ * \return         0 if successful
+ */
+typedef hi_s32 (*func_aead_get_tag)(hi_void *ctx, hi_u32 tag[AEAD_TAG_SIZE_IN_WORD], hi_u32 *taglen);
+
+/*! \struct of Symmetric cipher function template */
+typedef struct {
+    hi_u32 valid;               /*!<  vliad or not */
+    symc_alg alg;               /*!<  Alg of Symmetric cipher */
+    symc_mode mode;             /*!<  Mode of Symmetric cipher */
+    func_symc_setmode setmode;  /*!<  Set mode function */
+    func_symc_sm1_setround setround; /*!<  SM1 set round function */
+    func_symc_create  create;   /*!<  Create function */
+    func_symc_destroy destroy;  /*!<  destroy function */
+    func_symc_setkey  setkey;   /*!<  setkey function */
+    func_symc_setiv   setiv;    /*!<  setiv function */
+    func_symc_getiv   getiv;    /*!<  getiv function */
+    func_aead_set_aad setadd;   /*!<  setadd function */
+    func_aead_get_tag gettag;   /*!<  get tag function */
+    func_symc_crypto  crypto;   /*!<  crypto function */
+    func_symc_wait_done waitdone; /*!<  wait done */
+} symc_func;
+
+/**
+\brief  symc alloc channel.
+\param[out]  hard_chn symc channel.
+\retval     On success, func is returned.  On error, HI_NULL is returned.
+*/
+hi_s32 cryp_symc_alloc_chn(hi_u32 *hard_chn);
+
+/**
+\brief  symc free channel.
+\param[in]  hard_chn symc channel.
+\retval     On success, func is returned.  On error, HI_NULL is returned.
+*/
+hi_void cryp_symc_free_chn(hi_u32 hard_chn);
+
+/**
+\brief  Clone the function from template of aes engine.
+\param[in]  alg The alg of Symmetric cipher.
+\param[in]  mode The work mode.
+\retval     On success, func is returned.  On error, HI_NULL is returned.
+*/
+symc_func *cryp_get_symc_op(hi_cipher_alg alg, hi_cipher_work_mode mode);
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include/cryp_trng.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include/cryp_trng.h
@@ -1,0 +1,39 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : cryp_trng.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __CRYP_TRNG_H_
+#define __CRYP_TRNG_H_
+
+#include "drv_osal_lib.h"
+#include "drv_trng.h"
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      trng */
+/** @{ */  /** <!--[trng]*/
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      trng drivers*/
+/** @{*/  /** <!-- [trng]*/
+
+/**
+\brief get rand number.
+\param[out]  randnum rand number.
+\param[in]   timeout time out.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 cryp_trng_get_random( hi_u32 *randnum, hi_u32 timeout );
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/ext_aead.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/ext_aead.c
@@ -1,0 +1,343 @@
+/******************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : ext_aead.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "cryp_symc.h"
+#include "mbedtls/ccm.h"
+#include "mbedtls/gcm.h"
+
+#ifdef SOFT_AES_CCM_GCM_SUPPORT
+
+/**
+ * \brief          aes ccm context structure
+ */
+typedef struct {
+    hi_u32 key[SYMC_KEY_SIZE / 4];    /*!<  SYMC even round keys, default */
+    hi_u32 iv[AES_IV_SIZE / 4];       /*!<  symc IV */
+    hi_u32 tag[AEAD_TAG_SIZE / 4];    /*!<  aead tag */
+    hi_u32 ivlen;               /*!<  symc IV length */
+    hi_u32 klen;                /*!<  symc key length */
+    compat_addr aad;         /*!<  Associated Data */
+    hi_u32 alen;                /*!<  Associated Data length */
+    hi_u32 tlen;                /*!<  Tag length */
+}
+ext_aead_context;
+
+void *ext_mbedtls_aead_create(hi_u32 hard_chn)
+{
+    ext_aead_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx = crypto_calloc(1, sizeof(ext_aead_context));
+    if (ctx == HI_NULL) {
+        HI_LOG_ERROR("malloc failed \n");
+        HI_LOG_PRINT_FUNC_ERR(crypto_calloc, 0);
+        return HI_NULL;
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return ctx;
+}
+
+hi_s32 ext_mbedtls_aead_destory(void *ctx)
+{
+    HI_LOG_FUNC_ENTER();
+
+    if (ctx != HI_NULL) {
+        crypto_free(ctx);
+        ctx = HI_NULL;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 ext_mbedtls_aead_setiv(void *ctx, const hi_u8 *iv, hi_u32 ivlen, hi_u32 usage)
+{
+    ext_aead_context *aead = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(aead == HI_NULL);
+    HI_LOG_CHECK_PARAM(ivlen > AES_IV_SIZE);
+
+    if (iv != HI_NULL) {
+        crypto_memcpy(aead->iv, AES_IV_SIZE, iv, ivlen);
+        aead->ivlen = ivlen;
+        HI_LOG_DEBUG("ivlen %d\n", ivlen);
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 ext_mbedtls_aead_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen)
+{
+    hi_u32 klen = 0;
+    ext_aead_context *aead = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(aead == HI_NULL);
+    HI_LOG_CHECK_PARAM(fkey == HI_NULL);
+    HI_LOG_CHECK_PARAM(hisi_klen == HI_NULL);
+
+    switch (*hisi_klen) {
+        case HI_CIPHER_KEY_AES_128BIT: {
+            klen = AES_KEY_128BIT;
+            break;
+        }
+        case HI_CIPHER_KEY_AES_192BIT: {
+            klen = AES_KEY_192BIT;
+            break;
+        }
+        case HI_CIPHER_KEY_AES_256BIT: {
+            klen = AES_KEY_256BIT;
+            break;
+        }
+        default: {
+            HI_LOG_ERROR("Invalid aes key len: 0x%x\n", klen);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+    HI_LOG_INFO("key len %d, type %d\n", klen, hisi_klen);
+
+    crypto_memcpy(aead->key, SYMC_KEY_SIZE, fkey, klen);
+    aead->klen = klen;
+    *hisi_klen = klen;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 ext_mbedtls_aead_set_aad(void *ctx, compat_addr aad, hi_u32 alen, hi_u32 tlen)
+{
+    ext_aead_context *aead = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(aead == HI_NULL);
+
+    aead->aad = aad;
+    aead->alen = alen;
+    aead->tlen = tlen;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 ext_mbedtls_aead_get_tag(void *ctx, hi_u32 tag[AEAD_TAG_SIZE_IN_WORD], hi_u32 *taglen)
+{
+    ext_aead_context *aead = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(aead  == HI_NULL);
+    HI_LOG_CHECK_PARAM(*taglen < aead->tlen);
+
+    HI_LOG_DEBUG("tag buffer len %d, tag len %d\n", *taglen,  aead->tlen);
+
+    *taglen = aead->tlen;
+
+    crypto_memcpy(tag, AEAD_TAG_SIZE, aead->tag, aead->tlen);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 ext_mbedtls_aead_ccm_crypto(void *ctx,
+                                hi_u32 operation,
+                                compat_addr input[],
+                                compat_addr output[],
+                                hi_u32 length[],
+                                symc_node_usage usage_list[],
+                                hi_u32 pkg_num, hi_u32 last)
+{
+    ext_aead_context *aead = ctx;
+    mbedtls_ccm_context ccm;
+    crypto_mem mem_in, mem_out, aad;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(aead == HI_NULL);
+    HI_LOG_CHECK_PARAM(length == HI_NULL);
+    HI_LOG_CHECK_PARAM(pkg_num != 0x01);
+
+    ret = crypto_mem_open(&mem_in, input[0], length[0]);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("open mem of input failed\n");
+        ret = HI_ERR_CIPHER_FAILED_MEM;
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    ret = crypto_mem_open(&mem_out, output[0], length[0]);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("open mem of output failed\n");
+        ret = HI_ERR_CIPHER_FAILED_MEM;
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+        goto error1;
+    }
+
+    ret = crypto_mem_open(&aad, aead->aad, aead->alen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("open mem of aad failed\n");
+        ret = HI_ERR_CIPHER_FAILED_MEM;
+        HI_LOG_FUNC_EXIT();
+        goto error2;
+    }
+
+    mbedtls_ccm_init(&ccm);
+
+    HI_LOG_DEBUG("aead 0x%p, klen len: %d\n", aead, aead->klen);
+
+    ret = mbedtls_ccm_setkey(&ccm, MBEDTLS_CIPHER_ID_AES, (hi_u8 *)aead->key,
+                             aead->klen * BITS_IN_BYTE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(mbedtls_ccm_setkey, ret);
+        goto error3;
+    }
+
+    if (operation) {
+        ret = mbedtls_ccm_auth_decrypt(&ccm, length[0],
+                                       (hi_u8 *)aead->iv , aead->ivlen,
+                                       crypto_mem_virt(&aad), aead->alen,
+                                       crypto_mem_virt(&mem_in), crypto_mem_virt(&mem_out),
+                                       (hi_u8 *)aead->tag, aead->tlen);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(mbedtls_ccm_auth_decrypt, ret);
+        }
+    } else {
+        ret = mbedtls_ccm_encrypt_and_tag(&ccm, length[0],
+                                          (hi_u8 *)aead->iv , aead->ivlen,
+                                          crypto_mem_virt(&aad), aead->alen,
+                                          crypto_mem_virt(&mem_in), crypto_mem_virt(&mem_out),
+                                          (hi_u8 *)aead->tag, aead->tlen);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(mbedtls_ccm_encrypt_and_tag, ret);
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+error3:
+    mbedtls_ccm_free(&ccm);
+    crypto_mem_close(&aad);
+error2:
+    crypto_mem_close(&mem_out);
+error1:
+    crypto_mem_close(&mem_in);
+
+    return ret;
+}
+
+hi_s32 ext_mbedtls_aead_gcm_crypto(void *ctx,
+                                hi_u32 operation,
+                                compat_addr input[],
+                                compat_addr output[],
+                                hi_u32 length[],
+                                symc_node_usage usage_list[],
+                                hi_u32 pkg_num, hi_u32 last)
+{
+    ext_aead_context *aead = ctx;
+    mbedtls_gcm_context *gcm = HI_NULL;
+    crypto_mem mem_in, mem_out, aad;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(aead == HI_NULL);
+    HI_LOG_CHECK_PARAM(length == HI_NULL);
+    HI_LOG_CHECK_PARAM(pkg_num != 0x01);
+
+    crypto_memset(&aad, sizeof(aad), 0, sizeof(aad));
+    crypto_memset(&mem_in, sizeof(mem_in), 0, sizeof(mem_in));
+    crypto_memset(&mem_out, sizeof(mem_out), 0, sizeof(mem_out));
+
+    gcm = crypto_calloc(1, sizeof(mbedtls_gcm_context));
+    if (gcm == HI_NULL) {
+        HI_LOG_ERROR("crypto calloc for mbedtls gcm context failed\n");
+        ret = HI_ERR_CIPHER_FAILED_MEM;
+        HI_LOG_PRINT_FUNC_ERR(crypto_calloc, ret);
+        return ret;
+    }
+
+    ret = crypto_mem_open(&mem_in, input[0], length[0]);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("open mem of input failed\n");
+        ret = HI_ERR_CIPHER_FAILED_MEM;
+        HI_LOG_PRINT_FUNC_ERR(crypto_mem_open, ret);
+        goto error0;
+    }
+
+    ret = crypto_mem_open(&mem_out, output[0], length[0]);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("open mem of output failed\n");
+        ret = HI_ERR_CIPHER_FAILED_MEM;
+        HI_LOG_PRINT_FUNC_ERR(crypto_mem_open, ret);
+        goto error1;
+    }
+
+    ret = crypto_mem_open(&aad, aead->aad, aead->alen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("open mem of aad failed\n");
+        ret = HI_ERR_CIPHER_FAILED_MEM;
+        HI_LOG_PRINT_FUNC_ERR(crypto_mem_open, ret);
+        goto error2;
+    }
+
+    mbedtls_gcm_init(gcm);
+
+    ret = mbedtls_gcm_setkey(gcm, MBEDTLS_CIPHER_ID_AES, (hi_u8 *)aead->key,
+                             aead->klen * BITS_IN_BYTE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(mbedtls_gcm_setkey, ret);
+        goto error3;
+    }
+
+    ret = mbedtls_gcm_starts(gcm, operation ? MBEDTLS_DECRYPT : MBEDTLS_ENCRYPT,
+                             (hi_u8 *)aead->iv , aead->ivlen,
+                             crypto_mem_virt(&aad), aead->alen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(mbedtls_gcm_starts, ret);
+        goto error3;
+    }
+
+    ret = mbedtls_gcm_update(gcm, length[0], crypto_mem_virt(&mem_in),
+                             crypto_mem_virt(&mem_out));
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(mbedtls_gcm_update, ret);
+        goto error3;
+    }
+
+    ret = mbedtls_gcm_finish(gcm, (hi_u8 *)aead->tag, aead->tlen);
+
+error3:
+    mbedtls_gcm_free(gcm);
+    crypto_mem_close(&aad);
+error2:
+    crypto_mem_close(&mem_out);
+error1:
+    crypto_mem_close(&mem_in);
+error0:
+    crypto_free(gcm);
+    gcm = HI_NULL;
+
+    return ret;
+}
+
+#endif // End of SOFT_AES_CCM_GCM_SUPPORT

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/ext_hash.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/ext_hash.c
@@ -1,0 +1,152 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : ext_hash.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "cryp_hash.h"
+#include "mbedtls/md.h"
+
+#define HASH_MAX_BUFFER_SIZE    0x100000 /* 1M */
+
+#if defined(SOFT_SHA1_SUPPORT) \
+    || defined(SOFT_SHA256_SUPPORT) \
+    || defined(SOFT_SHA512_SUPPORT)
+
+void *mbedtls_hash_create(hash_mode mode)
+{
+    mbedtls_md_type_t md_type;
+    const mbedtls_md_info_t *info;
+    mbedtls_md_context_t *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* convert to mebdtls type */
+    md_type = MBEDTLS_MD_SHA1 + (mode - HASH_MODE_SHA1);
+
+    info = mbedtls_md_info_from_type(md_type);
+    if (info == HI_NULL) {
+        HI_LOG_ERROR("error, invalid hash mode %d\n", mode);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_NULL;
+    }
+
+    ctx = crypto_malloc(sizeof(mbedtls_md_context_t));
+    if (ctx == HI_NULL) {
+        HI_LOG_ERROR("malloc hash context buffer failed!");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+        return HI_NULL;
+    }
+    crypto_memset(ctx, sizeof(mbedtls_md_context_t), 0, sizeof(mbedtls_md_context_t));
+
+    mbedtls_md_init(ctx);
+    mbedtls_md_setup(ctx, info, HI_FALSE);
+    mbedtls_md_starts(ctx);
+
+    HI_LOG_FUNC_EXIT();
+
+    return ctx;
+}
+
+hi_s32 mbedtls_hash_update(void *ctx, hi_u8 *chunk, hi_u32 chunkLen, hash_chunk_src src)
+{
+    hi_u8 *ptr = HI_NULL;
+    hi_s32 ret = HI_FAILURE;
+    mbedtls_md_context_t *md = ctx;
+    hi_u32 offset = 0, length = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+
+    if (chunkLen == 0x00) {
+        return HI_SUCCESS;
+    }
+
+    if (src == HASH_CHUNCK_SRC_USER) {
+        ptr = crypto_malloc(HASH_MAX_BUFFER_SIZE);
+        if (ptr == HI_NULL) {
+            HI_LOG_ERROR("malloc hash chunk buffer failed, chunkLen 0x%x\n!", chunkLen);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+            return HI_ERR_CIPHER_FAILED_MEM;
+        }
+        crypto_memset(ptr, HASH_MAX_BUFFER_SIZE, 0, HASH_MAX_BUFFER_SIZE);
+
+        while (offset < chunkLen) {
+            length = chunkLen - offset;
+            if (length > HASH_MAX_BUFFER_SIZE) {
+                length = HASH_MAX_BUFFER_SIZE;
+            }
+            if (crypto_copy_from_user(ptr, chunk + offset, length)) {
+                HI_LOG_ERROR("copy hash chunk from user failed!");
+                HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+                ret = HI_ERR_CIPHER_FAILED_MEM;
+                goto exit;
+            }
+            ret = mbedtls_md_update(md, ptr, length);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_PRINT_FUNC_ERR(mbedtls_md_update, ret);
+                break;
+            }
+            crypto_msleep(1);
+            offset   += length;
+        }
+    } else {
+        ret = mbedtls_md_update(md, chunk, chunkLen);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(mbedtls_md_update, ret);
+        }
+    }
+
+exit:
+    if (ptr != HI_NULL) {
+        crypto_free(ptr);
+        ptr = HI_NULL;
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+hi_s32 mbedtls_hash_finish(void *ctx,  void *hash, hi_u32 *hashlen)
+{
+    mbedtls_md_context_t *md = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+
+    mbedtls_md_finish(md, hash);
+
+    *hashlen = mbedtls_md_get_size(md->md_info);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 mbedtls_hash_destory(void *ctx)
+{
+    mbedtls_md_context_t *md = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+
+    mbedtls_md_free(md);
+    crypto_free(ctx);
+    ctx = HI_NULL;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+#endif // End of SOFT_AES_CCM_GCM_SUPPORT

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/ext_sm3.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/ext_sm3.c
@@ -1,0 +1,407 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : ext_sm3.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "cryp_hash.h"
+
+#ifdef SOFT_SM3_SUPPORT
+
+/*************************** Internal Structure Definition ****************************/
+/** \addtogroup      sm3 */
+/** @{*/  /** <!-- [sm3]*/
+
+hi_u32 ROTATELEFT(hi_u32 x, hi_u32 n)
+{
+    n %= 32;
+
+    if (n == 0) {
+        return x;
+    }
+
+    return x << n | x >> (32 - n);
+}
+
+#define P0(x) ((x) ^  ROTATELEFT((x),9)  ^ ROTATELEFT((x),17))
+#define P1(x) ((x) ^  ROTATELEFT((x),15) ^ ROTATELEFT((x),23))
+
+#define FF0(x,y,z) ((x) ^ (y) ^ (z))
+#define FF1(x,y,z) (((x) & (y)) | ((x) & (z)) | ((y) & (z)))
+
+#define GG0(x,y,z) ((x) ^ (y) ^ (z))
+#define GG1(x,y,z) (((x) & (y)) | ((~(x)) & (z)))
+
+#define SM3_BLOCK_SIZE            64
+#define SM3_W_SIZE                ((SM3_BLOCK_SIZE) + (WORD_WIDTH))
+#define SM3_RESULT_SIZE_IN_WORD   ((SM3_RESULT_SIZE) / (WORD_WIDTH))
+#define SM3_PAD_MIN_SIZE          9
+#define SM3_PAD_LEN_SIZE          8
+#define SM3_BYTE_MSB              0x80
+
+/* SM3, the initial hash value, H(0)*/
+#define SM3_H0    0x7380166F
+#define SM3_H1    0x4914B2B9
+#define SM3_H2    0x172442D7
+#define SM3_H3    0xDA8A0600
+#define SM3_H4    0xA96F30BC
+#define SM3_H5    0x163138AA
+#define SM3_H6    0xE38DEE4D
+#define SM3_H7    0xB0FB0E4E
+
+#define HASH_MAX_BUFFER_SIZE    0x10000 /* 64K */
+
+/**
+ * \brief          aes ccm context structure
+ */
+typedef struct {
+    hi_u32 state[SM3_RESULT_SIZE_IN_WORD];
+    hi_u8  tail[SM3_BLOCK_SIZE];
+    hi_u32 tail_len;
+    hi_u32 total;
+}
+ext_sm3_context;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      sm3 */
+/** @{*/  /** <!-- [sm3]*/
+
+hi_s32 sm3_compress(hi_u32 digest[SM3_RESULT_SIZE_IN_WORD], const hi_u8 block[SM3_BLOCK_SIZE])
+{
+    hi_s32 j;
+    hi_u32 *W = HI_NULL;
+    hi_u32 *W1 = HI_NULL;
+    hi_u32 *T = HI_NULL;
+    const hi_u32 *local_block = (const hi_u32 *)block;
+    hi_u32 A = digest[0];
+    hi_u32 B = digest[1];
+    hi_u32 C = digest[2];
+    hi_u32 D = digest[3];
+    hi_u32 E = digest[4];
+    hi_u32 F = digest[5];
+    hi_u32 G = digest[6];
+    hi_u32 H = digest[7];
+    hi_u32 SS1, SS2, TT1, TT2;
+    hi_u32 *buf = HI_NULL;
+    hi_u32 buf_size = 0;
+
+    buf_size = sizeof(hi_u32) * (SM3_W_SIZE + SM3_BLOCK_SIZE + SM3_BLOCK_SIZE);
+    buf = (hi_u32 *)crypto_malloc(buf_size);
+    if (buf == HI_NULL) {
+        HI_LOG_ERROR("sm3 compress crypto malloc buff failed!\n");
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+    crypto_memset(buf, buf_size, 0, buf_size);
+    W = buf;
+    W1 = buf + SM3_W_SIZE;
+    T = buf + SM3_W_SIZE + SM3_BLOCK_SIZE;
+
+    for (j = 0; j < 16; j++) {
+        W[j] = CPU_TO_BE32(local_block[j]);
+    }
+    for (j = 16; j < SM3_W_SIZE; j++) {
+        W[j] = P1(W[j - 16] ^ W[j - 9] ^ ROTATELEFT(W[j - 3], 15)) ^ ROTATELEFT(W[j - 13], 7) ^ W[j - 6];
+    }
+    for (j = 0; j < SM3_BLOCK_SIZE; j++) {
+        W1[j] = W[j] ^ W[j + 4];
+    }
+
+    for (j = 0; j < 16; j++) {
+
+        T[j] = 0x79CC4519;
+        SS1 = ROTATELEFT((ROTATELEFT(A, 12) + E + ROTATELEFT(T[j], j)), 7);
+        SS2 = SS1 ^ ROTATELEFT(A, 12);
+        TT1 = FF0(A, B, C) + D + SS2 + W1[j];
+        TT2 = GG0(E, F, G) + H + SS1 + W[j];
+        D = C;
+        C = ROTATELEFT(B, 9);
+        B = A;
+        A = TT1;
+        H = G;
+        G = ROTATELEFT(F, 19);
+        F = E;
+        E = P0(TT2);
+    }
+
+    for (j = 16; j < SM3_BLOCK_SIZE; j++) {
+
+        T[j] = 0x7A879D8A;
+        SS1 = ROTATELEFT((ROTATELEFT(A, 12) + E + ROTATELEFT(T[j], j)), 7);
+        SS2 = SS1 ^ ROTATELEFT(A, 12);
+        TT1 = FF1(A, B, C) + D + SS2 + W1[j];
+        TT2 = GG1(E, F, G) + H + SS1 + W[j];
+        D = C;
+        C = ROTATELEFT(B, 9);
+        B = A;
+        A = TT1;
+        H = G;
+        G = ROTATELEFT(F, 19);
+        F = E;
+        E = P0(TT2);
+    }
+
+    digest[0] ^= A;
+    digest[1] ^= B;
+    digest[2] ^= C;
+    digest[3] ^= D;
+    digest[4] ^= E;
+    digest[5] ^= F;
+    digest[6] ^= G;
+    digest[7] ^= H;
+
+    if (buf != HI_NULL) {
+        crypto_free(buf);
+        buf = HI_NULL;
+    }
+
+    return HI_SUCCESS;
+}
+
+static void sm3_init(ext_sm3_context *ctx)
+{
+    HI_LOG_FUNC_ENTER();
+
+    ctx->state[0] = SM3_H0;
+    ctx->state[1] = SM3_H1;
+    ctx->state[2] = SM3_H2;
+    ctx->state[3] = SM3_H3;
+    ctx->state[4] = SM3_H4;
+    ctx->state[5] = SM3_H5;
+    ctx->state[6] = SM3_H6;
+    ctx->state[7] = SM3_H7;
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+static hi_s32 sm3_update(ext_sm3_context *ctx, const hi_u8 *data, hi_u32 data_len)
+{
+    hi_u32 left = 0;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx->total += data_len;
+
+    if (ctx->tail_len) {
+        left = SM3_BLOCK_SIZE - ctx->tail_len;
+        if (data_len < left) {
+            crypto_memcpy(ctx->tail + ctx->tail_len, left, data, data_len);
+            ctx->tail_len += data_len;
+            return HI_SUCCESS;
+        } else {
+            crypto_memcpy(ctx->tail + ctx->tail_len, left, data, left);
+            ret = sm3_compress(ctx->state, ctx->tail);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_PRINT_FUNC_ERR(sm3_compress, ret);
+                return ret;
+            }
+
+            data += left;
+            data_len -= left;
+        }
+    }
+
+    while (data_len >= SM3_BLOCK_SIZE) {
+        ret = sm3_compress(ctx->state, data);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(sm3_compress, ret);
+            return ret;
+        }
+
+        data += SM3_BLOCK_SIZE;
+        data_len -= SM3_BLOCK_SIZE;
+    }
+
+    ctx->tail_len = data_len;
+    if (data_len) {
+        crypto_memcpy(ctx->tail, SM3_BLOCK_SIZE, data, data_len);
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 sm3_final(ext_sm3_context *ctx, hi_u8 *digest)
+{
+    hi_s32 i = 0;
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 hash[SM3_RESULT_SIZE_IN_WORD] = {0};
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx->tail[ctx->tail_len] = SM3_BYTE_MSB;
+
+    /* a block is enough */
+    if (ctx->tail_len + SM3_PAD_MIN_SIZE <= SM3_BLOCK_SIZE) {
+        crypto_memset(ctx->tail + ctx->tail_len + 1, SM3_BLOCK_SIZE - ctx->tail_len - 1, 0,
+                      SM3_BLOCK_SIZE - ctx->tail_len - 1);
+    } else {
+        /* 2 block is request */
+        crypto_memset(ctx->tail + ctx->tail_len + 1, SM3_BLOCK_SIZE - ctx->tail_len - 1,
+                      0, SM3_BLOCK_SIZE - ctx->tail_len - 1);
+        ret = sm3_compress(ctx->state, ctx->tail);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(sm3_compress, ret);
+            return ret;
+        }
+        crypto_memset(ctx->tail, SM3_BLOCK_SIZE, 0, SM3_BLOCK_SIZE);
+    }
+
+    /* write 8 bytes fix data length * 8 */
+    ctx->tail[SM3_BLOCK_SIZE - 5] = (hi_u8)((ctx->total >> 29) & 0x07);
+    ctx->tail[SM3_BLOCK_SIZE - 4] = (hi_u8)((ctx->total >> 21) & 0xff);
+    ctx->tail[SM3_BLOCK_SIZE - 3] = (hi_u8)((ctx->total >> 13) & 0xff);
+    ctx->tail[SM3_BLOCK_SIZE - 2] = (hi_u8)((ctx->total >> 5)  & 0xff);
+    ctx->tail[SM3_BLOCK_SIZE - 1] = (hi_u8)((ctx->total << 3)  & 0xff);
+
+    ret = sm3_compress(ctx->state, ctx->tail);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sm3_compress, ret);
+        return ret;
+    }
+
+    for (i = 0; i < SM3_RESULT_SIZE_IN_WORD; i++) {
+        hash[i] = CPU_TO_BE32(ctx->state[i]);
+    }
+
+    crypto_memcpy(digest, SM3_RESULT_SIZE, hash, SM3_RESULT_SIZE);
+
+    HI_LOG_FUNC_EXIT();
+
+    return HI_SUCCESS;
+}
+
+void *ext_sm3_create(hash_mode mode)
+{
+    ext_sm3_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx = crypto_malloc(sizeof(ext_sm3_context));
+    if (ctx == HI_NULL) {
+        HI_LOG_ERROR("malloc hash context buffer failed!");
+        return HI_NULL;
+    }
+    crypto_memset(ctx, sizeof(ext_sm3_context), 0, sizeof(ext_sm3_context));
+
+    sm3_init(ctx);
+
+    HI_LOG_FUNC_EXIT();
+
+    return ctx;
+}
+
+hi_s32 ext_sm3_update(void *ctx, hi_u8 *chunk, hi_u32 chunkLen, hash_chunk_src src)
+{
+    hi_u8 *ptr = HI_NULL;
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 offset = 0, length = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+
+    if (chunkLen == 0x00) {
+        return HI_SUCCESS;
+    }
+
+    if (src == HASH_CHUNCK_SRC_USER) {
+        ptr = crypto_malloc(HASH_MAX_BUFFER_SIZE);
+        if (HI_NULL == ptr) {
+            HI_LOG_ERROR("malloc hash chunk buffer failed!");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+            return HI_ERR_CIPHER_FAILED_MEM;
+        }
+
+        while (offset < chunkLen) {
+            length = chunkLen - offset;
+            if (length > HASH_MAX_BUFFER_SIZE) {
+                length = HASH_MAX_BUFFER_SIZE;
+            }
+            ret = crypto_copy_from_user(ptr, chunk + offset, length);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_ERROR("copy hash chunk from user failed!");
+                HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+                goto exit;
+            }
+            ret = sm3_update(ctx, ptr, length);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_PRINT_FUNC_ERR(sm3_update, ret);
+                goto exit;
+            }
+
+            crypto_msleep(1);
+            offset += length;
+        }
+    } else {
+        if (chunk == HI_NULL) {
+            HI_LOG_ERROR("Invalid point,chunk is null!\n");
+            ret = HI_ERR_CIPHER_INVALID_POINT;
+            goto exit;
+        }
+        ret = sm3_update(ctx, chunk, chunkLen);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(sm3_update, ret);
+            goto exit;
+        }
+
+        ret = HI_SUCCESS;
+    }
+
+exit:
+    if (ptr != HI_NULL) {
+        crypto_free(ptr);
+        ptr = HI_NULL;
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+hi_s32 ext_sm3_finish(void *ctx,  void *hash, hi_u32 *hashlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+
+    ret = sm3_final(ctx, hash);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(sm3_final, ret);
+        return ret;
+    }
+    *hashlen = SM3_RESULT_SIZE;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 ext_sm3_destory(void *ctx)
+{
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+
+    crypto_free(ctx);
+    ctx  = HI_NULL;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+#endif
+/** @}*/  /** <!-- ==== API Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/ext_sm4.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/ext_sm4.c
@@ -1,0 +1,557 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : ext_sm4.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "cryp_symc.h"
+
+#ifdef SOFT_SM4_SUPPORT
+
+/************************ Internal Structure Definition **********************/
+/** \addtogroup      sm3 */
+/** @{*/  /** <!-- [sm3]*/
+
+static const hi_u32 FK[4] = {
+    0xa3b1bac6, 0x56aa3350, 0x677d9197, 0xb27022dc
+};
+
+static const hi_u32 CK[] = {
+    0x00070e15, 0x1c232a31, 0x383f464d, 0x545b6269,
+    0x70777e85, 0x8c939aa1, 0xa8afb6bd, 0xc4cbd2d9,
+    0xe0e7eef5, 0xfc030a11, 0x181f262d, 0x343b4249,
+    0x50575e65, 0x6c737a81, 0x888f969d, 0xa4abb2b9,
+    0xc0c7ced5, 0xdce3eaf1, 0xf8ff060d, 0x141b2229,
+    0x30373e45, 0x4c535a61, 0x686f767d, 0x848b9299,
+    0xa0a7aeb5, 0xbcc3cad1, 0xd8dfe6ed, 0xf4fb0209,
+    0x10171e25, 0x2c333a41, 0x484f565d, 0x646b7279
+};
+
+static const hi_u32 Sbox[16][16] = {
+    {0xd6, 0x90, 0xe9, 0xfe, 0xcc, 0xe1, 0x3d, 0xb7, 0x16, 0xb6, 0x14, 0xc2, 0x28, 0xfb, 0x2c, 0x05},
+    {0x2b, 0x67, 0x9a, 0x76, 0x2a, 0xbe, 0x04, 0xc3, 0xaa, 0x44, 0x13, 0x26, 0x49, 0x86, 0x06, 0x99},
+    {0x9c, 0x42, 0x50, 0xf4, 0x91, 0xef, 0x98, 0x7a, 0x33, 0x54, 0x0b, 0x43, 0xed, 0xcf, 0xac, 0x62},
+    {0xe4, 0xb3, 0x1c, 0xa9, 0xc9, 0x08, 0xe8, 0x95, 0x80, 0xdf, 0x94, 0xfa, 0x75, 0x8f, 0x3f, 0xa6},
+    {0x47, 0x07, 0xa7, 0xfc, 0xf3, 0x73, 0x17, 0xba, 0x83, 0x59, 0x3c, 0x19, 0xe6, 0x85, 0x4f, 0xa8},
+    {0x68, 0x6b, 0x81, 0xb2, 0x71, 0x64, 0xda, 0x8b, 0xf8, 0xeb, 0x0f, 0x4b, 0x70, 0x56, 0x9d, 0x35},
+    {0x1e, 0x24, 0x0e, 0x5e, 0x63, 0x58, 0xd1, 0xa2, 0x25, 0x22, 0x7c, 0x3b, 0x01, 0x21, 0x78, 0x87},
+    {0xd4, 0x00, 0x46, 0x57, 0x9f, 0xd3, 0x27, 0x52, 0x4c, 0x36, 0x02, 0xe7, 0xa0, 0xc4, 0xc8, 0x9e},
+    {0xea, 0xbf, 0x8a, 0xd2, 0x40, 0xc7, 0x38, 0xb5, 0xa3, 0xf7, 0xf2, 0xce, 0xf9, 0x61, 0x15, 0xa1},
+    {0xe0, 0xae, 0x5d, 0xa4, 0x9b, 0x34, 0x1a, 0x55, 0xad, 0x93, 0x32, 0x30, 0xf5, 0x8c, 0xb1, 0xe3},
+    {0x1d, 0xf6, 0xe2, 0x2e, 0x82, 0x66, 0xca, 0x60, 0xc0, 0x29, 0x23, 0xab, 0x0d, 0x53, 0x4e, 0x6f},
+    {0xd5, 0xdb, 0x37, 0x45, 0xde, 0xfd, 0x8e, 0x2f, 0x03, 0xff, 0x6a, 0x72, 0x6d, 0x6c, 0x5b, 0x51},
+    {0x8d, 0x1b, 0xaf, 0x92, 0xbb, 0xdd, 0xbc, 0x7f, 0x11, 0xd9, 0x5c, 0x41, 0x1f, 0x10, 0x5a, 0xd8},
+    {0x0a, 0xc1, 0x31, 0x88, 0xa5, 0xcd, 0x7b, 0xbd, 0x2d, 0x74, 0xd0, 0x12, 0xb8, 0xe5, 0xb4, 0xb0},
+    {0x89, 0x69, 0x97, 0x4a, 0x0c, 0x96, 0x77, 0x7e, 0x65, 0xb9, 0xf1, 0x09, 0xc5, 0x6e, 0xc6, 0x84},
+    {0x18, 0xf0, 0x7d, 0xec, 0x3a, 0xdc, 0x4d, 0x20, 0x79, 0xee, 0x5f, 0x3e, 0xd7, 0xcb, 0x39, 0x48}
+};
+
+#define GETU32(pt) (((hi_u32)(pt)[0] <<24) ^ ((hi_u32)(pt)[1] << 16) ^ ((hi_u32)(pt)[2] << 8) ^ ((hi_u32)(pt)[3]))
+#define PUTU32(ct, st) {(ct)[0] = (hi_u8)((st) >> 24); (ct)[1] = (hi_u8)((st) >> 16); (ct)[2] = (hi_u8)((st) >> 8); (ct)[3] = (hi_u8)(st);}
+
+#define SM4_BLOCK_SIZE  16
+#define KEY_EXT         0
+#define CIPHER          1
+
+typedef struct tagSM1_KEY_S {
+    hi_u32 rd_key[36];
+} sm4_key;
+
+typedef union {
+    hi_u32  i; /* i = {c[3], c[2], c[1], c[0]} */
+    hi_u8 c[4];
+} IS4;
+
+typedef struct {
+    hi_u8  key[SM4_KEY_SIZE];      /*!<  sm4 even round keys, default */
+    hi_u32 klen;                   /*!<  symc key length */
+    hi_u8  iv[AES_IV_SIZE];
+    symc_mode mode;
+}ext_sm4_context;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      sm4 */
+/** @{*/  /** <!-- [sm4]*/
+
+/* Sbox */
+hi_u32 Mix_R(const hi_u32 data_in, const int type)
+{
+    IS4 temp;
+    hi_u32 rep_rsl = 0;
+    hi_u8  sbox_tmp[4] = {0};
+    hi_u8  sbox_c = 0;
+    hi_u8  sbox_r = 0;
+    int j;
+
+    for (j = 0; j < 4; j++) {
+        sbox_tmp[j] = 0;
+        sbox_r = ((data_in << (j * 8)) >> 28);
+        sbox_c = ((data_in << (j * 8 + 4)) >> 28);
+        sbox_tmp[j] = Sbox[sbox_r][sbox_c];
+    }
+    temp.c[3] = sbox_tmp[0];
+    temp.c[2] = sbox_tmp[1];
+    temp.c[1] = sbox_tmp[2];
+    temp.c[0] = sbox_tmp[3];
+
+    /* linearity replace */
+    if (type == KEY_EXT) {
+        rep_rsl = temp.i
+                  ^ ((temp.i << 13) + ((temp.i >> 19) & 0x00001fff))
+                  ^ ((temp.i << 23) + ((temp.i >>  9) & 0x007fffff));
+    } else {
+        rep_rsl = temp.i
+                  ^ ((temp.i <<  2) + ((temp.i >> 30) & 0x00000003))
+                  ^ ((temp.i << 10) + ((temp.i >> 22) & 0x000003ff))
+                  ^ ((temp.i << 18) + ((temp.i >> 14) & 0x0003ffff))
+                  ^ ((temp.i << 24) + ((temp.i >>  8) & 0x00ffffff));
+    }
+
+    return rep_rsl;
+}
+
+/* Set key */
+int sm4_set_encrypt_key(const hi_u8 *userKey, const int bits, sm4_key *key)
+{
+    int i = 0;
+    hi_u32 k_temp[4] = {0};
+    hi_u32 K[36] = {0};
+    hi_u32 temp = 0;
+
+    if (!userKey || !key) {
+        return -1;
+    }
+
+    k_temp[0] = GETU32(userKey);
+    k_temp[1] = GETU32(userKey + 4);
+    k_temp[2] = GETU32(userKey + 8);
+    k_temp[3] = GETU32(userKey + 12);
+
+    for (i = 0; i < 4; i++) {
+        K[i] = k_temp[i] ^ FK[i];
+    }
+    i = 0;
+    while (1) {
+        temp = K[i + 1] ^ K[i + 2] ^ K[i + 3] ^ CK[i];
+        K[i + 4] = K[i] ^ Mix_R(temp, KEY_EXT);
+        key->rd_key[i] = K[i + 4];
+
+        if (++i == 32) {
+            return 0;
+        }
+    }
+
+    return 0;
+}
+
+/* SM4 Encrypt */
+void sm4_encrypt(const hi_u8 *in, hi_u8 *out, const sm4_key *key)
+{
+    hi_u32 s[36] = {0};
+    hi_u32 temp = 0;
+    int i;
+
+    s[0] = GETU32(in);
+    s[1] = GETU32(in + 4);
+    s[2] = GETU32(in + 8);
+    s[3] = GETU32(in + 12);
+
+    for (i = 0; i < 32; i++) {
+        temp = s[i + 1] ^ s[i + 2] ^ s[i + 3] ^ key->rd_key[i];
+        s[i + 4] = s[i] ^ Mix_R(temp, CIPHER);
+    }
+    PUTU32(out     , s[35]);
+    PUTU32(out +  4, s[34]);
+    PUTU32(out +  8, s[33]);
+    PUTU32(out + 12, s[32]);
+
+    return;
+}
+
+/* SM4 Decrypt */
+void sm4_decrypt(const hi_u8 *in, hi_u8 *out, const sm4_key *key)
+{
+    hi_u32 s[36] = {0};
+    hi_u32 temp = 0;
+    int i;
+
+    s[0] = GETU32(in);
+    s[1] = GETU32(in + 4);
+    s[2] = GETU32(in + 8);
+    s[3] = GETU32(in + 12);
+
+    for (i = 0; i < 32; i++) {
+        temp = s[i + 1] ^ s[i + 2] ^ s[i + 3] ^ key->rd_key[31 - i];
+        s[i + 4] = s[i] ^ Mix_R(temp, CIPHER);
+    }
+    PUTU32(out     , s[35]);
+    PUTU32(out +  4, s[34]);
+    PUTU32(out +  8, s[33]);
+    PUTU32(out + 12, s[32]);
+
+    return;
+}
+
+/* SM4 ECB Crypt */
+void sm4_ecb_crypt(const hi_u8 *in, hi_u8 *out, const sm4_key *key, const int dec)
+{
+    if (dec == SYMC_OPERATION_ENCRYPT) {
+        sm4_encrypt(in, out, key);
+    } else {
+        sm4_decrypt(in, out, key);
+    }
+    return;
+}
+
+/* SM4 CBC Crypt */
+void sm4_cbc_crypt(const hi_u8 *in, hi_u8 *out, const hi_u32 length, const sm4_key *key, hi_u8 *ivec, const int dec)
+{
+    hi_u32 n = 0;
+    hi_u32 len = length;
+    hi_u8 tmp[SM4_BLOCK_SIZE] = {0};
+
+    if (dec == SYMC_OPERATION_ENCRYPT) {
+        while (len >= SM4_BLOCK_SIZE) {
+            for (n = 0; n < SM4_BLOCK_SIZE; ++n) {
+                tmp[n] = in[n] ^ ivec[n];
+            }
+
+            sm4_encrypt(tmp, out, key);
+
+            memcpy((void *)ivec, out, SM4_BLOCK_SIZE);
+            len -= SM4_BLOCK_SIZE;
+            in  += SM4_BLOCK_SIZE;
+            out += SM4_BLOCK_SIZE;
+        }
+    } else {
+        while (len >= SM4_BLOCK_SIZE) {
+            memcpy(tmp, in, sizeof(tmp));
+            sm4_decrypt(tmp, out, key);
+            for (n = 0; n < SM4_BLOCK_SIZE; ++n) {
+                out[n] ^= ivec[n];
+            }
+            memcpy((void *)ivec, tmp, SM4_BLOCK_SIZE);
+            len -= SM4_BLOCK_SIZE;
+            in  += SM4_BLOCK_SIZE;
+            out += SM4_BLOCK_SIZE;
+        }
+    }
+
+    return;
+}
+
+/* increment counter (128bit int) by 2^64 */
+static void sm4_ctr128_inc(hi_u8 *counter)
+{
+    int i;
+
+    for (i = 15; i >= 0; i--) {
+        counter[i]++;
+        if (counter[i] != 0) {
+            return;
+        }
+    }
+    return;
+}
+
+/* SM4 CTR Crypt, CTR mode is big-endian. The rest of SM4 code is endian-neutral */
+void sm4_ctr128_crypt(const hi_u8 *in, hi_u8 *out, int length, const sm4_key *key, hi_u8 counter[SM4_BLOCK_SIZE], hi_u8 ecount_buf[SM4_BLOCK_SIZE], int *num)
+{
+    int n = 0;
+    int l = 0;
+    l = length;
+
+    n = *num;
+    while (l--) {
+        if (n == 0) {
+            sm4_encrypt(counter, ecount_buf, key);
+            sm4_ctr128_inc(counter);
+        }
+        *(out++) = *(in++) ^ ecount_buf[n];
+        n = (n + 1) % SM4_BLOCK_SIZE;
+    }
+    *num = n;
+
+    return;
+}
+
+/* SM4 ECB RM */
+hi_u32 sm4_ecb_rm(const hi_u8 *data_in, hi_u8 *data_out, int data_len, const hi_u8 *key, int bit, hi_u32 decrypt)
+{
+    sm4_key ctx;
+
+    sm4_set_encrypt_key(key, bit, &ctx);
+
+    while (data_len >= 16) {
+        sm4_ecb_crypt(data_in, data_out, &ctx, decrypt);
+        data_len = data_len - 16;
+        data_in  = data_in + 16;
+        data_out = data_out + 16;
+    }
+
+    return data_len;
+}
+
+/* SM4 CBC RM */
+hi_u32 sm4_cbc_rm(const hi_u8 *data_in, hi_u8 *data_out, int data_len,
+               const hi_u8 *key, int bit, hi_u32 decrypt,
+               hi_u8 *iv)
+{
+    int left_len;
+    int valid_data_len;
+    sm4_key ctx;
+
+    sm4_set_encrypt_key(key, bit, &ctx);
+
+    left_len = data_len % SM4_BLOCK_SIZE;
+    valid_data_len = data_len - left_len;
+    sm4_cbc_crypt(data_in, data_out, valid_data_len, &ctx, iv, decrypt);
+
+    return left_len;
+}
+
+/* SM4 CTR RM */
+hi_u32 sm4_ctr_rm(const hi_u8 *data_in, hi_u8 *data_out, int data_len,
+               const hi_u8 *key, int bit, hi_u32 decrypt,
+               const hi_u8 *iv)
+{
+    int num = 0;
+    int i;
+    hi_u32 valid_data_len = 0;
+    hi_u8 encrypt_cnt[16] = {0};
+    sm4_key ctx;
+
+    /* The SM4_ctr128_crypt request:
+     * The extra state information to record how much of the
+     * 128bit block we have used is contained in *num, and the
+     * encrypted counter is kept in ecount_buf. Both *num and
+     * ecount_buf must be initialized with zeros before the first
+     * called to SM4_ctr128_crypt().
+     */
+    for (i = 0; i < 16; i++) {
+        encrypt_cnt[i] = 0;
+    }
+
+    valid_data_len = data_len;
+
+    sm4_set_encrypt_key(key, bit, &ctx);
+    sm4_ctr128_crypt(data_in, data_out, valid_data_len, &ctx, (hi_u8 *)iv, encrypt_cnt, &num);
+
+    return 0;
+}
+
+void *ext_sm4_create(hi_u32 hard_chn)
+{
+    ext_sm4_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx = crypto_malloc(sizeof(ext_sm4_context));
+    if (ctx == HI_NULL) {
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+        return HI_NULL;
+    }
+    crypto_memset(ctx, sizeof(ext_sm4_context), 0, sizeof(ext_sm4_context));
+
+    HI_LOG_FUNC_EXIT();
+
+    return ctx;
+}
+
+hi_s32 ext_sm4_destory(void *ctx)
+{
+    HI_LOG_FUNC_ENTER();
+
+    if (ctx != HI_NULL) {
+        crypto_free(ctx);
+        ctx = HI_NULL;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void ext_sm4_setmode(void *ctx, symc_alg alg, symc_mode mode, symc_width width)
+{
+    ext_sm4_context *symc = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (symc == HI_NULL) {
+        HI_LOG_ERROR("ctx is null\n");
+        return;
+    }
+
+    if (width != SYMC_DAT_WIDTH_128) {
+        HI_LOG_ERROR("Invalid width: 0x%x\n", width);
+        return;
+    }
+
+    switch (mode) {
+        case SYMC_MODE_ECB:
+            symc->mode = SYMC_MODE_ECB;
+            break;
+        case SYMC_MODE_CBC:
+            symc->mode = SYMC_MODE_CBC;
+            break;
+        case SYMC_MODE_CTR:
+            symc->mode = SYMC_MODE_CTR;
+            break;
+        default:
+            HI_LOG_ERROR("unsupport mode %d\n", mode);
+            return;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+hi_s32 ext_sm4_setiv(void *ctx, const hi_u8 *iv, hi_u32 ivlen, hi_u32 usage)
+{
+    ext_sm4_context *symc = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc == HI_NULL);
+    HI_LOG_CHECK_PARAM(iv == HI_NULL);
+    HI_LOG_CHECK_PARAM(ivlen != HI_NULL);
+
+    crypto_memcpy(symc->iv, AES_IV_SIZE, iv, ivlen);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+void ext_sm4_getiv(void *ctx, hi_u8 *iv, hi_u32 *ivlen)
+{
+    ext_sm4_context *symc = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    if ((symc == HI_NULL) || (iv == HI_NULL) || (ivlen == HI_NULL)) {
+        return;
+    }
+
+    crypto_memcpy(iv, AES_IV_SIZE, symc->iv, AES_IV_SIZE);
+    *ivlen = AES_IV_SIZE;
+
+    HI_LOG_FUNC_EXIT();
+
+    return;
+}
+
+hi_s32 ext_sm4_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen)
+{
+    hi_u32 klen = 0;
+    ext_sm4_context *symc = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc == HI_NULL);
+    HI_LOG_CHECK_PARAM(fkey == HI_NULL);
+    HI_LOG_CHECK_PARAM(hisi_klen == HI_NULL);
+
+    switch (*hisi_klen) {
+        case HI_CIPHER_KEY_AES_128BIT:
+            klen = AES_KEY_128BIT;
+            break;
+        default:
+            HI_LOG_ERROR("Invalid aes key len: 0x%x\n", klen);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+    }
+    HI_LOG_INFO("key len %d, type %d\n", klen, hisi_klen);
+
+    crypto_memcpy(symc->key, SYMC_KEY_SIZE, fkey, klen);
+    symc->klen = klen;
+    *hisi_klen = klen;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 ext_sm4_crypto(void *ctx,
+                   hi_u32 operation,
+                   compat_addr input[],
+                   compat_addr output[],
+                   hi_u32 length[],
+                   symc_node_usage usage_list[],
+                   hi_u32 pkg_num, hi_u32 last)
+{
+    ext_sm4_context *symc = ctx;
+    crypto_mem mem_in, mem_out;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc == HI_NULL);
+    HI_LOG_CHECK_PARAM(length == HI_NULL);
+    HI_LOG_CHECK_PARAM(input == HI_NULL);
+    HI_LOG_CHECK_PARAM(output == HI_NULL);
+    HI_LOG_CHECK_PARAM(usage_list == HI_NULL);
+    HI_LOG_CHECK_PARAM(pkg_num != 0x01);
+
+    crypto_memset(&mem_in, sizeof(mem_in), 0, sizeof(mem_in));
+    crypto_memset(&mem_out, sizeof(mem_out), 0, sizeof(mem_out));
+
+    ret = crypto_mem_open(&mem_in, input[0], length[0]);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("open mem of input failed\n");
+        ret = HI_ERR_CIPHER_FAILED_MEM;
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        goto error0;
+    }
+
+    ret = crypto_mem_open(&mem_out, output[0], length[0]);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("open mem of output failed\n");
+        ret = HI_ERR_CIPHER_FAILED_MEM;
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        goto error1;
+    }
+
+    switch (symc->mode) {
+        case SYMC_MODE_ECB: {
+            sm4_ecb_rm(crypto_mem_virt(&mem_in), crypto_mem_virt(&mem_out),
+                       length[0], symc->key, symc->klen, operation);
+            break;
+        }
+        case SYMC_MODE_CBC: {
+            sm4_cbc_rm(crypto_mem_virt(&mem_in), crypto_mem_virt(&mem_out),
+                       length[0], symc->key, symc->klen, operation, symc->iv);
+            break;
+        }
+        case SYMC_MODE_CTR: {
+            sm4_ctr_rm(crypto_mem_virt(&mem_in), crypto_mem_virt(&mem_out),
+                       length[0], symc->key, symc->klen, operation, symc->iv);
+            break;
+        }
+        default: {
+            HI_PRINT("Err, Invalid mode 0x%x\n", symc->mode);
+            ret = HI_ERR_CIPHER_FAILED_MEM;
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    crypto_mem_close(&mem_out);
+error1:
+    crypto_mem_close(&mem_in);
+error0:
+
+    return ret;
+}
+
+#endif
+/** @}*/  /** <!-- ==== API Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/ext_symc.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/ext_symc.c
@@ -1,0 +1,288 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : ext_symc.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "cryp_symc.h"
+#include "mbedtls/cipher.h"
+
+#if defined(SOFT_AES_SUPPORT) || defined(SOFT_TDES_SUPPORT)
+
+/**
+ * \brief          aes ccm context structure
+ */
+typedef struct {
+    hi_u32 key[SYMC_KEY_SIZE / 4];    /*!<  SYMC even round keys, default */
+    hi_u32 klen;                /*!<  symc key length */
+    mbedtls_cipher_id_t cipher_id;
+    mbedtls_cipher_mode_t mode;
+    mbedtls_cipher_context_t cipher;
+}
+ext_symc_context;
+
+void *ext_mbedtls_symc_create(hi_u32 hard_chn)
+{
+    ext_symc_context *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    ctx = crypto_malloc(sizeof(ext_symc_context));
+    if (ctx == HI_NULL) {
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+        HI_LOG_ERROR("malloc failed \n");
+        return HI_NULL;
+    }
+    crypto_memset(ctx, sizeof(ext_symc_context), 0, sizeof(ext_symc_context));
+
+    mbedtls_cipher_init(&ctx->cipher);
+
+    HI_LOG_FUNC_EXIT();
+
+    return ctx;
+}
+
+hi_s32 ext_mbedtls_symc_destory(void *ctx)
+{
+    ext_symc_context *symc = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (ctx != HI_NULL) {
+        mbedtls_cipher_free(&symc->cipher);
+        crypto_free(ctx);
+        ctx = HI_NULL;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 ext_mbedtls_symc_setmode(void *ctx, symc_alg alg, symc_mode mode, symc_width width)
+{
+    ext_symc_context *symc = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc == HI_NULL);
+    HI_LOG_CHECK_PARAM(width != SYMC_DAT_WIDTH_128);
+
+    switch (alg) {
+        case SYMC_ALG_AES:
+            symc->cipher_id = MBEDTLS_CIPHER_ID_AES;
+            break;
+        case SYMC_ALG_TDES:
+            symc->cipher_id = MBEDTLS_CIPHER_ID_3DES;
+            break;
+        case SYMC_ALG_DES:
+            symc->cipher_id = MBEDTLS_CIPHER_ID_DES;
+            break;
+        default:
+            HI_LOG_ERROR("unsupport alg %d\n", alg);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    switch (mode) {
+        case SYMC_MODE_ECB:
+            symc->mode = MBEDTLS_MODE_ECB;
+            break;
+        case SYMC_MODE_CBC:
+            symc->mode = MBEDTLS_MODE_CBC;
+            break;
+        case SYMC_MODE_CFB:
+            symc->mode = MBEDTLS_MODE_CFB;
+            break;
+        case SYMC_MODE_OFB:
+            symc->mode = MBEDTLS_MODE_OFB;
+            break;
+        case SYMC_MODE_CTR:
+            symc->mode = MBEDTLS_MODE_CTR;
+            break;
+        default:
+            HI_LOG_ERROR("unsupport mode %d\n", mode);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    HI_LOG_DEBUG("cipher_id %d, mode %d\n", symc->cipher_id, symc->mode);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 ext_mbedtls_symc_setiv(void *ctx, const hi_u8 *iv, hi_u32 ivlen, hi_u32 usage)
+{
+    hi_s32 ret = HI_FAILURE;
+    ext_symc_context *symc = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc == HI_NULL);
+    HI_LOG_CHECK_PARAM(iv   == HI_NULL);
+    HI_LOG_CHECK_PARAM(ivlen > AES_IV_SIZE);
+
+    ret = mbedtls_cipher_set_iv(&symc->cipher, iv, ivlen);
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+hi_s32 ext_mbedtls_symc_getiv(void *ctx, hi_u8 *iv, hi_u32 *ivlen)
+{
+    ext_symc_context *symc = ctx;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc  == HI_NULL);
+    HI_LOG_CHECK_PARAM(iv    == HI_NULL);
+    HI_LOG_CHECK_PARAM(ivlen == HI_NULL);
+
+    crypto_memcpy(iv, AES_IV_SIZE, symc->cipher.iv, symc->cipher.iv_size);
+    *ivlen = symc->cipher.iv_size;
+
+    HI_LOG_FUNC_EXIT();
+
+    return HI_SUCCESS;
+}
+
+hi_s32 ext_mbedtls_symc_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 klen = 0;
+    ext_symc_context *symc = ctx;
+    const mbedtls_cipher_info_t *info = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc == HI_NULL);
+    HI_LOG_CHECK_PARAM(fkey == HI_NULL);
+    HI_LOG_CHECK_PARAM(hisi_klen == HI_NULL);
+
+    if (symc->cipher_id == MBEDTLS_CIPHER_ID_AES) {
+        switch (*hisi_klen) {
+            case HI_CIPHER_KEY_AES_128BIT:
+                klen = AES_KEY_128BIT;
+                break;
+            case HI_CIPHER_KEY_AES_192BIT:
+                klen = AES_KEY_192BIT;
+                break;
+            case HI_CIPHER_KEY_AES_256BIT:
+                klen = AES_KEY_256BIT;
+                break;
+            default:
+                HI_LOG_ERROR("Invalid aes key len: 0x%x\n", klen);
+                HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+                return HI_ERR_CIPHER_INVALID_PARA;
+        }
+        crypto_memcpy(symc->key, SYMC_KEY_SIZE, fkey, klen);
+    } else if (symc->cipher_id == MBEDTLS_CIPHER_ID_3DES) {
+        klen = TDES_KEY_192BIT;
+        crypto_memcpy(symc->key, SYMC_KEY_SIZE, fkey, klen);
+        if (*hisi_klen == HI_CIPHER_KEY_DES_2KEY) {
+            /* k3 = k1*/
+            symc->key[4] = symc->key[0];
+            symc->key[5] = symc->key[1];
+        }
+    } else if (symc->cipher_id == MBEDTLS_CIPHER_ID_DES) {
+        klen = DES_KEY_SIZE;
+        crypto_memcpy(symc->key, SYMC_KEY_SIZE, fkey, klen);
+    }
+    HI_LOG_INFO("key len %d, type %d\n", klen, *hisi_klen);
+
+    symc->klen = klen;
+
+    HI_LOG_DEBUG("cipher_id %d, klen %d, mode %d\n", symc->cipher_id, klen, symc->mode);
+    info = mbedtls_cipher_info_from_values(symc->cipher_id, klen * 8, symc->mode);
+    HI_LOG_CHECK_PARAM(info == HI_NULL);
+
+    ret = mbedtls_cipher_setup(&symc->cipher, info);
+
+    *hisi_klen = klen;
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+hi_s32 ext_mbedtls_symc_crypto(void *ctx,
+                            hi_u32 operation,
+                            compat_addr input[],
+                            compat_addr output[],
+                            hi_u32 length[],
+                            symc_node_usage usage_list[],
+                            hi_u32 pkg_num, hi_u32 last)
+{
+    ext_symc_context *symc = ctx;
+    crypto_mem mem_in, mem_out;
+    hi_u32 offset = 0;
+    size_t olen = 0;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(symc   == HI_NULL);
+    HI_LOG_CHECK_PARAM(input  == HI_NULL);
+    HI_LOG_CHECK_PARAM(output == HI_NULL);
+    HI_LOG_CHECK_PARAM(length == HI_NULL);
+    HI_LOG_CHECK_PARAM(pkg_num != 0x01);
+
+    ret = mbedtls_cipher_setkey(&symc->cipher, (hi_u8 *)symc->key, symc->klen * 8,
+                                operation ? MBEDTLS_DECRYPT : MBEDTLS_ENCRYPT);
+    if (ret != HI_SUCCESS)
+    { return ret; }
+
+    ret = crypto_mem_open(&mem_in, input[0], length[0]);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("open mem of input failed\n");
+        ret = HI_ERR_CIPHER_FAILED_MEM;
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        goto error0;
+    }
+
+    ret = crypto_mem_open(&mem_out, output[0], length[0]);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("open mem of output failed\n");
+        ret = HI_ERR_CIPHER_FAILED_MEM;
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        goto error1;
+    }
+
+    HI_LOG_DEBUG("symc 0x%p, klen len: %d\n", symc, symc->klen);
+
+    if (symc->mode == MBEDTLS_MODE_ECB) {
+        offset = 0;
+        while (offset < length[0]) {
+            ret = mbedtls_cipher_update(&symc->cipher, crypto_mem_virt(&mem_in) + offset,
+                                        mbedtls_cipher_get_block_size(&symc->cipher),
+                                        crypto_mem_virt(&mem_out) + offset, &olen);
+            if (ret != HI_SUCCESS) {
+                HI_LOG_ERROR("mbedtls_cipher_update failed\n");
+                break;
+            }
+            offset += mbedtls_cipher_get_block_size(&symc->cipher);
+        }
+    } else {
+        ret = mbedtls_cipher_update(&symc->cipher, crypto_mem_virt(&mem_in),
+                                    length[0], crypto_mem_virt(&mem_out), &olen);
+    }
+
+    HI_LOG_FUNC_EXIT();
+
+    crypto_mem_close(&mem_out);
+error1:
+    crypto_mem_close(&mem_in);
+error0:
+
+    return ret;
+}
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/ext_alg.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/ext_alg.h
@@ -1,0 +1,354 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : ext_alg.h
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __EXT_ALG_H_
+#define __EXT_ALG_H_
+
+#include "drv_osal_lib.h"
+#include "drv_hash.h"
+#include "drv_symc.h"
+
+/******************************* API Declaration *****************************/
+/** \addtogroup      hash */
+/** @{ */  /** <!--[hash]*/
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      cipher drivers*/
+/** @{*/  /** <!-- [cipher]*/
+
+/**
+ * \brief          Create symc handle
+ *
+ * \param handle   symc handle to be initialized
+ * \param hard_key symc use hard key ot not
+ */
+void *ext_mbedtls_aead_create(hi_u32 hard_key);
+
+/**
+ * \brief          Clear symc context
+ *
+ * \param handle      symc handle to be destory
+ */
+hi_s32 ext_mbedtls_aead_destory(void *ctx);
+
+/**
+ * \brief          symc iv schedule
+ *
+ * \param handle   symc handle
+ * \param IV       encryption key
+ * \param ivlen    length of iv
+ *
+ * \return         0 if successful.
+ */
+hi_s32 ext_mbedtls_aead_setiv(void *ctx, const hi_u8 *iv, hi_u32 ivlen, hi_u32 usage);
+
+/**
+ * \brief          symc key schedule
+ *
+ * \param ctx      SYMC handle
+ * \param key      SYMC key
+ * \param keylen   SYMC key length
+ *
+ * \return         0 if successful, or HI_SYMC_ERR_KEY_LEN_INVALID
+ */
+hi_s32 ext_mbedtls_aead_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen);
+
+/**
+ * \brief          SYMC alg and mode
+ *
+ * \param ctx      SYMC handle
+ * \param aad      Associated Data
+ * \param alen     Associated Data Length
+ * \param tlen     Tag length
+ *
+ * \return         0 if successful.
+ */
+hi_s32 ext_mbedtls_aead_set_aad( void *ctx, compat_addr aad, hi_u32 alen, hi_u32 tlen);
+
+/**
+\brief  get ccm/gcm tag.
+\param[in]   chn_num The channel number.
+\param[out]  tag The tag value.
+\param[out]  taglen tag length
+\retval     On received interception, HI_TRUE is returned  otherwise HI_FALSE is returned.
+*/
+hi_s32 ext_mbedtls_aead_get_tag(void *ctx, hi_u32 tag[AEAD_TAG_SIZE_IN_WORD], hi_u32 *taglen);
+
+/**
+ * \brief          aead ccm buffer encryption/decryption.
+ *
+ * Note: Due to the nature of aes you should use the same key schedule for
+ * both encryption and decryption.
+ *
+ * \param handle   symc handle
+ * \param decrypt  decrypt or encrypt
+ * \param mode     mode
+ * \param length   length of the input data
+ * \param input    buffer holding the input data
+ * \param output   buffer holding the output data
+ * \param usage_list usage of buffer
+ * \param pkg_num  numbers of buffer
+ *
+ * \return         0 if successful
+ */
+hi_s32 ext_mbedtls_aead_ccm_crypto(void *ctx,
+                                   hi_u32 operation,
+                                   compat_addr input[],
+                                   compat_addr output[],
+                                   hi_u32 length[],
+                                   hi_u32 usage_list[],
+                                   hi_u32 pkg_num, hi_u32 last);
+
+/**
+ * \brief          aead gcm buffer encryption/decryption.
+ *
+ * Note: Due to the nature of aes you should use the same key schedule for
+ * both encryption and decryption.
+ *
+ * \param handle   symc handle
+ * \param decrypt  decrypt or encrypt
+ * \param mode     mode
+ * \param length   length of the input data
+ * \param input    buffer holding the input data
+ * \param output   buffer holding the output data
+ * \param usage_list usage of buffer
+ * \param pkg_num  numbers of buffer
+ *
+ * \return         0 if successful
+ */
+hi_s32 ext_mbedtls_aead_gcm_crypto(void *ctx,
+                                   hi_u32 operation,
+                                   compat_addr input[],
+                                   compat_addr output[],
+                                   hi_u32 length[],
+                                   hi_u32 usage_list[],
+                                   hi_u32 pkg_num, hi_u32 last);
+
+/**
+ * \brief          Create symc handle
+ *
+ * \param handle   symc handle to be initialized
+ * \param hard_key symc use hard key ot not
+ */
+void *ext_mbedtls_symc_create(hi_u32 hard_key);
+
+/**
+ * \brief          Clear symc context
+ *
+ * \param handle      symc handle to be destory
+ */
+hi_s32 ext_mbedtls_symc_destory(void *ctx);
+
+/**
+ * \brief          SYMC alg and mode
+ *
+ * \param handle   SYMC handle
+ * \param alg      Symmetric cipher alg
+ * \param mode     Symmetric cipher mode
+ *
+ * \return         0 if successful.
+ */
+void ext_mbedtls_symc_setmode(void *ctx, symc_alg alg, symc_mode mode, symc_width width);
+
+/**
+ * \brief          symc iv schedule
+ *
+ * \param handle   symc handle
+ * \param IV       encryption key
+ * \param ivlen    length of iv
+ *
+ * \return         0 if successful.
+ */
+hi_s32 ext_mbedtls_symc_setiv(void *ctx, const hi_u8 *iv, hi_u32 ivlen, hi_u32 usage);
+
+/**
+ * \brief          Symc iv schedule
+ *
+ * \param handle   symc handle
+ * \param IV       Symc IV
+ * \param ivlen    must be 128, 192 or 256
+ *
+ * \return         0 if successful.
+ */
+void ext_mbedtls_symc_getiv(void *ctx, hi_u8 *iv, hi_u32 *ivlen);
+
+/**
+ * \brief          symc key schedule
+ *
+ * \param ctx      SYMC handle
+ * \param key      SYMC key
+ * \param keylen   SYMC key length
+ *
+ * \return         0 if successful, or HI_SYMC_ERR_KEY_LEN_INVALID
+ */
+hi_s32 ext_mbedtls_symc_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen);
+
+/**
+ * \brief          symc buffer encryption/decryption.
+ *
+ * Note: Due to the nature of aes you should use the same key schedule for
+ * both encryption and decryption.
+ *
+ * \param handle   symc handle
+ * \param decrypt  decrypt or encrypt
+ * \param mode     mode
+ * \param length   length of the input data
+ * \param input    buffer holding the input data
+ * \param output   buffer holding the output data
+ * \param usage_list usage of buffer
+ * \param pkg_num  numbers of buffer
+ *
+ * \return         0 if successful
+ */
+hi_s32 ext_mbedtls_symc_crypto(void *ctx,
+                               hi_u32 operation,
+                               compat_addr input[],
+                               compat_addr output[],
+                               hi_u32 length[],
+                               symc_node_usage usage_list[],
+                               hi_u32 pkg_num, hi_u32 last);
+
+/**
+ * \brief          Create sm4 handle
+ *
+ * \param handle   sm4 handle to be initialized
+ * \param hard_key sm4 use hard key ot not
+ */
+void *ext_sm4_create(hi_u32 hard_key);
+
+/**
+ * \brief          Clear sm4 context
+ *
+ * \param handle      sm4 handle to be destory
+ */
+hi_s32 ext_sm4_destory(void *ctx);
+
+/**
+ * \brief          sm4 alg and mode
+ *
+ * \param handle   sm4 handle
+ * \param alg      Symmetric cipher alg
+ * \param mode     Symmetric cipher mode
+ *
+ * \return         NA.
+ */
+void ext_sm4_setmode(void *ctx, symc_alg alg, symc_mode mode, symc_width width);
+
+/**
+ * \brief          sm4 iv schedule
+ *
+ * \param handle   sm4 handle
+ * \param IV       encryption key
+ * \param ivlen    length of iv
+ *
+ * \return         0 if successful.
+ */
+hi_s32 ext_sm4_setiv(void *ctx, const hi_u8 *iv, hi_u32 ivlen, hi_u32 usage);
+
+/**
+ * \brief          Symc iv schedule
+ *
+ * \param handle   symc handle
+ * \param IV       Symc IV
+ * \param ivlen    must be 128, 192 or 256
+ *
+ * \return         NA.
+ */
+void ext_sm4_getiv(void *ctx, hi_u8 *iv, hi_u32 *ivlen);
+
+/**
+ * \brief          sm4 key schedule
+ *
+ * \param ctx      sm4 handle
+ * \param key      sm4 key
+ * \param keylen   sm4 key length
+ *
+ * \return         0 if successful, or HI_SYMC_ERR_KEY_LEN_INVALID
+ */
+hi_s32 ext_sm4_setkey(void *ctx, const hi_u8 *fkey, const hi_u8 *skey, hi_u32 *hisi_klen);
+
+/**
+ * \brief          sm4 buffer encryption/decryption.
+ *
+ * Note: Due to the nature of aes you should use the same key schedule for
+ * both encryption and decryption.
+ *
+ * \param handle   sm4 handle
+ * \param decrypt  decrypt or encrypt
+ * \param mode     mode
+ * \param length   length of the input data
+ * \param input    buffer holding the input data
+ * \param output   buffer holding the output data
+ * \param usage_list usage of buffer
+ * \param pkg_num  numbers of buffer
+ *
+ * \return         0 if successful
+ */
+hi_s32 ext_sm4_crypto(void *ctx,
+                      hi_u32 operation,
+                      compat_addr input[],
+                      compat_addr output[],
+                      hi_u32 length[],
+                      symc_node_usage usage_list[],
+                      hi_u32 pkg_num, hi_u32 last);
+
+/**
+ * \brief          Clear hash context
+ *
+ * \param ctx      symc handle to be destory
+ */
+void *mbedtls_hash_create(hash_mode mode);
+
+/**
+ * \brief          Hash message chunk calculation
+ *
+ * Note: the message must be write to the buffer
+ * which get from cryp_hash_get_cpu_addr, and the length of message chunk
+ * can't large than the length which get from cryp_hash_get_cpu_addr.
+ *
+ * \param ctx      hash handle to be destory
+ * \param chunk    hash message to update
+ * \param length   length of hash message
+ * \param src      source of hash message
+ */
+hi_s32 mbedtls_hash_update(void *ctx, hi_u8 *chunk, hi_u32 chunkLen, hash_chunk_src src);
+
+/**
+ * \brief          HASH final digest
+ *
+ * \param ctx      Hash handle
+ * \param hash     HASH checksum result
+ * \param hashlen  Length of HASH checksum result
+ */
+hi_s32 mbedtls_hash_finish(void *ctx,  void *hash, hi_u32 *hashlen);
+
+/**
+ * \brief          Clear hash context
+ *
+ * \param ctx      symc handle to be destory
+ */
+hi_s32 mbedtls_hash_destory(void *ctx);
+
+/* sm3 */
+void *ext_sm3_create(hash_mode mode);
+
+hi_s32 ext_sm3_update(void *ctx, hi_u8 *chunk, hi_u32 chunkLen, hash_chunk_src src);
+
+hi_s32 ext_sm3_finish(void *ctx,  void *hash, hi_u32 *hashlen);
+
+hi_s32 ext_sm3_destory(void *ctx);
+
+/** @} */  /** <!-- ==== API declaration end ==== */
+#endif

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/aes.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/aes.h
@@ -1,0 +1,674 @@
+/**
+ * \file aes.h
+ *
+ * \brief   This file contains AES definitions and functions.
+ *
+ *          The Advanced Encryption Standard (AES) specifies a FIPS-approved
+ *          cryptographic algorithm that can be used to protect electronic
+ *          data.
+ *
+ *          The AES algorithm is a symmetric block cipher that can
+ *          encrypt and decrypt information. For more information, see
+ *          <em>FIPS Publication 197: Advanced Encryption Standard</em> and
+ *          <em>ISO/IEC 18033-2:2006: Information technology -- Security
+ *          techniques -- Encryption algorithms -- Part 2: Asymmetric
+ *          ciphers</em>.
+ *
+ *          The AES-XTS block mode is standardized by NIST SP 800-38E
+ *          <https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-38e.pdf>
+ *          and described in detail by IEEE P1619
+ *          <https://ieeexplore.ieee.org/servlet/opac?punumber=4375278>.
+ */
+
+/*  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_AES_H
+#define MBEDTLS_AES_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include <stddef.h>
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdint.h>
+#endif
+
+/* padlock.c and aesni.c rely on these values! */
+#define MBEDTLS_AES_ENCRYPT     1 /**< AES encryption. */
+#define MBEDTLS_AES_DECRYPT     0 /**< AES decryption. */
+
+/* Error codes in range 0x0020-0x0022 */
+#define MBEDTLS_ERR_AES_INVALID_KEY_LENGTH                -0x0020  /**< Invalid key length. */
+#define MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH              -0x0022  /**< Invalid data input length. */
+
+/* Error codes in range 0x0021-0x0025 */
+#define MBEDTLS_ERR_AES_BAD_INPUT_DATA                    -0x0021  /**< Invalid input data. */
+
+/* MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE is deprecated and should not be used. */
+#define MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE               -0x0023  /**< Feature not available. For example, an unsupported AES key size. */
+
+/* MBEDTLS_ERR_AES_HW_ACCEL_FAILED is deprecated and should not be used. */
+#define MBEDTLS_ERR_AES_HW_ACCEL_FAILED                   -0x0025  /**< AES hardware accelerator failed. */
+
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(MBEDTLS_AES_ALT)
+// Regular implementation
+//
+
+/**
+ * \brief The AES context-type definition.
+ */
+typedef struct mbedtls_aes_context
+{
+    int nr;                     /*!< The number of rounds. */
+    uint32_t *rk;               /*!< AES round keys. */
+    uint32_t buf[68];           /*!< Unaligned data buffer. This buffer can
+                                     hold 32 extra Bytes, which can be used for
+                                     one of the following purposes:
+                                     <ul><li>Alignment if VIA padlock is
+                                             used.</li>
+                                     <li>Simplifying key expansion in the 256-bit
+                                         case by generating an extra round key.
+                                         </li></ul> */
+}
+mbedtls_aes_context;
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+/**
+ * \brief The AES XTS context-type definition.
+ */
+typedef struct mbedtls_aes_xts_context
+{
+    mbedtls_aes_context crypt; /*!< The AES context to use for AES block
+                                        encryption or decryption. */
+    mbedtls_aes_context tweak; /*!< The AES context used for tweak
+                                        computation. */
+} mbedtls_aes_xts_context;
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+#else  /* MBEDTLS_AES_ALT */
+#include "aes_alt.h"
+#endif /* MBEDTLS_AES_ALT */
+
+/**
+ * \brief          This function initializes the specified AES context.
+ *
+ *                 It must be the first API called before using
+ *                 the context.
+ *
+ * \param ctx      The AES context to initialize. This must not be \c NULL.
+ */
+void mbedtls_aes_init( mbedtls_aes_context *ctx );
+
+/**
+ * \brief          This function releases and clears the specified AES context.
+ *
+ * \param ctx      The AES context to clear.
+ *                 If this is \c NULL, this function does nothing.
+ *                 Otherwise, the context must have been at least initialized.
+ */
+void mbedtls_aes_free( mbedtls_aes_context *ctx );
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+/**
+ * \brief          This function initializes the specified AES XTS context.
+ *
+ *                 It must be the first API called before using
+ *                 the context.
+ *
+ * \param ctx      The AES XTS context to initialize. This must not be \c NULL.
+ */
+void mbedtls_aes_xts_init( mbedtls_aes_xts_context *ctx );
+
+/**
+ * \brief          This function releases and clears the specified AES XTS context.
+ *
+ * \param ctx      The AES XTS context to clear.
+ *                 If this is \c NULL, this function does nothing.
+ *                 Otherwise, the context must have been at least initialized.
+ */
+void mbedtls_aes_xts_free( mbedtls_aes_xts_context *ctx );
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+/**
+ * \brief          This function sets the encryption key.
+ *
+ * \param ctx      The AES context to which the key should be bound.
+ *                 It must be initialized.
+ * \param key      The encryption key.
+ *                 This must be a readable buffer of size \p keybits bits.
+ * \param keybits  The size of data passed in bits. Valid options are:
+ *                 <ul><li>128 bits</li>
+ *                 <li>192 bits</li>
+ *                 <li>256 bits</li></ul>
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
+ */
+int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
+                    unsigned int keybits );
+
+/**
+ * \brief          This function sets the decryption key.
+ *
+ * \param ctx      The AES context to which the key should be bound.
+ *                 It must be initialized.
+ * \param key      The decryption key.
+ *                 This must be a readable buffer of size \p keybits bits.
+ * \param keybits  The size of data passed. Valid options are:
+ *                 <ul><li>128 bits</li>
+ *                 <li>192 bits</li>
+ *                 <li>256 bits</li></ul>
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
+ */
+int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
+                    unsigned int keybits );
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+/**
+ * \brief          This function prepares an XTS context for encryption and
+ *                 sets the encryption key.
+ *
+ * \param ctx      The AES XTS context to which the key should be bound.
+ *                 It must be initialized.
+ * \param key      The encryption key. This is comprised of the XTS key1
+ *                 concatenated with the XTS key2.
+ *                 This must be a readable buffer of size \p keybits bits.
+ * \param keybits  The size of \p key passed in bits. Valid options are:
+ *                 <ul><li>256 bits (each of key1 and key2 is a 128-bit key)</li>
+ *                 <li>512 bits (each of key1 and key2 is a 256-bit key)</li></ul>
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
+ */
+int mbedtls_aes_xts_setkey_enc( mbedtls_aes_xts_context *ctx,
+                                const unsigned char *key,
+                                unsigned int keybits );
+
+/**
+ * \brief          This function prepares an XTS context for decryption and
+ *                 sets the decryption key.
+ *
+ * \param ctx      The AES XTS context to which the key should be bound.
+ *                 It must be initialized.
+ * \param key      The decryption key. This is comprised of the XTS key1
+ *                 concatenated with the XTS key2.
+ *                 This must be a readable buffer of size \p keybits bits.
+ * \param keybits  The size of \p key passed in bits. Valid options are:
+ *                 <ul><li>256 bits (each of key1 and key2 is a 128-bit key)</li>
+ *                 <li>512 bits (each of key1 and key2 is a 256-bit key)</li></ul>
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
+ */
+int mbedtls_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
+                                const unsigned char *key,
+                                unsigned int keybits );
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+/**
+ * \brief          This function performs an AES single-block encryption or
+ *                 decryption operation.
+ *
+ *                 It performs the operation defined in the \p mode parameter
+ *                 (encrypt or decrypt), on the input data buffer defined in
+ *                 the \p input parameter.
+ *
+ *                 mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() or
+ *                 mbedtls_aes_setkey_dec() must be called before the first
+ *                 call to this API with the same context.
+ *
+ * \param ctx      The AES context to use for encryption or decryption.
+ *                 It must be initialized and bound to a key.
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or
+ *                 #MBEDTLS_AES_DECRYPT.
+ * \param input    The buffer holding the input data.
+ *                 It must be readable and at least \c 16 Bytes long.
+ * \param output   The buffer where the output data will be written.
+ *                 It must be writeable and at least \c 16 Bytes long.
+
+ * \return         \c 0 on success.
+ */
+int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
+                    int mode,
+                    const unsigned char input[16],
+                    unsigned char output[16] );
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+/**
+ * \brief  This function performs an AES-CBC encryption or decryption operation
+ *         on full blocks.
+ *
+ *         It performs the operation defined in the \p mode
+ *         parameter (encrypt/decrypt), on the input data buffer defined in
+ *         the \p input parameter.
+ *
+ *         It can be called as many times as needed, until all the input
+ *         data is processed. mbedtls_aes_init(), and either
+ *         mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called
+ *         before the first call to this API with the same context.
+ *
+ * \note   This function operates on full blocks, that is, the input size
+ *         must be a multiple of the AES block size of \c 16 Bytes.
+ *
+ * \note   Upon exit, the content of the IV is updated so that you can
+ *         call the same function again on the next
+ *         block(s) of data and get the same result as if it was
+ *         encrypted in one call. This allows a "streaming" usage.
+ *         If you need to retain the contents of the IV, you should
+ *         either save it manually or use the cipher module instead.
+ *
+ *
+ * \param ctx      The AES context to use for encryption or decryption.
+ *                 It must be initialized and bound to a key.
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or
+ *                 #MBEDTLS_AES_DECRYPT.
+ * \param length   The length of the input data in Bytes. This must be a
+ *                 multiple of the block size (\c 16 Bytes).
+ * \param iv       Initialization vector (updated after use).
+ *                 It must be a readable and writeable buffer of \c 16 Bytes.
+ * \param input    The buffer holding the input data.
+ *                 It must be readable and of size \p length Bytes.
+ * \param output   The buffer holding the output data.
+ *                 It must be writeable and of size \p length Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH
+ *                 on failure.
+ */
+int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
+                    int mode,
+                    size_t length,
+                    unsigned char iv[16],
+                    const unsigned char *input,
+                    unsigned char *output );
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+/**
+ * \brief      This function performs an AES-XTS encryption or decryption
+ *             operation for an entire XTS data unit.
+ *
+ *             AES-XTS encrypts or decrypts blocks based on their location as
+ *             defined by a data unit number. The data unit number must be
+ *             provided by \p data_unit.
+ *
+ *             NIST SP 800-38E limits the maximum size of a data unit to 2^20
+ *             AES blocks. If the data unit is larger than this, this function
+ *             returns #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH.
+ *
+ * \param ctx          The AES XTS context to use for AES XTS operations.
+ *                     It must be initialized and bound to a key.
+ * \param mode         The AES operation: #MBEDTLS_AES_ENCRYPT or
+ *                     #MBEDTLS_AES_DECRYPT.
+ * \param length       The length of a data unit in Bytes. This can be any
+ *                     length between 16 bytes and 2^24 bytes inclusive
+ *                     (between 1 and 2^20 block cipher blocks).
+ * \param data_unit    The address of the data unit encoded as an array of 16
+ *                     bytes in little-endian format. For disk encryption, this
+ *                     is typically the index of the block device sector that
+ *                     contains the data.
+ * \param input        The buffer holding the input data (which is an entire
+ *                     data unit). This function reads \p length Bytes from \p
+ *                     input.
+ * \param output       The buffer holding the output data (which is an entire
+ *                     data unit). This function writes \p length Bytes to \p
+ *                     output.
+ *
+ * \return             \c 0 on success.
+ * \return             #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH if \p length is
+ *                     smaller than an AES block in size (16 Bytes) or if \p
+ *                     length is larger than 2^20 blocks (16 MiB).
+ */
+int mbedtls_aes_crypt_xts( mbedtls_aes_xts_context *ctx,
+                           int mode,
+                           size_t length,
+                           const unsigned char data_unit[16],
+                           const unsigned char *input,
+                           unsigned char *output );
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+/**
+ * \brief This function performs an AES-CFB128 encryption or decryption
+ *        operation.
+ *
+ *        It performs the operation defined in the \p mode
+ *        parameter (encrypt or decrypt), on the input data buffer
+ *        defined in the \p input parameter.
+ *
+ *        For CFB, you must set up the context with mbedtls_aes_setkey_enc(),
+ *        regardless of whether you are performing an encryption or decryption
+ *        operation, that is, regardless of the \p mode parameter. This is
+ *        because CFB mode uses the same key schedule for encryption and
+ *        decryption.
+ *
+ * \note  Upon exit, the content of the IV is updated so that you can
+ *        call the same function again on the next
+ *        block(s) of data and get the same result as if it was
+ *        encrypted in one call. This allows a "streaming" usage.
+ *        If you need to retain the contents of the
+ *        IV, you must either save it manually or use the cipher
+ *        module instead.
+ *
+ *
+ * \param ctx      The AES context to use for encryption or decryption.
+ *                 It must be initialized and bound to a key.
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or
+ *                 #MBEDTLS_AES_DECRYPT.
+ * \param length   The length of the input data in Bytes.
+ * \param iv_off   The offset in IV (updated after use).
+ *                 It must point to a valid \c size_t.
+ * \param iv       The initialization vector (updated after use).
+ *                 It must be a readable and writeable buffer of \c 16 Bytes.
+ * \param input    The buffer holding the input data.
+ *                 It must be readable and of size \p length Bytes.
+ * \param output   The buffer holding the output data.
+ *                 It must be writeable and of size \p length Bytes.
+ *
+ * \return         \c 0 on success.
+ */
+int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
+                       int mode,
+                       size_t length,
+                       size_t *iv_off,
+                       unsigned char iv[16],
+                       const unsigned char *input,
+                       unsigned char *output );
+
+/**
+ * \brief This function performs an AES-CFB8 encryption or decryption
+ *        operation.
+ *
+ *        It performs the operation defined in the \p mode
+ *        parameter (encrypt/decrypt), on the input data buffer defined
+ *        in the \p input parameter.
+ *
+ *        Due to the nature of CFB, you must use the same key schedule for
+ *        both encryption and decryption operations. Therefore, you must
+ *        use the context initialized with mbedtls_aes_setkey_enc() for
+ *        both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
+ *
+ * \note  Upon exit, the content of the IV is updated so that you can
+ *        call the same function again on the next
+ *        block(s) of data and get the same result as if it was
+ *        encrypted in one call. This allows a "streaming" usage.
+ *        If you need to retain the contents of the
+ *        IV, you should either save it manually or use the cipher
+ *        module instead.
+ *
+ *
+ * \param ctx      The AES context to use for encryption or decryption.
+ *                 It must be initialized and bound to a key.
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or
+ *                 #MBEDTLS_AES_DECRYPT
+ * \param length   The length of the input data.
+ * \param iv       The initialization vector (updated after use).
+ *                 It must be a readable and writeable buffer of \c 16 Bytes.
+ * \param input    The buffer holding the input data.
+ *                 It must be readable and of size \p length Bytes.
+ * \param output   The buffer holding the output data.
+ *                 It must be writeable and of size \p length Bytes.
+ *
+ * \return         \c 0 on success.
+ */
+int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
+                    int mode,
+                    size_t length,
+                    unsigned char iv[16],
+                    const unsigned char *input,
+                    unsigned char *output );
+#endif /*MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+/**
+ * \brief       This function performs an AES-OFB (Output Feedback Mode)
+ *              encryption or decryption operation.
+ *
+ *              For OFB, you must set up the context with
+ *              mbedtls_aes_setkey_enc(), regardless of whether you are
+ *              performing an encryption or decryption operation. This is
+ *              because OFB mode uses the same key schedule for encryption and
+ *              decryption.
+ *
+ *              The OFB operation is identical for encryption or decryption,
+ *              therefore no operation mode needs to be specified.
+ *
+ * \note        Upon exit, the content of iv, the Initialisation Vector, is
+ *              updated so that you can call the same function again on the next
+ *              block(s) of data and get the same result as if it was encrypted
+ *              in one call. This allows a "streaming" usage, by initialising
+ *              iv_off to 0 before the first call, and preserving its value
+ *              between calls.
+ *
+ *              For non-streaming use, the iv should be initialised on each call
+ *              to a unique value, and iv_off set to 0 on each call.
+ *
+ *              If you need to retain the contents of the initialisation vector,
+ *              you must either save it manually or use the cipher module
+ *              instead.
+ *
+ * \warning     For the OFB mode, the initialisation vector must be unique
+ *              every encryption operation. Reuse of an initialisation vector
+ *              will compromise security.
+ *
+ * \param ctx      The AES context to use for encryption or decryption.
+ *                 It must be initialized and bound to a key.
+ * \param length   The length of the input data.
+ * \param iv_off   The offset in IV (updated after use).
+ *                 It must point to a valid \c size_t.
+ * \param iv       The initialization vector (updated after use).
+ *                 It must be a readable and writeable buffer of \c 16 Bytes.
+ * \param input    The buffer holding the input data.
+ *                 It must be readable and of size \p length Bytes.
+ * \param output   The buffer holding the output data.
+ *                 It must be writeable and of size \p length Bytes.
+ *
+ * \return         \c 0 on success.
+ */
+int mbedtls_aes_crypt_ofb( mbedtls_aes_context *ctx,
+                       size_t length,
+                       size_t *iv_off,
+                       unsigned char iv[16],
+                       const unsigned char *input,
+                       unsigned char *output );
+
+#endif /* MBEDTLS_CIPHER_MODE_OFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+/**
+ * \brief      This function performs an AES-CTR encryption or decryption
+ *             operation.
+ *
+ *             This function performs the operation defined in the \p mode
+ *             parameter (encrypt/decrypt), on the input data buffer
+ *             defined in the \p input parameter.
+ *
+ *             Due to the nature of CTR, you must use the same key schedule
+ *             for both encryption and decryption operations. Therefore, you
+ *             must use the context initialized with mbedtls_aes_setkey_enc()
+ *             for both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
+ *
+ * \warning    You must never reuse a nonce value with the same key. Doing so
+ *             would void the encryption for the two messages encrypted with
+ *             the same nonce and key.
+ *
+ *             There are two common strategies for managing nonces with CTR:
+ *
+ *             1. You can handle everything as a single message processed over
+ *             successive calls to this function. In that case, you want to
+ *             set \p nonce_counter and \p nc_off to 0 for the first call, and
+ *             then preserve the values of \p nonce_counter, \p nc_off and \p
+ *             stream_block across calls to this function as they will be
+ *             updated by this function.
+ *
+ *             With this strategy, you must not encrypt more than 2**128
+ *             blocks of data with the same key.
+ *
+ *             2. You can encrypt separate messages by dividing the \p
+ *             nonce_counter buffer in two areas: the first one used for a
+ *             per-message nonce, handled by yourself, and the second one
+ *             updated by this function internally.
+ *
+ *             For example, you might reserve the first 12 bytes for the
+ *             per-message nonce, and the last 4 bytes for internal use. In that
+ *             case, before calling this function on a new message you need to
+ *             set the first 12 bytes of \p nonce_counter to your chosen nonce
+ *             value, the last 4 to 0, and \p nc_off to 0 (which will cause \p
+ *             stream_block to be ignored). That way, you can encrypt at most
+ *             2**96 messages of up to 2**32 blocks each with the same key.
+ *
+ *             The per-message nonce (or information sufficient to reconstruct
+ *             it) needs to be communicated with the ciphertext and must be unique.
+ *             The recommended way to ensure uniqueness is to use a message
+ *             counter. An alternative is to generate random nonces, but this
+ *             limits the number of messages that can be securely encrypted:
+ *             for example, with 96-bit random nonces, you should not encrypt
+ *             more than 2**32 messages with the same key.
+ *
+ *             Note that for both stategies, sizes are measured in blocks and
+ *             that an AES block is 16 bytes.
+ *
+ * \warning    Upon return, \p stream_block contains sensitive data. Its
+ *             content must not be written to insecure storage and should be
+ *             securely discarded as soon as it's no longer needed.
+ *
+ * \param ctx              The AES context to use for encryption or decryption.
+ *                         It must be initialized and bound to a key.
+ * \param length           The length of the input data.
+ * \param nc_off           The offset in the current \p stream_block, for
+ *                         resuming within the current cipher stream. The
+ *                         offset pointer should be 0 at the start of a stream.
+ *                         It must point to a valid \c size_t.
+ * \param nonce_counter    The 128-bit nonce and counter.
+ *                         It must be a readable-writeable buffer of \c 16 Bytes.
+ * \param stream_block     The saved stream block for resuming. This is
+ *                         overwritten by the function.
+ *                         It must be a readable-writeable buffer of \c 16 Bytes.
+ * \param input            The buffer holding the input data.
+ *                         It must be readable and of size \p length Bytes.
+ * \param output           The buffer holding the output data.
+ *                         It must be writeable and of size \p length Bytes.
+ *
+ * \return                 \c 0 on success.
+ */
+int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
+                       size_t length,
+                       size_t *nc_off,
+                       unsigned char nonce_counter[16],
+                       unsigned char stream_block[16],
+                       const unsigned char *input,
+                       unsigned char *output );
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+/**
+ * \brief           Internal AES block encryption function. This is only
+ *                  exposed to allow overriding it using
+ *                  \c MBEDTLS_AES_ENCRYPT_ALT.
+ *
+ * \param ctx       The AES context to use for encryption.
+ * \param input     The plaintext block.
+ * \param output    The output (ciphertext) block.
+ *
+ * \return          \c 0 on success.
+ */
+int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
+                                  const unsigned char input[16],
+                                  unsigned char output[16] );
+
+/**
+ * \brief           Internal AES block decryption function. This is only
+ *                  exposed to allow overriding it using see
+ *                  \c MBEDTLS_AES_DECRYPT_ALT.
+ *
+ * \param ctx       The AES context to use for decryption.
+ * \param input     The ciphertext block.
+ * \param output    The output (plaintext) block.
+ *
+ * \return          \c 0 on success.
+ */
+int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
+                                  const unsigned char input[16],
+                                  unsigned char output[16] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief           Deprecated internal AES block encryption function
+ *                  without return value.
+ *
+ * \deprecated      Superseded by mbedtls_internal_aes_encrypt()
+ *
+ * \param ctx       The AES context to use for encryption.
+ * \param input     Plaintext block.
+ * \param output    Output (ciphertext) block.
+ */
+MBEDTLS_DEPRECATED void mbedtls_aes_encrypt( mbedtls_aes_context *ctx,
+                                             const unsigned char input[16],
+                                             unsigned char output[16] );
+
+/**
+ * \brief           Deprecated internal AES block decryption function
+ *                  without return value.
+ *
+ * \deprecated      Superseded by mbedtls_internal_aes_decrypt()
+ *
+ * \param ctx       The AES context to use for decryption.
+ * \param input     Ciphertext block.
+ * \param output    Output (plaintext) block.
+ */
+MBEDTLS_DEPRECATED void mbedtls_aes_decrypt( mbedtls_aes_context *ctx,
+                                             const unsigned char input[16],
+                                             unsigned char output[16] );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief          Checkup routine.
+ *
+ * \return         \c 0 on success.
+ * \return         \c 1 on failure.
+ */
+int mbedtls_aes_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* aes.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/aesni.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/aesni.h
@@ -1,0 +1,132 @@
+/**
+ * \file aesni.h
+ *
+ * \brief AES-NI for hardware AES acceleration on some Intel processors
+ *
+ * \warning These functions are only for internal use by other library
+ *          functions; you must not call them directly.
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_AESNI_H
+#define MBEDTLS_AESNI_H
+
+#include "aes.h"
+
+#define MBEDTLS_AESNI_AES      0x02000000u
+#define MBEDTLS_AESNI_CLMUL    0x00000002u
+
+#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) &&  \
+    ( defined(__amd64__) || defined(__x86_64__) )   &&  \
+    ! defined(MBEDTLS_HAVE_X86_64)
+#define MBEDTLS_HAVE_X86_64
+#endif
+
+#if defined(MBEDTLS_HAVE_X86_64)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief          Internal function to detect the AES-NI feature in CPUs.
+ *
+ * \note           This function is only for internal use by other library
+ *                 functions; you must not call it directly.
+ *
+ * \param what     The feature to detect
+ *                 (MBEDTLS_AESNI_AES or MBEDTLS_AESNI_CLMUL)
+ *
+ * \return         1 if CPU has support for the feature, 0 otherwise
+ */
+int mbedtls_aesni_has_support( unsigned int what );
+
+/**
+ * \brief          Internal AES-NI AES-ECB block encryption and decryption
+ *
+ * \note           This function is only for internal use by other library
+ *                 functions; you must not call it directly.
+ *
+ * \param ctx      AES context
+ * \param mode     MBEDTLS_AES_ENCRYPT or MBEDTLS_AES_DECRYPT
+ * \param input    16-byte input block
+ * \param output   16-byte output block
+ *
+ * \return         0 on success (cannot fail)
+ */
+int mbedtls_aesni_crypt_ecb( mbedtls_aes_context *ctx,
+                             int mode,
+                             const unsigned char input[16],
+                             unsigned char output[16] );
+
+/**
+ * \brief          Internal GCM multiplication: c = a * b in GF(2^128)
+ *
+ * \note           This function is only for internal use by other library
+ *                 functions; you must not call it directly.
+ *
+ * \param c        Result
+ * \param a        First operand
+ * \param b        Second operand
+ *
+ * \note           Both operands and result are bit strings interpreted as
+ *                 elements of GF(2^128) as per the GCM spec.
+ */
+void mbedtls_aesni_gcm_mult( unsigned char c[16],
+                             const unsigned char a[16],
+                             const unsigned char b[16] );
+
+/**
+ * \brief           Internal round key inversion. This function computes
+ *                  decryption round keys from the encryption round keys.
+ *
+ * \note            This function is only for internal use by other library
+ *                  functions; you must not call it directly.
+ *
+ * \param invkey    Round keys for the equivalent inverse cipher
+ * \param fwdkey    Original round keys (for encryption)
+ * \param nr        Number of rounds (that is, number of round keys minus one)
+ */
+void mbedtls_aesni_inverse_key( unsigned char *invkey,
+                                const unsigned char *fwdkey,
+                                int nr );
+
+/**
+ * \brief           Internal key expansion for encryption
+ *
+ * \note            This function is only for internal use by other library
+ *                  functions; you must not call it directly.
+ *
+ * \param rk        Destination buffer where the round keys are written
+ * \param key       Encryption key
+ * \param bits      Key size in bits (must be 128, 192 or 256)
+ *
+ * \return          0 if successful, or MBEDTLS_ERR_AES_INVALID_KEY_LENGTH
+ */
+int mbedtls_aesni_setkey_enc( unsigned char *rk,
+                              const unsigned char *key,
+                              size_t bits );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_HAVE_X86_64 */
+
+#endif /* MBEDTLS_AESNI_H */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/asn1.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/asn1.h
@@ -1,0 +1,358 @@
+/**
+ * \file asn1.h
+ *
+ * \brief Generic ASN.1 parsing
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_ASN1_H
+#define MBEDTLS_ASN1_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include <stddef.h>
+
+#if defined(MBEDTLS_BIGNUM_C)
+#include "bignum.h"
+#endif
+
+/**
+ * \addtogroup asn1_module
+ * \{
+ */
+
+/**
+ * \name ASN1 Error codes
+ * These error codes are OR'ed to X509 error codes for
+ * higher error granularity.
+ * ASN1 is a standard to specify data structures.
+ * \{
+ */
+#define MBEDTLS_ERR_ASN1_OUT_OF_DATA                      -0x0060  /**< Out of data when parsing an ASN1 data structure. */
+#define MBEDTLS_ERR_ASN1_UNEXPECTED_TAG                   -0x0062  /**< ASN1 tag was of an unexpected value. */
+#define MBEDTLS_ERR_ASN1_INVALID_LENGTH                   -0x0064  /**< Error when trying to determine the length or invalid length. */
+#define MBEDTLS_ERR_ASN1_LENGTH_MISMATCH                  -0x0066  /**< Actual length differs from expected length. */
+#define MBEDTLS_ERR_ASN1_INVALID_DATA                     -0x0068  /**< Data is invalid. (not used) */
+#define MBEDTLS_ERR_ASN1_ALLOC_FAILED                     -0x006A  /**< Memory allocation failed */
+#define MBEDTLS_ERR_ASN1_BUF_TOO_SMALL                    -0x006C  /**< Buffer too small when writing ASN.1 data structure. */
+
+/* \} name */
+
+/**
+ * \name DER constants
+ * These constants comply with the DER encoded ASN.1 type tags.
+ * DER encoding uses hexadecimal representation.
+ * An example DER sequence is:\n
+ * - 0x02 -- tag indicating INTEGER
+ * - 0x01 -- length in octets
+ * - 0x05 -- value
+ * Such sequences are typically read into \c ::mbedtls_x509_buf.
+ * \{
+ */
+#define MBEDTLS_ASN1_BOOLEAN                 0x01
+#define MBEDTLS_ASN1_INTEGER                 0x02
+#define MBEDTLS_ASN1_BIT_STRING              0x03
+#define MBEDTLS_ASN1_OCTET_STRING            0x04
+#define MBEDTLS_ASN1_NULL                    0x05
+#define MBEDTLS_ASN1_OID                     0x06
+#define MBEDTLS_ASN1_UTF8_STRING             0x0C
+#define MBEDTLS_ASN1_SEQUENCE                0x10
+#define MBEDTLS_ASN1_SET                     0x11
+#define MBEDTLS_ASN1_PRINTABLE_STRING        0x13
+#define MBEDTLS_ASN1_T61_STRING              0x14
+#define MBEDTLS_ASN1_IA5_STRING              0x16
+#define MBEDTLS_ASN1_UTC_TIME                0x17
+#define MBEDTLS_ASN1_GENERALIZED_TIME        0x18
+#define MBEDTLS_ASN1_UNIVERSAL_STRING        0x1C
+#define MBEDTLS_ASN1_BMP_STRING              0x1E
+#define MBEDTLS_ASN1_PRIMITIVE               0x00
+#define MBEDTLS_ASN1_CONSTRUCTED             0x20
+#define MBEDTLS_ASN1_CONTEXT_SPECIFIC        0x80
+
+/*
+ * Bit masks for each of the components of an ASN.1 tag as specified in
+ * ITU X.690 (08/2015), section 8.1 "General rules for encoding",
+ * paragraph 8.1.2.2:
+ *
+ * Bit  8     7   6   5          1
+ *     +-------+-----+------------+
+ *     | Class | P/C | Tag number |
+ *     +-------+-----+------------+
+ */
+#define MBEDTLS_ASN1_TAG_CLASS_MASK          0xC0
+#define MBEDTLS_ASN1_TAG_PC_MASK             0x20
+#define MBEDTLS_ASN1_TAG_VALUE_MASK          0x1F
+
+/* \} name */
+/* \} addtogroup asn1_module */
+
+/** Returns the size of the binary string, without the trailing \\0 */
+#define MBEDTLS_OID_SIZE(x) (sizeof(x) - 1)
+
+/**
+ * Compares an mbedtls_asn1_buf structure to a reference OID.
+ *
+ * Only works for 'defined' oid_str values (MBEDTLS_OID_HMAC_SHA1), you cannot use a
+ * 'unsigned char *oid' here!
+ */
+#define MBEDTLS_OID_CMP(oid_str, oid_buf)                                   \
+        ( ( MBEDTLS_OID_SIZE(oid_str) != (oid_buf)->len ) ||                \
+          memcmp( (oid_str), (oid_buf)->p, (oid_buf)->len) != 0 )
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \name Functions to parse ASN.1 data structures
+ * \{
+ */
+
+/**
+ * Type-length-value structure that allows for ASN1 using DER.
+ */
+typedef struct mbedtls_asn1_buf
+{
+    int tag;                /**< ASN1 type, e.g. MBEDTLS_ASN1_UTF8_STRING. */
+    size_t len;             /**< ASN1 length, in octets. */
+    unsigned char *p;       /**< ASN1 data, e.g. in ASCII. */
+}
+mbedtls_asn1_buf;
+
+/**
+ * Container for ASN1 bit strings.
+ */
+typedef struct mbedtls_asn1_bitstring
+{
+    size_t len;                 /**< ASN1 length, in octets. */
+    unsigned char unused_bits;  /**< Number of unused bits at the end of the string */
+    unsigned char *p;           /**< Raw ASN1 data for the bit string */
+}
+mbedtls_asn1_bitstring;
+
+/**
+ * Container for a sequence of ASN.1 items
+ */
+typedef struct mbedtls_asn1_sequence
+{
+    mbedtls_asn1_buf buf;                   /**< Buffer containing the given ASN.1 item. */
+    struct mbedtls_asn1_sequence *next;    /**< The next entry in the sequence. */
+}
+mbedtls_asn1_sequence;
+
+/**
+ * Container for a sequence or list of 'named' ASN.1 data items
+ */
+typedef struct mbedtls_asn1_named_data
+{
+    mbedtls_asn1_buf oid;                   /**< The object identifier. */
+    mbedtls_asn1_buf val;                   /**< The named value. */
+    struct mbedtls_asn1_named_data *next;  /**< The next entry in the sequence. */
+    unsigned char next_merged;      /**< Merge next item into the current one? */
+}
+mbedtls_asn1_named_data;
+
+/**
+ * \brief       Get the length of an ASN.1 element.
+ *              Updates the pointer to immediately behind the length.
+ *
+ * \param p     The position in the ASN.1 data
+ * \param end   End of data
+ * \param len   The variable that will receive the value
+ *
+ * \return      0 if successful, MBEDTLS_ERR_ASN1_OUT_OF_DATA on reaching
+ *              end of data, MBEDTLS_ERR_ASN1_INVALID_LENGTH if length is
+ *              unparseable.
+ */
+int mbedtls_asn1_get_len( unsigned char **p,
+                  const unsigned char *end,
+                  size_t *len );
+
+/**
+ * \brief       Get the tag and length of the tag. Check for the requested tag.
+ *              Updates the pointer to immediately behind the tag and length.
+ *
+ * \param p     The position in the ASN.1 data
+ * \param end   End of data
+ * \param len   The variable that will receive the length
+ * \param tag   The expected tag
+ *
+ * \return      0 if successful, MBEDTLS_ERR_ASN1_UNEXPECTED_TAG if tag did
+ *              not match requested tag, or another specific ASN.1 error code.
+ */
+int mbedtls_asn1_get_tag( unsigned char **p,
+                  const unsigned char *end,
+                  size_t *len, int tag );
+
+/**
+ * \brief       Retrieve a boolean ASN.1 tag and its value.
+ *              Updates the pointer to immediately behind the full tag.
+ *
+ * \param p     The position in the ASN.1 data
+ * \param end   End of data
+ * \param val   The variable that will receive the value
+ *
+ * \return      0 if successful or a specific ASN.1 error code.
+ */
+int mbedtls_asn1_get_bool( unsigned char **p,
+                   const unsigned char *end,
+                   int *val );
+
+/**
+ * \brief       Retrieve an integer ASN.1 tag and its value.
+ *              Updates the pointer to immediately behind the full tag.
+ *
+ * \param p     The position in the ASN.1 data
+ * \param end   End of data
+ * \param val   The variable that will receive the value
+ *
+ * \return      0 if successful or a specific ASN.1 error code.
+ */
+int mbedtls_asn1_get_int( unsigned char **p,
+                  const unsigned char *end,
+                  int *val );
+
+/**
+ * \brief       Retrieve a bitstring ASN.1 tag and its value.
+ *              Updates the pointer to immediately behind the full tag.
+ *
+ * \param p     The position in the ASN.1 data
+ * \param end   End of data
+ * \param bs    The variable that will receive the value
+ *
+ * \return      0 if successful or a specific ASN.1 error code.
+ */
+int mbedtls_asn1_get_bitstring( unsigned char **p, const unsigned char *end,
+                        mbedtls_asn1_bitstring *bs);
+
+/**
+ * \brief       Retrieve a bitstring ASN.1 tag without unused bits and its
+ *              value.
+ *              Updates the pointer to the beginning of the bit/octet string.
+ *
+ * \param p     The position in the ASN.1 data
+ * \param end   End of data
+ * \param len   Length of the actual bit/octect string in bytes
+ *
+ * \return      0 if successful or a specific ASN.1 error code.
+ */
+int mbedtls_asn1_get_bitstring_null( unsigned char **p, const unsigned char *end,
+                             size_t *len );
+
+/**
+ * \brief       Parses and splits an ASN.1 "SEQUENCE OF <tag>"
+ *              Updated the pointer to immediately behind the full sequence tag.
+ *
+ * \param p     The position in the ASN.1 data
+ * \param end   End of data
+ * \param cur   First variable in the chain to fill
+ * \param tag   Type of sequence
+ *
+ * \return      0 if successful or a specific ASN.1 error code.
+ */
+int mbedtls_asn1_get_sequence_of( unsigned char **p,
+                          const unsigned char *end,
+                          mbedtls_asn1_sequence *cur,
+                          int tag);
+
+#if defined(MBEDTLS_BIGNUM_C)
+/**
+ * \brief       Retrieve a MPI value from an integer ASN.1 tag.
+ *              Updates the pointer to immediately behind the full tag.
+ *
+ * \param p     The position in the ASN.1 data
+ * \param end   End of data
+ * \param X     The MPI that will receive the value
+ *
+ * \return      0 if successful or a specific ASN.1 or MPI error code.
+ */
+int mbedtls_asn1_get_mpi( unsigned char **p,
+                  const unsigned char *end,
+                  mbedtls_mpi *X );
+#endif /* MBEDTLS_BIGNUM_C */
+
+/**
+ * \brief       Retrieve an AlgorithmIdentifier ASN.1 sequence.
+ *              Updates the pointer to immediately behind the full
+ *              AlgorithmIdentifier.
+ *
+ * \param p     The position in the ASN.1 data
+ * \param end   End of data
+ * \param alg   The buffer to receive the OID
+ * \param params The buffer to receive the params (if any)
+ *
+ * \return      0 if successful or a specific ASN.1 or MPI error code.
+ */
+int mbedtls_asn1_get_alg( unsigned char **p,
+                  const unsigned char *end,
+                  mbedtls_asn1_buf *alg, mbedtls_asn1_buf *params );
+
+/**
+ * \brief       Retrieve an AlgorithmIdentifier ASN.1 sequence with NULL or no
+ *              params.
+ *              Updates the pointer to immediately behind the full
+ *              AlgorithmIdentifier.
+ *
+ * \param p     The position in the ASN.1 data
+ * \param end   End of data
+ * \param alg   The buffer to receive the OID
+ *
+ * \return      0 if successful or a specific ASN.1 or MPI error code.
+ */
+int mbedtls_asn1_get_alg_null( unsigned char **p,
+                       const unsigned char *end,
+                       mbedtls_asn1_buf *alg );
+
+/**
+ * \brief       Find a specific named_data entry in a sequence or list based on
+ *              the OID.
+ *
+ * \param list  The list to seek through
+ * \param oid   The OID to look for
+ * \param len   Size of the OID
+ *
+ * \return      NULL if not found, or a pointer to the existing entry.
+ */
+mbedtls_asn1_named_data *mbedtls_asn1_find_named_data( mbedtls_asn1_named_data *list,
+                                       const char *oid, size_t len );
+
+/**
+ * \brief       Free a mbedtls_asn1_named_data entry
+ *
+ * \param entry The named data entry to free
+ */
+void mbedtls_asn1_free_named_data( mbedtls_asn1_named_data *entry );
+
+/**
+ * \brief       Free all entries in a mbedtls_asn1_named_data list
+ *              Head will be set to NULL
+ *
+ * \param head  Pointer to the head of the list of named data entries to free
+ */
+void mbedtls_asn1_free_named_data_list( mbedtls_asn1_named_data **head );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* asn1.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/asn1write.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/asn1write.h
@@ -1,0 +1,322 @@
+/**
+ * \file asn1write.h
+ *
+ * \brief ASN.1 buffer writing functionality
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_ASN1_WRITE_H
+#define MBEDTLS_ASN1_WRITE_H
+
+#include "asn1.h"
+
+#define MBEDTLS_ASN1_CHK_ADD(g, f)                      \
+    do {                                                \
+        if( ( ret = f ) < 0 )                           \
+            return( ret );                              \
+        else                                            \
+            g += ret;                                   \
+    } while( 0 )
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief           Write a length field in ASN.1 format.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param len       The length value to write.
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
+ */
+int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start,
+                            size_t len );
+/**
+ * \brief           Write an ASN.1 tag in ASN.1 format.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param tag       The tag to write.
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
+ */
+int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start,
+                            unsigned char tag );
+
+/**
+ * \brief           Write raw buffer data.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param buf       The data buffer to write.
+ * \param size      The length of the data buffer.
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
+ */
+int mbedtls_asn1_write_raw_buffer( unsigned char **p, unsigned char *start,
+                                   const unsigned char *buf, size_t size );
+
+#if defined(MBEDTLS_BIGNUM_C)
+/**
+ * \brief           Write a arbitrary-precision number (#MBEDTLS_ASN1_INTEGER)
+ *                  in ASN.1 format.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param X         The MPI to write.
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
+ */
+int mbedtls_asn1_write_mpi( unsigned char **p, unsigned char *start,
+                            const mbedtls_mpi *X );
+#endif /* MBEDTLS_BIGNUM_C */
+
+/**
+ * \brief           Write a NULL tag (#MBEDTLS_ASN1_NULL) with zero data
+ *                  in ASN.1 format.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
+ */
+int mbedtls_asn1_write_null( unsigned char **p, unsigned char *start );
+
+/**
+ * \brief           Write an OID tag (#MBEDTLS_ASN1_OID) and data
+ *                  in ASN.1 format.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param oid       The OID to write.
+ * \param oid_len   The length of the OID.
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
+ */
+int mbedtls_asn1_write_oid( unsigned char **p, unsigned char *start,
+                            const char *oid, size_t oid_len );
+
+/**
+ * \brief           Write an AlgorithmIdentifier sequence in ASN.1 format.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param oid       The OID of the algorithm to write.
+ * \param oid_len   The length of the algorithm's OID.
+ * \param par_len   The length of the parameters, which must be already written.
+ *                  If 0, NULL parameters are added
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
+ */
+int mbedtls_asn1_write_algorithm_identifier( unsigned char **p,
+                                             unsigned char *start,
+                                             const char *oid, size_t oid_len,
+                                             size_t par_len );
+
+/**
+ * \brief           Write a boolean tag (#MBEDTLS_ASN1_BOOLEAN) and value
+ *                  in ASN.1 format.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param boolean   The boolean value to write, either \c 0 or \c 1.
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
+ */
+int mbedtls_asn1_write_bool( unsigned char **p, unsigned char *start,
+                             int boolean );
+
+/**
+ * \brief           Write an int tag (#MBEDTLS_ASN1_INTEGER) and value
+ *                  in ASN.1 format.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param val       The integer value to write.
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
+ */
+int mbedtls_asn1_write_int( unsigned char **p, unsigned char *start, int val );
+
+/**
+ * \brief           Write a string in ASN.1 format using a specific
+ *                  string encoding tag.
+
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param tag       The string encoding tag to write, e.g.
+ *                  #MBEDTLS_ASN1_UTF8_STRING.
+ * \param text      The string to write.
+ * \param text_len  The length of \p text in bytes (which might
+ *                  be strictly larger than the number of characters).
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative error code on failure.
+ */
+int mbedtls_asn1_write_tagged_string( unsigned char **p, unsigned char *start,
+                                      int tag, const char *text,
+                                      size_t text_len );
+
+/**
+ * \brief           Write a string in ASN.1 format using the PrintableString
+ *                  string encoding tag (#MBEDTLS_ASN1_PRINTABLE_STRING).
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param text      The string to write.
+ * \param text_len  The length of \p text in bytes (which might
+ *                  be strictly larger than the number of characters).
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative error code on failure.
+ */
+int mbedtls_asn1_write_printable_string( unsigned char **p,
+                                         unsigned char *start,
+                                         const char *text, size_t text_len );
+
+/**
+ * \brief           Write a UTF8 string in ASN.1 format using the UTF8String
+ *                  string encoding tag (#MBEDTLS_ASN1_PRINTABLE_STRING).
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param text      The string to write.
+ * \param text_len  The length of \p text in bytes (which might
+ *                  be strictly larger than the number of characters).
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative error code on failure.
+ */
+int mbedtls_asn1_write_utf8_string( unsigned char **p, unsigned char *start,
+                                    const char *text, size_t text_len );
+
+/**
+ * \brief           Write a string in ASN.1 format using the IA5String
+ *                  string encoding tag (#MBEDTLS_ASN1_IA5_STRING).
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param text      The string to write.
+ * \param text_len  The length of \p text in bytes (which might
+ *                  be strictly larger than the number of characters).
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative error code on failure.
+ */
+int mbedtls_asn1_write_ia5_string( unsigned char **p, unsigned char *start,
+                                   const char *text, size_t text_len );
+
+/**
+ * \brief           Write a bitstring tag (#MBEDTLS_ASN1_BIT_STRING) and
+ *                  value in ASN.1 format.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param buf       The bitstring to write.
+ * \param bits      The total number of bits in the bitstring.
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative error code on failure.
+ */
+int mbedtls_asn1_write_bitstring( unsigned char **p, unsigned char *start,
+                                  const unsigned char *buf, size_t bits );
+
+/**
+ * \brief           Write an octet string tag (#MBEDTLS_ASN1_OCTET_STRING)
+ *                  and value in ASN.1 format.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param buf       The buffer holding the data to write.
+ * \param size      The length of the data buffer \p buf.
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative error code on failure.
+ */
+int mbedtls_asn1_write_octet_string( unsigned char **p, unsigned char *start,
+                                     const unsigned char *buf, size_t size );
+
+/**
+ * \brief           Create or find a specific named_data entry for writing in a
+ *                  sequence or list based on the OID. If not already in there,
+ *                  a new entry is added to the head of the list.
+ *                  Warning: Destructive behaviour for the val data!
+ *
+ * \param list      The pointer to the location of the head of the list to seek
+ *                  through (will be updated in case of a new entry).
+ * \param oid       The OID to look for.
+ * \param oid_len   The size of the OID.
+ * \param val       The data to store (can be \c NULL if you want to fill
+ *                  it by hand).
+ * \param val_len   The minimum length of the data buffer needed.
+ *
+ * \return          A pointer to the new / existing entry on success.
+ * \return          \c NULL if if there was a memory allocation error.
+ */
+mbedtls_asn1_named_data *mbedtls_asn1_store_named_data( mbedtls_asn1_named_data **list,
+                                        const char *oid, size_t oid_len,
+                                        const unsigned char *val,
+                                        size_t val_len );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_ASN1_WRITE_H */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/bignum.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/bignum.h
@@ -1,0 +1,959 @@
+/**
+ * \file bignum.h
+ *
+ * \brief Multi-precision integer library
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_BIGNUM_H
+#define MBEDTLS_BIGNUM_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stddef.h>
+#include <stdint.h>
+#endif
+
+#if defined(MBEDTLS_FS_IO)
+#include <stdio.h>
+#endif
+
+#define MBEDTLS_ERR_MPI_FILE_IO_ERROR                     -0x0002  /**< An error occurred while reading from or writing to a file. */
+#define MBEDTLS_ERR_MPI_BAD_INPUT_DATA                    -0x0004  /**< Bad input parameters to function. */
+#define MBEDTLS_ERR_MPI_INVALID_CHARACTER                 -0x0006  /**< There is an invalid character in the digit string. */
+#define MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL                  -0x0008  /**< The buffer is too small to write to. */
+#define MBEDTLS_ERR_MPI_NEGATIVE_VALUE                    -0x000A  /**< The input arguments are negative or result in illegal output. */
+#define MBEDTLS_ERR_MPI_DIVISION_BY_ZERO                  -0x000C  /**< The input argument for division is zero, which is not allowed. */
+#define MBEDTLS_ERR_MPI_NOT_ACCEPTABLE                    -0x000E  /**< The input arguments are not acceptable. */
+#define MBEDTLS_ERR_MPI_ALLOC_FAILED                      -0x0010  /**< Memory allocation failed. */
+
+#define MBEDTLS_MPI_CHK(f) do { if( ( ret = f ) != 0 ) goto cleanup; } while( 0 )
+
+/*
+ * Maximum size MPIs are allowed to grow to in number of limbs.
+ */
+#define MBEDTLS_MPI_MAX_LIMBS                             10000
+
+#if !defined(MBEDTLS_MPI_WINDOW_SIZE)
+/*
+ * Maximum window size used for modular exponentiation. Default: 6
+ * Minimum value: 1. Maximum value: 6.
+ *
+ * Result is an array of ( 2 << MBEDTLS_MPI_WINDOW_SIZE ) MPIs used
+ * for the sliding window calculation. (So 64 by default)
+ *
+ * Reduction in size, reduces speed.
+ */
+#define MBEDTLS_MPI_WINDOW_SIZE                           6        /**< Maximum windows size used. */
+#endif /* !MBEDTLS_MPI_WINDOW_SIZE */
+
+#if !defined(MBEDTLS_MPI_MAX_SIZE)
+/*
+ * Maximum size of MPIs allowed in bits and bytes for user-MPIs.
+ * ( Default: 512 bytes => 4096 bits, Maximum tested: 2048 bytes => 16384 bits )
+ *
+ * Note: Calculations can temporarily result in larger MPIs. So the number
+ * of limbs required (MBEDTLS_MPI_MAX_LIMBS) is higher.
+ */
+#define MBEDTLS_MPI_MAX_SIZE                              1024     /**< Maximum number of bytes for usable MPIs. */
+#endif /* !MBEDTLS_MPI_MAX_SIZE */
+
+#define MBEDTLS_MPI_MAX_BITS                              ( 8 * MBEDTLS_MPI_MAX_SIZE )    /**< Maximum number of bits for usable MPIs. */
+
+/*
+ * When reading from files with mbedtls_mpi_read_file() and writing to files with
+ * mbedtls_mpi_write_file() the buffer should have space
+ * for a (short) label, the MPI (in the provided radix), the newline
+ * characters and the '\0'.
+ *
+ * By default we assume at least a 10 char label, a minimum radix of 10
+ * (decimal) and a maximum of 4096 bit numbers (1234 decimal chars).
+ * Autosized at compile time for at least a 10 char label, a minimum radix
+ * of 10 (decimal) for a number of MBEDTLS_MPI_MAX_BITS size.
+ *
+ * This used to be statically sized to 1250 for a maximum of 4096 bit
+ * numbers (1234 decimal chars).
+ *
+ * Calculate using the formula:
+ *  MBEDTLS_MPI_RW_BUFFER_SIZE = ceil(MBEDTLS_MPI_MAX_BITS / ln(10) * ln(2)) +
+ *                                LabelSize + 6
+ */
+#define MBEDTLS_MPI_MAX_BITS_SCALE100          ( 100 * MBEDTLS_MPI_MAX_BITS )
+#define MBEDTLS_LN_2_DIV_LN_10_SCALE100                 332
+#define MBEDTLS_MPI_RW_BUFFER_SIZE             ( ((MBEDTLS_MPI_MAX_BITS_SCALE100 + MBEDTLS_LN_2_DIV_LN_10_SCALE100 - 1) / MBEDTLS_LN_2_DIV_LN_10_SCALE100) + 10 + 6 )
+
+/*
+ * Define the base integer type, architecture-wise.
+ *
+ * 32 or 64-bit integer types can be forced regardless of the underlying
+ * architecture by defining MBEDTLS_HAVE_INT32 or MBEDTLS_HAVE_INT64
+ * respectively and undefining MBEDTLS_HAVE_ASM.
+ *
+ * Double-width integers (e.g. 128-bit in 64-bit architectures) can be
+ * disabled by defining MBEDTLS_NO_UDBL_DIVISION.
+ */
+#if !defined(MBEDTLS_HAVE_INT32)
+    #if defined(_MSC_VER) && defined(_M_AMD64)
+        /* Always choose 64-bit when using MSC */
+        #if !defined(MBEDTLS_HAVE_INT64)
+            #define MBEDTLS_HAVE_INT64
+        #endif /* !MBEDTLS_HAVE_INT64 */
+        typedef  int64_t mbedtls_mpi_sint;
+        typedef uint64_t mbedtls_mpi_uint;
+    #elif defined(__GNUC__) && (                         \
+        defined(__amd64__) || defined(__x86_64__)     || \
+        defined(__ppc64__) || defined(__powerpc64__)  || \
+        defined(__ia64__)  || defined(__alpha__)      || \
+        ( defined(__sparc__) && defined(__arch64__) ) || \
+        defined(__s390x__) || defined(__mips64) )
+        #if !defined(MBEDTLS_HAVE_INT64)
+            #define MBEDTLS_HAVE_INT64
+        #endif /* MBEDTLS_HAVE_INT64 */
+        typedef  int64_t mbedtls_mpi_sint;
+        typedef uint64_t mbedtls_mpi_uint;
+        #if !defined(MBEDTLS_NO_UDBL_DIVISION)
+            /* mbedtls_t_udbl defined as 128-bit unsigned int */
+            typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
+            #define MBEDTLS_HAVE_UDBL
+        #endif /* !MBEDTLS_NO_UDBL_DIVISION */
+    #elif defined(__ARMCC_VERSION) && defined(__aarch64__)
+        /*
+         * __ARMCC_VERSION is defined for both armcc and armclang and
+         * __aarch64__ is only defined by armclang when compiling 64-bit code
+         */
+        #if !defined(MBEDTLS_HAVE_INT64)
+            #define MBEDTLS_HAVE_INT64
+        #endif /* !MBEDTLS_HAVE_INT64 */
+        typedef  int64_t mbedtls_mpi_sint;
+        typedef uint64_t mbedtls_mpi_uint;
+        #if !defined(MBEDTLS_NO_UDBL_DIVISION)
+            /* mbedtls_t_udbl defined as 128-bit unsigned int */
+            typedef __uint128_t mbedtls_t_udbl;
+            #define MBEDTLS_HAVE_UDBL
+        #endif /* !MBEDTLS_NO_UDBL_DIVISION */
+    #elif defined(MBEDTLS_HAVE_INT64)
+        /* Force 64-bit integers with unknown compiler */
+        typedef  int64_t mbedtls_mpi_sint;
+        typedef uint64_t mbedtls_mpi_uint;
+    #endif
+#endif /* !MBEDTLS_HAVE_INT32 */
+
+#if !defined(MBEDTLS_HAVE_INT64)
+    /* Default to 32-bit compilation */
+    #if !defined(MBEDTLS_HAVE_INT32)
+        #define MBEDTLS_HAVE_INT32
+    #endif /* !MBEDTLS_HAVE_INT32 */
+    typedef  int32_t mbedtls_mpi_sint;
+    typedef uint32_t mbedtls_mpi_uint;
+    #if !defined(MBEDTLS_NO_UDBL_DIVISION)
+        typedef uint64_t mbedtls_t_udbl;
+    #endif /* !MBEDTLS_NO_UDBL_DIVISION */
+#endif /* !MBEDTLS_HAVE_INT64 */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief          MPI structure
+ */
+typedef struct mbedtls_mpi
+{
+    int s;              /*!<  integer sign      */
+    size_t n;           /*!<  total # of limbs  */
+    mbedtls_mpi_uint *p;          /*!<  pointer to limbs  */
+}
+mbedtls_mpi;
+
+/**
+ * \brief           Initialize an MPI context.
+ *
+ *                  This makes the MPI ready to be set or freed,
+ *                  but does not define a value for the MPI.
+ *
+ * \param X         The MPI context to initialize. This must not be \c NULL.
+ */
+void mbedtls_mpi_init( mbedtls_mpi *X );
+
+/**
+ * \brief          This function frees the components of an MPI context.
+ *
+ * \param X        The MPI context to be cleared. This may be \c NULL,
+ *                 in which case this function is a no-op. If it is
+ *                 not \c NULL, it must point to an initialized MPI.
+ */
+void mbedtls_mpi_free( mbedtls_mpi *X );
+
+/**
+ * \brief          Enlarge an MPI to the specified number of limbs.
+ *
+ * \note           This function does nothing if the MPI is
+ *                 already large enough.
+ *
+ * \param X        The MPI to grow. It must be initialized.
+ * \param nblimbs  The target number of limbs.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
+ * \return         Another negative error code on other kinds of failure.
+ */
+int mbedtls_mpi_grow( mbedtls_mpi *X, size_t nblimbs );
+
+/**
+ * \brief          This function resizes an MPI downwards, keeping at least the
+ *                 specified number of limbs.
+ *
+ *                 If \c X is smaller than \c nblimbs, it is resized up
+ *                 instead.
+ *
+ * \param X        The MPI to shrink. This must point to an initialized MPI.
+ * \param nblimbs  The minimum number of limbs to keep.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed
+ *                 (this can only happen when resizing up).
+ * \return         Another negative error code on other kinds of failure.
+ */
+int mbedtls_mpi_shrink( mbedtls_mpi *X, size_t nblimbs );
+
+/**
+ * \brief          Make a copy of an MPI.
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param Y        The source MPI. This must point to an initialized MPI.
+ *
+ * \note           The limb-buffer in the destination MPI is enlarged
+ *                 if necessary to hold the value in the source MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
+ * \return         Another negative error code on other kinds of failure.
+ */
+int mbedtls_mpi_copy( mbedtls_mpi *X, const mbedtls_mpi *Y );
+
+/**
+ * \brief          Swap the contents of two MPIs.
+ *
+ * \param X        The first MPI. It must be initialized.
+ * \param Y        The second MPI. It must be initialized.
+ */
+void mbedtls_mpi_swap( mbedtls_mpi *X, mbedtls_mpi *Y );
+
+/**
+ * \brief          Perform a safe conditional copy of MPI which doesn't
+ *                 reveal whether the condition was true or not.
+ *
+ * \param X        The MPI to conditionally assign to. This must point
+ *                 to an initialized MPI.
+ * \param Y        The MPI to be assigned from. This must point to an
+ *                 initialized MPI.
+ * \param assign   The condition deciding whether to perform the
+ *                 assignment or not. Possible values:
+ *                 * \c 1: Perform the assignment `X = Y`.
+ *                 * \c 0: Keep the original value of \p X.
+ *
+ * \note           This function is equivalent to
+ *                      `if( assign ) mbedtls_mpi_copy( X, Y );`
+ *                 except that it avoids leaking any information about whether
+ *                 the assignment was done or not (the above code may leak
+ *                 information through branch prediction and/or memory access
+ *                 patterns analysis).
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
+ * \return         Another negative error code on other kinds of failure.
+ */
+int mbedtls_mpi_safe_cond_assign( mbedtls_mpi *X, const mbedtls_mpi *Y, unsigned char assign );
+
+/**
+ * \brief          Perform a safe conditional swap which doesn't
+ *                 reveal whether the condition was true or not.
+ *
+ * \param X        The first MPI. This must be initialized.
+ * \param Y        The second MPI. This must be initialized.
+ * \param assign   The condition deciding whether to perform
+ *                 the swap or not. Possible values:
+ *                 * \c 1: Swap the values of \p X and \p Y.
+ *                 * \c 0: Keep the original values of \p X and \p Y.
+ *
+ * \note           This function is equivalent to
+ *                      if( assign ) mbedtls_mpi_swap( X, Y );
+ *                 except that it avoids leaking any information about whether
+ *                 the assignment was done or not (the above code may leak
+ *                 information through branch prediction and/or memory access
+ *                 patterns analysis).
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
+ * \return         Another negative error code on other kinds of failure.
+ *
+ */
+int mbedtls_mpi_safe_cond_swap( mbedtls_mpi *X, mbedtls_mpi *Y, unsigned char assign );
+
+/**
+ * \brief          Store integer value in MPI.
+ *
+ * \param X        The MPI to set. This must be initialized.
+ * \param z        The value to use.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
+ * \return         Another negative error code on other kinds of failure.
+ */
+int mbedtls_mpi_lset( mbedtls_mpi *X, mbedtls_mpi_sint z );
+
+/**
+ * \brief          Get a specific bit from an MPI.
+ *
+ * \param X        The MPI to query. This must be initialized.
+ * \param pos      Zero-based index of the bit to query.
+ *
+ * \return         \c 0 or \c 1 on success, depending on whether bit \c pos
+ *                 of \c X is unset or set.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_mpi_get_bit( const mbedtls_mpi *X, size_t pos );
+
+/**
+ * \brief          Modify a specific bit in an MPI.
+ *
+ * \note           This function will grow the target MPI if necessary to set a
+ *                 bit to \c 1 in a not yet existing limb. It will not grow if
+ *                 the bit should be set to \c 0.
+ *
+ * \param X        The MPI to modify. This must be initialized.
+ * \param pos      Zero-based index of the bit to modify.
+ * \param val      The desired value of bit \c pos: \c 0 or \c 1.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
+ * \return         Another negative error code on other kinds of failure.
+ */
+int mbedtls_mpi_set_bit( mbedtls_mpi *X, size_t pos, unsigned char val );
+
+/**
+ * \brief          Return the number of bits of value \c 0 before the
+ *                 least significant bit of value \c 1.
+ *
+ * \note           This is the same as the zero-based index of
+ *                 the least significant bit of value \c 1.
+ *
+ * \param X        The MPI to query.
+ *
+ * \return         The number of bits of value \c 0 before the least significant
+ *                 bit of value \c 1 in \p X.
+ */
+size_t mbedtls_mpi_lsb( const mbedtls_mpi *X );
+
+/**
+ * \brief          Return the number of bits up to and including the most
+ *                 significant bit of value \c 1.
+ *
+ * * \note         This is same as the one-based index of the most
+ *                 significant bit of value \c 1.
+ *
+ * \param X        The MPI to query. This must point to an initialized MPI.
+ *
+ * \return         The number of bits up to and including the most
+ *                 significant bit of value \c 1.
+ */
+size_t mbedtls_mpi_bitlen( const mbedtls_mpi *X );
+
+/**
+ * \brief          Return the total size of an MPI value in bytes.
+ *
+ * \param X        The MPI to use. This must point to an initialized MPI.
+ *
+ * \note           The value returned by this function may be less than
+ *                 the number of bytes used to store \p X internally.
+ *                 This happens if and only if there are trailing bytes
+ *                 of value zero.
+ *
+ * \return         The least number of bytes capable of storing
+ *                 the absolute value of \p X.
+ */
+size_t mbedtls_mpi_size( const mbedtls_mpi *X );
+
+/**
+ * \brief          Import an MPI from an ASCII string.
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param radix    The numeric base of the input string.
+ * \param s        Null-terminated string buffer.
+ *
+ * \return         \c 0 if successful.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_mpi_read_string( mbedtls_mpi *X, int radix, const char *s );
+
+/**
+ * \brief          Export an MPI to an ASCII string.
+ *
+ * \param X        The source MPI. This must point to an initialized MPI.
+ * \param radix    The numeric base of the output string.
+ * \param buf      The buffer to write the string to. This must be writable
+ *                 buffer of length \p buflen Bytes.
+ * \param buflen   The available size in Bytes of \p buf.
+ * \param olen     The address at which to store the length of the string
+ *                 written, including the  final \c NULL byte. This must
+ *                 not be \c NULL.
+ *
+ * \note           You can call this function with `buflen == 0` to obtain the
+ *                 minimum required buffer size in `*olen`.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL if the target buffer \p buf
+ *                 is too small to hold the value of \p X in the desired base.
+ *                 In this case, `*olen` is nonetheless updated to contain the
+ *                 size of \p buf required for a successful call.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_write_string( const mbedtls_mpi *X, int radix,
+                              char *buf, size_t buflen, size_t *olen );
+
+#if defined(MBEDTLS_FS_IO)
+/**
+ * \brief          Read an MPI from a line in an opened file.
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param radix    The numeric base of the string representation used
+ *                 in the source line.
+ * \param fin      The input file handle to use. This must not be \c NULL.
+ *
+ * \note           On success, this function advances the file stream
+ *                 to the end of the current line or to EOF.
+ *
+ *                 The function returns \c 0 on an empty line.
+ *
+ *                 Leading whitespaces are ignored, as is a
+ *                 '0x' prefix for radix \c 16.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL if the file read buffer
+ *                 is too small.
+ * \return         Another negative error code on failure.
+ */
+int mbedtls_mpi_read_file( mbedtls_mpi *X, int radix, FILE *fin );
+
+/**
+ * \brief          Export an MPI into an opened file.
+ *
+ * \param p        A string prefix to emit prior to the MPI data.
+ *                 For example, this might be a label, or "0x" when
+ *                 printing in base \c 16. This may be \c NULL if no prefix
+ *                 is needed.
+ * \param X        The source MPI. This must point to an initialized MPI.
+ * \param radix    The numeric base to be used in the emitted string.
+ * \param fout     The output file handle. This may be \c NULL, in which case
+ *                 the output is written to \c stdout.
+ *
+ * \return         \c 0 if successful.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_mpi_write_file( const char *p, const mbedtls_mpi *X,
+                            int radix, FILE *fout );
+#endif /* MBEDTLS_FS_IO */
+
+/**
+ * \brief          Import an MPI from unsigned big endian binary data.
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param buf      The input buffer. This must be a readable buffer of length
+ *                 \p buflen Bytes.
+ * \param buflen   The length of the input buffer \p p in Bytes.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_read_binary( mbedtls_mpi *X, const unsigned char *buf,
+                             size_t buflen );
+
+/**
+ * \brief          Export an MPI into unsigned big endian binary data
+ *                 of fixed size.
+ *
+ * \param X        The source MPI. This must point to an initialized MPI.
+ * \param buf      The output buffer. This must be a writable buffer of length
+ *                 \p buflen Bytes.
+ * \param buflen   The size of the output buffer \p buf in Bytes.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL if \p buf isn't
+ *                 large enough to hold the value of \p X.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_write_binary( const mbedtls_mpi *X, unsigned char *buf,
+                              size_t buflen );
+
+/**
+ * \brief          Perform a left-shift on an MPI: X <<= count
+ *
+ * \param X        The MPI to shift. This must point to an initialized MPI.
+ * \param count    The number of bits to shift by.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_shift_l( mbedtls_mpi *X, size_t count );
+
+/**
+ * \brief          Perform a right-shift on an MPI: X >>= count
+ *
+ * \param X        The MPI to shift. This must point to an initialized MPI.
+ * \param count    The number of bits to shift by.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_shift_r( mbedtls_mpi *X, size_t count );
+
+/**
+ * \brief          Compare the absolute values of two MPIs.
+ *
+ * \param X        The left-hand MPI. This must point to an initialized MPI.
+ * \param Y        The right-hand MPI. This must point to an initialized MPI.
+ *
+ * \return         \c 1 if `|X|` is greater than `|Y|`.
+ * \return         \c -1 if `|X|` is lesser than `|Y|`.
+ * \return         \c 0 if `|X|` is equal to `|Y|`.
+ */
+int mbedtls_mpi_cmp_abs( const mbedtls_mpi *X, const mbedtls_mpi *Y );
+
+/**
+ * \brief          Compare two MPIs.
+ *
+ * \param X        The left-hand MPI. This must point to an initialized MPI.
+ * \param Y        The right-hand MPI. This must point to an initialized MPI.
+ *
+ * \return         \c 1 if \p X is greater than \p Y.
+ * \return         \c -1 if \p X is lesser than \p Y.
+ * \return         \c 0 if \p X is equal to \p Y.
+ */
+int mbedtls_mpi_cmp_mpi( const mbedtls_mpi *X, const mbedtls_mpi *Y );
+
+/**
+ * \brief          Compare an MPI with an integer.
+ *
+ * \param X        The left-hand MPI. This must point to an initialized MPI.
+ * \param z        The integer value to compare \p X to.
+ *
+ * \return         \c 1 if \p X is greater than \p z.
+ * \return         \c -1 if \p X is lesser than \p z.
+ * \return         \c 0 if \p X is equal to \p z.
+ */
+int mbedtls_mpi_cmp_int( const mbedtls_mpi *X, mbedtls_mpi_sint z );
+
+/**
+ * \brief          Perform an unsigned addition of MPIs: X = |A| + |B|
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The first summand. This must point to an initialized MPI.
+ * \param B        The second summand. This must point to an initialized MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_add_abs( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         const mbedtls_mpi *B );
+
+/**
+ * \brief          Perform an unsigned subtraction of MPIs: X = |A| - |B|
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The minuend. This must point to an initialized MPI.
+ * \param B        The subtrahend. This must point to an initialized MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_NEGATIVE_VALUE if \p B is greater than \p A.
+ * \return         Another negative error code on different kinds of failure.
+ *
+ */
+int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         const mbedtls_mpi *B );
+
+/**
+ * \brief          Perform a signed addition of MPIs: X = A + B
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The first summand. This must point to an initialized MPI.
+ * \param B        The second summand. This must point to an initialized MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_add_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         const mbedtls_mpi *B );
+
+/**
+ * \brief          Perform a signed subtraction of MPIs: X = A - B
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The minuend. This must point to an initialized MPI.
+ * \param B        The subtrahend. This must point to an initialized MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_sub_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         const mbedtls_mpi *B );
+
+/**
+ * \brief          Perform a signed addition of an MPI and an integer: X = A + b
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The first summand. This must point to an initialized MPI.
+ * \param b        The second summand.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_add_int( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         mbedtls_mpi_sint b );
+
+/**
+ * \brief          Perform a signed subtraction of an MPI and an integer:
+ *                 X = A - b
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The minuend. This must point to an initialized MPI.
+ * \param b        The subtrahend.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_sub_int( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         mbedtls_mpi_sint b );
+
+/**
+ * \brief          Perform a multiplication of two MPIs: X = A * B
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The first factor. This must point to an initialized MPI.
+ * \param B        The second factor. This must point to an initialized MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         Another negative error code on different kinds of failure.
+ *
+ */
+int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         const mbedtls_mpi *B );
+
+/**
+ * \brief          Perform a multiplication of an MPI with an unsigned integer:
+ *                 X = A * b
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The first factor. This must point to an initialized MPI.
+ * \param b        The second factor.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         Another negative error code on different kinds of failure.
+ *
+ */
+int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         mbedtls_mpi_uint b );
+
+/**
+ * \brief          Perform a division with remainder of two MPIs:
+ *                 A = Q * B + R
+ *
+ * \param Q        The destination MPI for the quotient.
+ *                 This may be \c NULL if the value of the
+ *                 quotient is not needed.
+ * \param R        The destination MPI for the remainder value.
+ *                 This may be \c NULL if the value of the
+ *                 remainder is not needed.
+ * \param A        The dividend. This must point to an initialized MPi.
+ * \param B        The divisor. This must point to an initialized MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_DIVISION_BY_ZERO if \p B equals zero.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_div_mpi( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
+                         const mbedtls_mpi *B );
+
+/**
+ * \brief          Perform a division with remainder of an MPI by an integer:
+ *                 A = Q * b + R
+ *
+ * \param Q        The destination MPI for the quotient.
+ *                 This may be \c NULL if the value of the
+ *                 quotient is not needed.
+ * \param R        The destination MPI for the remainder value.
+ *                 This may be \c NULL if the value of the
+ *                 remainder is not needed.
+ * \param A        The dividend. This must point to an initialized MPi.
+ * \param b        The divisor.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_DIVISION_BY_ZERO if \p b equals zero.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_div_int( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
+                         mbedtls_mpi_sint b );
+
+/**
+ * \brief          Perform a modular reduction. R = A mod B
+ *
+ * \param R        The destination MPI for the residue value.
+ *                 This must point to an initialized MPI.
+ * \param A        The MPI to compute the residue of.
+ *                 This must point to an initialized MPI.
+ * \param B        The base of the modular reduction.
+ *                 This must point to an initialized MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_DIVISION_BY_ZERO if \p B equals zero.
+ * \return         #MBEDTLS_ERR_MPI_NEGATIVE_VALUE if \p B is negative.
+ * \return         Another negative error code on different kinds of failure.
+ *
+ */
+int mbedtls_mpi_mod_mpi( mbedtls_mpi *R, const mbedtls_mpi *A,
+                         const mbedtls_mpi *B );
+
+/**
+ * \brief          Perform a modular reduction with respect to an integer.
+ *                 r = A mod b
+ *
+ * \param r        The address at which to store the residue.
+ *                 This must not be \c NULL.
+ * \param A        The MPI to compute the residue of.
+ *                 This must point to an initialized MPi.
+ * \param b        The integer base of the modular reduction.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_DIVISION_BY_ZERO if \p b equals zero.
+ * \return         #MBEDTLS_ERR_MPI_NEGATIVE_VALUE if \p b is negative.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_mod_int( mbedtls_mpi_uint *r, const mbedtls_mpi *A,
+                         mbedtls_mpi_sint b );
+
+/**
+ * \brief          Perform a sliding-window exponentiation: X = A^E mod N
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The base of the exponentiation.
+ *                 This must point to an initialized MPI.
+ * \param E        The exponent MPI. This must point to an initialized MPI.
+ * \param N        The base for the modular reduction. This must point to an
+ *                 initialized MPI.
+ * \param _RR      A helper MPI depending solely on \p N which can be used to
+ *                 speed-up multiple modular exponentiations for the same value
+ *                 of \p N. This may be \c NULL. If it is not \c NULL, it must
+ *                 point to an initialized MPI. If it hasn't been used after
+ *                 the call to mbedtls_mpi_init(), this function will compute
+ *                 the helper value and store it in \p _RR for reuse on
+ *                 subsequent calls to this function. Otherwise, the function
+ *                 will assume that \p _RR holds the helper value set by a
+ *                 previous call to mbedtls_mpi_exp_mod(), and reuse it.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \c N is negative or
+ *                 even, or if \c E is negative.
+ * \return         Another negative error code on different kinds of failures.
+ *
+ */
+int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         const mbedtls_mpi *E, const mbedtls_mpi *N,
+                         mbedtls_mpi *_RR );
+
+/**
+ * \brief          Fill an MPI with a number of random bytes.
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param size     The number of random bytes to generate.
+ * \param f_rng    The RNG function to use. This must not be \c NULL.
+ * \param p_rng    The RNG parameter to be passed to \p f_rng. This may be
+ *                 \c NULL if \p f_rng doesn't need a context argument.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         Another negative error code on failure.
+ *
+ * \note           The bytes obtained from the RNG are interpreted
+ *                 as a big-endian representation of an MPI; this can
+ *                 be relevant in applications like deterministic ECDSA.
+ */
+int mbedtls_mpi_fill_random( mbedtls_mpi *X, size_t size,
+                     int (*f_rng)(void *, unsigned char *, size_t),
+                     void *p_rng );
+
+/**
+ * \brief          Compute the greatest common divisor: G = gcd(A, B)
+ *
+ * \param G        The destination MPI. This must point to an initialized MPI.
+ * \param A        The first operand. This must point to an initialized MPI.
+ * \param B        The second operand. This must point to an initialized MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         Another negative error code on different kinds of failure.
+ */
+int mbedtls_mpi_gcd( mbedtls_mpi *G, const mbedtls_mpi *A,
+                     const mbedtls_mpi *B );
+
+/**
+ * \brief          Compute the modular inverse: X = A^-1 mod N
+ *
+ * \param X        The destination MPI. This must point to an initialized MPI.
+ * \param A        The MPI to calculate the modular inverse of. This must point
+ *                 to an initialized MPI.
+ * \param N        The base of the modular inversion. This must point to an
+ *                 initialized MPI.
+ *
+ * \return         \c 0 if successful.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if \p N is less than
+ *                 or equal to one.
+ * \return         #MBEDTLS_ERR_MPI_NOT_ACCEPTABLE if \p has no modular inverse
+ *                 with respect to \p N.
+ */
+int mbedtls_mpi_inv_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         const mbedtls_mpi *N );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          Perform a Miller-Rabin primality test with error
+ *                 probability of 2<sup>-80</sup>.
+ *
+ * \deprecated     Superseded by mbedtls_mpi_is_prime_ext() which allows
+ *                 specifying the number of Miller-Rabin rounds.
+ *
+ * \param X        The MPI to check for primality.
+ *                 This must point to an initialized MPI.
+ * \param f_rng    The RNG function to use. This must not be \c NULL.
+ * \param p_rng    The RNG parameter to be passed to \p f_rng.
+ *                 This may be \c NULL if \p f_rng doesn't use a
+ *                 context parameter.
+ *
+ * \return         \c 0 if successful, i.e. \p X is probably prime.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_NOT_ACCEPTABLE if \p X is not prime.
+ * \return         Another negative error code on other kinds of failure.
+ */
+MBEDTLS_DEPRECATED int mbedtls_mpi_is_prime( const mbedtls_mpi *X,
+                          int (*f_rng)(void *, unsigned char *, size_t),
+                          void *p_rng );
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief          Miller-Rabin primality test.
+ *
+ * \warning        If \p X is potentially generated by an adversary, for example
+ *                 when validating cryptographic parameters that you didn't
+ *                 generate yourself and that are supposed to be prime, then
+ *                 \p rounds should be at least the half of the security
+ *                 strength of the cryptographic algorithm. On the other hand,
+ *                 if \p X is chosen uniformly or non-adversially (as is the
+ *                 case when mbedtls_mpi_gen_prime calls this function), then
+ *                 \p rounds can be much lower.
+ *
+ * \param X        The MPI to check for primality.
+ *                 This must point to an initialized MPI.
+ * \param rounds   The number of bases to perform the Miller-Rabin primality
+ *                 test for. The probability of returning 0 on a composite is
+ *                 at most 2<sup>-2*\p rounds</sup>.
+ * \param f_rng    The RNG function to use. This must not be \c NULL.
+ * \param p_rng    The RNG parameter to be passed to \p f_rng.
+ *                 This may be \c NULL if \p f_rng doesn't use
+ *                 a context parameter.
+ *
+ * \return         \c 0 if successful, i.e. \p X is probably prime.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_NOT_ACCEPTABLE if \p X is not prime.
+ * \return         Another negative error code on other kinds of failure.
+ */
+int mbedtls_mpi_is_prime_ext( const mbedtls_mpi *X, int rounds,
+                              int (*f_rng)(void *, unsigned char *, size_t),
+                              void *p_rng );
+/**
+ * \brief Flags for mbedtls_mpi_gen_prime()
+ *
+ * Each of these flags is a constraint on the result X returned by
+ * mbedtls_mpi_gen_prime().
+ */
+typedef enum {
+    MBEDTLS_MPI_GEN_PRIME_FLAG_DH =      0x0001, /**< (X-1)/2 is prime too */
+    MBEDTLS_MPI_GEN_PRIME_FLAG_LOW_ERR = 0x0002, /**< lower error rate from 2<sup>-80</sup> to 2<sup>-128</sup> */
+} mbedtls_mpi_gen_prime_flag_t;
+
+/**
+ * \brief          Generate a prime number.
+ *
+ * \param X        The destination MPI to store the generated prime in.
+ *                 This must point to an initialized MPi.
+ * \param nbits    The required size of the destination MPI in bits.
+ *                 This must be between \c 3 and #MBEDTLS_MPI_MAX_BITS.
+ * \param flags    A mask of flags of type #mbedtls_mpi_gen_prime_flag_t.
+ * \param f_rng    The RNG function to use. This must not be \c NULL.
+ * \param p_rng    The RNG parameter to be passed to \p f_rng.
+ *                 This may be \c NULL if \p f_rng doesn't use
+ *                 a context parameter.
+ *
+ * \return         \c 0 if successful, in which case \p X holds a
+ *                 probably prime number.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
+ * \return         #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if `nbits` is not between
+ *                 \c 3 and #MBEDTLS_MPI_MAX_BITS.
+ */
+int mbedtls_mpi_gen_prime( mbedtls_mpi *X, size_t nbits, int flags,
+                   int (*f_rng)(void *, unsigned char *, size_t),
+                   void *p_rng );
+
+/**
+ * \brief          Checkup routine
+ *
+ * \return         0 if successful, or 1 if the test failed
+ */
+int mbedtls_mpi_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* bignum.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/bn_mul.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/bn_mul.h
@@ -1,0 +1,909 @@
+/**
+ * \file bn_mul.h
+ *
+ * \brief Multi-precision integer library
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+/*
+ *      Multiply source vector [s] with b, add result
+ *       to destination vector [d] and set carry c.
+ *
+ *      Currently supports:
+ *
+ *         . IA-32 (386+)         . AMD64 / EM64T
+ *         . IA-32 (SSE2)         . Motorola 68000
+ *         . PowerPC, 32-bit      . MicroBlaze
+ *         . PowerPC, 64-bit      . TriCore
+ *         . SPARC v8             . ARM v3+
+ *         . Alpha                . MIPS32
+ *         . C, longlong          . C, generic
+ */
+#ifndef MBEDTLS_BN_MUL_H
+#define MBEDTLS_BN_MUL_H
+
+#include "bignum.h"
+
+#if defined(MBEDTLS_HAVE_ASM)
+
+#ifndef asm
+#define asm __asm
+#endif
+
+/* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
+#if defined(__GNUC__) && \
+    ( !defined(__ARMCC_VERSION) || __ARMCC_VERSION >= 6000000 )
+
+/*
+ * Disable use of the i386 assembly code below if option -O0, to disable all
+ * compiler optimisations, is passed, detected with __OPTIMIZE__
+ * This is done as the number of registers used in the assembly code doesn't
+ * work with the -O0 option.
+ */
+#if defined(__i386__) && defined(__OPTIMIZE__)
+
+#define MULADDC_INIT                        \
+    asm(                                    \
+        "movl   %%ebx, %0           \n\t"   \
+        "movl   %5, %%esi           \n\t"   \
+        "movl   %6, %%edi           \n\t"   \
+        "movl   %7, %%ecx           \n\t"   \
+        "movl   %8, %%ebx           \n\t"
+
+#define MULADDC_CORE                        \
+        "lodsl                      \n\t"   \
+        "mull   %%ebx               \n\t"   \
+        "addl   %%ecx,   %%eax      \n\t"   \
+        "adcl   $0,      %%edx      \n\t"   \
+        "addl   (%%edi), %%eax      \n\t"   \
+        "adcl   $0,      %%edx      \n\t"   \
+        "movl   %%edx,   %%ecx      \n\t"   \
+        "stosl                      \n\t"
+
+#if defined(MBEDTLS_HAVE_SSE2)
+
+#define MULADDC_HUIT                            \
+        "movd     %%ecx,     %%mm1      \n\t"   \
+        "movd     %%ebx,     %%mm0      \n\t"   \
+        "movd     (%%edi),   %%mm3      \n\t"   \
+        "paddq    %%mm3,     %%mm1      \n\t"   \
+        "movd     (%%esi),   %%mm2      \n\t"   \
+        "pmuludq  %%mm0,     %%mm2      \n\t"   \
+        "movd     4(%%esi),  %%mm4      \n\t"   \
+        "pmuludq  %%mm0,     %%mm4      \n\t"   \
+        "movd     8(%%esi),  %%mm6      \n\t"   \
+        "pmuludq  %%mm0,     %%mm6      \n\t"   \
+        "movd     12(%%esi), %%mm7      \n\t"   \
+        "pmuludq  %%mm0,     %%mm7      \n\t"   \
+        "paddq    %%mm2,     %%mm1      \n\t"   \
+        "movd     4(%%edi),  %%mm3      \n\t"   \
+        "paddq    %%mm4,     %%mm3      \n\t"   \
+        "movd     8(%%edi),  %%mm5      \n\t"   \
+        "paddq    %%mm6,     %%mm5      \n\t"   \
+        "movd     12(%%edi), %%mm4      \n\t"   \
+        "paddq    %%mm4,     %%mm7      \n\t"   \
+        "movd     %%mm1,     (%%edi)    \n\t"   \
+        "movd     16(%%esi), %%mm2      \n\t"   \
+        "pmuludq  %%mm0,     %%mm2      \n\t"   \
+        "psrlq    $32,       %%mm1      \n\t"   \
+        "movd     20(%%esi), %%mm4      \n\t"   \
+        "pmuludq  %%mm0,     %%mm4      \n\t"   \
+        "paddq    %%mm3,     %%mm1      \n\t"   \
+        "movd     24(%%esi), %%mm6      \n\t"   \
+        "pmuludq  %%mm0,     %%mm6      \n\t"   \
+        "movd     %%mm1,     4(%%edi)   \n\t"   \
+        "psrlq    $32,       %%mm1      \n\t"   \
+        "movd     28(%%esi), %%mm3      \n\t"   \
+        "pmuludq  %%mm0,     %%mm3      \n\t"   \
+        "paddq    %%mm5,     %%mm1      \n\t"   \
+        "movd     16(%%edi), %%mm5      \n\t"   \
+        "paddq    %%mm5,     %%mm2      \n\t"   \
+        "movd     %%mm1,     8(%%edi)   \n\t"   \
+        "psrlq    $32,       %%mm1      \n\t"   \
+        "paddq    %%mm7,     %%mm1      \n\t"   \
+        "movd     20(%%edi), %%mm5      \n\t"   \
+        "paddq    %%mm5,     %%mm4      \n\t"   \
+        "movd     %%mm1,     12(%%edi)  \n\t"   \
+        "psrlq    $32,       %%mm1      \n\t"   \
+        "paddq    %%mm2,     %%mm1      \n\t"   \
+        "movd     24(%%edi), %%mm5      \n\t"   \
+        "paddq    %%mm5,     %%mm6      \n\t"   \
+        "movd     %%mm1,     16(%%edi)  \n\t"   \
+        "psrlq    $32,       %%mm1      \n\t"   \
+        "paddq    %%mm4,     %%mm1      \n\t"   \
+        "movd     28(%%edi), %%mm5      \n\t"   \
+        "paddq    %%mm5,     %%mm3      \n\t"   \
+        "movd     %%mm1,     20(%%edi)  \n\t"   \
+        "psrlq    $32,       %%mm1      \n\t"   \
+        "paddq    %%mm6,     %%mm1      \n\t"   \
+        "movd     %%mm1,     24(%%edi)  \n\t"   \
+        "psrlq    $32,       %%mm1      \n\t"   \
+        "paddq    %%mm3,     %%mm1      \n\t"   \
+        "movd     %%mm1,     28(%%edi)  \n\t"   \
+        "addl     $32,       %%edi      \n\t"   \
+        "addl     $32,       %%esi      \n\t"   \
+        "psrlq    $32,       %%mm1      \n\t"   \
+        "movd     %%mm1,     %%ecx      \n\t"
+
+#define MULADDC_STOP                    \
+        "emms                   \n\t"   \
+        "movl   %4, %%ebx       \n\t"   \
+        "movl   %%ecx, %1       \n\t"   \
+        "movl   %%edi, %2       \n\t"   \
+        "movl   %%esi, %3       \n\t"   \
+        : "=m" (t), "=m" (c), "=m" (d), "=m" (s)        \
+        : "m" (t), "m" (s), "m" (d), "m" (c), "m" (b)   \
+        : "eax", "ebx", "ecx", "edx", "esi", "edi"      \
+    );
+
+#else
+
+#define MULADDC_STOP                    \
+        "movl   %4, %%ebx       \n\t"   \
+        "movl   %%ecx, %1       \n\t"   \
+        "movl   %%edi, %2       \n\t"   \
+        "movl   %%esi, %3       \n\t"   \
+        : "=m" (t), "=m" (c), "=m" (d), "=m" (s)        \
+        : "m" (t), "m" (s), "m" (d), "m" (c), "m" (b)   \
+        : "eax", "ebx", "ecx", "edx", "esi", "edi"      \
+    );
+#endif /* SSE2 */
+#endif /* i386 */
+
+#if defined(__amd64__) || defined (__x86_64__)
+
+#define MULADDC_INIT                        \
+    asm(                                    \
+        "xorq   %%r8, %%r8\n"
+
+#define MULADDC_CORE                        \
+        "movq   (%%rsi), %%rax\n"           \
+        "mulq   %%rbx\n"                    \
+        "addq   $8, %%rsi\n"                \
+        "addq   %%rcx, %%rax\n"             \
+        "movq   %%r8, %%rcx\n"              \
+        "adcq   $0, %%rdx\n"                \
+        "nop    \n"                         \
+        "addq   %%rax, (%%rdi)\n"           \
+        "adcq   %%rdx, %%rcx\n"             \
+        "addq   $8, %%rdi\n"
+
+#define MULADDC_STOP                        \
+        : "+c" (c), "+D" (d), "+S" (s)      \
+        : "b" (b)                           \
+        : "rax", "rdx", "r8"                \
+    );
+
+#endif /* AMD64 */
+
+#if defined(__mc68020__) || defined(__mcpu32__)
+
+#define MULADDC_INIT                    \
+    asm(                                \
+        "movl   %3, %%a2        \n\t"   \
+        "movl   %4, %%a3        \n\t"   \
+        "movl   %5, %%d3        \n\t"   \
+        "movl   %6, %%d2        \n\t"   \
+        "moveq  #0, %%d0        \n\t"
+
+#define MULADDC_CORE                    \
+        "movel  %%a2@+, %%d1    \n\t"   \
+        "mulul  %%d2, %%d4:%%d1 \n\t"   \
+        "addl   %%d3, %%d1      \n\t"   \
+        "addxl  %%d0, %%d4      \n\t"   \
+        "moveq  #0,   %%d3      \n\t"   \
+        "addl   %%d1, %%a3@+    \n\t"   \
+        "addxl  %%d4, %%d3      \n\t"
+
+#define MULADDC_STOP                    \
+        "movl   %%d3, %0        \n\t"   \
+        "movl   %%a3, %1        \n\t"   \
+        "movl   %%a2, %2        \n\t"   \
+        : "=m" (c), "=m" (d), "=m" (s)              \
+        : "m" (s), "m" (d), "m" (c), "m" (b)        \
+        : "d0", "d1", "d2", "d3", "d4", "a2", "a3"  \
+    );
+
+#define MULADDC_HUIT                        \
+        "movel  %%a2@+,  %%d1       \n\t"   \
+        "mulul  %%d2,    %%d4:%%d1  \n\t"   \
+        "addxl  %%d3,    %%d1       \n\t"   \
+        "addxl  %%d0,    %%d4       \n\t"   \
+        "addl   %%d1,    %%a3@+     \n\t"   \
+        "movel  %%a2@+,  %%d1       \n\t"   \
+        "mulul  %%d2,    %%d3:%%d1  \n\t"   \
+        "addxl  %%d4,    %%d1       \n\t"   \
+        "addxl  %%d0,    %%d3       \n\t"   \
+        "addl   %%d1,    %%a3@+     \n\t"   \
+        "movel  %%a2@+,  %%d1       \n\t"   \
+        "mulul  %%d2,    %%d4:%%d1  \n\t"   \
+        "addxl  %%d3,    %%d1       \n\t"   \
+        "addxl  %%d0,    %%d4       \n\t"   \
+        "addl   %%d1,    %%a3@+     \n\t"   \
+        "movel  %%a2@+,  %%d1       \n\t"   \
+        "mulul  %%d2,    %%d3:%%d1  \n\t"   \
+        "addxl  %%d4,    %%d1       \n\t"   \
+        "addxl  %%d0,    %%d3       \n\t"   \
+        "addl   %%d1,    %%a3@+     \n\t"   \
+        "movel  %%a2@+,  %%d1       \n\t"   \
+        "mulul  %%d2,    %%d4:%%d1  \n\t"   \
+        "addxl  %%d3,    %%d1       \n\t"   \
+        "addxl  %%d0,    %%d4       \n\t"   \
+        "addl   %%d1,    %%a3@+     \n\t"   \
+        "movel  %%a2@+,  %%d1       \n\t"   \
+        "mulul  %%d2,    %%d3:%%d1  \n\t"   \
+        "addxl  %%d4,    %%d1       \n\t"   \
+        "addxl  %%d0,    %%d3       \n\t"   \
+        "addl   %%d1,    %%a3@+     \n\t"   \
+        "movel  %%a2@+,  %%d1       \n\t"   \
+        "mulul  %%d2,    %%d4:%%d1  \n\t"   \
+        "addxl  %%d3,    %%d1       \n\t"   \
+        "addxl  %%d0,    %%d4       \n\t"   \
+        "addl   %%d1,    %%a3@+     \n\t"   \
+        "movel  %%a2@+,  %%d1       \n\t"   \
+        "mulul  %%d2,    %%d3:%%d1  \n\t"   \
+        "addxl  %%d4,    %%d1       \n\t"   \
+        "addxl  %%d0,    %%d3       \n\t"   \
+        "addl   %%d1,    %%a3@+     \n\t"   \
+        "addxl  %%d0,    %%d3       \n\t"
+
+#endif /* MC68000 */
+
+#if defined(__powerpc64__) || defined(__ppc64__)
+
+#if defined(__MACH__) && defined(__APPLE__)
+
+#define MULADDC_INIT                        \
+    asm(                                    \
+        "ld     r3, %3              \n\t"   \
+        "ld     r4, %4              \n\t"   \
+        "ld     r5, %5              \n\t"   \
+        "ld     r6, %6              \n\t"   \
+        "addi   r3, r3, -8          \n\t"   \
+        "addi   r4, r4, -8          \n\t"   \
+        "addic  r5, r5,  0          \n\t"
+
+#define MULADDC_CORE                        \
+        "ldu    r7, 8(r3)           \n\t"   \
+        "mulld  r8, r7, r6          \n\t"   \
+        "mulhdu r9, r7, r6          \n\t"   \
+        "adde   r8, r8, r5          \n\t"   \
+        "ld     r7, 8(r4)           \n\t"   \
+        "addze  r5, r9              \n\t"   \
+        "addc   r8, r8, r7          \n\t"   \
+        "stdu   r8, 8(r4)           \n\t"
+
+#define MULADDC_STOP                        \
+        "addze  r5, r5              \n\t"   \
+        "addi   r4, r4, 8           \n\t"   \
+        "addi   r3, r3, 8           \n\t"   \
+        "std    r5, %0              \n\t"   \
+        "std    r4, %1              \n\t"   \
+        "std    r3, %2              \n\t"   \
+        : "=m" (c), "=m" (d), "=m" (s)              \
+        : "m" (s), "m" (d), "m" (c), "m" (b)        \
+        : "r3", "r4", "r5", "r6", "r7", "r8", "r9"  \
+    );
+
+
+#else /* __MACH__ && __APPLE__ */
+
+#define MULADDC_INIT                        \
+    asm(                                    \
+        "ld     %%r3, %3            \n\t"   \
+        "ld     %%r4, %4            \n\t"   \
+        "ld     %%r5, %5            \n\t"   \
+        "ld     %%r6, %6            \n\t"   \
+        "addi   %%r3, %%r3, -8      \n\t"   \
+        "addi   %%r4, %%r4, -8      \n\t"   \
+        "addic  %%r5, %%r5,  0      \n\t"
+
+#define MULADDC_CORE                        \
+        "ldu    %%r7, 8(%%r3)       \n\t"   \
+        "mulld  %%r8, %%r7, %%r6    \n\t"   \
+        "mulhdu %%r9, %%r7, %%r6    \n\t"   \
+        "adde   %%r8, %%r8, %%r5    \n\t"   \
+        "ld     %%r7, 8(%%r4)       \n\t"   \
+        "addze  %%r5, %%r9          \n\t"   \
+        "addc   %%r8, %%r8, %%r7    \n\t"   \
+        "stdu   %%r8, 8(%%r4)       \n\t"
+
+#define MULADDC_STOP                        \
+        "addze  %%r5, %%r5          \n\t"   \
+        "addi   %%r4, %%r4, 8       \n\t"   \
+        "addi   %%r3, %%r3, 8       \n\t"   \
+        "std    %%r5, %0            \n\t"   \
+        "std    %%r4, %1            \n\t"   \
+        "std    %%r3, %2            \n\t"   \
+        : "=m" (c), "=m" (d), "=m" (s)              \
+        : "m" (s), "m" (d), "m" (c), "m" (b)        \
+        : "r3", "r4", "r5", "r6", "r7", "r8", "r9"  \
+    );
+
+#endif /* __MACH__ && __APPLE__ */
+
+#elif defined(__powerpc__) || defined(__ppc__) /* end PPC64/begin PPC32  */
+
+#if defined(__MACH__) && defined(__APPLE__)
+
+#define MULADDC_INIT                    \
+    asm(                                \
+        "lwz    r3, %3          \n\t"   \
+        "lwz    r4, %4          \n\t"   \
+        "lwz    r5, %5          \n\t"   \
+        "lwz    r6, %6          \n\t"   \
+        "addi   r3, r3, -4      \n\t"   \
+        "addi   r4, r4, -4      \n\t"   \
+        "addic  r5, r5,  0      \n\t"
+
+#define MULADDC_CORE                    \
+        "lwzu   r7, 4(r3)       \n\t"   \
+        "mullw  r8, r7, r6      \n\t"   \
+        "mulhwu r9, r7, r6      \n\t"   \
+        "adde   r8, r8, r5      \n\t"   \
+        "lwz    r7, 4(r4)       \n\t"   \
+        "addze  r5, r9          \n\t"   \
+        "addc   r8, r8, r7      \n\t"   \
+        "stwu   r8, 4(r4)       \n\t"
+
+#define MULADDC_STOP                    \
+        "addze  r5, r5          \n\t"   \
+        "addi   r4, r4, 4       \n\t"   \
+        "addi   r3, r3, 4       \n\t"   \
+        "stw    r5, %0          \n\t"   \
+        "stw    r4, %1          \n\t"   \
+        "stw    r3, %2          \n\t"   \
+        : "=m" (c), "=m" (d), "=m" (s)              \
+        : "m" (s), "m" (d), "m" (c), "m" (b)        \
+        : "r3", "r4", "r5", "r6", "r7", "r8", "r9"  \
+    );
+
+#else /* __MACH__ && __APPLE__ */
+
+#define MULADDC_INIT                        \
+    asm(                                    \
+        "lwz    %%r3, %3            \n\t"   \
+        "lwz    %%r4, %4            \n\t"   \
+        "lwz    %%r5, %5            \n\t"   \
+        "lwz    %%r6, %6            \n\t"   \
+        "addi   %%r3, %%r3, -4      \n\t"   \
+        "addi   %%r4, %%r4, -4      \n\t"   \
+        "addic  %%r5, %%r5,  0      \n\t"
+
+#define MULADDC_CORE                        \
+        "lwzu   %%r7, 4(%%r3)       \n\t"   \
+        "mullw  %%r8, %%r7, %%r6    \n\t"   \
+        "mulhwu %%r9, %%r7, %%r6    \n\t"   \
+        "adde   %%r8, %%r8, %%r5    \n\t"   \
+        "lwz    %%r7, 4(%%r4)       \n\t"   \
+        "addze  %%r5, %%r9          \n\t"   \
+        "addc   %%r8, %%r8, %%r7    \n\t"   \
+        "stwu   %%r8, 4(%%r4)       \n\t"
+
+#define MULADDC_STOP                        \
+        "addze  %%r5, %%r5          \n\t"   \
+        "addi   %%r4, %%r4, 4       \n\t"   \
+        "addi   %%r3, %%r3, 4       \n\t"   \
+        "stw    %%r5, %0            \n\t"   \
+        "stw    %%r4, %1            \n\t"   \
+        "stw    %%r3, %2            \n\t"   \
+        : "=m" (c), "=m" (d), "=m" (s)              \
+        : "m" (s), "m" (d), "m" (c), "m" (b)        \
+        : "r3", "r4", "r5", "r6", "r7", "r8", "r9"  \
+    );
+
+#endif /* __MACH__ && __APPLE__ */
+
+#endif /* PPC32 */
+
+/*
+ * The Sparc(64) assembly is reported to be broken.
+ * Disable it for now, until we're able to fix it.
+ */
+#if 0 && defined(__sparc__)
+#if defined(__sparc64__)
+
+#define MULADDC_INIT                                    \
+    asm(                                                \
+                "ldx     %3, %%o0               \n\t"   \
+                "ldx     %4, %%o1               \n\t"   \
+                "ld      %5, %%o2               \n\t"   \
+                "ld      %6, %%o3               \n\t"
+
+#define MULADDC_CORE                                    \
+                "ld      [%%o0], %%o4           \n\t"   \
+                "inc     4, %%o0                \n\t"   \
+                "ld      [%%o1], %%o5           \n\t"   \
+                "umul    %%o3, %%o4, %%o4       \n\t"   \
+                "addcc   %%o4, %%o2, %%o4       \n\t"   \
+                "rd      %%y, %%g1              \n\t"   \
+                "addx    %%g1, 0, %%g1          \n\t"   \
+                "addcc   %%o4, %%o5, %%o4       \n\t"   \
+                "st      %%o4, [%%o1]           \n\t"   \
+                "addx    %%g1, 0, %%o2          \n\t"   \
+                "inc     4, %%o1                \n\t"
+
+        #define MULADDC_STOP                            \
+                "st      %%o2, %0               \n\t"   \
+                "stx     %%o1, %1               \n\t"   \
+                "stx     %%o0, %2               \n\t"   \
+        : "=m" (c), "=m" (d), "=m" (s)          \
+        : "m" (s), "m" (d), "m" (c), "m" (b)    \
+        : "g1", "o0", "o1", "o2", "o3", "o4",   \
+          "o5"                                  \
+        );
+
+#else /* __sparc64__ */
+
+#define MULADDC_INIT                                    \
+    asm(                                                \
+                "ld      %3, %%o0               \n\t"   \
+                "ld      %4, %%o1               \n\t"   \
+                "ld      %5, %%o2               \n\t"   \
+                "ld      %6, %%o3               \n\t"
+
+#define MULADDC_CORE                                    \
+                "ld      [%%o0], %%o4           \n\t"   \
+                "inc     4, %%o0                \n\t"   \
+                "ld      [%%o1], %%o5           \n\t"   \
+                "umul    %%o3, %%o4, %%o4       \n\t"   \
+                "addcc   %%o4, %%o2, %%o4       \n\t"   \
+                "rd      %%y, %%g1              \n\t"   \
+                "addx    %%g1, 0, %%g1          \n\t"   \
+                "addcc   %%o4, %%o5, %%o4       \n\t"   \
+                "st      %%o4, [%%o1]           \n\t"   \
+                "addx    %%g1, 0, %%o2          \n\t"   \
+                "inc     4, %%o1                \n\t"
+
+#define MULADDC_STOP                                    \
+                "st      %%o2, %0               \n\t"   \
+                "st      %%o1, %1               \n\t"   \
+                "st      %%o0, %2               \n\t"   \
+        : "=m" (c), "=m" (d), "=m" (s)          \
+        : "m" (s), "m" (d), "m" (c), "m" (b)    \
+        : "g1", "o0", "o1", "o2", "o3", "o4",   \
+          "o5"                                  \
+        );
+
+#endif /* __sparc64__ */
+#endif /* __sparc__ */
+
+#if defined(__microblaze__) || defined(microblaze)
+
+#define MULADDC_INIT                    \
+    asm(                                \
+        "lwi   r3,   %3         \n\t"   \
+        "lwi   r4,   %4         \n\t"   \
+        "lwi   r5,   %5         \n\t"   \
+        "lwi   r6,   %6         \n\t"   \
+        "andi  r7,   r6, 0xffff \n\t"   \
+        "bsrli r6,   r6, 16     \n\t"
+
+#define MULADDC_CORE                    \
+        "lhui  r8,   r3,   0    \n\t"   \
+        "addi  r3,   r3,   2    \n\t"   \
+        "lhui  r9,   r3,   0    \n\t"   \
+        "addi  r3,   r3,   2    \n\t"   \
+        "mul   r10,  r9,  r6    \n\t"   \
+        "mul   r11,  r8,  r7    \n\t"   \
+        "mul   r12,  r9,  r7    \n\t"   \
+        "mul   r13,  r8,  r6    \n\t"   \
+        "bsrli  r8, r10,  16    \n\t"   \
+        "bsrli  r9, r11,  16    \n\t"   \
+        "add   r13, r13,  r8    \n\t"   \
+        "add   r13, r13,  r9    \n\t"   \
+        "bslli r10, r10,  16    \n\t"   \
+        "bslli r11, r11,  16    \n\t"   \
+        "add   r12, r12, r10    \n\t"   \
+        "addc  r13, r13,  r0    \n\t"   \
+        "add   r12, r12, r11    \n\t"   \
+        "addc  r13, r13,  r0    \n\t"   \
+        "lwi   r10,  r4,   0    \n\t"   \
+        "add   r12, r12, r10    \n\t"   \
+        "addc  r13, r13,  r0    \n\t"   \
+        "add   r12, r12,  r5    \n\t"   \
+        "addc   r5, r13,  r0    \n\t"   \
+        "swi   r12,  r4,   0    \n\t"   \
+        "addi   r4,  r4,   4    \n\t"
+
+#define MULADDC_STOP                    \
+        "swi   r5,   %0         \n\t"   \
+        "swi   r4,   %1         \n\t"   \
+        "swi   r3,   %2         \n\t"   \
+        : "=m" (c), "=m" (d), "=m" (s)              \
+        : "m" (s), "m" (d), "m" (c), "m" (b)        \
+        : "r3", "r4", "r5", "r6", "r7", "r8",       \
+          "r9", "r10", "r11", "r12", "r13"          \
+    );
+
+#endif /* MicroBlaze */
+
+#if defined(__tricore__)
+
+#define MULADDC_INIT                            \
+    asm(                                        \
+        "ld.a   %%a2, %3                \n\t"   \
+        "ld.a   %%a3, %4                \n\t"   \
+        "ld.w   %%d4, %5                \n\t"   \
+        "ld.w   %%d1, %6                \n\t"   \
+        "xor    %%d5, %%d5              \n\t"
+
+#define MULADDC_CORE                            \
+        "ld.w   %%d0,   [%%a2+]         \n\t"   \
+        "madd.u %%e2, %%e4, %%d0, %%d1  \n\t"   \
+        "ld.w   %%d0,   [%%a3]          \n\t"   \
+        "addx   %%d2,    %%d2,  %%d0    \n\t"   \
+        "addc   %%d3,    %%d3,    0     \n\t"   \
+        "mov    %%d4,    %%d3           \n\t"   \
+        "st.w  [%%a3+],  %%d2           \n\t"
+
+#define MULADDC_STOP                            \
+        "st.w   %0, %%d4                \n\t"   \
+        "st.a   %1, %%a3                \n\t"   \
+        "st.a   %2, %%a2                \n\t"   \
+        : "=m" (c), "=m" (d), "=m" (s)          \
+        : "m" (s), "m" (d), "m" (c), "m" (b)    \
+        : "d0", "d1", "e2", "d4", "a2", "a3"    \
+    );
+
+#endif /* TriCore */
+
+/*
+ * Note, gcc -O0 by default uses r7 for the frame pointer, so it complains about
+ * our use of r7 below, unless -fomit-frame-pointer is passed.
+ *
+ * On the other hand, -fomit-frame-pointer is implied by any -Ox options with
+ * x !=0, which we can detect using __OPTIMIZE__ (which is also defined by
+ * clang and armcc5 under the same conditions).
+ *
+ * So, only use the optimized assembly below for optimized build, which avoids
+ * the build error and is pretty reasonable anyway.
+ */
+#if defined(__GNUC__) && !defined(__OPTIMIZE__)
+#define MULADDC_CANNOT_USE_R7
+#endif
+
+#if defined(__arm__) && !defined(MULADDC_CANNOT_USE_R7)
+
+#if defined(__thumb__) && !defined(__thumb2__)
+
+#define MULADDC_INIT                                    \
+    asm(                                                \
+            "ldr    r0, %3                      \n\t"   \
+            "ldr    r1, %4                      \n\t"   \
+            "ldr    r2, %5                      \n\t"   \
+            "ldr    r3, %6                      \n\t"   \
+            "lsr    r7, r3, #16                 \n\t"   \
+            "mov    r9, r7                      \n\t"   \
+            "lsl    r7, r3, #16                 \n\t"   \
+            "lsr    r7, r7, #16                 \n\t"   \
+            "mov    r8, r7                      \n\t"
+
+#define MULADDC_CORE                                    \
+            "ldmia  r0!, {r6}                   \n\t"   \
+            "lsr    r7, r6, #16                 \n\t"   \
+            "lsl    r6, r6, #16                 \n\t"   \
+            "lsr    r6, r6, #16                 \n\t"   \
+            "mov    r4, r8                      \n\t"   \
+            "mul    r4, r6                      \n\t"   \
+            "mov    r3, r9                      \n\t"   \
+            "mul    r6, r3                      \n\t"   \
+            "mov    r5, r9                      \n\t"   \
+            "mul    r5, r7                      \n\t"   \
+            "mov    r3, r8                      \n\t"   \
+            "mul    r7, r3                      \n\t"   \
+            "lsr    r3, r6, #16                 \n\t"   \
+            "add    r5, r5, r3                  \n\t"   \
+            "lsr    r3, r7, #16                 \n\t"   \
+            "add    r5, r5, r3                  \n\t"   \
+            "add    r4, r4, r2                  \n\t"   \
+            "mov    r2, #0                      \n\t"   \
+            "adc    r5, r2                      \n\t"   \
+            "lsl    r3, r6, #16                 \n\t"   \
+            "add    r4, r4, r3                  \n\t"   \
+            "adc    r5, r2                      \n\t"   \
+            "lsl    r3, r7, #16                 \n\t"   \
+            "add    r4, r4, r3                  \n\t"   \
+            "adc    r5, r2                      \n\t"   \
+            "ldr    r3, [r1]                    \n\t"   \
+            "add    r4, r4, r3                  \n\t"   \
+            "adc    r2, r5                      \n\t"   \
+            "stmia  r1!, {r4}                   \n\t"
+
+#define MULADDC_STOP                                    \
+            "str    r2, %0                      \n\t"   \
+            "str    r1, %1                      \n\t"   \
+            "str    r0, %2                      \n\t"   \
+         : "=m" (c),  "=m" (d), "=m" (s)        \
+         : "m" (s), "m" (d), "m" (c), "m" (b)   \
+         : "r0", "r1", "r2", "r3", "r4", "r5",  \
+           "r6", "r7", "r8", "r9", "cc"         \
+         );
+
+#elif defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+
+#define MULADDC_INIT                            \
+    asm(
+
+#define MULADDC_CORE                            \
+            "ldr    r0, [%0], #4        \n\t"   \
+            "ldr    r1, [%1]            \n\t"   \
+            "umaal  r1, %2, %3, r0      \n\t"   \
+            "str    r1, [%1], #4        \n\t"
+
+#define MULADDC_STOP                            \
+         : "=r" (s),  "=r" (d), "=r" (c)        \
+         : "r" (b), "0" (s), "1" (d), "2" (c)   \
+         : "r0", "r1", "memory"                 \
+         );
+
+#else
+
+#define MULADDC_INIT                                    \
+    asm(                                                \
+            "ldr    r0, %3                      \n\t"   \
+            "ldr    r1, %4                      \n\t"   \
+            "ldr    r2, %5                      \n\t"   \
+            "ldr    r3, %6                      \n\t"
+
+#define MULADDC_CORE                                    \
+            "ldr    r4, [r0], #4                \n\t"   \
+            "mov    r5, #0                      \n\t"   \
+            "ldr    r6, [r1]                    \n\t"   \
+            "umlal  r2, r5, r3, r4              \n\t"   \
+            "adds   r7, r6, r2                  \n\t"   \
+            "adc    r2, r5, #0                  \n\t"   \
+            "str    r7, [r1], #4                \n\t"
+
+#define MULADDC_STOP                                    \
+            "str    r2, %0                      \n\t"   \
+            "str    r1, %1                      \n\t"   \
+            "str    r0, %2                      \n\t"   \
+         : "=m" (c),  "=m" (d), "=m" (s)        \
+         : "m" (s), "m" (d), "m" (c), "m" (b)   \
+         : "r0", "r1", "r2", "r3", "r4", "r5",  \
+           "r6", "r7", "cc"                     \
+         );
+
+#endif /* Thumb */
+
+#endif /* ARMv3 */
+
+#if defined(__alpha__)
+
+#define MULADDC_INIT                    \
+    asm(                                \
+        "ldq    $1, %3          \n\t"   \
+        "ldq    $2, %4          \n\t"   \
+        "ldq    $3, %5          \n\t"   \
+        "ldq    $4, %6          \n\t"
+
+#define MULADDC_CORE                    \
+        "ldq    $6,  0($1)      \n\t"   \
+        "addq   $1,  8, $1      \n\t"   \
+        "mulq   $6, $4, $7      \n\t"   \
+        "umulh  $6, $4, $6      \n\t"   \
+        "addq   $7, $3, $7      \n\t"   \
+        "cmpult $7, $3, $3      \n\t"   \
+        "ldq    $5,  0($2)      \n\t"   \
+        "addq   $7, $5, $7      \n\t"   \
+        "cmpult $7, $5, $5      \n\t"   \
+        "stq    $7,  0($2)      \n\t"   \
+        "addq   $2,  8, $2      \n\t"   \
+        "addq   $6, $3, $3      \n\t"   \
+        "addq   $5, $3, $3      \n\t"
+
+#define MULADDC_STOP                                    \
+        "stq    $3, %0          \n\t"   \
+        "stq    $2, %1          \n\t"   \
+        "stq    $1, %2          \n\t"   \
+        : "=m" (c), "=m" (d), "=m" (s)              \
+        : "m" (s), "m" (d), "m" (c), "m" (b)        \
+        : "$1", "$2", "$3", "$4", "$5", "$6", "$7"  \
+    );
+#endif /* Alpha */
+
+#if defined(__mips__) && !defined(__mips64)
+
+#define MULADDC_INIT                    \
+    asm(                                \
+        "lw     $10, %3         \n\t"   \
+        "lw     $11, %4         \n\t"   \
+        "lw     $12, %5         \n\t"   \
+        "lw     $13, %6         \n\t"
+
+#define MULADDC_CORE                    \
+        "lw     $14, 0($10)     \n\t"   \
+        "multu  $13, $14        \n\t"   \
+        "addi   $10, $10, 4     \n\t"   \
+        "mflo   $14             \n\t"   \
+        "mfhi   $9              \n\t"   \
+        "addu   $14, $12, $14   \n\t"   \
+        "lw     $15, 0($11)     \n\t"   \
+        "sltu   $12, $14, $12   \n\t"   \
+        "addu   $15, $14, $15   \n\t"   \
+        "sltu   $14, $15, $14   \n\t"   \
+        "addu   $12, $12, $9    \n\t"   \
+        "sw     $15, 0($11)     \n\t"   \
+        "addu   $12, $12, $14   \n\t"   \
+        "addi   $11, $11, 4     \n\t"
+
+#define MULADDC_STOP                    \
+        "sw     $12, %0         \n\t"   \
+        "sw     $11, %1         \n\t"   \
+        "sw     $10, %2         \n\t"   \
+        : "=m" (c), "=m" (d), "=m" (s)                      \
+        : "m" (s), "m" (d), "m" (c), "m" (b)                \
+        : "$9", "$10", "$11", "$12", "$13", "$14", "$15"    \
+    );
+
+#endif /* MIPS */
+#endif /* GNUC */
+
+#if (defined(_MSC_VER) && defined(_M_IX86)) || defined(__WATCOMC__)
+
+#define MULADDC_INIT                            \
+    __asm   mov     esi, s                      \
+    __asm   mov     edi, d                      \
+    __asm   mov     ecx, c                      \
+    __asm   mov     ebx, b
+
+#define MULADDC_CORE                            \
+    __asm   lodsd                               \
+    __asm   mul     ebx                         \
+    __asm   add     eax, ecx                    \
+    __asm   adc     edx, 0                      \
+    __asm   add     eax, [edi]                  \
+    __asm   adc     edx, 0                      \
+    __asm   mov     ecx, edx                    \
+    __asm   stosd
+
+#if defined(MBEDTLS_HAVE_SSE2)
+
+#define EMIT __asm _emit
+
+#define MULADDC_HUIT                            \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0xC9             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0xC3             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x1F             \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xCB             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x16             \
+    EMIT 0x0F  EMIT 0xF4  EMIT 0xD0             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x66  EMIT 0x04  \
+    EMIT 0x0F  EMIT 0xF4  EMIT 0xE0             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x76  EMIT 0x08  \
+    EMIT 0x0F  EMIT 0xF4  EMIT 0xF0             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x7E  EMIT 0x0C  \
+    EMIT 0x0F  EMIT 0xF4  EMIT 0xF8             \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xCA             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x5F  EMIT 0x04  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xDC             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x6F  EMIT 0x08  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xEE             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x67  EMIT 0x0C  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xFC             \
+    EMIT 0x0F  EMIT 0x7E  EMIT 0x0F             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x56  EMIT 0x10  \
+    EMIT 0x0F  EMIT 0xF4  EMIT 0xD0             \
+    EMIT 0x0F  EMIT 0x73  EMIT 0xD1  EMIT 0x20  \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x66  EMIT 0x14  \
+    EMIT 0x0F  EMIT 0xF4  EMIT 0xE0             \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xCB             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x76  EMIT 0x18  \
+    EMIT 0x0F  EMIT 0xF4  EMIT 0xF0             \
+    EMIT 0x0F  EMIT 0x7E  EMIT 0x4F  EMIT 0x04  \
+    EMIT 0x0F  EMIT 0x73  EMIT 0xD1  EMIT 0x20  \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x5E  EMIT 0x1C  \
+    EMIT 0x0F  EMIT 0xF4  EMIT 0xD8             \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xCD             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x6F  EMIT 0x10  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xD5             \
+    EMIT 0x0F  EMIT 0x7E  EMIT 0x4F  EMIT 0x08  \
+    EMIT 0x0F  EMIT 0x73  EMIT 0xD1  EMIT 0x20  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xCF             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x6F  EMIT 0x14  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xE5             \
+    EMIT 0x0F  EMIT 0x7E  EMIT 0x4F  EMIT 0x0C  \
+    EMIT 0x0F  EMIT 0x73  EMIT 0xD1  EMIT 0x20  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xCA             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x6F  EMIT 0x18  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xF5             \
+    EMIT 0x0F  EMIT 0x7E  EMIT 0x4F  EMIT 0x10  \
+    EMIT 0x0F  EMIT 0x73  EMIT 0xD1  EMIT 0x20  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xCC             \
+    EMIT 0x0F  EMIT 0x6E  EMIT 0x6F  EMIT 0x1C  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xDD             \
+    EMIT 0x0F  EMIT 0x7E  EMIT 0x4F  EMIT 0x14  \
+    EMIT 0x0F  EMIT 0x73  EMIT 0xD1  EMIT 0x20  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xCE             \
+    EMIT 0x0F  EMIT 0x7E  EMIT 0x4F  EMIT 0x18  \
+    EMIT 0x0F  EMIT 0x73  EMIT 0xD1  EMIT 0x20  \
+    EMIT 0x0F  EMIT 0xD4  EMIT 0xCB             \
+    EMIT 0x0F  EMIT 0x7E  EMIT 0x4F  EMIT 0x1C  \
+    EMIT 0x83  EMIT 0xC7  EMIT 0x20             \
+    EMIT 0x83  EMIT 0xC6  EMIT 0x20             \
+    EMIT 0x0F  EMIT 0x73  EMIT 0xD1  EMIT 0x20  \
+    EMIT 0x0F  EMIT 0x7E  EMIT 0xC9
+
+#define MULADDC_STOP                            \
+    EMIT 0x0F  EMIT 0x77                        \
+    __asm   mov     c, ecx                      \
+    __asm   mov     d, edi                      \
+    __asm   mov     s, esi                      \
+
+#else
+
+#define MULADDC_STOP                            \
+    __asm   mov     c, ecx                      \
+    __asm   mov     d, edi                      \
+    __asm   mov     s, esi                      \
+
+#endif /* SSE2 */
+#endif /* MSVC */
+
+#endif /* MBEDTLS_HAVE_ASM */
+
+#if !defined(MULADDC_CORE)
+#if defined(MBEDTLS_HAVE_UDBL)
+
+#define MULADDC_INIT                    \
+{                                       \
+    mbedtls_t_udbl r;                           \
+    mbedtls_mpi_uint r0, r1;
+
+#define MULADDC_CORE                    \
+    r   = *(s++) * (mbedtls_t_udbl) b;          \
+    r0  = (mbedtls_mpi_uint) r;                   \
+    r1  = (mbedtls_mpi_uint)( r >> biL );         \
+    r0 += c;  r1 += (r0 <  c);          \
+    r0 += *d; r1 += (r0 < *d);          \
+    c = r1; *(d++) = r0;
+
+#define MULADDC_STOP                    \
+}
+
+#else
+#define MULADDC_INIT                    \
+{                                       \
+    mbedtls_mpi_uint s0, s1, b0, b1;              \
+    mbedtls_mpi_uint r0, r1, rx, ry;              \
+    b0 = ( b << biH ) >> biH;           \
+    b1 = ( b >> biH );
+
+#define MULADDC_CORE                    \
+    s0 = ( *s << biH ) >> biH;          \
+    s1 = ( *s >> biH ); s++;            \
+    rx = s0 * b1; r0 = s0 * b0;         \
+    ry = s1 * b0; r1 = s1 * b1;         \
+    r1 += ( rx >> biH );                \
+    r1 += ( ry >> biH );                \
+    rx <<= biH; ry <<= biH;             \
+    r0 += rx; r1 += (r0 < rx);          \
+    r0 += ry; r1 += (r0 < ry);          \
+    r0 +=  c; r1 += (r0 <  c);          \
+    r0 += *d; r1 += (r0 < *d);          \
+    c = r1; *(d++) = r0;
+
+#define MULADDC_STOP                    \
+}
+
+#endif /* C (generic)  */
+#endif /* C (longlong) */
+
+#endif /* bn_mul.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/ccm.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/ccm.h
@@ -1,0 +1,304 @@
+/**
+ * \file ccm.h
+ *
+ * \brief This file provides an API for the CCM authenticated encryption
+ *        mode for block ciphers.
+ *
+ * CCM combines Counter mode encryption with CBC-MAC authentication
+ * for 128-bit block ciphers.
+ *
+ * Input to CCM includes the following elements:
+ * <ul><li>Payload - data that is both authenticated and encrypted.</li>
+ * <li>Associated data (Adata) - data that is authenticated but not
+ * encrypted, For example, a header.</li>
+ * <li>Nonce - A unique value that is assigned to the payload and the
+ * associated data.</li></ul>
+ *
+ * Definition of CCM:
+ * http://csrc.nist.gov/publications/nistpubs/800-38C/SP800-38C_updated-July20_2007.pdf
+ * RFC 3610 "Counter with CBC-MAC (CCM)"
+ *
+ * Related:
+ * RFC 5116 "An Interface and Algorithms for Authenticated Encryption"
+ *
+ * Definition of CCM*:
+ * IEEE 802.15.4 - IEEE Standard for Local and metropolitan area networks
+ * Integer representation is fixed most-significant-octet-first order and
+ * the representation of octets is most-significant-bit-first order. This is
+ * consistent with RFC 3610.
+ */
+/*
+ *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_CCM_H
+#define MBEDTLS_CCM_H
+
+#include "cipher.h"
+
+#define MBEDTLS_ERR_CCM_BAD_INPUT       -0x000D /**< Bad input parameters to the function. */
+#define MBEDTLS_ERR_CCM_AUTH_FAILED     -0x000F /**< Authenticated decryption failed. */
+
+/* MBEDTLS_ERR_CCM_HW_ACCEL_FAILED is deprecated and should not be used. */
+#define MBEDTLS_ERR_CCM_HW_ACCEL_FAILED -0x0011 /**< CCM hardware accelerator failed. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(MBEDTLS_CCM_ALT)
+// Regular implementation
+//
+
+/**
+ * \brief    The CCM context-type definition. The CCM context is passed
+ *           to the APIs called.
+ */
+typedef struct mbedtls_ccm_context
+{
+    mbedtls_cipher_context_t cipher_ctx;    /*!< The cipher context used. */
+}
+mbedtls_ccm_context;
+
+#else  /* MBEDTLS_CCM_ALT */
+#include "ccm_alt.h"
+#endif /* MBEDTLS_CCM_ALT */
+
+/**
+ * \brief           This function initializes the specified CCM context,
+ *                  to make references valid, and prepare the context
+ *                  for mbedtls_ccm_setkey() or mbedtls_ccm_free().
+ *
+ * \param ctx       The CCM context to initialize. This must not be \c NULL.
+ */
+void mbedtls_ccm_init( mbedtls_ccm_context *ctx );
+
+/**
+ * \brief           This function initializes the CCM context set in the
+ *                  \p ctx parameter and sets the encryption key.
+ *
+ * \param ctx       The CCM context to initialize. This must be an initialized
+ *                  context.
+ * \param cipher    The 128-bit block cipher to use.
+ * \param key       The encryption key. This must not be \c NULL.
+ * \param keybits   The key size in bits. This must be acceptable by the cipher.
+ *
+ * \return          \c 0 on success.
+ * \return          A CCM or cipher-specific error code on failure.
+ */
+int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
+                        mbedtls_cipher_id_t cipher,
+                        const unsigned char *key,
+                        unsigned int keybits );
+
+/**
+ * \brief   This function releases and clears the specified CCM context
+ *          and underlying cipher sub-context.
+ *
+ * \param ctx       The CCM context to clear. If this is \c NULL, the function
+ *                  has no effect. Otherwise, this must be initialized.
+ */
+void mbedtls_ccm_free( mbedtls_ccm_context *ctx );
+
+/**
+ * \brief           This function encrypts a buffer using CCM.
+ *
+ * \note            The tag is written to a separate buffer. To concatenate
+ *                  the \p tag with the \p output, as done in <em>RFC-3610:
+ *                  Counter with CBC-MAC (CCM)</em>, use
+ *                  \p tag = \p output + \p length, and make sure that the
+ *                  output buffer is at least \p length + \p tag_len wide.
+ *
+ * \param ctx       The CCM context to use for encryption. This must be
+ *                  initialized and bound to a key.
+ * \param length    The length of the input data in Bytes.
+ * \param iv        The initialization vector (nonce). This must be a readable
+ *                  buffer of at least \p iv_len Bytes.
+ * \param iv_len    The length of the nonce in Bytes: 7, 8, 9, 10, 11, 12,
+ *                  or 13. The length L of the message length field is
+ *                  15 - \p iv_len.
+ * \param add       The additional data field. If \p add_len is greater than
+ *                  zero, \p add must be a readable buffer of at least that
+ *                  length.
+ * \param add_len   The length of additional data in Bytes.
+ *                  This must be less than `2^16 - 2^8`.
+ * \param input     The buffer holding the input data. If \p length is greater
+ *                  than zero, \p input must be a readable buffer of at least
+ *                  that length.
+ * \param output    The buffer holding the output data. If \p length is greater
+ *                  than zero, \p output must be a writable buffer of at least
+ *                  that length.
+ * \param tag       The buffer holding the authentication field. This must be a
+ *                  readable buffer of at least \p tag_len Bytes.
+ * \param tag_len   The length of the authentication field to generate in Bytes:
+ *                  4, 6, 8, 10, 12, 14 or 16.
+ *
+ * \return          \c 0 on success.
+ * \return          A CCM or cipher-specific error code on failure.
+ */
+int mbedtls_ccm_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
+                         const unsigned char *iv, size_t iv_len,
+                         const unsigned char *add, size_t add_len,
+                         const unsigned char *input, unsigned char *output,
+                         unsigned char *tag, size_t tag_len );
+
+/**
+ * \brief           This function encrypts a buffer using CCM*.
+ *
+ * \note            The tag is written to a separate buffer. To concatenate
+ *                  the \p tag with the \p output, as done in <em>RFC-3610:
+ *                  Counter with CBC-MAC (CCM)</em>, use
+ *                  \p tag = \p output + \p length, and make sure that the
+ *                  output buffer is at least \p length + \p tag_len wide.
+ *
+ * \note            When using this function in a variable tag length context,
+ *                  the tag length has to be encoded into the \p iv passed to
+ *                  this function.
+ *
+ * \param ctx       The CCM context to use for encryption. This must be
+ *                  initialized and bound to a key.
+ * \param length    The length of the input data in Bytes.
+ * \param iv        The initialization vector (nonce). This must be a readable
+ *                  buffer of at least \p iv_len Bytes.
+ * \param iv_len    The length of the nonce in Bytes: 7, 8, 9, 10, 11, 12,
+ *                  or 13. The length L of the message length field is
+ *                  15 - \p iv_len.
+ * \param add       The additional data field. This must be a readable buffer of
+ *                  at least \p add_len Bytes.
+ * \param add_len   The length of additional data in Bytes.
+ *                  This must be less than 2^16 - 2^8.
+ * \param input     The buffer holding the input data. If \p length is greater
+ *                  than zero, \p input must be a readable buffer of at least
+ *                  that length.
+ * \param output    The buffer holding the output data. If \p length is greater
+ *                  than zero, \p output must be a writable buffer of at least
+ *                  that length.
+ * \param tag       The buffer holding the authentication field. This must be a
+ *                  readable buffer of at least \p tag_len Bytes.
+ * \param tag_len   The length of the authentication field to generate in Bytes:
+ *                  0, 4, 6, 8, 10, 12, 14 or 16.
+ *
+ * \warning         Passing \c 0 as \p tag_len means that the message is no
+ *                  longer authenticated.
+ *
+ * \return          \c 0 on success.
+ * \return          A CCM or cipher-specific error code on failure.
+ */
+int mbedtls_ccm_star_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
+                         const unsigned char *iv, size_t iv_len,
+                         const unsigned char *add, size_t add_len,
+                         const unsigned char *input, unsigned char *output,
+                         unsigned char *tag, size_t tag_len );
+
+/**
+ * \brief           This function performs a CCM authenticated decryption of a
+ *                  buffer.
+ *
+ * \param ctx       The CCM context to use for decryption. This must be
+ *                  initialized and bound to a key.
+ * \param length    The length of the input data in Bytes.
+ * \param iv        The initialization vector (nonce). This must be a readable
+ *                  buffer of at least \p iv_len Bytes.
+ * \param iv_len    The length of the nonce in Bytes: 7, 8, 9, 10, 11, 12,
+ *                  or 13. The length L of the message length field is
+ *                  15 - \p iv_len.
+ * \param add       The additional data field. This must be a readable buffer
+ *                  of at least that \p add_len Bytes..
+ * \param add_len   The length of additional data in Bytes.
+ *                  This must be less than 2^16 - 2^8.
+ * \param input     The buffer holding the input data. If \p length is greater
+ *                  than zero, \p input must be a readable buffer of at least
+ *                  that length.
+ * \param output    The buffer holding the output data. If \p length is greater
+ *                  than zero, \p output must be a writable buffer of at least
+ *                  that length.
+ * \param tag       The buffer holding the authentication field. This must be a
+ *                  readable buffer of at least \p tag_len Bytes.
+ * \param tag_len   The length of the authentication field to generate in Bytes:
+ *                  4, 6, 8, 10, 12, 14 or 16.
+ *
+ * \return          \c 0 on success. This indicates that the message is authentic.
+ * \return          #MBEDTLS_ERR_CCM_AUTH_FAILED if the tag does not match.
+ * \return          A cipher-specific error code on calculation failure.
+ */
+int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
+                      const unsigned char *iv, size_t iv_len,
+                      const unsigned char *add, size_t add_len,
+                      const unsigned char *input, unsigned char *output,
+                      const unsigned char *tag, size_t tag_len );
+
+/**
+ * \brief           This function performs a CCM* authenticated decryption of a
+ *                  buffer.
+ *
+ * \note            When using this function in a variable tag length context,
+ *                  the tag length has to be decoded from \p iv and passed to
+ *                  this function as \p tag_len. (\p tag needs to be adjusted
+ *                  accordingly.)
+ *
+ * \param ctx       The CCM context to use for decryption. This must be
+ *                  initialized and bound to a key.
+ * \param length    The length of the input data in Bytes.
+ * \param iv        The initialization vector (nonce). This must be a readable
+ *                  buffer of at least \p iv_len Bytes.
+ * \param iv_len    The length of the nonce in Bytes: 7, 8, 9, 10, 11, 12,
+ *                  or 13. The length L of the message length field is
+ *                  15 - \p iv_len.
+ * \param add       The additional data field. This must be a readable buffer of
+ *                  at least that \p add_len Bytes.
+ * \param add_len   The length of additional data in Bytes.
+ *                  This must be less than 2^16 - 2^8.
+ * \param input     The buffer holding the input data. If \p length is greater
+ *                  than zero, \p input must be a readable buffer of at least
+ *                  that length.
+ * \param output    The buffer holding the output data. If \p length is greater
+ *                  than zero, \p output must be a writable buffer of at least
+ *                  that length.
+ * \param tag       The buffer holding the authentication field. This must be a
+ *                  readable buffer of at least \p tag_len Bytes.
+ * \param tag_len   The length of the authentication field in Bytes.
+ *                  0, 4, 6, 8, 10, 12, 14 or 16.
+ *
+ * \warning         Passing \c 0 as \p tag_len means that the message is nos
+ *                  longer authenticated.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_CCM_AUTH_FAILED if the tag does not match.
+ * \return          A cipher-specific error code on calculation failure.
+ */
+int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
+                      const unsigned char *iv, size_t iv_len,
+                      const unsigned char *add, size_t add_len,
+                      const unsigned char *input, unsigned char *output,
+                      const unsigned char *tag, size_t tag_len );
+
+#if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
+/**
+ * \brief          The CCM checkup routine.
+ *
+ * \return         \c 0 on success.
+ * \return         \c 1 on failure.
+ */
+int mbedtls_ccm_self_test( int verbose );
+#endif /* MBEDTLS_SELF_TEST && MBEDTLS_AES_C */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_CCM_H */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/check_config.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/check_config.h
@@ -1,0 +1,698 @@
+/**
+ * \file check_config.h
+ *
+ * \brief Consistency checks for configuration options
+ */
+/*
+ *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+/*
+ * It is recommended to include this file from your config.h
+ * in order to catch dependency issues early.
+ */
+
+#ifndef MBEDTLS_CHECK_CONFIG_H
+#define MBEDTLS_CHECK_CONFIG_H
+
+/*
+ * We assume CHAR_BIT is 8 in many places. In practice, this is true on our
+ * target platforms, so not an issue, but let's just be extra sure.
+ */
+#define CHAR_BIT   8
+#if CHAR_BIT != 8
+#error "mbed TLS requires a platform with 8-bit chars"
+#endif
+
+#if defined(_WIN32)
+#if !defined(MBEDTLS_PLATFORM_C)
+#error "MBEDTLS_PLATFORM_C is required on Windows"
+#endif
+
+/* Fix the config here. Not convenient to put an #ifdef _WIN32 in config.h as
+ * it would confuse config.pl. */
+#if !defined(MBEDTLS_PLATFORM_SNPRINTF_ALT) && \
+    !defined(MBEDTLS_PLATFORM_SNPRINTF_MACRO)
+#define MBEDTLS_PLATFORM_SNPRINTF_ALT
+#endif
+#endif /* _WIN32 */
+
+#if defined(TARGET_LIKE_MBED) && \
+    ( defined(MBEDTLS_NET_C) || defined(MBEDTLS_TIMING_C) )
+#error "The NET and TIMING modules are not available for mbed OS - please use the network and timing functions provided by mbed OS"
+#endif
+
+#if defined(MBEDTLS_DEPRECATED_WARNING) && \
+    !defined(__GNUC__) && !defined(__clang__)
+#error "MBEDTLS_DEPRECATED_WARNING only works with GCC and Clang"
+#endif
+
+#if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_HAVE_TIME)
+#error "MBEDTLS_HAVE_TIME_DATE without MBEDTLS_HAVE_TIME does not make sense"
+#endif
+
+#if defined(MBEDTLS_AESNI_C) && !defined(MBEDTLS_HAVE_ASM)
+#error "MBEDTLS_AESNI_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CTR_DRBG_C) && !defined(MBEDTLS_AES_C)
+#error "MBEDTLS_CTR_DRBG_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_DHM_C) && !defined(MBEDTLS_BIGNUM_C)
+#error "MBEDTLS_DHM_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT) && !defined(MBEDTLS_SSL_TRUNCATED_HMAC)
+#error "MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_CMAC_C) && \
+    !defined(MBEDTLS_AES_C) && !defined(MBEDTLS_DES_C)
+#error "MBEDTLS_CMAC_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_NIST_KW_C) && \
+    ( !defined(MBEDTLS_AES_C) || !defined(MBEDTLS_CIPHER_C) )
+#error "MBEDTLS_NIST_KW_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECDH_C) && !defined(MBEDTLS_ECP_C)
+#error "MBEDTLS_ECDH_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECDSA_C) &&            \
+    ( !defined(MBEDTLS_ECP_C) ||           \
+      !defined(MBEDTLS_ASN1_PARSE_C) ||    \
+      !defined(MBEDTLS_ASN1_WRITE_C) )
+#error "MBEDTLS_ECDSA_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECJPAKE_C) &&           \
+    ( !defined(MBEDTLS_ECP_C) || !defined(MBEDTLS_MD_C) )
+#error "MBEDTLS_ECJPAKE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECP_RESTARTABLE)           && \
+    ( defined(MBEDTLS_ECDH_COMPUTE_SHARED_ALT) || \
+      defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)     || \
+      defined(MBEDTLS_ECDSA_SIGN_ALT)          || \
+      defined(MBEDTLS_ECDSA_VERIFY_ALT)        || \
+      defined(MBEDTLS_ECDSA_GENKEY_ALT)        || \
+      defined(MBEDTLS_ECP_INTERNAL_ALT)        || \
+      defined(MBEDTLS_ECP_ALT) )
+#error "MBEDTLS_ECP_RESTARTABLE defined, but it cannot coexist with an alternative ECP implementation"
+#endif
+
+#if defined(MBEDTLS_ECDSA_DETERMINISTIC) && !defined(MBEDTLS_HMAC_DRBG_C)
+#error "MBEDTLS_ECDSA_DETERMINISTIC defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECP_C) && ( !defined(MBEDTLS_BIGNUM_C) || (   \
+    !defined(MBEDTLS_ECP_DP_SECP192R1_ENABLED) &&                  \
+    !defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED) &&                  \
+    !defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED) &&                  \
+    !defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED) &&                  \
+    !defined(MBEDTLS_ECP_DP_SECP521R1_ENABLED) &&                  \
+    !defined(MBEDTLS_ECP_DP_BP256R1_ENABLED)   &&                  \
+    !defined(MBEDTLS_ECP_DP_BP384R1_ENABLED)   &&                  \
+    !defined(MBEDTLS_ECP_DP_BP512R1_ENABLED)   &&                  \
+    !defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED) &&                  \
+    !defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED) &&                  \
+    !defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED) ) )
+#error "MBEDTLS_ECP_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PK_PARSE_C) && !defined(MBEDTLS_ASN1_PARSE_C)
+#error "MBEDTLS_PK_PARSE_C defined, but not all prerequesites"
+#endif
+
+#if defined(MBEDTLS_ENTROPY_C) && (!defined(MBEDTLS_SHA512_C) &&      \
+                                    !defined(MBEDTLS_SHA256_C))
+#error "MBEDTLS_ENTROPY_C defined, but not all prerequisites"
+#endif
+#if defined(MBEDTLS_ENTROPY_C) && defined(MBEDTLS_SHA512_C) &&         \
+    defined(MBEDTLS_CTR_DRBG_ENTROPY_LEN) && (MBEDTLS_CTR_DRBG_ENTROPY_LEN > 64)
+#error "MBEDTLS_CTR_DRBG_ENTROPY_LEN value too high"
+#endif
+#if defined(MBEDTLS_ENTROPY_C) &&                                            \
+    ( !defined(MBEDTLS_SHA512_C) || defined(MBEDTLS_ENTROPY_FORCE_SHA256) ) \
+    && defined(MBEDTLS_CTR_DRBG_ENTROPY_LEN) && (MBEDTLS_CTR_DRBG_ENTROPY_LEN > 32)
+#error "MBEDTLS_CTR_DRBG_ENTROPY_LEN value too high"
+#endif
+#if defined(MBEDTLS_ENTROPY_C) && \
+    defined(MBEDTLS_ENTROPY_FORCE_SHA256) && !defined(MBEDTLS_SHA256_C)
+#error "MBEDTLS_ENTROPY_FORCE_SHA256 defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_TEST_NULL_ENTROPY) && \
+    ( !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES) )
+#error "MBEDTLS_TEST_NULL_ENTROPY defined, but not all prerequisites"
+#endif
+#if defined(MBEDTLS_TEST_NULL_ENTROPY) && \
+     ( defined(MBEDTLS_ENTROPY_NV_SEED) || defined(MBEDTLS_ENTROPY_HARDWARE_ALT) || \
+    defined(MBEDTLS_HAVEGE_C) )
+#error "MBEDTLS_TEST_NULL_ENTROPY defined, but entropy sources too"
+#endif
+
+#if defined(MBEDTLS_GCM_C) && (                                        \
+        !defined(MBEDTLS_AES_C) && !defined(MBEDTLS_CAMELLIA_C) )
+#error "MBEDTLS_GCM_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECP_RANDOMIZE_JAC_ALT) && !defined(MBEDTLS_ECP_INTERNAL_ALT)
+#error "MBEDTLS_ECP_RANDOMIZE_JAC_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECP_ADD_MIXED_ALT) && !defined(MBEDTLS_ECP_INTERNAL_ALT)
+#error "MBEDTLS_ECP_ADD_MIXED_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECP_DOUBLE_JAC_ALT) && !defined(MBEDTLS_ECP_INTERNAL_ALT)
+#error "MBEDTLS_ECP_DOUBLE_JAC_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECP_NORMALIZE_JAC_MANY_ALT) && !defined(MBEDTLS_ECP_INTERNAL_ALT)
+#error "MBEDTLS_ECP_NORMALIZE_JAC_MANY_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECP_NORMALIZE_JAC_ALT) && !defined(MBEDTLS_ECP_INTERNAL_ALT)
+#error "MBEDTLS_ECP_NORMALIZE_JAC_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECP_DOUBLE_ADD_MXZ_ALT) && !defined(MBEDTLS_ECP_INTERNAL_ALT)
+#error "MBEDTLS_ECP_DOUBLE_ADD_MXZ_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECP_RANDOMIZE_MXZ_ALT) && !defined(MBEDTLS_ECP_INTERNAL_ALT)
+#error "MBEDTLS_ECP_RANDOMIZE_MXZ_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ECP_NORMALIZE_MXZ_ALT) && !defined(MBEDTLS_ECP_INTERNAL_ALT)
+#error "MBEDTLS_ECP_NORMALIZE_MXZ_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_HAVEGE_C) && !defined(MBEDTLS_TIMING_C)
+#error "MBEDTLS_HAVEGE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_HKDF_C) && !defined(MBEDTLS_MD_C)
+#error "MBEDTLS_HKDF_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_HMAC_DRBG_C) && !defined(MBEDTLS_MD_C)
+#error "MBEDTLS_HMAC_DRBG_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED) &&                 \
+    ( !defined(MBEDTLS_ECDH_C) || !defined(MBEDTLS_X509_CRT_PARSE_C) )
+#error "MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED) &&                 \
+    ( !defined(MBEDTLS_ECDH_C) || !defined(MBEDTLS_X509_CRT_PARSE_C) )
+#error "MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED) && !defined(MBEDTLS_DHM_C)
+#error "MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED) &&                     \
+    !defined(MBEDTLS_ECDH_C)
+#error "MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED) &&                   \
+    ( !defined(MBEDTLS_DHM_C) || !defined(MBEDTLS_RSA_C) ||           \
+      !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_PKCS1_V15) )
+#error "MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED) &&                 \
+    ( !defined(MBEDTLS_ECDH_C) || !defined(MBEDTLS_RSA_C) ||          \
+      !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_PKCS1_V15) )
+#error "MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED) &&                 \
+    ( !defined(MBEDTLS_ECDH_C) || !defined(MBEDTLS_ECDSA_C) ||          \
+      !defined(MBEDTLS_X509_CRT_PARSE_C) )
+#error "MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED) &&                   \
+    ( !defined(MBEDTLS_RSA_C) || !defined(MBEDTLS_X509_CRT_PARSE_C) || \
+      !defined(MBEDTLS_PKCS1_V15) )
+#error "MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_KEY_EXCHANGE_RSA_ENABLED) &&                       \
+    ( !defined(MBEDTLS_RSA_C) || !defined(MBEDTLS_X509_CRT_PARSE_C) || \
+      !defined(MBEDTLS_PKCS1_V15) )
+#error "MBEDTLS_KEY_EXCHANGE_RSA_ENABLED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) &&                    \
+    ( !defined(MBEDTLS_ECJPAKE_C) || !defined(MBEDTLS_SHA256_C) ||      \
+      !defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED) )
+#error "MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) &&                          \
+    ( !defined(MBEDTLS_PLATFORM_C) || !defined(MBEDTLS_PLATFORM_MEMORY) )
+#error "MBEDTLS_MEMORY_BUFFER_ALLOC_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PADLOCK_C) && !defined(MBEDTLS_HAVE_ASM)
+#error "MBEDTLS_PADLOCK_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PEM_PARSE_C) && !defined(MBEDTLS_BASE64_C)
+#error "MBEDTLS_PEM_PARSE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PEM_WRITE_C) && !defined(MBEDTLS_BASE64_C)
+#error "MBEDTLS_PEM_WRITE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PK_C) && \
+    ( !defined(MBEDTLS_RSA_C) && !defined(MBEDTLS_ECP_C) )
+#error "MBEDTLS_PK_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PK_PARSE_C) && !defined(MBEDTLS_PK_C)
+#error "MBEDTLS_PK_PARSE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PK_WRITE_C) && !defined(MBEDTLS_PK_C)
+#error "MBEDTLS_PK_WRITE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PKCS11_C) && !defined(MBEDTLS_PK_C)
+#error "MBEDTLS_PKCS11_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_EXIT_ALT) && !defined(MBEDTLS_PLATFORM_C)
+#error "MBEDTLS_PLATFORM_EXIT_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_EXIT_MACRO) && !defined(MBEDTLS_PLATFORM_C)
+#error "MBEDTLS_PLATFORM_EXIT_MACRO defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_EXIT_MACRO) &&\
+    ( defined(MBEDTLS_PLATFORM_STD_EXIT) ||\
+        defined(MBEDTLS_PLATFORM_EXIT_ALT) )
+#error "MBEDTLS_PLATFORM_EXIT_MACRO and MBEDTLS_PLATFORM_STD_EXIT/MBEDTLS_PLATFORM_EXIT_ALT cannot be defined simultaneously"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_TIME_ALT) &&\
+    ( !defined(MBEDTLS_PLATFORM_C) ||\
+        !defined(MBEDTLS_HAVE_TIME) )
+#error "MBEDTLS_PLATFORM_TIME_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_TIME_MACRO) &&\
+    ( !defined(MBEDTLS_PLATFORM_C) ||\
+        !defined(MBEDTLS_HAVE_TIME) )
+#error "MBEDTLS_PLATFORM_TIME_MACRO defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_TIME_TYPE_MACRO) &&\
+    ( !defined(MBEDTLS_PLATFORM_C) ||\
+        !defined(MBEDTLS_HAVE_TIME) )
+#error "MBEDTLS_PLATFORM_TIME_TYPE_MACRO defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_TIME_MACRO) &&\
+    ( defined(MBEDTLS_PLATFORM_STD_TIME) ||\
+        defined(MBEDTLS_PLATFORM_TIME_ALT) )
+#error "MBEDTLS_PLATFORM_TIME_MACRO and MBEDTLS_PLATFORM_STD_TIME/MBEDTLS_PLATFORM_TIME_ALT cannot be defined simultaneously"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_TIME_TYPE_MACRO) &&\
+    ( defined(MBEDTLS_PLATFORM_STD_TIME) ||\
+        defined(MBEDTLS_PLATFORM_TIME_ALT) )
+#error "MBEDTLS_PLATFORM_TIME_TYPE_MACRO and MBEDTLS_PLATFORM_STD_TIME/MBEDTLS_PLATFORM_TIME_ALT cannot be defined simultaneously"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_FPRINTF_ALT) && !defined(MBEDTLS_PLATFORM_C)
+#error "MBEDTLS_PLATFORM_FPRINTF_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_FPRINTF_MACRO) && !defined(MBEDTLS_PLATFORM_C)
+#error "MBEDTLS_PLATFORM_FPRINTF_MACRO defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_FPRINTF_MACRO) &&\
+    ( defined(MBEDTLS_PLATFORM_STD_FPRINTF) ||\
+        defined(MBEDTLS_PLATFORM_FPRINTF_ALT) )
+#error "MBEDTLS_PLATFORM_FPRINTF_MACRO and MBEDTLS_PLATFORM_STD_FPRINTF/MBEDTLS_PLATFORM_FPRINTF_ALT cannot be defined simultaneously"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_FREE_MACRO) &&\
+    ( !defined(MBEDTLS_PLATFORM_C) || !defined(MBEDTLS_PLATFORM_MEMORY) )
+#error "MBEDTLS_PLATFORM_FREE_MACRO defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_FREE_MACRO) &&\
+    defined(MBEDTLS_PLATFORM_STD_FREE)
+#error "MBEDTLS_PLATFORM_FREE_MACRO and MBEDTLS_PLATFORM_STD_FREE cannot be defined simultaneously"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_FREE_MACRO) && !defined(MBEDTLS_PLATFORM_CALLOC_MACRO)
+#error "MBEDTLS_PLATFORM_CALLOC_MACRO must be defined if MBEDTLS_PLATFORM_FREE_MACRO is"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_CALLOC_MACRO) &&\
+    ( !defined(MBEDTLS_PLATFORM_C) || !defined(MBEDTLS_PLATFORM_MEMORY) )
+#error "MBEDTLS_PLATFORM_CALLOC_MACRO defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_CALLOC_MACRO) &&\
+    defined(MBEDTLS_PLATFORM_STD_CALLOC)
+#error "MBEDTLS_PLATFORM_CALLOC_MACRO and MBEDTLS_PLATFORM_STD_CALLOC cannot be defined simultaneously"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_CALLOC_MACRO) && !defined(MBEDTLS_PLATFORM_FREE_MACRO)
+#error "MBEDTLS_PLATFORM_FREE_MACRO must be defined if MBEDTLS_PLATFORM_CALLOC_MACRO is"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_MEMORY) && !defined(MBEDTLS_PLATFORM_C)
+#error "MBEDTLS_PLATFORM_MEMORY defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_PRINTF_ALT) && !defined(MBEDTLS_PLATFORM_C)
+#error "MBEDTLS_PLATFORM_PRINTF_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_PRINTF_MACRO) && !defined(MBEDTLS_PLATFORM_C)
+#error "MBEDTLS_PLATFORM_PRINTF_MACRO defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_PRINTF_MACRO) &&\
+    ( defined(MBEDTLS_PLATFORM_STD_PRINTF) ||\
+        defined(MBEDTLS_PLATFORM_PRINTF_ALT) )
+#error "MBEDTLS_PLATFORM_PRINTF_MACRO and MBEDTLS_PLATFORM_STD_PRINTF/MBEDTLS_PLATFORM_PRINTF_ALT cannot be defined simultaneously"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_SNPRINTF_ALT) && !defined(MBEDTLS_PLATFORM_C)
+#error "MBEDTLS_PLATFORM_SNPRINTF_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_SNPRINTF_MACRO) && !defined(MBEDTLS_PLATFORM_C)
+#error "MBEDTLS_PLATFORM_SNPRINTF_MACRO defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_SNPRINTF_MACRO) &&\
+    ( defined(MBEDTLS_PLATFORM_STD_SNPRINTF) ||\
+        defined(MBEDTLS_PLATFORM_SNPRINTF_ALT) )
+#error "MBEDTLS_PLATFORM_SNPRINTF_MACRO and MBEDTLS_PLATFORM_STD_SNPRINTF/MBEDTLS_PLATFORM_SNPRINTF_ALT cannot be defined simultaneously"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_STD_MEM_HDR) &&\
+    !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS)
+#error "MBEDTLS_PLATFORM_STD_MEM_HDR defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_STD_CALLOC) && !defined(MBEDTLS_PLATFORM_MEMORY)
+#error "MBEDTLS_PLATFORM_STD_CALLOC defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_STD_CALLOC) && !defined(MBEDTLS_PLATFORM_MEMORY)
+#error "MBEDTLS_PLATFORM_STD_CALLOC defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_STD_FREE) && !defined(MBEDTLS_PLATFORM_MEMORY)
+#error "MBEDTLS_PLATFORM_STD_FREE defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_STD_EXIT) &&\
+    !defined(MBEDTLS_PLATFORM_EXIT_ALT)
+#error "MBEDTLS_PLATFORM_STD_EXIT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_STD_TIME) &&\
+    ( !defined(MBEDTLS_PLATFORM_TIME_ALT) ||\
+        !defined(MBEDTLS_HAVE_TIME) )
+#error "MBEDTLS_PLATFORM_STD_TIME defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_STD_FPRINTF) &&\
+    !defined(MBEDTLS_PLATFORM_FPRINTF_ALT)
+#error "MBEDTLS_PLATFORM_STD_FPRINTF defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_STD_PRINTF) &&\
+    !defined(MBEDTLS_PLATFORM_PRINTF_ALT)
+#error "MBEDTLS_PLATFORM_STD_PRINTF defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_STD_SNPRINTF) &&\
+    !defined(MBEDTLS_PLATFORM_SNPRINTF_ALT)
+#error "MBEDTLS_PLATFORM_STD_SNPRINTF defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ENTROPY_NV_SEED) &&\
+    ( !defined(MBEDTLS_PLATFORM_C) || !defined(MBEDTLS_ENTROPY_C) )
+#error "MBEDTLS_ENTROPY_NV_SEED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_NV_SEED_ALT) &&\
+    !defined(MBEDTLS_ENTROPY_NV_SEED)
+#error "MBEDTLS_PLATFORM_NV_SEED_ALT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_STD_NV_SEED_READ) &&\
+    !defined(MBEDTLS_PLATFORM_NV_SEED_ALT)
+#error "MBEDTLS_PLATFORM_STD_NV_SEED_READ defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_STD_NV_SEED_WRITE) &&\
+    !defined(MBEDTLS_PLATFORM_NV_SEED_ALT)
+#error "MBEDTLS_PLATFORM_STD_NV_SEED_WRITE defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_NV_SEED_READ_MACRO) &&\
+    ( defined(MBEDTLS_PLATFORM_STD_NV_SEED_READ) ||\
+      defined(MBEDTLS_PLATFORM_NV_SEED_ALT) )
+#error "MBEDTLS_PLATFORM_NV_SEED_READ_MACRO and MBEDTLS_PLATFORM_STD_NV_SEED_READ cannot be defined simultaneously"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO) &&\
+    ( defined(MBEDTLS_PLATFORM_STD_NV_SEED_WRITE) ||\
+      defined(MBEDTLS_PLATFORM_NV_SEED_ALT) )
+#error "MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO and MBEDTLS_PLATFORM_STD_NV_SEED_WRITE cannot be defined simultaneously"
+#endif
+
+#if defined(MBEDTLS_RSA_C) && ( !defined(MBEDTLS_BIGNUM_C) ||         \
+    !defined(MBEDTLS_OID_C) )
+#error "MBEDTLS_RSA_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_RSA_C) && ( !defined(MBEDTLS_PKCS1_V21) &&         \
+    !defined(MBEDTLS_PKCS1_V15) )
+#error "MBEDTLS_RSA_C defined, but none of the PKCS1 versions enabled"
+#endif
+
+#if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT) &&                        \
+    ( !defined(MBEDTLS_RSA_C) || !defined(MBEDTLS_PKCS1_V21) )
+#error "MBEDTLS_X509_RSASSA_PSS_SUPPORT defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_PROTO_SSL3) && ( !defined(MBEDTLS_MD5_C) ||     \
+    !defined(MBEDTLS_SHA1_C) )
+#error "MBEDTLS_SSL_PROTO_SSL3 defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1) && ( !defined(MBEDTLS_MD5_C) ||     \
+    !defined(MBEDTLS_SHA1_C) )
+#error "MBEDTLS_SSL_PROTO_TLS1 defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_1) && ( !defined(MBEDTLS_MD5_C) ||     \
+    !defined(MBEDTLS_SHA1_C) )
+#error "MBEDTLS_SSL_PROTO_TLS1_1 defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2) && ( !defined(MBEDTLS_SHA1_C) &&     \
+    !defined(MBEDTLS_SHA256_C) && !defined(MBEDTLS_SHA512_C) )
+#error "MBEDTLS_SSL_PROTO_TLS1_2 defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_PROTO_DTLS)     && \
+    !defined(MBEDTLS_SSL_PROTO_TLS1_1)  && \
+    !defined(MBEDTLS_SSL_PROTO_TLS1_2)
+#error "MBEDTLS_SSL_PROTO_DTLS defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_CLI_C) && !defined(MBEDTLS_SSL_TLS_C)
+#error "MBEDTLS_SSL_CLI_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_TLS_C) && ( !defined(MBEDTLS_CIPHER_C) ||     \
+    !defined(MBEDTLS_MD_C) )
+#error "MBEDTLS_SSL_TLS_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_SRV_C) && !defined(MBEDTLS_SSL_TLS_C)
+#error "MBEDTLS_SSL_SRV_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_TLS_C) && (!defined(MBEDTLS_SSL_PROTO_SSL3) && \
+    !defined(MBEDTLS_SSL_PROTO_TLS1) && !defined(MBEDTLS_SSL_PROTO_TLS1_1) && \
+    !defined(MBEDTLS_SSL_PROTO_TLS1_2))
+#error "MBEDTLS_SSL_TLS_C defined, but no protocols are active"
+#endif
+
+#if defined(MBEDTLS_SSL_TLS_C) && (defined(MBEDTLS_SSL_PROTO_SSL3) && \
+    defined(MBEDTLS_SSL_PROTO_TLS1_1) && !defined(MBEDTLS_SSL_PROTO_TLS1))
+#error "Illegal protocol selection"
+#endif
+
+#if defined(MBEDTLS_SSL_TLS_C) && (defined(MBEDTLS_SSL_PROTO_TLS1) && \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2) && !defined(MBEDTLS_SSL_PROTO_TLS1_1))
+#error "Illegal protocol selection"
+#endif
+
+#if defined(MBEDTLS_SSL_TLS_C) && (defined(MBEDTLS_SSL_PROTO_SSL3) && \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2) && (!defined(MBEDTLS_SSL_PROTO_TLS1) || \
+    !defined(MBEDTLS_SSL_PROTO_TLS1_1)))
+#error "Illegal protocol selection"
+#endif
+
+#if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) && !defined(MBEDTLS_SSL_PROTO_DTLS)
+#error "MBEDTLS_SSL_DTLS_HELLO_VERIFY  defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE) && \
+    !defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
+#error "MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE  defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY) &&                              \
+    ( !defined(MBEDTLS_SSL_TLS_C) || !defined(MBEDTLS_SSL_PROTO_DTLS) )
+#error "MBEDTLS_SSL_DTLS_ANTI_REPLAY  defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_DTLS_BADMAC_LIMIT) &&                              \
+    ( !defined(MBEDTLS_SSL_TLS_C) || !defined(MBEDTLS_SSL_PROTO_DTLS) )
+#error "MBEDTLS_SSL_DTLS_BADMAC_LIMIT  defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) &&   \
+    !defined(MBEDTLS_SSL_PROTO_TLS1)   &&      \
+    !defined(MBEDTLS_SSL_PROTO_TLS1_1) &&      \
+    !defined(MBEDTLS_SSL_PROTO_TLS1_2)
+#error "MBEDTLS_SSL_ENCRYPT_THEN_MAC defined, but not all prerequsites"
+#endif
+
+#if defined(MBEDTLS_SSL_EXTENDED_MASTER_SECRET) && \
+    !defined(MBEDTLS_SSL_PROTO_TLS1)   &&          \
+    !defined(MBEDTLS_SSL_PROTO_TLS1_1) &&          \
+    !defined(MBEDTLS_SSL_PROTO_TLS1_2)
+#error "MBEDTLS_SSL_EXTENDED_MASTER_SECRET defined, but not all prerequsites"
+#endif
+
+#if defined(MBEDTLS_SSL_TICKET_C) && !defined(MBEDTLS_CIPHER_C)
+#error "MBEDTLS_SSL_TICKET_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_CBC_RECORD_SPLITTING) && \
+    !defined(MBEDTLS_SSL_PROTO_SSL3) && !defined(MBEDTLS_SSL_PROTO_TLS1)
+#error "MBEDTLS_SSL_CBC_RECORD_SPLITTING defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) && \
+        !defined(MBEDTLS_X509_CRT_PARSE_C)
+#error "MBEDTLS_SSL_SERVER_NAME_INDICATION defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_THREADING_PTHREAD)
+#if !defined(MBEDTLS_THREADING_C) || defined(MBEDTLS_THREADING_IMPL)
+#error "MBEDTLS_THREADING_PTHREAD defined, but not all prerequisites"
+#endif
+#define MBEDTLS_THREADING_IMPL
+#endif
+
+#if defined(MBEDTLS_THREADING_ALT)
+#if !defined(MBEDTLS_THREADING_C) || defined(MBEDTLS_THREADING_IMPL)
+#error "MBEDTLS_THREADING_ALT defined, but not all prerequisites"
+#endif
+#define MBEDTLS_THREADING_IMPL
+#endif
+
+#if defined(MBEDTLS_THREADING_C) && !defined(MBEDTLS_THREADING_IMPL)
+#error "MBEDTLS_THREADING_C defined, single threading implementation required"
+#endif
+#undef MBEDTLS_THREADING_IMPL
+
+#if defined(MBEDTLS_VERSION_FEATURES) && !defined(MBEDTLS_VERSION_C)
+#error "MBEDTLS_VERSION_FEATURES defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_X509_USE_C) && ( !defined(MBEDTLS_BIGNUM_C) ||  \
+    !defined(MBEDTLS_OID_C) || !defined(MBEDTLS_ASN1_PARSE_C) ||      \
+    !defined(MBEDTLS_PK_PARSE_C) )
+#error "MBEDTLS_X509_USE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_X509_CREATE_C) && ( !defined(MBEDTLS_BIGNUM_C) ||  \
+    !defined(MBEDTLS_OID_C) || !defined(MBEDTLS_ASN1_WRITE_C) ||       \
+    !defined(MBEDTLS_PK_WRITE_C) )
+#error "MBEDTLS_X509_CREATE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_X509_CRT_PARSE_C) && ( !defined(MBEDTLS_X509_USE_C) )
+#error "MBEDTLS_X509_CRT_PARSE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_X509_CRL_PARSE_C) && ( !defined(MBEDTLS_X509_USE_C) )
+#error "MBEDTLS_X509_CRL_PARSE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_X509_CSR_PARSE_C) && ( !defined(MBEDTLS_X509_USE_C) )
+#error "MBEDTLS_X509_CSR_PARSE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_X509_CRT_WRITE_C) && ( !defined(MBEDTLS_X509_CREATE_C) )
+#error "MBEDTLS_X509_CRT_WRITE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_X509_CSR_WRITE_C) && ( !defined(MBEDTLS_X509_CREATE_C) )
+#error "MBEDTLS_X509_CSR_WRITE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_HAVE_INT32) && defined(MBEDTLS_HAVE_INT64)
+#error "MBEDTLS_HAVE_INT32 and MBEDTLS_HAVE_INT64 cannot be defined simultaneously"
+#endif /* MBEDTLS_HAVE_INT32 && MBEDTLS_HAVE_INT64 */
+
+#if ( defined(MBEDTLS_HAVE_INT32) || defined(MBEDTLS_HAVE_INT64) ) && \
+    defined(MBEDTLS_HAVE_ASM)
+#error "MBEDTLS_HAVE_INT32/MBEDTLS_HAVE_INT64 and MBEDTLS_HAVE_ASM cannot be defined simultaneously"
+#endif /* (MBEDTLS_HAVE_INT32 || MBEDTLS_HAVE_INT64) && MBEDTLS_HAVE_ASM */
+
+/*
+ * Avoid warning from -pedantic. This is a convenient place for this
+ * workaround since this is included by every single file before the
+ * #if defined(MBEDTLS_xxx_C) that results in emtpy translation units.
+ */
+typedef int mbedtls_iso_c_forbids_empty_translation_units;
+
+#endif /* MBEDTLS_CHECK_CONFIG_H */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/cipher.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/cipher.h
@@ -1,0 +1,872 @@
+/**
+ * \file cipher.h
+ *
+ * \brief This file contains an abstraction interface for use with the cipher
+ * primitives provided by the library. It provides a common interface to all of
+ * the available cipher operations.
+ *
+ * \author Adriaan de Jong <dejong@fox-it.com>
+ */
+/*
+ *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_CIPHER_H
+#define MBEDTLS_CIPHER_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include <stddef.h>
+#include "mbedtls/platform_util.h"
+
+#if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
+#define MBEDTLS_CIPHER_MODE_AEAD
+#endif
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+#define MBEDTLS_CIPHER_MODE_WITH_PADDING
+#endif
+
+#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER) || \
+    defined(MBEDTLS_CHACHA20_C)
+#define MBEDTLS_CIPHER_MODE_STREAM
+#endif
+
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
+#define MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE  -0x6080  /**< The selected feature is not available. */
+#define MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA       -0x6100  /**< Bad input parameters. */
+#define MBEDTLS_ERR_CIPHER_ALLOC_FAILED         -0x6180  /**< Failed to allocate memory. */
+#define MBEDTLS_ERR_CIPHER_INVALID_PADDING      -0x6200  /**< Input data contains invalid padding and is rejected. */
+#define MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED  -0x6280  /**< Decryption of block requires a full block. */
+#define MBEDTLS_ERR_CIPHER_AUTH_FAILED          -0x6300  /**< Authentication failed (for AEAD modes). */
+#define MBEDTLS_ERR_CIPHER_INVALID_CONTEXT      -0x6380  /**< The context is invalid. For example, because it was freed. */
+
+/* MBEDTLS_ERR_CIPHER_HW_ACCEL_FAILED is deprecated and should not be used. */
+#define MBEDTLS_ERR_CIPHER_HW_ACCEL_FAILED      -0x6400  /**< Cipher hardware accelerator failed. */
+
+#define MBEDTLS_CIPHER_VARIABLE_IV_LEN     0x01    /**< Cipher accepts IVs of variable length. */
+#define MBEDTLS_CIPHER_VARIABLE_KEY_LEN    0x02    /**< Cipher accepts keys of variable length. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief     Supported cipher types.
+ *
+ * \warning   RC4 and DES are considered weak ciphers and their use
+ *            constitutes a security risk. Arm recommends considering stronger
+ *            ciphers instead.
+ */
+typedef enum {
+    MBEDTLS_CIPHER_ID_NONE = 0,  /**< Placeholder to mark the end of cipher ID lists. */
+    MBEDTLS_CIPHER_ID_NULL,      /**< The identity cipher, treated as a stream cipher. */
+    MBEDTLS_CIPHER_ID_AES,       /**< The AES cipher. */
+    MBEDTLS_CIPHER_ID_DES,       /**< The DES cipher. */
+    MBEDTLS_CIPHER_ID_3DES,      /**< The Triple DES cipher. */
+    MBEDTLS_CIPHER_ID_CAMELLIA,  /**< The Camellia cipher. */
+    MBEDTLS_CIPHER_ID_BLOWFISH,  /**< The Blowfish cipher. */
+    MBEDTLS_CIPHER_ID_ARC4,      /**< The RC4 cipher. */
+    MBEDTLS_CIPHER_ID_ARIA,      /**< The Aria cipher. */
+    MBEDTLS_CIPHER_ID_CHACHA20,  /**< The ChaCha20 cipher. */
+} mbedtls_cipher_id_t;
+
+/**
+ * \brief     Supported {cipher type, cipher mode} pairs.
+ *
+ * \warning   RC4 and DES are considered weak ciphers and their use
+ *            constitutes a security risk. Arm recommends considering stronger
+ *            ciphers instead.
+ */
+typedef enum {
+    MBEDTLS_CIPHER_NONE = 0,             /**< Placeholder to mark the end of cipher-pair lists. */
+    MBEDTLS_CIPHER_NULL,                 /**< The identity stream cipher. */
+    MBEDTLS_CIPHER_AES_128_ECB,          /**< AES cipher with 128-bit ECB mode. */
+    MBEDTLS_CIPHER_AES_192_ECB,          /**< AES cipher with 192-bit ECB mode. */
+    MBEDTLS_CIPHER_AES_256_ECB,          /**< AES cipher with 256-bit ECB mode. */
+    MBEDTLS_CIPHER_AES_128_CBC,          /**< AES cipher with 128-bit CBC mode. */
+    MBEDTLS_CIPHER_AES_192_CBC,          /**< AES cipher with 192-bit CBC mode. */
+    MBEDTLS_CIPHER_AES_256_CBC,          /**< AES cipher with 256-bit CBC mode. */
+    MBEDTLS_CIPHER_AES_128_CFB128,       /**< AES cipher with 128-bit CFB128 mode. */
+    MBEDTLS_CIPHER_AES_192_CFB128,       /**< AES cipher with 192-bit CFB128 mode. */
+    MBEDTLS_CIPHER_AES_256_CFB128,       /**< AES cipher with 256-bit CFB128 mode. */
+    MBEDTLS_CIPHER_AES_128_CTR,          /**< AES cipher with 128-bit CTR mode. */
+    MBEDTLS_CIPHER_AES_192_CTR,          /**< AES cipher with 192-bit CTR mode. */
+    MBEDTLS_CIPHER_AES_256_CTR,          /**< AES cipher with 256-bit CTR mode. */
+    MBEDTLS_CIPHER_AES_128_GCM,          /**< AES cipher with 128-bit GCM mode. */
+    MBEDTLS_CIPHER_AES_192_GCM,          /**< AES cipher with 192-bit GCM mode. */
+    MBEDTLS_CIPHER_AES_256_GCM,          /**< AES cipher with 256-bit GCM mode. */
+    MBEDTLS_CIPHER_CAMELLIA_128_ECB,     /**< Camellia cipher with 128-bit ECB mode. */
+    MBEDTLS_CIPHER_CAMELLIA_192_ECB,     /**< Camellia cipher with 192-bit ECB mode. */
+    MBEDTLS_CIPHER_CAMELLIA_256_ECB,     /**< Camellia cipher with 256-bit ECB mode. */
+    MBEDTLS_CIPHER_CAMELLIA_128_CBC,     /**< Camellia cipher with 128-bit CBC mode. */
+    MBEDTLS_CIPHER_CAMELLIA_192_CBC,     /**< Camellia cipher with 192-bit CBC mode. */
+    MBEDTLS_CIPHER_CAMELLIA_256_CBC,     /**< Camellia cipher with 256-bit CBC mode. */
+    MBEDTLS_CIPHER_CAMELLIA_128_CFB128,  /**< Camellia cipher with 128-bit CFB128 mode. */
+    MBEDTLS_CIPHER_CAMELLIA_192_CFB128,  /**< Camellia cipher with 192-bit CFB128 mode. */
+    MBEDTLS_CIPHER_CAMELLIA_256_CFB128,  /**< Camellia cipher with 256-bit CFB128 mode. */
+    MBEDTLS_CIPHER_CAMELLIA_128_CTR,     /**< Camellia cipher with 128-bit CTR mode. */
+    MBEDTLS_CIPHER_CAMELLIA_192_CTR,     /**< Camellia cipher with 192-bit CTR mode. */
+    MBEDTLS_CIPHER_CAMELLIA_256_CTR,     /**< Camellia cipher with 256-bit CTR mode. */
+    MBEDTLS_CIPHER_CAMELLIA_128_GCM,     /**< Camellia cipher with 128-bit GCM mode. */
+    MBEDTLS_CIPHER_CAMELLIA_192_GCM,     /**< Camellia cipher with 192-bit GCM mode. */
+    MBEDTLS_CIPHER_CAMELLIA_256_GCM,     /**< Camellia cipher with 256-bit GCM mode. */
+    MBEDTLS_CIPHER_DES_ECB,              /**< DES cipher with ECB mode. */
+    MBEDTLS_CIPHER_DES_CBC,              /**< DES cipher with CBC mode. */
+    MBEDTLS_CIPHER_DES_EDE_ECB,          /**< DES cipher with EDE ECB mode. */
+    MBEDTLS_CIPHER_DES_EDE_CBC,          /**< DES cipher with EDE CBC mode. */
+    MBEDTLS_CIPHER_DES_EDE3_ECB,         /**< DES cipher with EDE3 ECB mode. */
+    MBEDTLS_CIPHER_DES_EDE3_CBC,         /**< DES cipher with EDE3 CBC mode. */
+    MBEDTLS_CIPHER_BLOWFISH_ECB,         /**< Blowfish cipher with ECB mode. */
+    MBEDTLS_CIPHER_BLOWFISH_CBC,         /**< Blowfish cipher with CBC mode. */
+    MBEDTLS_CIPHER_BLOWFISH_CFB64,       /**< Blowfish cipher with CFB64 mode. */
+    MBEDTLS_CIPHER_BLOWFISH_CTR,         /**< Blowfish cipher with CTR mode. */
+    MBEDTLS_CIPHER_ARC4_128,             /**< RC4 cipher with 128-bit mode. */
+    MBEDTLS_CIPHER_AES_128_CCM,          /**< AES cipher with 128-bit CCM mode. */
+    MBEDTLS_CIPHER_AES_192_CCM,          /**< AES cipher with 192-bit CCM mode. */
+    MBEDTLS_CIPHER_AES_256_CCM,          /**< AES cipher with 256-bit CCM mode. */
+    MBEDTLS_CIPHER_CAMELLIA_128_CCM,     /**< Camellia cipher with 128-bit CCM mode. */
+    MBEDTLS_CIPHER_CAMELLIA_192_CCM,     /**< Camellia cipher with 192-bit CCM mode. */
+    MBEDTLS_CIPHER_CAMELLIA_256_CCM,     /**< Camellia cipher with 256-bit CCM mode. */
+    MBEDTLS_CIPHER_ARIA_128_ECB,         /**< Aria cipher with 128-bit key and ECB mode. */
+    MBEDTLS_CIPHER_ARIA_192_ECB,         /**< Aria cipher with 192-bit key and ECB mode. */
+    MBEDTLS_CIPHER_ARIA_256_ECB,         /**< Aria cipher with 256-bit key and ECB mode. */
+    MBEDTLS_CIPHER_ARIA_128_CBC,         /**< Aria cipher with 128-bit key and CBC mode. */
+    MBEDTLS_CIPHER_ARIA_192_CBC,         /**< Aria cipher with 192-bit key and CBC mode. */
+    MBEDTLS_CIPHER_ARIA_256_CBC,         /**< Aria cipher with 256-bit key and CBC mode. */
+    MBEDTLS_CIPHER_ARIA_128_CFB128,      /**< Aria cipher with 128-bit key and CFB-128 mode. */
+    MBEDTLS_CIPHER_ARIA_192_CFB128,      /**< Aria cipher with 192-bit key and CFB-128 mode. */
+    MBEDTLS_CIPHER_ARIA_256_CFB128,      /**< Aria cipher with 256-bit key and CFB-128 mode. */
+    MBEDTLS_CIPHER_ARIA_128_CTR,         /**< Aria cipher with 128-bit key and CTR mode. */
+    MBEDTLS_CIPHER_ARIA_192_CTR,         /**< Aria cipher with 192-bit key and CTR mode. */
+    MBEDTLS_CIPHER_ARIA_256_CTR,         /**< Aria cipher with 256-bit key and CTR mode. */
+    MBEDTLS_CIPHER_ARIA_128_GCM,         /**< Aria cipher with 128-bit key and GCM mode. */
+    MBEDTLS_CIPHER_ARIA_192_GCM,         /**< Aria cipher with 192-bit key and GCM mode. */
+    MBEDTLS_CIPHER_ARIA_256_GCM,         /**< Aria cipher with 256-bit key and GCM mode. */
+    MBEDTLS_CIPHER_ARIA_128_CCM,         /**< Aria cipher with 128-bit key and CCM mode. */
+    MBEDTLS_CIPHER_ARIA_192_CCM,         /**< Aria cipher with 192-bit key and CCM mode. */
+    MBEDTLS_CIPHER_ARIA_256_CCM,         /**< Aria cipher with 256-bit key and CCM mode. */
+    MBEDTLS_CIPHER_AES_128_OFB,          /**< AES 128-bit cipher in OFB mode. */
+    MBEDTLS_CIPHER_AES_192_OFB,          /**< AES 192-bit cipher in OFB mode. */
+    MBEDTLS_CIPHER_AES_256_OFB,          /**< AES 256-bit cipher in OFB mode. */
+    MBEDTLS_CIPHER_AES_128_XTS,          /**< AES 128-bit cipher in XTS block mode. */
+    MBEDTLS_CIPHER_AES_256_XTS,          /**< AES 256-bit cipher in XTS block mode. */
+    MBEDTLS_CIPHER_CHACHA20,             /**< ChaCha20 stream cipher. */
+    MBEDTLS_CIPHER_CHACHA20_POLY1305,    /**< ChaCha20-Poly1305 AEAD cipher. */
+} mbedtls_cipher_type_t;
+
+/** Supported cipher modes. */
+typedef enum {
+    MBEDTLS_MODE_NONE = 0,               /**< None. */
+    MBEDTLS_MODE_ECB,                    /**< The ECB cipher mode. */
+    MBEDTLS_MODE_CBC,                    /**< The CBC cipher mode. */
+    MBEDTLS_MODE_CFB,                    /**< The CFB cipher mode. */
+    MBEDTLS_MODE_OFB,                    /**< The OFB cipher mode. */
+    MBEDTLS_MODE_CTR,                    /**< The CTR cipher mode. */
+    MBEDTLS_MODE_GCM,                    /**< The GCM cipher mode. */
+    MBEDTLS_MODE_STREAM,                 /**< The stream cipher mode. */
+    MBEDTLS_MODE_CCM,                    /**< The CCM cipher mode. */
+    MBEDTLS_MODE_XTS,                    /**< The XTS cipher mode. */
+    MBEDTLS_MODE_CHACHAPOLY,             /**< The ChaCha-Poly cipher mode. */
+} mbedtls_cipher_mode_t;
+
+/** Supported cipher padding types. */
+typedef enum {
+    MBEDTLS_PADDING_PKCS7 = 0,     /**< PKCS7 padding (default).        */
+    MBEDTLS_PADDING_ONE_AND_ZEROS, /**< ISO/IEC 7816-4 padding.         */
+    MBEDTLS_PADDING_ZEROS_AND_LEN, /**< ANSI X.923 padding.             */
+    MBEDTLS_PADDING_ZEROS,         /**< Zero padding (not reversible). */
+    MBEDTLS_PADDING_NONE,          /**< Never pad (full blocks only).   */
+} mbedtls_cipher_padding_t;
+
+/** Type of operation. */
+typedef enum {
+    MBEDTLS_OPERATION_NONE = -1,
+    MBEDTLS_DECRYPT = 0,
+    MBEDTLS_ENCRYPT,
+} mbedtls_operation_t;
+
+enum {
+    /** Undefined key length. */
+    MBEDTLS_KEY_LENGTH_NONE = 0,
+    /** Key length, in bits (including parity), for DES keys. */
+    MBEDTLS_KEY_LENGTH_DES  = 64,
+    /** Key length in bits, including parity, for DES in two-key EDE. */
+    MBEDTLS_KEY_LENGTH_DES_EDE = 128,
+    /** Key length in bits, including parity, for DES in three-key EDE. */
+    MBEDTLS_KEY_LENGTH_DES_EDE3 = 192,
+};
+
+/** Maximum length of any IV, in Bytes. */
+#define MBEDTLS_MAX_IV_LENGTH      16
+/** Maximum block size of any cipher, in Bytes. */
+#define MBEDTLS_MAX_BLOCK_LENGTH   16
+
+/**
+ * Base cipher information (opaque struct).
+ */
+typedef struct mbedtls_cipher_base_t mbedtls_cipher_base_t;
+
+/**
+ * CMAC context (opaque struct).
+ */
+typedef struct mbedtls_cmac_context_t mbedtls_cmac_context_t;
+
+/**
+ * Cipher information. Allows calling cipher functions
+ * in a generic way.
+ */
+typedef struct mbedtls_cipher_info_t
+{
+    /** Full cipher identifier. For example,
+     * MBEDTLS_CIPHER_AES_256_CBC.
+     */
+    mbedtls_cipher_type_t type;
+
+    /** The cipher mode. For example, MBEDTLS_MODE_CBC. */
+    mbedtls_cipher_mode_t mode;
+
+    /** The cipher key length, in bits. This is the
+     * default length for variable sized ciphers.
+     * Includes parity bits for ciphers like DES.
+     */
+    unsigned int key_bitlen;
+
+    /** Name of the cipher. */
+    const char * name;
+
+    /** IV or nonce size, in Bytes.
+     * For ciphers that accept variable IV sizes,
+     * this is the recommended size.
+     */
+    unsigned int iv_size;
+
+    /** Bitflag comprised of MBEDTLS_CIPHER_VARIABLE_IV_LEN and
+     *  MBEDTLS_CIPHER_VARIABLE_KEY_LEN indicating whether the
+     *  cipher supports variable IV or variable key sizes, respectively.
+     */
+    int flags;
+
+    /** The block size, in Bytes. */
+    unsigned int block_size;
+
+    /** Struct for base cipher information and functions. */
+    const mbedtls_cipher_base_t *base;
+
+} mbedtls_cipher_info_t;
+
+/**
+ * Generic cipher context.
+ */
+typedef struct mbedtls_cipher_context_t
+{
+    /** Information about the associated cipher. */
+    const mbedtls_cipher_info_t *cipher_info;
+
+    /** Key length to use. */
+    int key_bitlen;
+
+    /** Operation that the key of the context has been
+     * initialized for.
+     */
+    mbedtls_operation_t operation;
+
+#if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
+    /** Padding functions to use, if relevant for
+     * the specific cipher mode.
+     */
+    void (*add_padding)( unsigned char *output, size_t olen, size_t data_len );
+    int (*get_padding)( unsigned char *input, size_t ilen, size_t *data_len );
+#endif
+
+    /** Buffer for input that has not been processed yet. */
+    unsigned char unprocessed_data[MBEDTLS_MAX_BLOCK_LENGTH];
+
+    /** Number of Bytes that have not been processed yet. */
+    size_t unprocessed_len;
+
+    /** Current IV or NONCE_COUNTER for CTR-mode, data unit (or sector) number
+     * for XTS-mode. */
+    unsigned char iv[MBEDTLS_MAX_IV_LENGTH];
+
+    /** IV size in Bytes, for ciphers with variable-length IVs. */
+    size_t iv_size;
+
+    /** The cipher-specific context. */
+    void *cipher_ctx;
+
+#if defined(MBEDTLS_CMAC_C)
+    /** CMAC-specific context. */
+    mbedtls_cmac_context_t *cmac_ctx;
+#endif
+} mbedtls_cipher_context_t;
+
+/**
+ * \brief This function retrieves the list of ciphers supported by the generic
+ * cipher module.
+ *
+ * \return      A statically-allocated array of ciphers. The last entry
+ *              is zero.
+ */
+const int *mbedtls_cipher_list( void );
+
+/**
+ * \brief               This function retrieves the cipher-information
+ *                      structure associated with the given cipher name.
+ *
+ * \param cipher_name   Name of the cipher to search for. This must not be
+ *                      \c NULL.
+ *
+ * \return              The cipher information structure associated with the
+ *                      given \p cipher_name.
+ * \return              \c NULL if the associated cipher information is not found.
+ */
+const mbedtls_cipher_info_t *mbedtls_cipher_info_from_string( const char *cipher_name );
+
+/**
+ * \brief               This function retrieves the cipher-information
+ *                      structure associated with the given cipher type.
+ *
+ * \param cipher_type   Type of the cipher to search for.
+ *
+ * \return              The cipher information structure associated with the
+ *                      given \p cipher_type.
+ * \return              \c NULL if the associated cipher information is not found.
+ */
+const mbedtls_cipher_info_t *mbedtls_cipher_info_from_type( const mbedtls_cipher_type_t cipher_type );
+
+/**
+ * \brief               This function retrieves the cipher-information
+ *                      structure associated with the given cipher ID,
+ *                      key size and mode.
+ *
+ * \param cipher_id     The ID of the cipher to search for. For example,
+ *                      #MBEDTLS_CIPHER_ID_AES.
+ * \param key_bitlen    The length of the key in bits.
+ * \param mode          The cipher mode. For example, #MBEDTLS_MODE_CBC.
+ *
+ * \return              The cipher information structure associated with the
+ *                      given \p cipher_id.
+ * \return              \c NULL if the associated cipher information is not found.
+ */
+const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values( const mbedtls_cipher_id_t cipher_id,
+                                              int key_bitlen,
+                                              const mbedtls_cipher_mode_t mode );
+
+/**
+ * \brief               This function initializes a \p cipher_context as NONE.
+ *
+ * \param ctx           The context to be initialized. This must not be \c NULL.
+ */
+void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx );
+
+/**
+ * \brief               This function frees and clears the cipher-specific
+ *                      context of \p ctx. Freeing \p ctx itself remains the
+ *                      responsibility of the caller.
+ *
+ * \param ctx           The context to be freed. If this is \c NULL, the
+ *                      function has no effect, otherwise this must point to an
+ *                      initialized context.
+ */
+void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
+
+
+/**
+ * \brief               This function initializes and fills the cipher-context
+ *                      structure with the appropriate values. It also clears
+ *                      the structure.
+ *
+ * \param ctx           The context to initialize. This must be initialized.
+ * \param cipher_info   The cipher to use.
+ *
+ * \return              \c 0 on success.
+ * \return              #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
+ *                      parameter-verification failure.
+ * \return              #MBEDTLS_ERR_CIPHER_ALLOC_FAILED if allocation of the
+ *                      cipher-specific context fails.
+ *
+ * \internal Currently, the function also clears the structure.
+ * In future versions, the caller will be required to call
+ * mbedtls_cipher_init() on the structure first.
+ */
+int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx,
+                          const mbedtls_cipher_info_t *cipher_info );
+
+/**
+ * \brief        This function returns the block size of the given cipher.
+ *
+ * \param ctx    The context of the cipher. This must be initialized.
+ *
+ * \return       The block size of the underlying cipher.
+ * \return       \c 0 if \p ctx has not been initialized.
+ */
+static inline unsigned int mbedtls_cipher_get_block_size(
+    const mbedtls_cipher_context_t *ctx )
+{
+    MBEDTLS_INTERNAL_VALIDATE_RET( ctx != NULL, 0 );
+    if( ctx->cipher_info == NULL )
+        return 0;
+
+    return ctx->cipher_info->block_size;
+}
+
+/**
+ * \brief        This function returns the mode of operation for
+ *               the cipher. For example, MBEDTLS_MODE_CBC.
+ *
+ * \param ctx    The context of the cipher. This must be initialized.
+ *
+ * \return       The mode of operation.
+ * \return       #MBEDTLS_MODE_NONE if \p ctx has not been initialized.
+ */
+static inline mbedtls_cipher_mode_t mbedtls_cipher_get_cipher_mode(
+    const mbedtls_cipher_context_t *ctx )
+{
+    MBEDTLS_INTERNAL_VALIDATE_RET( ctx != NULL, MBEDTLS_MODE_NONE );
+    if( ctx->cipher_info == NULL )
+        return MBEDTLS_MODE_NONE;
+
+    return ctx->cipher_info->mode;
+}
+
+/**
+ * \brief       This function returns the size of the IV or nonce
+ *              of the cipher, in Bytes.
+ *
+ * \param ctx   The context of the cipher. This must be initialized.
+ *
+ * \return      The recommended IV size if no IV has been set.
+ * \return      \c 0 for ciphers not using an IV or a nonce.
+ * \return      The actual size if an IV has been set.
+ */
+static inline int mbedtls_cipher_get_iv_size(
+    const mbedtls_cipher_context_t *ctx )
+{
+    MBEDTLS_INTERNAL_VALIDATE_RET( ctx != NULL, 0 );
+    if( ctx->cipher_info == NULL )
+        return 0;
+
+    if( ctx->iv_size != 0 )
+        return (int) ctx->iv_size;
+
+    return (int) ctx->cipher_info->iv_size;
+}
+
+/**
+ * \brief               This function returns the type of the given cipher.
+ *
+ * \param ctx           The context of the cipher. This must be initialized.
+ *
+ * \return              The type of the cipher.
+ * \return              #MBEDTLS_CIPHER_NONE if \p ctx has not been initialized.
+ */
+static inline mbedtls_cipher_type_t mbedtls_cipher_get_type(
+    const mbedtls_cipher_context_t *ctx )
+{
+    MBEDTLS_INTERNAL_VALIDATE_RET(
+        ctx != NULL, MBEDTLS_CIPHER_NONE );
+    if( ctx->cipher_info == NULL )
+        return MBEDTLS_CIPHER_NONE;
+
+    return ctx->cipher_info->type;
+}
+
+/**
+ * \brief               This function returns the name of the given cipher
+ *                      as a string.
+ *
+ * \param ctx           The context of the cipher. This must be initialized.
+ *
+ * \return              The name of the cipher.
+ * \return              NULL if \p ctx has not been not initialized.
+ */
+static inline const char *mbedtls_cipher_get_name(
+    const mbedtls_cipher_context_t *ctx )
+{
+    MBEDTLS_INTERNAL_VALIDATE_RET( ctx != NULL, 0 );
+    if( ctx->cipher_info == NULL )
+        return 0;
+
+    return ctx->cipher_info->name;
+}
+
+/**
+ * \brief               This function returns the key length of the cipher.
+ *
+ * \param ctx           The context of the cipher. This must be initialized.
+ *
+ * \return              The key length of the cipher in bits.
+ * \return              #MBEDTLS_KEY_LENGTH_NONE if ctx \p has not been
+ *                      initialized.
+ */
+static inline int mbedtls_cipher_get_key_bitlen(
+    const mbedtls_cipher_context_t *ctx )
+{
+    MBEDTLS_INTERNAL_VALIDATE_RET(
+        ctx != NULL, MBEDTLS_KEY_LENGTH_NONE );
+    if( ctx->cipher_info == NULL )
+        return MBEDTLS_KEY_LENGTH_NONE;
+
+    return (int) ctx->cipher_info->key_bitlen;
+}
+
+/**
+ * \brief          This function returns the operation of the given cipher.
+ *
+ * \param ctx      The context of the cipher. This must be initialized.
+ *
+ * \return         The type of operation: #MBEDTLS_ENCRYPT or #MBEDTLS_DECRYPT.
+ * \return         #MBEDTLS_OPERATION_NONE if \p ctx has not been initialized.
+ */
+static inline mbedtls_operation_t mbedtls_cipher_get_operation(
+    const mbedtls_cipher_context_t *ctx )
+{
+    MBEDTLS_INTERNAL_VALIDATE_RET(
+        ctx != NULL, MBEDTLS_OPERATION_NONE );
+    if( ctx->cipher_info == NULL )
+        return MBEDTLS_OPERATION_NONE;
+
+    return ctx->operation;
+}
+
+/**
+ * \brief               This function sets the key to use with the given context.
+ *
+ * \param ctx           The generic cipher context. This must be initialized and
+ *                      bound to a cipher information structure.
+ * \param key           The key to use. This must be a readable buffer of at
+ *                      least \p key_bitlen Bits.
+ * \param key_bitlen    The key length to use, in Bits.
+ * \param operation     The operation that the key will be used for:
+ *                      #MBEDTLS_ENCRYPT or #MBEDTLS_DECRYPT.
+ *
+ * \return              \c 0 on success.
+ * \return              #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
+ *                      parameter-verification failure.
+ * \return              A cipher-specific error code on failure.
+ */
+int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
+                           const unsigned char *key,
+                           int key_bitlen,
+                           const mbedtls_operation_t operation );
+
+#if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
+/**
+ * \brief               This function sets the padding mode, for cipher modes
+ *                      that use padding.
+ *
+ *                      The default passing mode is PKCS7 padding.
+ *
+ * \param ctx           The generic cipher context. This must be initialized and
+ *                      bound to a cipher information structure.
+ * \param mode          The padding mode.
+ *
+ * \return              \c 0 on success.
+ * \return              #MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE
+ *                      if the selected padding mode is not supported.
+ * \return              #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA if the cipher mode
+ *                      does not support padding.
+ */
+int mbedtls_cipher_set_padding_mode( mbedtls_cipher_context_t *ctx,
+                                     mbedtls_cipher_padding_t mode );
+#endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
+
+/**
+ * \brief           This function sets the initialization vector (IV)
+ *                  or nonce.
+ *
+ * \note            Some ciphers do not use IVs nor nonce. For these
+ *                  ciphers, this function has no effect.
+ *
+ * \param ctx       The generic cipher context. This must be initialized and
+ *                  bound to a cipher information structure.
+ * \param iv        The IV to use, or NONCE_COUNTER for CTR-mode ciphers. This
+ *                  must be a readable buffer of at least \p iv_len Bytes.
+ * \param iv_len    The IV length for ciphers with variable-size IV.
+ *                  This parameter is discarded by ciphers with fixed-size IV.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
+ *                  parameter-verification failure.
+ */
+int mbedtls_cipher_set_iv( mbedtls_cipher_context_t *ctx,
+                           const unsigned char *iv,
+                           size_t iv_len );
+
+/**
+ * \brief         This function resets the cipher state.
+ *
+ * \param ctx     The generic cipher context. This must be initialized.
+ *
+ * \return        \c 0 on success.
+ * \return        #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
+ *                parameter-verification failure.
+ */
+int mbedtls_cipher_reset( mbedtls_cipher_context_t *ctx );
+
+#if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
+/**
+ * \brief               This function adds additional data for AEAD ciphers.
+ *                      Currently supported with GCM and ChaCha20+Poly1305.
+ *                      This must be called exactly once, after
+ *                      mbedtls_cipher_reset().
+ *
+ * \param ctx           The generic cipher context. This must be initialized.
+ * \param ad            The additional data to use. This must be a readable
+ *                      buffer of at least \p ad_len Bytes.
+ * \param ad_len        the Length of \p ad Bytes.
+ *
+ * \return              \c 0 on success.
+ * \return              A specific error code on failure.
+ */
+int mbedtls_cipher_update_ad( mbedtls_cipher_context_t *ctx,
+                      const unsigned char *ad, size_t ad_len );
+#endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
+
+/**
+ * \brief               The generic cipher update function. It encrypts or
+ *                      decrypts using the given cipher context. Writes as
+ *                      many block-sized blocks of data as possible to output.
+ *                      Any data that cannot be written immediately is either
+ *                      added to the next block, or flushed when
+ *                      mbedtls_cipher_finish() is called.
+ *                      Exception: For MBEDTLS_MODE_ECB, expects a single block
+ *                      in size. For example, 16 Bytes for AES.
+ *
+ * \note                If the underlying cipher is used in GCM mode, all calls
+ *                      to this function, except for the last one before
+ *                      mbedtls_cipher_finish(), must have \p ilen as a
+ *                      multiple of the block size of the cipher.
+ *
+ * \param ctx           The generic cipher context. This must be initialized and
+ *                      bound to a key.
+ * \param input         The buffer holding the input data. This must be a
+ *                      readable buffer of at least \p ilen Bytes.
+ * \param ilen          The length of the input data.
+ * \param output        The buffer for the output data. This must be able to
+ *                      hold at least `ilen + block_size`. This must not be the
+ *                      same buffer as \p input.
+ * \param olen          The length of the output data, to be updated with the
+ *                      actual number of Bytes written. This must not be
+ *                      \c NULL.
+ *
+ * \return              \c 0 on success.
+ * \return              #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
+ *                      parameter-verification failure.
+ * \return              #MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE on an
+ *                      unsupported mode for a cipher.
+ * \return              A cipher-specific error code on failure.
+ */
+int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *input,
+                   size_t ilen, unsigned char *output, size_t *olen );
+
+/**
+ * \brief               The generic cipher finalization function. If data still
+ *                      needs to be flushed from an incomplete block, the data
+ *                      contained in it is padded to the size of
+ *                      the last block, and written to the \p output buffer.
+ *
+ * \param ctx           The generic cipher context. This must be initialized and
+ *                      bound to a key.
+ * \param output        The buffer to write data to. This needs to be a writable
+ *                      buffer of at least \p block_size Bytes.
+ * \param olen          The length of the data written to the \p output buffer.
+ *                      This may not be \c NULL.
+ *
+ * \return              \c 0 on success.
+ * \return              #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
+ *                      parameter-verification failure.
+ * \return              #MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED on decryption
+ *                      expecting a full block but not receiving one.
+ * \return              #MBEDTLS_ERR_CIPHER_INVALID_PADDING on invalid padding
+ *                      while decrypting.
+ * \return              A cipher-specific error code on failure.
+ */
+int mbedtls_cipher_finish( mbedtls_cipher_context_t *ctx,
+                   unsigned char *output, size_t *olen );
+
+#if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
+/**
+ * \brief               This function writes a tag for AEAD ciphers.
+ *                      Currently supported with GCM and ChaCha20+Poly1305.
+ *                      This must be called after mbedtls_cipher_finish().
+ *
+ * \param ctx           The generic cipher context. This must be initialized,
+ *                      bound to a key, and have just completed a cipher
+ *                      operation through mbedtls_cipher_finish() the tag for
+ *                      which should be written.
+ * \param tag           The buffer to write the tag to. This must be a writable
+ *                      buffer of at least \p tag_len Bytes.
+ * \param tag_len       The length of the tag to write.
+ *
+ * \return              \c 0 on success.
+ * \return              A specific error code on failure.
+ */
+int mbedtls_cipher_write_tag( mbedtls_cipher_context_t *ctx,
+                      unsigned char *tag, size_t tag_len );
+
+/**
+ * \brief               This function checks the tag for AEAD ciphers.
+ *                      Currently supported with GCM and ChaCha20+Poly1305.
+ *                      This must be called after mbedtls_cipher_finish().
+ *
+ * \param ctx           The generic cipher context. This must be initialized.
+ * \param tag           The buffer holding the tag. This must be a readable
+ *                      buffer of at least \p tag_len Bytes.
+ * \param tag_len       The length of the tag to check.
+ *
+ * \return              \c 0 on success.
+ * \return              A specific error code on failure.
+ */
+int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
+                      const unsigned char *tag, size_t tag_len );
+#endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
+
+/**
+ * \brief               The generic all-in-one encryption/decryption function,
+ *                      for all ciphers except AEAD constructs.
+ *
+ * \param ctx           The generic cipher context. This must be initialized.
+ * \param iv            The IV to use, or NONCE_COUNTER for CTR-mode ciphers.
+ *                      This must be a readable buffer of at least \p iv_len
+ *                      Bytes.
+ * \param iv_len        The IV length for ciphers with variable-size IV.
+ *                      This parameter is discarded by ciphers with fixed-size
+ *                      IV.
+ * \param input         The buffer holding the input data. This must be a
+ *                      readable buffer of at least \p ilen Bytes.
+ * \param ilen          The length of the input data in Bytes.
+ * \param output        The buffer for the output data. This must be able to
+ *                      hold at least `ilen + block_size`. This must not be the
+ *                      same buffer as \p input.
+ * \param olen          The length of the output data, to be updated with the
+ *                      actual number of Bytes written. This must not be
+ *                      \c NULL.
+ *
+ * \note                Some ciphers do not use IVs nor nonce. For these
+ *                      ciphers, use \p iv = NULL and \p iv_len = 0.
+ *
+ * \return              \c 0 on success.
+ * \return              #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
+ *                      parameter-verification failure.
+ * \return              #MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED on decryption
+ *                      expecting a full block but not receiving one.
+ * \return              #MBEDTLS_ERR_CIPHER_INVALID_PADDING on invalid padding
+ *                      while decrypting.
+ * \return              A cipher-specific error code on failure.
+ */
+int mbedtls_cipher_crypt( mbedtls_cipher_context_t *ctx,
+                  const unsigned char *iv, size_t iv_len,
+                  const unsigned char *input, size_t ilen,
+                  unsigned char *output, size_t *olen );
+
+#if defined(MBEDTLS_CIPHER_MODE_AEAD)
+/**
+ * \brief               The generic autenticated encryption (AEAD) function.
+ *
+ * \param ctx           The generic cipher context. This must be initialized and
+ *                      bound to a key.
+ * \param iv            The IV to use, or NONCE_COUNTER for CTR-mode ciphers.
+ *                      This must be a readable buffer of at least \p iv_len
+ *                      Bytes.
+ * \param iv_len        The IV length for ciphers with variable-size IV.
+ *                      This parameter is discarded by ciphers with fixed-size IV.
+ * \param ad            The additional data to authenticate. This must be a
+ *                      readable buffer of at least \p ad_len Bytes.
+ * \param ad_len        The length of \p ad.
+ * \param input         The buffer holding the input data. This must be a
+ *                      readable buffer of at least \p ilen Bytes.
+ * \param ilen          The length of the input data.
+ * \param output        The buffer for the output data. This must be able to
+ *                      hold at least \p ilen Bytes.
+ * \param olen          The length of the output data, to be updated with the
+ *                      actual number of Bytes written. This must not be
+ *                      \c NULL.
+ * \param tag           The buffer for the authentication tag. This must be a
+ *                      writable buffer of at least \p tag_len Bytes.
+ * \param tag_len       The desired length of the authentication tag.
+ *
+ * \return              \c 0 on success.
+ * \return              #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
+ *                      parameter-verification failure.
+ * \return              A cipher-specific error code on failure.
+ */
+int mbedtls_cipher_auth_encrypt( mbedtls_cipher_context_t *ctx,
+                         const unsigned char *iv, size_t iv_len,
+                         const unsigned char *ad, size_t ad_len,
+                         const unsigned char *input, size_t ilen,
+                         unsigned char *output, size_t *olen,
+                         unsigned char *tag, size_t tag_len );
+
+/**
+ * \brief               The generic autenticated decryption (AEAD) function.
+ *
+ * \note                If the data is not authentic, then the output buffer
+ *                      is zeroed out to prevent the unauthentic plaintext being
+ *                      used, making this interface safer.
+ *
+ * \param ctx           The generic cipher context. This must be initialized and
+ *                      and bound to a key.
+ * \param iv            The IV to use, or NONCE_COUNTER for CTR-mode ciphers.
+ *                      This must be a readable buffer of at least \p iv_len
+ *                      Bytes.
+ * \param iv_len        The IV length for ciphers with variable-size IV.
+ *                      This parameter is discarded by ciphers with fixed-size IV.
+ * \param ad            The additional data to be authenticated. This must be a
+ *                      readable buffer of at least \p ad_len Bytes.
+ * \param ad_len        The length of \p ad.
+ * \param input         The buffer holding the input data. This must be a
+ *                      readable buffer of at least \p ilen Bytes.
+ * \param ilen          The length of the input data.
+ * \param output        The buffer for the output data.
+ *                      This must be able to hold at least \p ilen Bytes.
+ * \param olen          The length of the output data, to be updated with the
+ *                      actual number of Bytes written. This must not be
+ *                      \c NULL.
+ * \param tag           The buffer holding the authentication tag. This must be
+ *                      a readable buffer of at least \p tag_len Bytes.
+ * \param tag_len       The length of the authentication tag.
+ *
+ * \return              \c 0 on success.
+ * \return              #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
+ *                      parameter-verification failure.
+ * \return              #MBEDTLS_ERR_CIPHER_AUTH_FAILED if data is not authentic.
+ * \return              A cipher-specific error code on failure.
+ */
+int mbedtls_cipher_auth_decrypt( mbedtls_cipher_context_t *ctx,
+                         const unsigned char *iv, size_t iv_len,
+                         const unsigned char *ad, size_t ad_len,
+                         const unsigned char *input, size_t ilen,
+                         unsigned char *output, size_t *olen,
+                         const unsigned char *tag, size_t tag_len );
+#endif /* MBEDTLS_CIPHER_MODE_AEAD */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_CIPHER_H */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/cipher_internal.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/cipher_internal.h
@@ -1,0 +1,125 @@
+/**
+ * \file cipher_internal.h
+ *
+ * \brief Cipher wrappers.
+ *
+ * \author Adriaan de Jong <dejong@fox-it.com>
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_CIPHER_WRAP_H
+#define MBEDTLS_CIPHER_WRAP_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include "cipher.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Base cipher information. The non-mode specific functions and values.
+ */
+struct mbedtls_cipher_base_t
+{
+    /** Base Cipher type (e.g. MBEDTLS_CIPHER_ID_AES) */
+    mbedtls_cipher_id_t cipher;
+
+    /** Encrypt using ECB */
+    int (*ecb_func)( void *ctx, mbedtls_operation_t mode,
+                     const unsigned char *input, unsigned char *output );
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    /** Encrypt using CBC */
+    int (*cbc_func)( void *ctx, mbedtls_operation_t mode, size_t length,
+                     unsigned char *iv, const unsigned char *input,
+                     unsigned char *output );
+#endif
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    /** Encrypt using CFB (Full length) */
+    int (*cfb_func)( void *ctx, mbedtls_operation_t mode, size_t length, size_t *iv_off,
+                     unsigned char *iv, const unsigned char *input,
+                     unsigned char *output );
+#endif
+
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    /** Encrypt using OFB (Full length) */
+    int (*ofb_func)( void *ctx, size_t length, size_t *iv_off,
+                     unsigned char *iv,
+                     const unsigned char *input,
+                     unsigned char *output );
+#endif
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    /** Encrypt using CTR */
+    int (*ctr_func)( void *ctx, size_t length, size_t *nc_off,
+                     unsigned char *nonce_counter, unsigned char *stream_block,
+                     const unsigned char *input, unsigned char *output );
+#endif
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    /** Encrypt or decrypt using XTS. */
+    int (*xts_func)( void *ctx, mbedtls_operation_t mode, size_t length,
+                     const unsigned char data_unit[16],
+                     const unsigned char *input, unsigned char *output );
+#endif
+
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    /** Encrypt using STREAM */
+    int (*stream_func)( void *ctx, size_t length,
+                        const unsigned char *input, unsigned char *output );
+#endif
+
+    /** Set key for encryption purposes */
+    int (*setkey_enc_func)( void *ctx, const unsigned char *key,
+                            unsigned int key_bitlen );
+
+    /** Set key for decryption purposes */
+    int (*setkey_dec_func)( void *ctx, const unsigned char *key,
+                            unsigned int key_bitlen);
+
+    /** Allocate a new context */
+    void * (*ctx_alloc_func)( void );
+
+    /** Free the given context */
+    void (*ctx_free_func)( void *ctx );
+
+};
+
+typedef struct
+{
+    mbedtls_cipher_type_t type;
+    const mbedtls_cipher_info_t *info;
+} mbedtls_cipher_definition_t;
+
+extern const mbedtls_cipher_definition_t mbedtls_cipher_definitions[];
+
+extern int mbedtls_cipher_supported[];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_CIPHER_WRAP_H */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/config.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/config.h
@@ -1,0 +1,3310 @@
+/**
+ * \file config.h
+ *
+ * \brief Configuration options (set of defines)
+ *
+ *  This set of compile-time options may be used to enable
+ *  or disable features selectively, and reduce the global
+ *  memory footprint.
+ */
+/*
+ *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_CONFIG_H
+#define MBEDTLS_CONFIG_H
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
+#define _CRT_SECURE_NO_DEPRECATE 1
+#endif
+
+#include "drv_osal_chip.h"
+
+/**
+ * \name SECTION: System support
+ *
+ * This section sets system specific settings.
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_HAVE_ASM
+ *
+ * The compiler has support for asm().
+ *
+ * Requires support for asm() in compiler.
+ *
+ * Used in:
+ *      library/aria.c
+ *      library/timing.c
+ *      include/mbedtls/bn_mul.h
+ *
+ * Required by:
+ *      MBEDTLS_AESNI_C
+ *      MBEDTLS_PADLOCK_C
+ *
+ * Comment to disable the use of assembly code.
+ */
+//#define MBEDTLS_HAVE_ASM
+
+/**
+ * \def MBEDTLS_NO_UDBL_DIVISION
+ *
+ * The platform lacks support for double-width integer division (64-bit
+ * division on a 32-bit platform, 128-bit division on a 64-bit platform).
+ *
+ * Used in:
+ *      include/mbedtls/bignum.h
+ *      library/bignum.c
+ *
+ * The bignum code uses double-width division to speed up some operations.
+ * Double-width division is often implemented in software that needs to
+ * be linked with the program. The presence of a double-width integer
+ * type is usually detected automatically through preprocessor macros,
+ * but the automatic detection cannot know whether the code needs to
+ * and can be linked with an implementation of division for that type.
+ * By default division is assumed to be usable if the type is present.
+ * Uncomment this option to prevent the use of double-width division.
+ *
+ * Note that division for the native integer type is always required.
+ * Furthermore, a 64-bit type is always required even on a 32-bit
+ * platform, but it need not support multiplication or division. In some
+ * cases it is also desirable to disable some double-width operations. For
+ * example, if double-width division is implemented in software, disabling
+ * it can reduce code size in some embedded targets.
+ */
+//#define MBEDTLS_NO_UDBL_DIVISION
+
+/**
+ * \def MBEDTLS_NO_64BIT_MULTIPLICATION
+ *
+ * The platform lacks support for 32x32 -> 64-bit multiplication.
+ *
+ * Used in:
+ *      library/poly1305.c
+ *
+ * Some parts of the library may use multiplication of two unsigned 32-bit
+ * operands with a 64-bit result in order to speed up computations. On some
+ * platforms, this is not available in hardware and has to be implemented in
+ * software, usually in a library provided by the toolchain.
+ *
+ * Sometimes it is not desirable to have to link to that library. This option
+ * removes the dependency of that library on platforms that lack a hardware
+ * 64-bit multiplier by embedding a software implementation in Mbed TLS.
+ *
+ * Note that depending on the compiler, this may decrease performance compared
+ * to using the library function provided by the toolchain.
+ */
+//#define MBEDTLS_NO_64BIT_MULTIPLICATION
+
+/**
+ * \def MBEDTLS_HAVE_SSE2
+ *
+ * CPU supports SSE2 instruction set.
+ *
+ * Uncomment if the CPU supports SSE2 (IA-32 specific).
+ */
+//#define MBEDTLS_HAVE_SSE2
+
+/**
+ * \def MBEDTLS_HAVE_TIME
+ *
+ * System has time.h and time().
+ * The time does not need to be correct, only time differences are used,
+ * by contrast with MBEDTLS_HAVE_TIME_DATE
+ *
+ * Defining MBEDTLS_HAVE_TIME allows you to specify MBEDTLS_PLATFORM_TIME_ALT,
+ * MBEDTLS_PLATFORM_TIME_MACRO, MBEDTLS_PLATFORM_TIME_TYPE_MACRO and
+ * MBEDTLS_PLATFORM_STD_TIME.
+ *
+ * Comment if your system does not support time functions
+ */
+//#define MBEDTLS_HAVE_TIME
+
+/**
+ * \def MBEDTLS_HAVE_TIME_DATE
+ *
+ * System has time.h, time(), and an implementation for
+ * mbedtls_platform_gmtime_r() (see below).
+ * The time needs to be correct (not necesarily very accurate, but at least
+ * the date should be correct). This is used to verify the validity period of
+ * X.509 certificates.
+ *
+ * Comment if your system does not have a correct clock.
+ *
+ * \note mbedtls_platform_gmtime_r() is an abstraction in platform_util.h that
+ * behaves similarly to the gmtime_r() function from the C standard. Refer to
+ * the documentation for mbedtls_platform_gmtime_r() for more information.
+ *
+ * \note It is possible to configure an implementation for
+ * mbedtls_platform_gmtime_r() at compile-time by using the macro
+ * MBEDTLS_PLATFORM_GMTIME_R_ALT.
+ */
+//#define MBEDTLS_HAVE_TIME_DATE
+
+/**
+ * \def MBEDTLS_PLATFORM_MEMORY
+ *
+ * Enable the memory allocation layer.
+ *
+ * By default mbed TLS uses the system-provided calloc() and free().
+ * This allows different allocators (self-implemented or provided) to be
+ * provided to the platform abstraction layer.
+ *
+ * Enabling MBEDTLS_PLATFORM_MEMORY without the
+ * MBEDTLS_PLATFORM_{FREE,CALLOC}_MACROs will provide
+ * "mbedtls_platform_set_calloc_free()" allowing you to set an alternative calloc() and
+ * free() function pointer at runtime.
+ *
+ * Enabling MBEDTLS_PLATFORM_MEMORY and specifying
+ * MBEDTLS_PLATFORM_{CALLOC,FREE}_MACROs will allow you to specify the
+ * alternate function at compile time.
+ *
+ * Requires: MBEDTLS_PLATFORM_C
+ *
+ * Enable this layer to allow use of alternative memory allocators.
+ */
+#define MBEDTLS_PLATFORM_MEMORY
+
+/**
+ * \def MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+ *
+ * Do not assign standard functions in the platform layer (e.g. calloc() to
+ * MBEDTLS_PLATFORM_STD_CALLOC and printf() to MBEDTLS_PLATFORM_STD_PRINTF)
+ *
+ * This makes sure there are no linking errors on platforms that do not support
+ * these functions. You will HAVE to provide alternatives, either at runtime
+ * via the platform_set_xxx() functions or at compile time by setting
+ * the MBEDTLS_PLATFORM_STD_XXX defines, or enabling a
+ * MBEDTLS_PLATFORM_XXX_MACRO.
+ *
+ * Requires: MBEDTLS_PLATFORM_C
+ *
+ * Uncomment to prevent default assignment of standard functions in the
+ * platform layer.
+ */
+#define MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+
+/**
+ * \def MBEDTLS_PLATFORM_EXIT_ALT
+ *
+ * MBEDTLS_PLATFORM_XXX_ALT: Uncomment a macro to let mbed TLS support the
+ * function in the platform abstraction layer.
+ *
+ * Example: In case you uncomment MBEDTLS_PLATFORM_PRINTF_ALT, mbed TLS will
+ * provide a function "mbedtls_platform_set_printf()" that allows you to set an
+ * alternative printf function pointer.
+ *
+ * All these define require MBEDTLS_PLATFORM_C to be defined!
+ *
+ * \note MBEDTLS_PLATFORM_SNPRINTF_ALT is required on Windows;
+ * it will be enabled automatically by check_config.h
+ *
+ * \warning MBEDTLS_PLATFORM_XXX_ALT cannot be defined at the same time as
+ * MBEDTLS_PLATFORM_XXX_MACRO!
+ *
+ * Requires: MBEDTLS_PLATFORM_TIME_ALT requires MBEDTLS_HAVE_TIME
+ *
+ * Uncomment a macro to enable alternate implementation of specific base
+ * platform function
+ */
+//#define MBEDTLS_PLATFORM_EXIT_ALT
+//#define MBEDTLS_PLATFORM_TIME_ALT
+//#define MBEDTLS_PLATFORM_FPRINTF_ALT
+//#define MBEDTLS_PLATFORM_PRINTF_ALT
+//#define MBEDTLS_PLATFORM_SNPRINTF_ALT
+//#define MBEDTLS_PLATFORM_NV_SEED_ALT
+//#define MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT
+
+/**
+ * \def MBEDTLS_DEPRECATED_WARNING
+ *
+ * Mark deprecated functions so that they generate a warning if used.
+ * Functions deprecated in one version will usually be removed in the next
+ * version. You can enable this to help you prepare the transition to a new
+ * major version by making sure your code is not using these functions.
+ *
+ * This only works with GCC and Clang. With other compilers, you may want to
+ * use MBEDTLS_DEPRECATED_REMOVED
+ *
+ * Uncomment to get warnings on using deprecated functions.
+ */
+//#define MBEDTLS_DEPRECATED_WARNING
+
+/**
+ * \def MBEDTLS_DEPRECATED_REMOVED
+ *
+ * Remove deprecated functions so that they generate an error if used.
+ * Functions deprecated in one version will usually be removed in the next
+ * version. You can enable this to help you prepare the transition to a new
+ * major version by making sure your code is not using these functions.
+ *
+ * Uncomment to get errors on using deprecated functions.
+ */
+//#define MBEDTLS_DEPRECATED_REMOVED
+
+/**
+ * \def MBEDTLS_CHECK_PARAMS
+ *
+ * This configuration option controls whether the library validates more of
+ * the parameters passed to it.
+ *
+ * When this flag is not defined, the library only attempts to validate an
+ * input parameter if: (1) they may come from the outside world (such as the
+ * network, the filesystem, etc.) or (2) not validating them could result in
+ * internal memory errors such as overflowing a buffer controlled by the
+ * library. On the other hand, it doesn't attempt to validate parameters whose
+ * values are fully controlled by the application (such as pointers).
+ *
+ * When this flag is defined, the library additionally attempts to validate
+ * parameters that are fully controlled by the application, and should always
+ * be valid if the application code is fully correct and trusted.
+ *
+ * For example, when a function accepts as input a pointer to a buffer that may
+ * contain untrusted data, and its documentation mentions that this pointer
+ * must not be NULL:
+ * - the pointer is checked to be non-NULL only if this option is enabled
+ * - the content of the buffer is always validated
+ *
+ * When this flag is defined, if a library function receives a parameter that
+ * is invalid, it will:
+ * - invoke the macro MBEDTLS_PARAM_FAILED() which by default expands to a
+ *   call to the function mbedtls_param_failed()
+ * - immediately return (with a specific error code unless the function
+ *   returns void and can't communicate an error).
+ *
+ * When defining this flag, you also need to:
+ * - either provide a definition of the function mbedtls_param_failed() in
+ *   your application (see platform_util.h for its prototype) as the library
+ *   calls that function, but does not provide a default definition for it,
+ * - or provide a different definition of the macro MBEDTLS_PARAM_FAILED()
+ *   below if the above mechanism is not flexible enough to suit your needs.
+ *   See the documentation of this macro later in this file.
+ *
+ * Uncomment to enable validation of application-controlled parameters.
+ */
+//#define MBEDTLS_CHECK_PARAMS
+
+/* \} name SECTION: System support */
+
+/**
+ * \name SECTION: mbed TLS feature support
+ *
+ * This section sets support for features that are or are not needed
+ * within the modules that are enabled.
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_TIMING_ALT
+ *
+ * Uncomment to provide your own alternate implementation for mbedtls_timing_hardclock(),
+ * mbedtls_timing_get_timer(), mbedtls_set_alarm(), mbedtls_set/get_delay()
+ *
+ * Only works if you have MBEDTLS_TIMING_C enabled.
+ *
+ * You will need to provide a header "timing_alt.h" and an implementation at
+ * compile time.
+ */
+//#define MBEDTLS_TIMING_ALT
+
+/**
+ * \def MBEDTLS_AES_ALT
+ *
+ * MBEDTLS__MODULE_NAME__ALT: Uncomment a macro to let mbed TLS use your
+ * alternate core implementation of a symmetric crypto, an arithmetic or hash
+ * module (e.g. platform specific assembly optimized implementations). Keep
+ * in mind that the function prototypes should remain the same.
+ *
+ * This replaces the whole module. If you only want to replace one of the
+ * functions, use one of the MBEDTLS__FUNCTION_NAME__ALT flags.
+ *
+ * Example: In case you uncomment MBEDTLS_AES_ALT, mbed TLS will no longer
+ * provide the "struct mbedtls_aes_context" definition and omit the base
+ * function declarations and implementations. "aes_alt.h" will be included from
+ * "aes.h" to include the new function definitions.
+ *
+ * Uncomment a macro to enable alternate implementation of the corresponding
+ * module.
+ *
+ * \warning   MD2, MD4, MD5, ARC4, DES and SHA-1 are considered weak and their
+ *            use constitutes a security risk. If possible, we recommend
+ *            avoiding dependencies on them, and considering stronger message
+ *            digests and ciphers instead.
+ *
+ */
+//#define MBEDTLS_AES_ALT
+//#define MBEDTLS_ARC4_ALT
+//#define MBEDTLS_ARIA_ALT
+//#define MBEDTLS_BLOWFISH_ALT
+//#define MBEDTLS_CAMELLIA_ALT
+//#define MBEDTLS_CCM_ALT
+//#define MBEDTLS_CHACHA20_ALT
+//#define MBEDTLS_CHACHAPOLY_ALT
+//#define MBEDTLS_CMAC_ALT
+//#define MBEDTLS_DES_ALT
+//#define MBEDTLS_DHM_ALT
+//#define MBEDTLS_ECJPAKE_ALT
+//#define MBEDTLS_GCM_ALT
+//#define MBEDTLS_NIST_KW_ALT
+//#define MBEDTLS_MD2_ALT
+//#define MBEDTLS_MD4_ALT
+//#define MBEDTLS_MD5_ALT
+//#define MBEDTLS_POLY1305_ALT
+//#define MBEDTLS_RIPEMD160_ALT
+//#define MBEDTLS_RSA_ALT
+//#define MBEDTLS_SHA1_ALT
+//#define MBEDTLS_SHA256_ALT
+//#define MBEDTLS_SHA512_ALT
+//#define MBEDTLS_XTEA_ALT
+
+/*
+ * When replacing the elliptic curve module, pleace consider, that it is
+ * implemented with two .c files:
+ *      - ecp.c
+ *      - ecp_curves.c
+ * You can replace them very much like all the other MBEDTLS__MODULE_NAME__ALT
+ * macros as described above. The only difference is that you have to make sure
+ * that you provide functionality for both .c files.
+ */
+//#define MBEDTLS_ECP_ALT
+
+/**
+ * \def MBEDTLS_MD2_PROCESS_ALT
+ *
+ * MBEDTLS__FUNCTION_NAME__ALT: Uncomment a macro to let mbed TLS use you
+ * alternate core implementation of symmetric crypto or hash function. Keep in
+ * mind that function prototypes should remain the same.
+ *
+ * This replaces only one function. The header file from mbed TLS is still
+ * used, in contrast to the MBEDTLS__MODULE_NAME__ALT flags.
+ *
+ * Example: In case you uncomment MBEDTLS_SHA256_PROCESS_ALT, mbed TLS will
+ * no longer provide the mbedtls_sha1_process() function, but it will still provide
+ * the other function (using your mbedtls_sha1_process() function) and the definition
+ * of mbedtls_sha1_context, so your implementation of mbedtls_sha1_process must be compatible
+ * with this definition.
+ *
+ * \note Because of a signature change, the core AES encryption and decryption routines are
+ *       currently named mbedtls_aes_internal_encrypt and mbedtls_aes_internal_decrypt,
+ *       respectively. When setting up alternative implementations, these functions should
+ *       be overriden, but the wrapper functions mbedtls_aes_decrypt and mbedtls_aes_encrypt
+ *       must stay untouched.
+ *
+ * \note If you use the AES_xxx_ALT macros, then is is recommended to also set
+ *       MBEDTLS_AES_ROM_TABLES in order to help the linker garbage-collect the AES
+ *       tables.
+ *
+ * Uncomment a macro to enable alternate implementation of the corresponding
+ * function.
+ *
+ * \warning   MD2, MD4, MD5, DES and SHA-1 are considered weak and their use
+ *            constitutes a security risk. If possible, we recommend avoiding
+ *            dependencies on them, and considering stronger message digests
+ *            and ciphers instead.
+ *
+ */
+//#define MBEDTLS_MD2_PROCESS_ALT
+//#define MBEDTLS_MD4_PROCESS_ALT
+//#define MBEDTLS_MD5_PROCESS_ALT
+//#define MBEDTLS_RIPEMD160_PROCESS_ALT
+//#define MBEDTLS_SHA1_PROCESS_ALT
+//#define MBEDTLS_SHA256_PROCESS_ALT
+//#define MBEDTLS_SHA512_PROCESS_ALT
+//#define MBEDTLS_DES_SETKEY_ALT
+//#define MBEDTLS_DES_CRYPT_ECB_ALT
+//#define MBEDTLS_DES3_CRYPT_ECB_ALT
+//#define MBEDTLS_AES_SETKEY_ENC_ALT
+//#define MBEDTLS_AES_SETKEY_DEC_ALT
+//#define MBEDTLS_AES_ENCRYPT_ALT
+//#define MBEDTLS_AES_DECRYPT_ALT
+//#define MBEDTLS_ECDH_GEN_PUBLIC_ALT
+//#define MBEDTLS_ECDH_COMPUTE_SHARED_ALT
+//#define MBEDTLS_ECDSA_VERIFY_ALT
+//#define MBEDTLS_ECDSA_SIGN_ALT
+//#define MBEDTLS_ECDSA_GENKEY_ALT
+
+/**
+ * \def MBEDTLS_ECP_INTERNAL_ALT
+ *
+ * Expose a part of the internal interface of the Elliptic Curve Point module.
+ *
+ * MBEDTLS_ECP__FUNCTION_NAME__ALT: Uncomment a macro to let mbed TLS use your
+ * alternative core implementation of elliptic curve arithmetic. Keep in mind
+ * that function prototypes should remain the same.
+ *
+ * This partially replaces one function. The header file from mbed TLS is still
+ * used, in contrast to the MBEDTLS_ECP_ALT flag. The original implementation
+ * is still present and it is used for group structures not supported by the
+ * alternative.
+ *
+ * Any of these options become available by defining MBEDTLS_ECP_INTERNAL_ALT
+ * and implementing the following functions:
+ *      unsigned char mbedtls_internal_ecp_grp_capable(
+ *          const mbedtls_ecp_group *grp )
+ *      int  mbedtls_internal_ecp_init( const mbedtls_ecp_group *grp )
+ *      void mbedtls_internal_ecp_free( const mbedtls_ecp_group *grp )
+ * The mbedtls_internal_ecp_grp_capable function should return 1 if the
+ * replacement functions implement arithmetic for the given group and 0
+ * otherwise.
+ * The functions mbedtls_internal_ecp_init and mbedtls_internal_ecp_free are
+ * called before and after each point operation and provide an opportunity to
+ * implement optimized set up and tear down instructions.
+ *
+ * Example: In case you uncomment MBEDTLS_ECP_INTERNAL_ALT and
+ * MBEDTLS_ECP_DOUBLE_JAC_ALT, mbed TLS will still provide the ecp_double_jac
+ * function, but will use your mbedtls_internal_ecp_double_jac if the group is
+ * supported (your mbedtls_internal_ecp_grp_capable function returns 1 when
+ * receives it as an argument). If the group is not supported then the original
+ * implementation is used. The other functions and the definition of
+ * mbedtls_ecp_group and mbedtls_ecp_point will not change, so your
+ * implementation of mbedtls_internal_ecp_double_jac and
+ * mbedtls_internal_ecp_grp_capable must be compatible with this definition.
+ *
+ * Uncomment a macro to enable alternate implementation of the corresponding
+ * function.
+ */
+/* Required for all the functions in this section */
+//#define MBEDTLS_ECP_INTERNAL_ALT
+/* Support for Weierstrass curves with Jacobi representation */
+//#define MBEDTLS_ECP_RANDOMIZE_JAC_ALT
+//#define MBEDTLS_ECP_ADD_MIXED_ALT
+//#define MBEDTLS_ECP_DOUBLE_JAC_ALT
+//#define MBEDTLS_ECP_NORMALIZE_JAC_MANY_ALT
+//#define MBEDTLS_ECP_NORMALIZE_JAC_ALT
+/* Support for curves with Montgomery arithmetic */
+//#define MBEDTLS_ECP_DOUBLE_ADD_MXZ_ALT
+//#define MBEDTLS_ECP_RANDOMIZE_MXZ_ALT
+//#define MBEDTLS_ECP_NORMALIZE_MXZ_ALT
+
+/**
+ * \def MBEDTLS_TEST_NULL_ENTROPY
+ *
+ * Enables testing and use of mbed TLS without any configured entropy sources.
+ * This permits use of the library on platforms before an entropy source has
+ * been integrated (see for example the MBEDTLS_ENTROPY_HARDWARE_ALT or the
+ * MBEDTLS_ENTROPY_NV_SEED switches).
+ *
+ * WARNING! This switch MUST be disabled in production builds, and is suitable
+ * only for development.
+ * Enabling the switch negates any security provided by the library.
+ *
+ * Requires MBEDTLS_ENTROPY_C, MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+ *
+ */
+//#define MBEDTLS_TEST_NULL_ENTROPY
+
+/**
+ * \def MBEDTLS_ENTROPY_HARDWARE_ALT
+ *
+ * Uncomment this macro to let mbed TLS use your own implementation of a
+ * hardware entropy collector.
+ *
+ * Your function must be called \c mbedtls_hardware_poll(), have the same
+ * prototype as declared in entropy_poll.h, and accept NULL as first argument.
+ *
+ * Uncomment to use your own hardware entropy collector.
+ */
+//#define MBEDTLS_ENTROPY_HARDWARE_ALT
+
+/**
+ * \def MBEDTLS_AES_ROM_TABLES
+ *
+ * Use precomputed AES tables stored in ROM.
+ *
+ * Uncomment this macro to use precomputed AES tables stored in ROM.
+ * Comment this macro to generate AES tables in RAM at runtime.
+ *
+ * Tradeoff: Using precomputed ROM tables reduces RAM usage by ~8kb
+ * (or ~2kb if \c MBEDTLS_AES_FEWER_TABLES is used) and reduces the
+ * initialization time before the first AES operation can be performed.
+ * It comes at the cost of additional ~8kb ROM use (resp. ~2kb if \c
+ * MBEDTLS_AES_FEWER_TABLES below is used), and potentially degraded
+ * performance if ROM access is slower than RAM access.
+ *
+ * This option is independent of \c MBEDTLS_AES_FEWER_TABLES.
+ *
+ */
+//#define MBEDTLS_AES_ROM_TABLES
+
+/**
+ * \def MBEDTLS_AES_FEWER_TABLES
+ *
+ * Use less ROM/RAM for AES tables.
+ *
+ * Uncommenting this macro omits 75% of the AES tables from
+ * ROM / RAM (depending on the value of \c MBEDTLS_AES_ROM_TABLES)
+ * by computing their values on the fly during operations
+ * (the tables are entry-wise rotations of one another).
+ *
+ * Tradeoff: Uncommenting this reduces the RAM / ROM footprint
+ * by ~6kb but at the cost of more arithmetic operations during
+ * runtime. Specifically, one has to compare 4 accesses within
+ * different tables to 4 accesses with additional arithmetic
+ * operations within the same table. The performance gain/loss
+ * depends on the system and memory details.
+ *
+ * This option is independent of \c MBEDTLS_AES_ROM_TABLES.
+ *
+ */
+//#define MBEDTLS_AES_FEWER_TABLES
+
+/**
+ * \def MBEDTLS_CAMELLIA_SMALL_MEMORY
+ *
+ * Use less ROM for the Camellia implementation (saves about 768 bytes).
+ *
+ * Uncomment this macro to use less memory for Camellia.
+ */
+//#define MBEDTLS_CAMELLIA_SMALL_MEMORY
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_CBC
+ *
+ * Enable Cipher Block Chaining mode (CBC) for symmetric ciphers.
+ */
+#if defined(SOFT_AES_SUPPORT) || defined(SOFT_TDES_SUPPORT)
+#define MBEDTLS_CIPHER_MODE_CBC
+#endif
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_CFB
+ *
+ * Enable Cipher Feedback mode (CFB) for symmetric ciphers.
+ */
+#if defined(SOFT_AES_SUPPORT)
+#define MBEDTLS_CIPHER_MODE_CFB
+#endif
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_CTR
+ *
+ * Enable Counter Block Cipher mode (CTR) for symmetric ciphers.
+ */
+#if defined(SOFT_AES_SUPPORT)
+#define MBEDTLS_CIPHER_MODE_CTR
+#endif
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_OFB
+ *
+ * Enable Output Feedback mode (OFB) for symmetric ciphers.
+ */
+#if defined(SOFT_AES_SUPPORT)
+#define MBEDTLS_CIPHER_MODE_OFB
+#endif
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_XTS
+ *
+ * Enable Xor-encrypt-xor with ciphertext stealing mode (XTS) for AES.
+ */
+//#define MBEDTLS_CIPHER_MODE_XTS
+
+/**
+ * \def MBEDTLS_CIPHER_NULL_CIPHER
+ *
+ * Enable NULL cipher.
+ * Warning: Only do so when you know what you are doing. This allows for
+ * encryption or channels without any security!
+ *
+ * Requires MBEDTLS_ENABLE_WEAK_CIPHERSUITES as well to enable
+ * the following ciphersuites:
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_NULL_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_NULL_SHA
+ *      MBEDTLS_TLS_RSA_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_RSA_WITH_NULL_MD5
+ *      MBEDTLS_TLS_RSA_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_NULL_SHA
+ *      MBEDTLS_TLS_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_NULL_SHA
+ *
+ * Uncomment this macro to enable the NULL cipher and ciphersuites
+ */
+//#define MBEDTLS_CIPHER_NULL_CIPHER
+
+/**
+ * \def MBEDTLS_CIPHER_PADDING_PKCS7
+ *
+ * MBEDTLS_CIPHER_PADDING_XXX: Uncomment or comment macros to add support for
+ * specific padding modes in the cipher layer with cipher modes that support
+ * padding (e.g. CBC)
+ *
+ * If you disable all padding modes, only full blocks can be used with CBC.
+ *
+ * Enable padding modes in the cipher layer.
+ */
+//#define MBEDTLS_CIPHER_PADDING_PKCS7
+//#define MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
+//#define MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
+//#define MBEDTLS_CIPHER_PADDING_ZEROS
+
+/**
+ * \def MBEDTLS_ENABLE_WEAK_CIPHERSUITES
+ *
+ * Enable weak ciphersuites in SSL / TLS.
+ * Warning: Only do so when you know what you are doing. This allows for
+ * channels with virtually no security at all!
+ *
+ * This enables the following ciphersuites:
+ *      MBEDTLS_TLS_RSA_WITH_DES_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_DES_CBC_SHA
+ *
+ * Uncomment this macro to enable weak ciphersuites
+ *
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
+ */
+//#define MBEDTLS_ENABLE_WEAK_CIPHERSUITES
+
+/**
+ * \def MBEDTLS_REMOVE_ARC4_CIPHERSUITES
+ *
+ * Remove RC4 ciphersuites by default in SSL / TLS.
+ * This flag removes the ciphersuites based on RC4 from the default list as
+ * returned by mbedtls_ssl_list_ciphersuites(). However, it is still possible to
+ * enable (some of) them with mbedtls_ssl_conf_ciphersuites() by including them
+ * explicitly.
+ *
+ * Uncomment this macro to remove RC4 ciphersuites by default.
+ */
+//#define MBEDTLS_REMOVE_ARC4_CIPHERSUITES
+
+/**
+ * \def MBEDTLS_ECP_DP_SECP192R1_ENABLED
+ *
+ * MBEDTLS_ECP_XXXX_ENABLED: Enables specific curves within the Elliptic Curve
+ * module.  By default all supported curves are enabled.
+ *
+ * Comment macros to disable the curve and functions for it
+ */
+//#define MBEDTLS_ECP_DP_SECP192R1_ENABLED
+//#define MBEDTLS_ECP_DP_SECP224R1_ENABLED
+#if defined(SOFT_SM2_SUPPORT) || defined(SOFT_ECC_SUPPORT)
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+#endif
+//#define MBEDTLS_ECP_DP_SECP384R1_ENABLED
+//#define MBEDTLS_ECP_DP_SECP521R1_ENABLED
+//#define MBEDTLS_ECP_DP_SECP192K1_ENABLED
+//#define MBEDTLS_ECP_DP_SECP224K1_ENABLED
+//#define MBEDTLS_ECP_DP_SECP256K1_ENABLED
+//#define MBEDTLS_ECP_DP_BP256R1_ENABLED
+//#define MBEDTLS_ECP_DP_BP384R1_ENABLED
+//#define MBEDTLS_ECP_DP_BP512R1_ENABLED
+//#define MBEDTLS_ECP_DP_CURVE25519_ENABLED
+
+/**
+ * \def MBEDTLS_ECP_NIST_OPTIM
+ *
+ * Enable specific 'modulo p' routines for each NIST prime.
+ * Depending on the prime and architecture, makes operations 4 to 8 times
+ * faster on the corresponding curve.
+ *
+ * Comment this macro to disable NIST curves optimisation.
+ */
+//#define MBEDTLS_ECP_NIST_OPTIM
+
+/**
+ * \def MBEDTLS_ECP_RESTARTABLE
+ *
+ * Enable "non-blocking" ECC operations that can return early and be resumed.
+ *
+ * This allows various functions to pause by returning
+ * #MBEDTLS_ERR_ECP_IN_PROGRESS (or, for functions in the SSL module,
+ * #MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) and then be called later again in
+ * order to further progress and eventually complete their operation. This is
+ * controlled through mbedtls_ecp_set_max_ops() which limits the maximum
+ * number of ECC operations a function may perform before pausing; see
+ * mbedtls_ecp_set_max_ops() for more information.
+ *
+ * This is useful in non-threaded environments if you want to avoid blocking
+ * for too long on ECC (and, hence, X.509 or SSL/TLS) operations.
+ *
+ * Uncomment this macro to enable restartable ECC computations.
+ *
+ * \note  This option only works with the default software implementation of
+ *        elliptic curve functionality. It is incompatible with
+ *        MBEDTLS_ECP_ALT, MBEDTLS_ECDH_XXX_ALT and MBEDTLS_ECDSA_XXX_ALT.
+ */
+//#define MBEDTLS_ECP_RESTARTABLE
+
+/**
+ * \def MBEDTLS_ECDSA_DETERMINISTIC
+ *
+ * Enable deterministic ECDSA (RFC 6979).
+ * Standard ECDSA is "fragile" in the sense that lack of entropy when signing
+ * may result in a compromise of the long-term signing key. This is avoided by
+ * the deterministic variant.
+ *
+ * Requires: MBEDTLS_HMAC_DRBG_C
+ *
+ * Comment this macro to disable deterministic ECDSA.
+ */
+//#define MBEDTLS_ECDSA_DETERMINISTIC
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+ *
+ * Enable the PSK based ciphersuite modes in SSL / TLS.
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_RC4_128_SHA
+ */
+//#define MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
+ *
+ * Enable the DHE-PSK based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_DHM_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_RC4_128_SHA
+ *
+ * \warning    Using DHE constitutes a security risk as it
+ *             is not possible to validate custom DH parameters.
+ *             If possible, it is recommended users should consider
+ *             preferring other methods of key exchange.
+ *             See dhm.h for more details.
+ *
+ */
+//#define MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
+ *
+ * Enable the ECDHE-PSK based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_RC4_128_SHA
+ */
+//#define MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
+ *
+ * Enable the RSA-PSK based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
+ */
+//#define MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+ *
+ * Enable the RSA-only based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_RSA_WITH_RC4_128_MD5
+ */
+//#define MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+ *
+ * Enable the DHE-RSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_DHM_C, MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+ */
+//#define MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+ *
+ * Enable the ECDHE-RSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_RC4_128_SHA
+ */
+//#define MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+ *
+ * Enable the ECDHE-ECDSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_ECDSA_C, MBEDTLS_X509_CRT_PARSE_C,
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+ */
+//#define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
+ *
+ * Enable the ECDH-ECDSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ */
+//#define MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
+ *
+ * Enable the ECDH-RSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ */
+//#define MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+ *
+ * Enable the ECJPAKE based ciphersuite modes in SSL / TLS.
+ *
+ * \warning This is currently experimental. EC J-PAKE support is based on the
+ * Thread v1.0.0 specification; incompatible changes to the specification
+ * might still happen. For this reason, this is disabled by default.
+ *
+ * Requires: MBEDTLS_ECJPAKE_C
+ *           MBEDTLS_SHA256_C
+ *           MBEDTLS_ECP_DP_SECP256R1_ENABLED
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
+ */
+//#define MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+
+/**
+ * \def MBEDTLS_PK_PARSE_EC_EXTENDED
+ *
+ * Enhance support for reading EC keys using variants of SEC1 not allowed by
+ * RFC 5915 and RFC 5480.
+ *
+ * Currently this means parsing the SpecifiedECDomain choice of EC
+ * parameters (only known groups are supported, not arbitrary domains, to
+ * avoid validation issues).
+ *
+ * Disable if you only need to support RFC 5915 + 5480 key formats.
+ */
+//#define MBEDTLS_PK_PARSE_EC_EXTENDED
+
+/**
+ * \def MBEDTLS_ERROR_STRERROR_DUMMY
+ *
+ * Enable a dummy error function to make use of mbedtls_strerror() in
+ * third party libraries easier when MBEDTLS_ERROR_C is disabled
+ * (no effect when MBEDTLS_ERROR_C is enabled).
+ *
+ * You can safely disable this if MBEDTLS_ERROR_C is enabled, or if you're
+ * not using mbedtls_strerror() or error_strerror() in your application.
+ *
+ * Disable if you run into name conflicts and want to really remove the
+ * mbedtls_strerror()
+ */
+//#define MBEDTLS_ERROR_STRERROR_DUMMY
+
+/**
+ * \def MBEDTLS_GENPRIME
+ *
+ * Enable the prime-number generation code.
+ *
+ * Requires: MBEDTLS_BIGNUM_C
+ */
+#define MBEDTLS_GENPRIME
+
+/**
+ * \def MBEDTLS_FS_IO
+ *
+ * Enable functions that use the filesystem.
+ */
+//#define MBEDTLS_FS_IO
+
+/**
+ * \def MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+ *
+ * Do not add default entropy sources. These are the platform specific,
+ * mbedtls_timing_hardclock and HAVEGE based poll functions.
+ *
+ * This is useful to have more control over the added entropy sources in an
+ * application.
+ *
+ * Uncomment this macro to prevent loading of default entropy functions.
+ */
+//#define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+
+/**
+ * \def MBEDTLS_NO_PLATFORM_ENTROPY
+ *
+ * Do not use built-in platform entropy functions.
+ * This is useful if your platform does not support
+ * standards like the /dev/urandom or Windows CryptoAPI.
+ *
+ * Uncomment this macro to disable the built-in platform entropy functions.
+ */
+//#define MBEDTLS_NO_PLATFORM_ENTROPY
+
+/**
+ * \def MBEDTLS_ENTROPY_FORCE_SHA256
+ *
+ * Force the entropy accumulator to use a SHA-256 accumulator instead of the
+ * default SHA-512 based one (if both are available).
+ *
+ * Requires: MBEDTLS_SHA256_C
+ *
+ * On 32-bit systems SHA-256 can be much faster than SHA-512. Use this option
+ * if you have performance concerns.
+ *
+ * This option is only useful if both MBEDTLS_SHA256_C and
+ * MBEDTLS_SHA512_C are defined. Otherwise the available hash module is used.
+ */
+//#define MBEDTLS_ENTROPY_FORCE_SHA256
+
+/**
+ * \def MBEDTLS_ENTROPY_NV_SEED
+ *
+ * Enable the non-volatile (NV) seed file-based entropy source.
+ * (Also enables the NV seed read/write functions in the platform layer)
+ *
+ * This is crucial (if not required) on systems that do not have a
+ * cryptographic entropy source (in hardware or kernel) available.
+ *
+ * Requires: MBEDTLS_ENTROPY_C, MBEDTLS_PLATFORM_C
+ *
+ * \note The read/write functions that are used by the entropy source are
+ *       determined in the platform layer, and can be modified at runtime and/or
+ *       compile-time depending on the flags (MBEDTLS_PLATFORM_NV_SEED_*) used.
+ *
+ * \note If you use the default implementation functions that read a seedfile
+ *       with regular fopen(), please make sure you make a seedfile with the
+ *       proper name (defined in MBEDTLS_PLATFORM_STD_NV_SEED_FILE) and at
+ *       least MBEDTLS_ENTROPY_BLOCK_SIZE bytes in size that can be read from
+ *       and written to or you will get an entropy source error! The default
+ *       implementation will only use the first MBEDTLS_ENTROPY_BLOCK_SIZE
+ *       bytes from the file.
+ *
+ * \note The entropy collector will write to the seed file before entropy is
+ *       given to an external source, to update it.
+ */
+//#define MBEDTLS_ENTROPY_NV_SEED
+
+/**
+ * \def MBEDTLS_MEMORY_DEBUG
+ *
+ * Enable debugging of buffer allocator memory issues. Automatically prints
+ * (to stderr) all (fatal) messages on memory allocation issues. Enables
+ * function for 'debug output' of allocated memory.
+ *
+ * Requires: MBEDTLS_MEMORY_BUFFER_ALLOC_C
+ *
+ * Uncomment this macro to let the buffer allocator print out error messages.
+ */
+//#define MBEDTLS_MEMORY_DEBUG
+
+/**
+ * \def MBEDTLS_MEMORY_BACKTRACE
+ *
+ * Include backtrace information with each allocated block.
+ *
+ * Requires: MBEDTLS_MEMORY_BUFFER_ALLOC_C
+ *           GLIBC-compatible backtrace() an backtrace_symbols() support
+ *
+ * Uncomment this macro to include backtrace information
+ */
+//#define MBEDTLS_MEMORY_BACKTRACE
+
+/**
+ * \def MBEDTLS_PK_RSA_ALT_SUPPORT
+ *
+ * Support external private RSA keys (eg from a HSM) in the PK layer.
+ *
+ * Comment this macro to disable support for external private RSA keys.
+ */
+//#define MBEDTLS_PK_RSA_ALT_SUPPORT
+
+/**
+ * \def MBEDTLS_PKCS1_V15
+ *
+ * Enable support for PKCS#1 v1.5 encoding.
+ *
+ * Requires: MBEDTLS_RSA_C
+ *
+ * This enables support for PKCS#1 v1.5 operations.
+ */
+#define MBEDTLS_PKCS1_V15
+
+/**
+ * \def MBEDTLS_PKCS1_V21
+ *
+ * Enable support for PKCS#1 v2.1 encoding.
+ *
+ * Requires: MBEDTLS_MD_C, MBEDTLS_RSA_C
+ *
+ * This enables support for RSAES-OAEP and RSASSA-PSS operations.
+ */
+#define MBEDTLS_PKCS1_V21
+
+/**
+ * \def MBEDTLS_RSA_NO_CRT
+ *
+ * Do not use the Chinese Remainder Theorem for the RSA private operation.
+ *
+ * Uncomment this macro to disable the use of CRT in RSA.
+ *
+ */
+#define MBEDTLS_RSA_NO_CRT
+
+/**
+ * \def MBEDTLS_SELF_TEST
+ *
+ * Enable the checkup functions (*_self_test).
+ */
+//#define MBEDTLS_SELF_TEST
+
+/**
+ * \def MBEDTLS_SHA256_SMALLER
+ *
+ * Enable an implementation of SHA-256 that has lower ROM footprint but also
+ * lower performance.
+ *
+ * The default implementation is meant to be a reasonnable compromise between
+ * performance and size. This version optimizes more aggressively for size at
+ * the expense of performance. Eg on Cortex-M4 it reduces the size of
+ * mbedtls_sha256_process() from ~2KB to ~0.5KB for a performance hit of about
+ * 30%.
+ *
+ * Uncomment to enable the smaller implementation of SHA256.
+ */
+//#define MBEDTLS_SHA256_SMALLER
+
+/**
+ * \def MBEDTLS_SSL_ALL_ALERT_MESSAGES
+ *
+ * Enable sending of alert messages in case of encountered errors as per RFC.
+ * If you choose not to send the alert messages, mbed TLS can still communicate
+ * with other servers, only debugging of failures is harder.
+ *
+ * The advantage of not sending alert messages, is that no information is given
+ * about reasons for failures thus preventing adversaries of gaining intel.
+ *
+ * Enable sending of all alert messages
+ */
+//#define MBEDTLS_SSL_ALL_ALERT_MESSAGES
+
+/**
+ * \def MBEDTLS_SSL_ASYNC_PRIVATE
+ *
+ * Enable asynchronous external private key operations in SSL. This allows
+ * you to configure an SSL connection to call an external cryptographic
+ * module to perform private key operations instead of performing the
+ * operation inside the library.
+ *
+ */
+//#define MBEDTLS_SSL_ASYNC_PRIVATE
+
+/**
+ * \def MBEDTLS_SSL_DEBUG_ALL
+ *
+ * Enable the debug messages in SSL module for all issues.
+ * Debug messages have been disabled in some places to prevent timing
+ * attacks due to (unbalanced) debugging function calls.
+ *
+ * If you need all error reporting you should enable this during debugging,
+ * but remove this for production servers that should log as well.
+ *
+ * Uncomment this macro to report all debug messages on errors introducing
+ * a timing side-channel.
+ *
+ */
+//#define MBEDTLS_SSL_DEBUG_ALL
+
+/** \def MBEDTLS_SSL_ENCRYPT_THEN_MAC
+ *
+ * Enable support for Encrypt-then-MAC, RFC 7366.
+ *
+ * This allows peers that both support it to use a more robust protection for
+ * ciphersuites using CBC, providing deep resistance against timing attacks
+ * on the padding or underlying cipher.
+ *
+ * This only affects CBC ciphersuites, and is useless if none is defined.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_TLS1    or
+ *           MBEDTLS_SSL_PROTO_TLS1_1  or
+ *           MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Comment this macro to disable support for Encrypt-then-MAC
+ */
+//#define MBEDTLS_SSL_ENCRYPT_THEN_MAC
+
+/** \def MBEDTLS_SSL_EXTENDED_MASTER_SECRET
+ *
+ * Enable support for Extended Master Secret, aka Session Hash
+ * (draft-ietf-tls-session-hash-02).
+ *
+ * This was introduced as "the proper fix" to the Triple Handshake familiy of
+ * attacks, but it is recommended to always use it (even if you disable
+ * renegotiation), since it actually fixes a more fundamental issue in the
+ * original SSL/TLS design, and has implications beyond Triple Handshake.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_TLS1    or
+ *           MBEDTLS_SSL_PROTO_TLS1_1  or
+ *           MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Comment this macro to disable support for Extended Master Secret.
+ */
+//#define MBEDTLS_SSL_EXTENDED_MASTER_SECRET
+
+/**
+ * \def MBEDTLS_SSL_FALLBACK_SCSV
+ *
+ * Enable support for FALLBACK_SCSV (draft-ietf-tls-downgrade-scsv-00).
+ *
+ * For servers, it is recommended to always enable this, unless you support
+ * only one version of TLS, or know for sure that none of your clients
+ * implements a fallback strategy.
+ *
+ * For clients, you only need this if you're using a fallback strategy, which
+ * is not recommended in the first place, unless you absolutely need it to
+ * interoperate with buggy (version-intolerant) servers.
+ *
+ * Comment this macro to disable support for FALLBACK_SCSV
+ */
+//#define MBEDTLS_SSL_FALLBACK_SCSV
+
+/**
+ * \def MBEDTLS_SSL_HW_RECORD_ACCEL
+ *
+ * Enable hooking functions in SSL module for hardware acceleration of
+ * individual records.
+ *
+ * Uncomment this macro to enable hooking functions.
+ */
+//#define MBEDTLS_SSL_HW_RECORD_ACCEL
+
+/**
+ * \def MBEDTLS_SSL_CBC_RECORD_SPLITTING
+ *
+ * Enable 1/n-1 record splitting for CBC mode in SSLv3 and TLS 1.0.
+ *
+ * This is a countermeasure to the BEAST attack, which also minimizes the risk
+ * of interoperability issues compared to sending 0-length records.
+ *
+ * Comment this macro to disable 1/n-1 record splitting.
+ */
+//#define MBEDTLS_SSL_CBC_RECORD_SPLITTING
+
+/**
+ * \def MBEDTLS_SSL_RENEGOTIATION
+ *
+ * Enable support for TLS renegotiation.
+ *
+ * The two main uses of renegotiation are (1) refresh keys on long-lived
+ * connections and (2) client authentication after the initial handshake.
+ * If you don't need renegotiation, it's probably better to disable it, since
+ * it has been associated with security issues in the past and is easy to
+ * misuse/misunderstand.
+ *
+ * Comment this to disable support for renegotiation.
+ *
+ * \note   Even if this option is disabled, both client and server are aware
+ *         of the Renegotiation Indication Extension (RFC 5746) used to
+ *         prevent the SSL renegotiation attack (see RFC 5746 Sect. 1).
+ *         (See \c mbedtls_ssl_conf_legacy_renegotiation for the
+ *          configuration of this extension).
+ *
+ */
+//#define MBEDTLS_SSL_RENEGOTIATION
+
+/**
+ * \def MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO
+ *
+ * Enable support for receiving and parsing SSLv2 Client Hello messages for the
+ * SSL Server module (MBEDTLS_SSL_SRV_C).
+ *
+ * Uncomment this macro to enable support for SSLv2 Client Hello messages.
+ */
+//#define MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO
+
+/**
+ * \def MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE
+ *
+ * Pick the ciphersuite according to the client's preferences rather than ours
+ * in the SSL Server module (MBEDTLS_SSL_SRV_C).
+ *
+ * Uncomment this macro to respect client's ciphersuite order
+ */
+//#define MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE
+
+/**
+ * \def MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+ *
+ * Enable support for RFC 6066 max_fragment_length extension in SSL.
+ *
+ * Comment this macro to disable support for the max_fragment_length extension
+ */
+//#define MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+
+/**
+ * \def MBEDTLS_SSL_PROTO_SSL3
+ *
+ * Enable support for SSL 3.0.
+ *
+ * Requires: MBEDTLS_MD5_C
+ *           MBEDTLS_SHA1_C
+ *
+ * Comment this macro to disable support for SSL 3.0
+ */
+//#define MBEDTLS_SSL_PROTO_SSL3
+
+/**
+ * \def MBEDTLS_SSL_PROTO_TLS1
+ *
+ * Enable support for TLS 1.0.
+ *
+ * Requires: MBEDTLS_MD5_C
+ *           MBEDTLS_SHA1_C
+ *
+ * Comment this macro to disable support for TLS 1.0
+ */
+//#define MBEDTLS_SSL_PROTO_TLS1
+
+/**
+ * \def MBEDTLS_SSL_PROTO_TLS1_1
+ *
+ * Enable support for TLS 1.1 (and DTLS 1.0 if DTLS is enabled).
+ *
+ * Requires: MBEDTLS_MD5_C
+ *           MBEDTLS_SHA1_C
+ *
+ * Comment this macro to disable support for TLS 1.1 / DTLS 1.0
+ */
+//#define MBEDTLS_SSL_PROTO_TLS1_1
+
+/**
+ * \def MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Enable support for TLS 1.2 (and DTLS 1.2 if DTLS is enabled).
+ *
+ * Requires: MBEDTLS_SHA1_C or MBEDTLS_SHA256_C or MBEDTLS_SHA512_C
+ *           (Depends on ciphersuites)
+ *
+ * Comment this macro to disable support for TLS 1.2 / DTLS 1.2
+ */
+//#define MBEDTLS_SSL_PROTO_TLS1_2
+
+/**
+ * \def MBEDTLS_SSL_PROTO_DTLS
+ *
+ * Enable support for DTLS (all available versions).
+ *
+ * Enable this and MBEDTLS_SSL_PROTO_TLS1_1 to enable DTLS 1.0,
+ * and/or this and MBEDTLS_SSL_PROTO_TLS1_2 to enable DTLS 1.2.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_TLS1_1
+ *        or MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Comment this macro to disable support for DTLS
+ */
+//#define MBEDTLS_SSL_PROTO_DTLS
+
+/**
+ * \def MBEDTLS_SSL_ALPN
+ *
+ * Enable support for RFC 7301 Application Layer Protocol Negotiation.
+ *
+ * Comment this macro to disable support for ALPN.
+ */
+//#define MBEDTLS_SSL_ALPN
+
+/**
+ * \def MBEDTLS_SSL_DTLS_ANTI_REPLAY
+ *
+ * Enable support for the anti-replay mechanism in DTLS.
+ *
+ * Requires: MBEDTLS_SSL_TLS_C
+ *           MBEDTLS_SSL_PROTO_DTLS
+ *
+ * \warning Disabling this is often a security risk!
+ * See mbedtls_ssl_conf_dtls_anti_replay() for details.
+ *
+ * Comment this to disable anti-replay in DTLS.
+ */
+//#define MBEDTLS_SSL_DTLS_ANTI_REPLAY
+
+/**
+ * \def MBEDTLS_SSL_DTLS_HELLO_VERIFY
+ *
+ * Enable support for HelloVerifyRequest on DTLS servers.
+ *
+ * This feature is highly recommended to prevent DTLS servers being used as
+ * amplifiers in DoS attacks against other hosts. It should always be enabled
+ * unless you know for sure amplification cannot be a problem in the
+ * environment in which your server operates.
+ *
+ * \warning Disabling this can ba a security risk! (see above)
+ *
+ * Requires: MBEDTLS_SSL_PROTO_DTLS
+ *
+ * Comment this to disable support for HelloVerifyRequest.
+ */
+//#define MBEDTLS_SSL_DTLS_HELLO_VERIFY
+
+/**
+ * \def MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
+ *
+ * Enable server-side support for clients that reconnect from the same port.
+ *
+ * Some clients unexpectedly close the connection and try to reconnect using the
+ * same source port. This needs special support from the server to handle the
+ * new connection securely, as described in section 4.2.8 of RFC 6347. This
+ * flag enables that support.
+ *
+ * Requires: MBEDTLS_SSL_DTLS_HELLO_VERIFY
+ *
+ * Comment this to disable support for clients reusing the source port.
+ */
+//#define MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
+
+/**
+ * \def MBEDTLS_SSL_DTLS_BADMAC_LIMIT
+ *
+ * Enable support for a limit of records with bad MAC.
+ *
+ * See mbedtls_ssl_conf_dtls_badmac_limit().
+ *
+ * Requires: MBEDTLS_SSL_PROTO_DTLS
+ */
+//#define MBEDTLS_SSL_DTLS_BADMAC_LIMIT
+
+/**
+ * \def MBEDTLS_SSL_SESSION_TICKETS
+ *
+ * Enable support for RFC 5077 session tickets in SSL.
+ * Client-side, provides full support for session tickets (maintainance of a
+ * session store remains the responsibility of the application, though).
+ * Server-side, you also need to provide callbacks for writing and parsing
+ * tickets, including authenticated encryption and key management. Example
+ * callbacks are provided by MBEDTLS_SSL_TICKET_C.
+ *
+ * Comment this macro to disable support for SSL session tickets
+ */
+//#define MBEDTLS_SSL_SESSION_TICKETS
+
+/**
+ * \def MBEDTLS_SSL_EXPORT_KEYS
+ *
+ * Enable support for exporting key block and master secret.
+ * This is required for certain users of TLS, e.g. EAP-TLS.
+ *
+ * Comment this macro to disable support for key export
+ */
+//#define MBEDTLS_SSL_EXPORT_KEYS
+
+/**
+ * \def MBEDTLS_SSL_SERVER_NAME_INDICATION
+ *
+ * Enable support for RFC 6066 server name indication (SNI) in SSL.
+ *
+ * Requires: MBEDTLS_X509_CRT_PARSE_C
+ *
+ * Comment this macro to disable support for server name indication in SSL
+ */
+//#define MBEDTLS_SSL_SERVER_NAME_INDICATION
+
+/**
+ * \def MBEDTLS_SSL_TRUNCATED_HMAC
+ *
+ * Enable support for RFC 6066 truncated HMAC in SSL.
+ *
+ * Comment this macro to disable support for truncated HMAC in SSL
+ */
+//#define MBEDTLS_SSL_TRUNCATED_HMAC
+/**
+ * \def MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT
+ *
+ * Fallback to old (pre-2.7), non-conforming implementation of the truncated
+ * HMAC extension which also truncates the HMAC key. Note that this option is
+ * only meant for a transitory upgrade period and is likely to be removed in
+ * a future version of the library.
+ *
+ * \warning The old implementation is non-compliant and has a security weakness
+ *          (2^80 brute force attack on the HMAC key used for a single,
+ *          uninterrupted connection). This should only be enabled temporarily
+ *          when (1) the use of truncated HMAC is essential in order to save
+ *          bandwidth, and (2) the peer is an Mbed TLS stack that doesn't use
+ *          the fixed implementation yet (pre-2.7).
+ *
+ * \deprecated This option is deprecated and will likely be removed in a
+ *             future version of Mbed TLS.
+ *
+ * Uncomment to fallback to old, non-compliant truncated HMAC implementation.
+ *
+ * Requires: MBEDTLS_SSL_TRUNCATED_HMAC
+ */
+//#define MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT
+
+/**
+ * \def MBEDTLS_THREADING_ALT
+ *
+ * Provide your own alternate threading implementation.
+ *
+ * Requires: MBEDTLS_THREADING_C
+ *
+ * Uncomment this to allow your own alternate threading implementation.
+ */
+//#define MBEDTLS_THREADING_ALT
+
+/**
+ * \def MBEDTLS_THREADING_PTHREAD
+ *
+ * Enable the pthread wrapper layer for the threading layer.
+ *
+ * Requires: MBEDTLS_THREADING_C
+ *
+ * Uncomment this to enable pthread mutexes.
+ */
+//#define MBEDTLS_THREADING_PTHREAD
+
+/**
+ * \def MBEDTLS_VERSION_FEATURES
+ *
+ * Allow run-time checking of compile-time enabled features. Thus allowing users
+ * to check at run-time if the library is for instance compiled with threading
+ * support via mbedtls_version_check_feature().
+ *
+ * Requires: MBEDTLS_VERSION_C
+ *
+ * Comment this to disable run-time checking and save ROM space
+ */
+//#define MBEDTLS_VERSION_FEATURES
+
+/**
+ * \def MBEDTLS_X509_ALLOW_EXTENSIONS_NON_V3
+ *
+ * If set, the X509 parser will not break-off when parsing an X509 certificate
+ * and encountering an extension in a v1 or v2 certificate.
+ *
+ * Uncomment to prevent an error.
+ */
+//#define MBEDTLS_X509_ALLOW_EXTENSIONS_NON_V3
+
+/**
+ * \def MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+ *
+ * If set, the X509 parser will not break-off when parsing an X509 certificate
+ * and encountering an unknown critical extension.
+ *
+ * \warning Depending on your PKI use, enabling this can be a security risk!
+ *
+ * Uncomment to prevent an error.
+ */
+//#define MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+
+/**
+ * \def MBEDTLS_X509_CHECK_KEY_USAGE
+ *
+ * Enable verification of the keyUsage extension (CA and leaf certificates).
+ *
+ * Disabling this avoids problems with mis-issued and/or misused
+ * (intermediate) CA and leaf certificates.
+ *
+ * \warning Depending on your PKI use, disabling this can be a security risk!
+ *
+ * Comment to skip keyUsage checking for both CA and leaf certificates.
+ */
+//#define MBEDTLS_X509_CHECK_KEY_USAGE
+
+/**
+ * \def MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
+ *
+ * Enable verification of the extendedKeyUsage extension (leaf certificates).
+ *
+ * Disabling this avoids problems with mis-issued and/or misused certificates.
+ *
+ * \warning Depending on your PKI use, disabling this can be a security risk!
+ *
+ * Comment to skip extendedKeyUsage checking for certificates.
+ */
+//#define MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
+
+/**
+ * \def MBEDTLS_X509_RSASSA_PSS_SUPPORT
+ *
+ * Enable parsing and verification of X.509 certificates, CRLs and CSRS
+ * signed with RSASSA-PSS (aka PKCS#1 v2.1).
+ *
+ * Comment this macro to disallow using RSASSA-PSS in certificates.
+ */
+//#define MBEDTLS_X509_RSASSA_PSS_SUPPORT
+
+/**
+ * \def MBEDTLS_ZLIB_SUPPORT
+ *
+ * If set, the SSL/TLS module uses ZLIB to support compression and
+ * decompression of packet data.
+ *
+ * \warning TLS-level compression MAY REDUCE SECURITY! See for example the
+ * CRIME attack. Before enabling this option, you should examine with care if
+ * CRIME or similar exploits may be a applicable to your use case.
+ *
+ * \note Currently compression can't be used with DTLS.
+ *
+ * \deprecated This feature is deprecated and will be removed
+ *             in the next major revision of the library.
+ *
+ * Used in: library/ssl_tls.c
+ *          library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * This feature requires zlib library and headers to be present.
+ *
+ * Uncomment to enable use of ZLIB
+ */
+//#define MBEDTLS_ZLIB_SUPPORT
+/* \} name SECTION: mbed TLS feature support */
+
+/**
+ * \name SECTION: mbed TLS modules
+ *
+ * This section enables or disables entire modules in mbed TLS
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_AESNI_C
+ *
+ * Enable AES-NI support on x86-64.
+ *
+ * Module:  library/aesni.c
+ * Caller:  library/aes.c
+ *
+ * Requires: MBEDTLS_HAVE_ASM
+ *
+ * This modules adds support for the AES-NI instructions on x86-64
+ */
+//#define MBEDTLS_AESNI_C
+
+/**
+ * \def MBEDTLS_AES_C
+ *
+ * Enable the AES block cipher.
+ *
+ * Module:  library/aes.c
+ * Caller:  library/cipher.c
+ *          library/pem.c
+ *          library/ctr_drbg.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA
+ *
+ * PEM_PARSE uses AES for decrypting encrypted keys.
+ */
+#if defined(SOFT_AES_CCM_GCM_SUPPORT) || defined(SOFT_AES_SUPPORT)
+#define MBEDTLS_AES_C
+#endif
+
+/**
+ * \def MBEDTLS_ARC4_C
+ *
+ * Enable the ARCFOUR stream cipher.
+ *
+ * Module:  library/arc4.c
+ * Caller:  library/cipher.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_RSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_RSA_WITH_RC4_128_MD5
+ *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_PSK_WITH_RC4_128_SHA
+ *
+ * \warning   ARC4 is considered a weak cipher and its use constitutes a
+ *            security risk. If possible, we recommend avoidng dependencies on
+ *            it, and considering stronger ciphers instead.
+ *
+ */
+//#define MBEDTLS_ARC4_C
+
+/**
+ * \def MBEDTLS_ASN1_PARSE_C
+ *
+ * Enable the generic ASN1 parser.
+ *
+ * Module:  library/asn1.c
+ * Caller:  library/x509.c
+ *          library/dhm.c
+ *          library/pkcs12.c
+ *          library/pkcs5.c
+ *          library/pkparse.c
+ */
+#define MBEDTLS_ASN1_PARSE_C
+
+/**
+ * \def MBEDTLS_ASN1_WRITE_C
+ *
+ * Enable the generic ASN1 writer.
+ *
+ * Module:  library/asn1write.c
+ * Caller:  library/ecdsa.c
+ *          library/pkwrite.c
+ *          library/x509_create.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
+ */
+#if defined(SOFT_ECC_SUPPORT)
+#define MBEDTLS_ASN1_WRITE_C
+#endif
+
+/**
+ * \def MBEDTLS_BASE64_C
+ *
+ * Enable the Base64 module.
+ *
+ * Module:  library/base64.c
+ * Caller:  library/pem.c
+ *
+ * This module is required for PEM support (required by X.509).
+ */
+//#define MBEDTLS_BASE64_C
+
+/**
+ * \def MBEDTLS_BIGNUM_C
+ *
+ * Enable the multi-precision integer library.
+ *
+ * Module:  library/bignum.c
+ * Caller:  library/dhm.c
+ *          library/ecp.c
+ *          library/ecdsa.c
+ *          library/rsa.c
+ *          library/rsa_internal.c
+ *          library/ssl_tls.c
+ *
+ * This module is required for RSA, DHM and ECC (ECDH, ECDSA) support.
+ */
+#define MBEDTLS_BIGNUM_C
+
+/**
+ * \def MBEDTLS_BLOWFISH_C
+ *
+ * Enable the Blowfish block cipher.
+ *
+ * Module:  library/blowfish.c
+ */
+//#define MBEDTLS_BLOWFISH_C
+
+/**
+ * \def MBEDTLS_CAMELLIA_C
+ *
+ * Enable the Camellia block cipher.
+ *
+ * Module:  library/camellia.c
+ * Caller:  library/cipher.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ */
+//#define MBEDTLS_CAMELLIA_C
+
+/**
+ * \def MBEDTLS_ARIA_C
+ *
+ * Enable the ARIA block cipher.
+ *
+ * Module:  library/aria.c
+ * Caller:  library/cipher.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_ARIA_256_CBC_SHA384
+ */
+//#define MBEDTLS_ARIA_C
+
+/**
+ * \def MBEDTLS_CCM_C
+ *
+ * Enable the Counter with CBC-MAC (CCM) mode for 128-bit block cipher.
+ *
+ * Module:  library/ccm.c
+ *
+ * Requires: MBEDTLS_AES_C or MBEDTLS_CAMELLIA_C
+ *
+ * This module enables the AES-CCM ciphersuites, if other requisites are
+ * enabled as well.
+ */
+#ifdef SOFT_AES_CCM_GCM_SUPPORT
+#define MBEDTLS_CCM_C
+#endif
+
+/**
+ * \def MBEDTLS_CERTS_C
+ *
+ * Enable the test certificates.
+ *
+ * Module:  library/certs.c
+ * Caller:
+ *
+ * This module is used for testing (ssl_client/server).
+ */
+//#define MBEDTLS_CERTS_C
+
+/**
+ * \def MBEDTLS_CHACHA20_C
+ *
+ * Enable the ChaCha20 stream cipher.
+ *
+ * Module:  library/chacha20.c
+ */
+/**
+ * \def MBEDTLS_CHACHA20_C
+ *
+ * Enable the ChaCha20 stream cipher.
+ *
+ * Module:  library/chacha20.c
+ */
+//#define MBEDTLS_CHACHA20_C
+
+/**
+ * \def MBEDTLS_CHACHAPOLY_C
+ *
+ * Enable the ChaCha20-Poly1305 AEAD algorithm.
+ *
+ * Module:  library/chachapoly.c
+ *
+ * This module requires: MBEDTLS_CHACHA20_C, MBEDTLS_POLY1305_C
+ */
+//#define MBEDTLS_CHACHAPOLY_C
+
+/**
+ * \def MBEDTLS_CIPHER_C
+ *
+ * Enable the generic cipher layer.
+ *
+ * Module:  library/cipher.c
+ * Caller:  library/ssl_tls.c
+ *
+ * Uncomment to enable generic cipher wrappers.
+ */
+
+#if defined(SOFT_AES_CCM_GCM_SUPPORT) || defined(SOFT_AES_SUPPORT) || defined(SOFT_TDES_SUPPORT)
+#define MBEDTLS_CIPHER_C
+#endif
+
+/**
+ * \def MBEDTLS_CMAC_C
+ *
+ * Enable the CMAC (Cipher-based Message Authentication Code) mode for block
+ * ciphers.
+ *
+ * Module:  library/cmac.c
+ *
+ * Requires: MBEDTLS_AES_C or MBEDTLS_DES_C
+ *
+ */
+//#define MBEDTLS_CMAC_C
+
+/**
+ * \def MBEDTLS_CTR_DRBG_C
+ *
+ * Enable the CTR_DRBG AES-based random generator.
+ * The CTR_DRBG generator uses AES-256 by default.
+ * To use AES-128 instead, enable MBEDTLS_CTR_DRBG_USE_128_BIT_KEY below.
+ *
+ * Module:  library/ctr_drbg.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_AES_C
+ *
+ * This module provides the CTR_DRBG AES-256 random number generator.
+ */
+//#define MBEDTLS_CTR_DRBG_C
+
+/**
+ * \def MBEDTLS_DEBUG_C
+ *
+ * Enable the debug functions.
+ *
+ * Module:  library/debug.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *          library/ssl_tls.c
+ *
+ * This module provides debugging functions.
+ */
+//#define MBEDTLS_DEBUG_C
+
+/**
+ * \def MBEDTLS_DES_C
+ *
+ * Enable the DES block cipher.
+ *
+ * Module:  library/des.c
+ * Caller:  library/pem.c
+ *          library/cipher.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_3DES_EDE_CBC_SHA
+ *
+ * PEM_PARSE uses DES/3DES for decrypting encrypted keys.
+ *
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
+ */
+#if defined(SOFT_TDES_SUPPORT)
+#define MBEDTLS_DES_C
+#endif
+
+/**
+ * \def MBEDTLS_DHM_C
+ *
+ * Enable the Diffie-Hellman-Merkle module.
+ *
+ * Module:  library/dhm.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * This module is used by the following key exchanges:
+ *      DHE-RSA, DHE-PSK
+ *
+ * \warning    Using DHE constitutes a security risk as it
+ *             is not possible to validate custom DH parameters.
+ *             If possible, it is recommended users should consider
+ *             preferring other methods of key exchange.
+ *             See dhm.h for more details.
+ *
+ */
+//#define MBEDTLS_DHM_C
+
+/**
+ * \def MBEDTLS_ECDH_C
+ *
+ * Enable the elliptic curve Diffie-Hellman library.
+ *
+ * Module:  library/ecdh.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * This module is used by the following key exchanges:
+ *      ECDHE-ECDSA, ECDHE-RSA, DHE-PSK
+ *
+ * Requires: MBEDTLS_ECP_C
+ */
+#if defined(SOFT_ECC_SUPPORT)
+#define MBEDTLS_ECDH_C
+#endif
+
+/**
+ * \def MBEDTLS_ECDSA_C
+ *
+ * Enable the elliptic curve DSA library.
+ *
+ * Module:  library/ecdsa.c
+ * Caller:
+ *
+ * This module is used by the following key exchanges:
+ *      ECDHE-ECDSA
+ *
+ * Requires: MBEDTLS_ECP_C, MBEDTLS_ASN1_WRITE_C, MBEDTLS_ASN1_PARSE_C
+ */
+#if defined(SOFT_ECC_SUPPORT)
+#define MBEDTLS_ECDSA_C
+#endif
+
+/**
+ * \def MBEDTLS_ECJPAKE_C
+ *
+ * Enable the elliptic curve J-PAKE library.
+ *
+ * \warning This is currently experimental. EC J-PAKE support is based on the
+ * Thread v1.0.0 specification; incompatible changes to the specification
+ * might still happen. For this reason, this is disabled by default.
+ *
+ * Module:  library/ecjpake.c
+ * Caller:
+ *
+ * This module is used by the following key exchanges:
+ *      ECJPAKE
+ *
+ * Requires: MBEDTLS_ECP_C, MBEDTLS_MD_C
+ */
+//#define MBEDTLS_ECJPAKE_C
+
+/**
+ * \def MBEDTLS_ECP_C
+ *
+ * Enable the elliptic curve over GF(p) library.
+ *
+ * Module:  library/ecp.c
+ * Caller:  library/ecdh.c
+ *          library/ecdsa.c
+ *          library/ecjpake.c
+ *
+ * Requires: MBEDTLS_BIGNUM_C and at least one MBEDTLS_ECP_DP_XXX_ENABLED
+ */
+#if defined(SOFT_SM2_SUPPORT) || defined(SOFT_ECC_SUPPORT)
+#define MBEDTLS_ECP_C
+#endif
+
+/**
+ * \def MBEDTLS_ENTROPY_C
+ *
+ * Enable the platform-specific entropy code.
+ *
+ * Module:  library/entropy.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SHA512_C or MBEDTLS_SHA256_C
+ *
+ * This module provides a generic entropy pool
+ */
+//#define MBEDTLS_ENTROPY_C
+
+/**
+ * \def MBEDTLS_ERROR_C
+ *
+ * Enable error code to error string conversion.
+ *
+ * Module:  library/error.c
+ * Caller:
+ *
+ * This module enables mbedtls_strerror().
+ */
+//#define MBEDTLS_ERROR_C
+
+/**
+ * \def MBEDTLS_GCM_C
+ *
+ * Enable the Galois/Counter Mode (GCM) for AES.
+ *
+ * Module:  library/gcm.c
+ *
+ * Requires: MBEDTLS_AES_C or MBEDTLS_CAMELLIA_C
+ *
+ * This module enables the AES-GCM and CAMELLIA-GCM ciphersuites, if other
+ * requisites are enabled as well.
+ */
+#ifdef SOFT_AES_CCM_GCM_SUPPORT
+#define MBEDTLS_GCM_C
+#endif
+
+/**
+ * \def MBEDTLS_HAVEGE_C
+ *
+ * Enable the HAVEGE random generator.
+ *
+ * Warning: the HAVEGE random generator is not suitable for virtualized
+ *          environments
+ *
+ * Warning: the HAVEGE random generator is dependent on timing and specific
+ *          processor traits. It is therefore not advised to use HAVEGE as
+ *          your applications primary random generator or primary entropy pool
+ *          input. As a secondary input to your entropy pool, it IS able add
+ *          the (limited) extra entropy it provides.
+ *
+ * Module:  library/havege.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_TIMING_C
+ *
+ * Uncomment to enable the HAVEGE random generator.
+ */
+//#define MBEDTLS_HAVEGE_C
+
+/**
+ * \def MBEDTLS_HKDF_C
+ *
+ * Enable the HKDF algorithm (RFC 5869).
+ *
+ * Module:  library/hkdf.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_MD_C
+ *
+ * This module adds support for the Hashed Message Authentication Code
+ * (HMAC)-based key derivation function (HKDF).
+ */
+//#define MBEDTLS_HKDF_C
+
+/**
+ * \def MBEDTLS_HMAC_DRBG_C
+ *
+ * Enable the HMAC_DRBG random generator.
+ *
+ * Module:  library/hmac_drbg.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_MD_C
+ *
+ * Uncomment to enable the HMAC_DRBG random number geerator.
+ */
+//#define MBEDTLS_HMAC_DRBG_C
+
+/**
+ * \def MBEDTLS_NIST_KW_C
+ *
+ * Enable the Key Wrapping mode for 128-bit block ciphers,
+ * as defined in NIST SP 800-38F. Only KW and KWP modes
+ * are supported. At the moment, only AES is approved by NIST.
+ *
+ * Module:  library/nist_kw.c
+ *
+ * Requires: MBEDTLS_AES_C and MBEDTLS_CIPHER_C
+ */
+//#define MBEDTLS_NIST_KW_C
+
+/**
+ * \def MBEDTLS_MD_C
+ *
+ * Enable the generic message digest layer.
+ *
+ * Module:  library/md.c
+ * Caller:
+ *
+ * Uncomment to enable generic message digest wrappers.
+ */
+#define MBEDTLS_MD_C
+
+/**
+ * \def MBEDTLS_MD2_C
+ *
+ * Enable the MD2 hash algorithm.
+ *
+ * Module:  library/md2.c
+ * Caller:
+ *
+ * Uncomment to enable support for (rare) MD2-signed X.509 certs.
+ *
+ * \warning   MD2 is considered a weak message digest and its use constitutes a
+ *            security risk. If possible, we recommend avoiding dependencies on
+ *            it, and considering stronger message digests instead.
+ *
+ */
+//#define MBEDTLS_MD2_C
+
+/**
+ * \def MBEDTLS_MD4_C
+ *
+ * Enable the MD4 hash algorithm.
+ *
+ * Module:  library/md4.c
+ * Caller:
+ *
+ * Uncomment to enable support for (rare) MD4-signed X.509 certs.
+ *
+ * \warning   MD4 is considered a weak message digest and its use constitutes a
+ *            security risk. If possible, we recommend avoiding dependencies on
+ *            it, and considering stronger message digests instead.
+ *
+ */
+//#define MBEDTLS_MD4_C
+
+/**
+ * \def MBEDTLS_MD5_C
+ *
+ * Enable the MD5 hash algorithm.
+ *
+ * Module:  library/md5.c
+ * Caller:  library/md.c
+ *          library/pem.c
+ *          library/ssl_tls.c
+ *
+ * This module is required for SSL/TLS up to version 1.1, and for TLS 1.2
+ * depending on the handshake parameters. Further, it is used for checking
+ * MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
+ * encrypted keys.
+ *
+ * \warning   MD5 is considered a weak message digest and its use constitutes a
+ *            security risk. If possible, we recommend avoiding dependencies on
+ *            it, and considering stronger message digests instead.
+ *
+ */
+//#define MBEDTLS_MD5_C
+
+/**
+ * \def MBEDTLS_MEMORY_BUFFER_ALLOC_C
+ *
+ * Enable the buffer allocator implementation that makes use of a (stack)
+ * based buffer to 'allocate' dynamic memory. (replaces calloc() and free()
+ * calls)
+ *
+ * Module:  library/memory_buffer_alloc.c
+ *
+ * Requires: MBEDTLS_PLATFORM_C
+ *           MBEDTLS_PLATFORM_MEMORY (to use it within mbed TLS)
+ *
+ * Enable this module to enable the buffer memory allocator.
+ */
+//#define MBEDTLS_MEMORY_BUFFER_ALLOC_C
+
+/**
+ * \def MBEDTLS_NET_C
+ *
+ * Enable the TCP and UDP over IPv6/IPv4 networking routines.
+ *
+ * \note This module only works on POSIX/Unix (including Linux, BSD and OS X)
+ * and Windows. For other platforms, you'll want to disable it, and write your
+ * own networking callbacks to be passed to \c mbedtls_ssl_set_bio().
+ *
+ * \note See also our Knowledge Base article about porting to a new
+ * environment:
+ * https://tls.mbed.org/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS
+ *
+ * Module:  library/net_sockets.c
+ *
+ * This module provides networking routines.
+ */
+//#define MBEDTLS_NET_C
+
+/**
+ * \def MBEDTLS_OID_C
+ *
+ * Enable the OID database.
+ *
+ * Module:  library/oid.c
+ * Caller:  library/asn1write.c
+ *          library/pkcs5.c
+ *          library/pkparse.c
+ *          library/pkwrite.c
+ *          library/rsa.c
+ *          library/x509.c
+ *          library/x509_create.c
+ *          library/x509_crl.c
+ *          library/x509_crt.c
+ *          library/x509_csr.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
+ *
+ * This modules translates between OIDs and internal values.
+ */
+#define MBEDTLS_OID_C
+
+/**
+ * \def MBEDTLS_PADLOCK_C
+ *
+ * Enable VIA Padlock support on x86.
+ *
+ * Module:  library/padlock.c
+ * Caller:  library/aes.c
+ *
+ * Requires: MBEDTLS_HAVE_ASM
+ *
+ * This modules adds support for the VIA PadLock on x86.
+ */
+//#define MBEDTLS_PADLOCK_C
+
+/**
+ * \def MBEDTLS_PEM_PARSE_C
+ *
+ * Enable PEM decoding / parsing.
+ *
+ * Module:  library/pem.c
+ * Caller:  library/dhm.c
+ *          library/pkparse.c
+ *          library/x509_crl.c
+ *          library/x509_crt.c
+ *          library/x509_csr.c
+ *
+ * Requires: MBEDTLS_BASE64_C
+ *
+ * This modules adds support for decoding / parsing PEM files.
+ */
+//#define MBEDTLS_PEM_PARSE_C
+
+/**
+ * \def MBEDTLS_PEM_WRITE_C
+ *
+ * Enable PEM encoding / writing.
+ *
+ * Module:  library/pem.c
+ * Caller:  library/pkwrite.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
+ *
+ * Requires: MBEDTLS_BASE64_C
+ *
+ * This modules adds support for encoding / writing PEM files.
+ */
+//#define MBEDTLS_PEM_WRITE_C
+
+/**
+ * \def MBEDTLS_PK_C
+ *
+ * Enable the generic public (asymetric) key layer.
+ *
+ * Module:  library/pk.c
+ * Caller:  library/ssl_tls.c
+ *          library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * Requires: MBEDTLS_RSA_C or MBEDTLS_ECP_C
+ *
+ * Uncomment to enable generic public key wrappers.
+ */
+//#define MBEDTLS_PK_C
+
+/**
+ * \def MBEDTLS_PK_PARSE_C
+ *
+ * Enable the generic public (asymetric) key parser.
+ *
+ * Module:  library/pkparse.c
+ * Caller:  library/x509_crt.c
+ *          library/x509_csr.c
+ *
+ * Requires: MBEDTLS_PK_C
+ *
+ * Uncomment to enable generic public key parse functions.
+ */
+//#define MBEDTLS_PK_PARSE_C
+
+/**
+ * \def MBEDTLS_PK_WRITE_C
+ *
+ * Enable the generic public (asymetric) key writer.
+ *
+ * Module:  library/pkwrite.c
+ * Caller:  library/x509write.c
+ *
+ * Requires: MBEDTLS_PK_C
+ *
+ * Uncomment to enable generic public key write functions.
+ */
+//#define MBEDTLS_PK_WRITE_C
+
+/**
+ * \def MBEDTLS_PKCS5_C
+ *
+ * Enable PKCS#5 functions.
+ *
+ * Module:  library/pkcs5.c
+ *
+ * Requires: MBEDTLS_MD_C
+ *
+ * This module adds support for the PKCS#5 functions.
+ */
+//#define MBEDTLS_PKCS5_C
+
+/**
+ * \def MBEDTLS_PKCS11_C
+ *
+ * Enable wrapper for PKCS#11 smartcard support.
+ *
+ * Module:  library/pkcs11.c
+ * Caller:  library/pk.c
+ *
+ * Requires: MBEDTLS_PK_C
+ *
+ * This module enables SSL/TLS PKCS #11 smartcard support.
+ * Requires the presence of the PKCS#11 helper library (libpkcs11-helper)
+ */
+//#define MBEDTLS_PKCS11_C
+
+/**
+ * \def MBEDTLS_PKCS12_C
+ *
+ * Enable PKCS#12 PBE functions.
+ * Adds algorithms for parsing PKCS#8 encrypted private keys
+ *
+ * Module:  library/pkcs12.c
+ * Caller:  library/pkparse.c
+ *
+ * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_CIPHER_C, MBEDTLS_MD_C
+ * Can use:  MBEDTLS_ARC4_C
+ *
+ * This module enables PKCS#12 functions.
+ */
+//#define MBEDTLS_PKCS12_C
+
+/**
+ * \def MBEDTLS_PLATFORM_C
+ *
+ * Enable the platform abstraction layer that allows you to re-assign
+ * functions like calloc(), free(), snprintf(), printf(), fprintf(), exit().
+ *
+ * Enabling MBEDTLS_PLATFORM_C enables to use of MBEDTLS_PLATFORM_XXX_ALT
+ * or MBEDTLS_PLATFORM_XXX_MACRO directives, allowing the functions mentioned
+ * above to be specified at runtime or compile time respectively.
+ *
+ * \note This abstraction layer must be enabled on Windows (including MSYS2)
+ * as other module rely on it for a fixed snprintf implementation.
+ *
+ * Module:  library/platform.c
+ * Caller:  Most other .c files
+ *
+ * This module enables abstraction of common (libc) functions.
+ */
+#define MBEDTLS_PLATFORM_C
+
+/**
+ * \def MBEDTLS_POLY1305_C
+ *
+ * Enable the Poly1305 MAC algorithm.
+ *
+ * Module:  library/poly1305.c
+ * Caller:  library/chachapoly.c
+ */
+//#define MBEDTLS_POLY1305_C
+
+/**
+ * \def MBEDTLS_RIPEMD160_C
+ *
+ * Enable the RIPEMD-160 hash algorithm.
+ *
+ * Module:  library/ripemd160.c
+ * Caller:  library/md.c
+ *
+ */
+//#define MBEDTLS_RIPEMD160_C
+
+/**
+ * \def MBEDTLS_RSA_C
+ *
+ * Enable the RSA public-key cryptosystem.
+ *
+ * Module:  library/rsa.c
+ *          library/rsa_internal.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *          library/ssl_tls.c
+ *          library/x509.c
+ *
+ * This module is used by the following key exchanges:
+ *      RSA, DHE-RSA, ECDHE-RSA, RSA-PSK
+ *
+ * Requires: MBEDTLS_BIGNUM_C, MBEDTLS_OID_C
+ */
+#define MBEDTLS_RSA_C
+
+/**
+ * \def MBEDTLS_SHA1_C
+ *
+ * Enable the SHA1 cryptographic hash algorithm.
+ *
+ * Module:  library/sha1.c
+ * Caller:  library/md.c
+ *          library/ssl_cli.c
+ *          library/ssl_srv.c
+ *          library/ssl_tls.c
+ *          library/x509write_crt.c
+ *
+ * This module is required for SSL/TLS up to version 1.1, for TLS 1.2
+ * depending on the handshake parameters, and for SHA1-signed certificates.
+ *
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. If possible, we recommend avoiding dependencies
+ *            on it, and considering stronger message digests instead.
+ *
+ */
+#ifdef SOFT_SHA1_SUPPORT
+#define MBEDTLS_SHA1_C
+#endif
+
+/**
+ * \def MBEDTLS_SHA256_C
+ *
+ * Enable the SHA-224 and SHA-256 cryptographic hash algorithms.
+ *
+ * Module:  library/sha256.c
+ * Caller:  library/entropy.c
+ *          library/md.c
+ *          library/ssl_cli.c
+ *          library/ssl_srv.c
+ *          library/ssl_tls.c
+ *
+ * This module adds support for SHA-224 and SHA-256.
+ * This module is required for the SSL/TLS 1.2 PRF function.
+ */
+#ifdef SOFT_SHA256_SUPPORT
+#define MBEDTLS_SHA256_C
+#endif
+
+/**
+ * \def MBEDTLS_SHA512_C
+ *
+ * Enable the SHA-384 and SHA-512 cryptographic hash algorithms.
+ *
+ * Module:  library/sha512.c
+ * Caller:  library/entropy.c
+ *          library/md.c
+ *          library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * This module adds support for SHA-384 and SHA-512.
+ */
+#ifdef SOFT_SHA512_SUPPORT
+#define MBEDTLS_SHA512_C
+#endif
+
+/**
+ * \def MBEDTLS_SSL_CACHE_C
+ *
+ * Enable simple SSL cache implementation.
+ *
+ * Module:  library/ssl_cache.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SSL_CACHE_C
+ */
+//#define MBEDTLS_SSL_CACHE_C
+
+/**
+ * \def MBEDTLS_SSL_COOKIE_C
+ *
+ * Enable basic implementation of DTLS cookies for hello verification.
+ *
+ * Module:  library/ssl_cookie.c
+ * Caller:
+ */
+//#define MBEDTLS_SSL_COOKIE_C
+
+/**
+ * \def MBEDTLS_SSL_TICKET_C
+ *
+ * Enable an implementation of TLS server-side callbacks for session tickets.
+ *
+ * Module:  library/ssl_ticket.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_CIPHER_C
+ */
+//#define MBEDTLS_SSL_TICKET_C
+
+/**
+ * \def MBEDTLS_SSL_CLI_C
+ *
+ * Enable the SSL/TLS client code.
+ *
+ * Module:  library/ssl_cli.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SSL_TLS_C
+ *
+ * This module is required for SSL/TLS client support.
+ */
+//#define MBEDTLS_SSL_CLI_C
+
+/**
+ * \def MBEDTLS_SSL_SRV_C
+ *
+ * Enable the SSL/TLS server code.
+ *
+ * Module:  library/ssl_srv.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SSL_TLS_C
+ *
+ * This module is required for SSL/TLS server support.
+ */
+//#define MBEDTLS_SSL_SRV_C
+
+/**
+ * \def MBEDTLS_SSL_TLS_C
+ *
+ * Enable the generic SSL/TLS code.
+ *
+ * Module:  library/ssl_tls.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * Requires: MBEDTLS_CIPHER_C, MBEDTLS_MD_C
+ *           and at least one of the MBEDTLS_SSL_PROTO_XXX defines
+ *
+ * This module is required for SSL/TLS.
+ */
+//#define MBEDTLS_SSL_TLS_C
+
+/**
+ * \def MBEDTLS_THREADING_C
+ *
+ * Enable the threading abstraction layer.
+ * By default mbed TLS assumes it is used in a non-threaded environment or that
+ * contexts are not shared between threads. If you do intend to use contexts
+ * between threads, you will need to enable this layer to prevent race
+ * conditions. See also our Knowledge Base article about threading:
+ * https://tls.mbed.org/kb/development/thread-safety-and-multi-threading
+ *
+ * Module:  library/threading.c
+ *
+ * This allows different threading implementations (self-implemented or
+ * provided).
+ *
+ * You will have to enable either MBEDTLS_THREADING_ALT or
+ * MBEDTLS_THREADING_PTHREAD.
+ *
+ * Enable this layer to allow use of mutexes within mbed TLS
+ */
+//#define MBEDTLS_THREADING_C
+
+/**
+ * \def MBEDTLS_TIMING_C
+ *
+ * Enable the semi-portable timing interface.
+ *
+ * \note The provided implementation only works on POSIX/Unix (including Linux,
+ * BSD and OS X) and Windows. On other platforms, you can either disable that
+ * module and provide your own implementations of the callbacks needed by
+ * \c mbedtls_ssl_set_timer_cb() for DTLS, or leave it enabled and provide
+ * your own implementation of the whole module by setting
+ * \c MBEDTLS_TIMING_ALT in the current file.
+ *
+ * \note See also our Knowledge Base article about porting to a new
+ * environment:
+ * https://tls.mbed.org/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS
+ *
+ * Module:  library/timing.c
+ * Caller:  library/havege.c
+ *
+ * This module is used by the HAVEGE random number generator.
+ */
+//#define MBEDTLS_TIMING_C
+
+/**
+ * \def MBEDTLS_VERSION_C
+ *
+ * Enable run-time version information.
+ *
+ * Module:  library/version.c
+ *
+ * This module provides run-time version information.
+ */
+//#define MBEDTLS_VERSION_C
+
+/**
+ * \def MBEDTLS_X509_USE_C
+ *
+ * Enable X.509 core for using certificates.
+ *
+ * Module:  library/x509.c
+ * Caller:  library/x509_crl.c
+ *          library/x509_crt.c
+ *          library/x509_csr.c
+ *
+ * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_BIGNUM_C, MBEDTLS_OID_C,
+ *           MBEDTLS_PK_PARSE_C
+ *
+ * This module is required for the X.509 parsing modules.
+ */
+//#define MBEDTLS_X509_USE_C
+
+/**
+ * \def MBEDTLS_X509_CRT_PARSE_C
+ *
+ * Enable X.509 certificate parsing.
+ *
+ * Module:  library/x509_crt.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *          library/ssl_tls.c
+ *
+ * Requires: MBEDTLS_X509_USE_C
+ *
+ * This module is required for X.509 certificate parsing.
+ */
+//#define MBEDTLS_X509_CRT_PARSE_C
+
+/**
+ * \def MBEDTLS_X509_CRL_PARSE_C
+ *
+ * Enable X.509 CRL parsing.
+ *
+ * Module:  library/x509_crl.c
+ * Caller:  library/x509_crt.c
+ *
+ * Requires: MBEDTLS_X509_USE_C
+ *
+ * This module is required for X.509 CRL parsing.
+ */
+//#define MBEDTLS_X509_CRL_PARSE_C
+
+/**
+ * \def MBEDTLS_X509_CSR_PARSE_C
+ *
+ * Enable X.509 Certificate Signing Request (CSR) parsing.
+ *
+ * Module:  library/x509_csr.c
+ * Caller:  library/x509_crt_write.c
+ *
+ * Requires: MBEDTLS_X509_USE_C
+ *
+ * This module is used for reading X.509 certificate request.
+ */
+//#define MBEDTLS_X509_CSR_PARSE_C
+
+/**
+ * \def MBEDTLS_X509_CREATE_C
+ *
+ * Enable X.509 core for creating certificates.
+ *
+ * Module:  library/x509_create.c
+ *
+ * Requires: MBEDTLS_BIGNUM_C, MBEDTLS_OID_C, MBEDTLS_PK_WRITE_C
+ *
+ * This module is the basis for creating X.509 certificates and CSRs.
+ */
+//#define MBEDTLS_X509_CREATE_C
+
+/**
+ * \def MBEDTLS_X509_CRT_WRITE_C
+ *
+ * Enable creating X.509 certificates.
+ *
+ * Module:  library/x509_crt_write.c
+ *
+ * Requires: MBEDTLS_X509_CREATE_C
+ *
+ * This module is required for X.509 certificate creation.
+ */
+//#define MBEDTLS_X509_CRT_WRITE_C
+
+/**
+ * \def MBEDTLS_X509_CSR_WRITE_C
+ *
+ * Enable creating X.509 Certificate Signing Requests (CSR).
+ *
+ * Module:  library/x509_csr_write.c
+ *
+ * Requires: MBEDTLS_X509_CREATE_C
+ *
+ * This module is required for X.509 certificate request writing.
+ */
+//#define MBEDTLS_X509_CSR_WRITE_C
+
+/**
+ * \def MBEDTLS_XTEA_C
+ *
+ * Enable the XTEA block cipher.
+ *
+ * Module:  library/xtea.c
+ * Caller:
+ */
+//#define MBEDTLS_XTEA_C
+
+/* \} name SECTION: mbed TLS modules */
+
+/**
+ * \name SECTION: Module configuration options
+ *
+ * This section allows for the setting of module specific sizes and
+ * configuration options. The default values are already present in the
+ * relevant header files and should suffice for the regular use cases.
+ *
+ * Our advice is to enable options and change their values here
+ * only if you have a good reason and know the consequences.
+ *
+ * Please check the respective header file for documentation on these
+ * parameters (to prevent duplicate documentation).
+ * \{
+ */
+
+/* MPI / BIGNUM options */
+//#define MBEDTLS_MPI_WINDOW_SIZE            6 /**< Maximum windows size used. */
+#define MBEDTLS_MPI_MAX_SIZE                512 /**< Maximum number of bytes for usable MPIs. */
+
+/* CTR_DRBG options */
+//#define MBEDTLS_CTR_DRBG_ENTROPY_LEN               48 /**< Amount of entropy used per seed by default (48 with SHA-512, 32 with SHA-256) */
+//#define MBEDTLS_CTR_DRBG_RESEED_INTERVAL        10000 /**< Interval before reseed is performed by default */
+//#define MBEDTLS_CTR_DRBG_MAX_INPUT                256 /**< Maximum number of additional input bytes */
+//#define MBEDTLS_CTR_DRBG_MAX_REQUEST             1024 /**< Maximum number of requested bytes per call */
+//#define MBEDTLS_CTR_DRBG_MAX_SEED_INPUT           384 /**< Maximum size of (re)seed buffer */
+//#define MBEDTLS_CTR_DRBG_USE_128_BIT_KEY              /**< Use 128-bit key for CTR_DRBG - may reduce security (see ctr_drbg.h) */
+
+/* HMAC_DRBG options */
+//#define MBEDTLS_HMAC_DRBG_RESEED_INTERVAL   10000 /**< Interval before reseed is performed by default */
+//#define MBEDTLS_HMAC_DRBG_MAX_INPUT           256 /**< Maximum number of additional input bytes */
+//#define MBEDTLS_HMAC_DRBG_MAX_REQUEST        1024 /**< Maximum number of requested bytes per call */
+//#define MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT      384 /**< Maximum size of (re)seed buffer */
+
+/* ECP options */
+//#define MBEDTLS_ECP_MAX_BITS             521 /**< Maximum bit size of groups */
+//#define MBEDTLS_ECP_WINDOW_SIZE            6 /**< Maximum window size used */
+//#define MBEDTLS_ECP_FIXED_POINT_OPTIM      1 /**< Enable fixed-point speed-up */
+
+/* Entropy options */
+//#define MBEDTLS_ENTROPY_MAX_SOURCES                20 /**< Maximum number of sources supported */
+//#define MBEDTLS_ENTROPY_MAX_GATHER                128 /**< Maximum amount requested from entropy sources */
+//#define MBEDTLS_ENTROPY_MIN_HARDWARE               32 /**< Default minimum number of bytes required for the hardware entropy source mbedtls_hardware_poll() before entropy is released */
+
+/* Memory buffer allocator options */
+//#define MBEDTLS_MEMORY_ALIGN_MULTIPLE      4 /**< Align on multiples of this value */
+
+/* Platform options */
+//#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h> /**< Header to include if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
+//#define MBEDTLS_PLATFORM_STD_CALLOC        calloc /**< Default allocator to use, can be undefined */
+//#define MBEDTLS_PLATFORM_STD_FREE            free /**< Default free to use, can be undefined */
+//#define MBEDTLS_PLATFORM_STD_EXIT            exit /**< Default exit to use, can be undefined */
+//#define MBEDTLS_PLATFORM_STD_TIME            time /**< Default time to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
+//#define MBEDTLS_PLATFORM_STD_FPRINTF      fprintf /**< Default fprintf to use, can be undefined */
+//#define MBEDTLS_PLATFORM_STD_PRINTF        printf /**< Default printf to use, can be undefined */
+/* Note: your snprintf must correclty zero-terminate the buffer! */
+//#define MBEDTLS_PLATFORM_STD_SNPRINTF    snprintf /**< Default snprintf to use, can be undefined */
+//#define MBEDTLS_PLATFORM_STD_EXIT_SUCCESS       0 /**< Default exit value to use, can be undefined */
+//#define MBEDTLS_PLATFORM_STD_EXIT_FAILURE       1 /**< Default exit value to use, can be undefined */
+//#define MBEDTLS_PLATFORM_STD_NV_SEED_READ   mbedtls_platform_std_nv_seed_read /**< Default nv_seed_read function to use, can be undefined */
+//#define MBEDTLS_PLATFORM_STD_NV_SEED_WRITE  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
+//#define MBEDTLS_PLATFORM_STD_NV_SEED_FILE  "seedfile" /**< Seed file to read/write with default implementation */
+
+/* To Use Function Macros MBEDTLS_PLATFORM_C must be enabled */
+/* MBEDTLS_PLATFORM_XXX_MACRO and MBEDTLS_PLATFORM_XXX_ALT cannot both be defined */
+#define MBEDTLS_PLATFORM_CALLOC_MACRO        crypto_calloc /**< Default allocator macro to use, can be undefined */
+#define MBEDTLS_PLATFORM_FREE_MACRO          crypto_free /**< Default free macro to use, can be undefined */
+//#define MBEDTLS_PLATFORM_EXIT_MACRO            exit /**< Default exit macro to use, can be undefined */
+//#define MBEDTLS_PLATFORM_TIME_MACRO            time /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
+//#define MBEDTLS_PLATFORM_TIME_TYPE_MACRO       time_t /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
+//#define MBEDTLS_PLATFORM_FPRINTF_MACRO      fprintf /**< Default fprintf macro to use, can be undefined */
+#define MBEDTLS_PLATFORM_PRINTF_MACRO        printk /**< Default printf macro to use, can be undefined */
+/* Note: your snprintf must correclty zero-terminate the buffer! */
+#define MBEDTLS_PLATFORM_SNPRINTF_MACRO        snprintf /**< Default snprintf macro to use, can be undefined */
+//#define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO   mbedtls_platform_std_nv_seed_read /**< Default nv_seed_read function to use, can be undefined */
+//#define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
+
+/**
+ * \brief       This macro is invoked by the library when an invalid parameter
+ *              is detected that is only checked with MBEDTLS_CHECK_PARAMS
+ *              (see the documentation of that option for context).
+ *
+ *              When you leave this undefined here, a default definition is
+ *              provided that invokes the function mbedtls_param_failed(),
+ *              which is declared in platform_util.h for the benefit of the
+ *              library, but that you need to define in your application.
+ *
+ *              When you define this here, this replaces the default
+ *              definition in platform_util.h (which no longer declares the
+ *              function mbedtls_param_failed()) and it is your responsibility
+ *              to make sure this macro expands to something suitable (in
+ *              particular, that all the necessary declarations are visible
+ *              from within the library - you can ensure that by providing
+ *              them in this file next to the macro definition).
+ *
+ *              Note that you may define this macro to expand to nothing, in
+ *              which case you don't have to worry about declarations or
+ *              definitions. However, you will then be notified about invalid
+ *              parameters only in non-void functions, and void function will
+ *              just silently return early on invalid parameters, which
+ *              partially negates the benefits of enabling
+ *              #MBEDTLS_CHECK_PARAMS in the first place, so is discouraged.
+ *
+ * \param cond  The expression that should evaluate to true, but doesn't.
+ */
+//#define MBEDTLS_PARAM_FAILED( cond )
+
+/* SSL Cache options */
+//#define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */
+//#define MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES      50 /**< Maximum entries in cache */
+
+/* SSL options */
+
+/** \def MBEDTLS_SSL_MAX_CONTENT_LEN
+ *
+ * Maximum length (in bytes) of incoming and outgoing plaintext fragments.
+ *
+ * This determines the size of both the incoming and outgoing TLS I/O buffers
+ * in such a way that both are capable of holding the specified amount of
+ * plaintext data, regardless of the protection mechanism used.
+ *
+ * To configure incoming and outgoing I/O buffers separately, use
+ * #MBEDTLS_SSL_IN_CONTENT_LEN and #MBEDTLS_SSL_OUT_CONTENT_LEN,
+ * which overwrite the value set by this option.
+ *
+ * \note When using a value less than the default of 16KB on the client, it is
+ *       recommended to use the Maximum Fragment Length (MFL) extension to
+ *       inform the server about this limitation. On the server, there
+ *       is no supported, standardized way of informing the client about
+ *       restriction on the maximum size of incoming messages, and unless
+ *       the limitation has been communicated by other means, it is recommended
+ *       to only change the outgoing buffer size #MBEDTLS_SSL_OUT_CONTENT_LEN
+ *       while keeping the default value of 16KB for the incoming buffer.
+ *
+ * Uncomment to set the maximum plaintext size of both
+ * incoming and outgoing I/O buffers.
+ */
+//#define MBEDTLS_SSL_MAX_CONTENT_LEN             16384
+
+/** \def MBEDTLS_SSL_IN_CONTENT_LEN
+ *
+ * Maximum length (in bytes) of incoming plaintext fragments.
+ *
+ * This determines the size of the incoming TLS I/O buffer in such a way
+ * that it is capable of holding the specified amount of plaintext data,
+ * regardless of the protection mechanism used.
+ *
+ * If this option is undefined, it inherits its value from
+ * #MBEDTLS_SSL_MAX_CONTENT_LEN.
+ *
+ * \note When using a value less than the default of 16KB on the client, it is
+ *       recommended to use the Maximum Fragment Length (MFL) extension to
+ *       inform the server about this limitation. On the server, there
+ *       is no supported, standardized way of informing the client about
+ *       restriction on the maximum size of incoming messages, and unless
+ *       the limitation has been communicated by other means, it is recommended
+ *       to only change the outgoing buffer size #MBEDTLS_SSL_OUT_CONTENT_LEN
+ *       while keeping the default value of 16KB for the incoming buffer.
+ *
+ * Uncomment to set the maximum plaintext size of the incoming I/O buffer
+ * independently of the outgoing I/O buffer.
+ */
+//#define MBEDTLS_SSL_IN_CONTENT_LEN              16384
+
+/** \def MBEDTLS_SSL_OUT_CONTENT_LEN
+ *
+ * Maximum length (in bytes) of outgoing plaintext fragments.
+ *
+ * This determines the size of the outgoing TLS I/O buffer in such a way
+ * that it is capable of holding the specified amount of plaintext data,
+ * regardless of the protection mechanism used.
+ *
+ * If this option undefined, it inherits its value from
+ * #MBEDTLS_SSL_MAX_CONTENT_LEN.
+ *
+ * It is possible to save RAM by setting a smaller outward buffer, while keeping
+ * the default inward 16384 byte buffer to conform to the TLS specification.
+ *
+ * The minimum required outward buffer size is determined by the handshake
+ * protocol's usage. Handshaking will fail if the outward buffer is too small.
+ * The specific size requirement depends on the configured ciphers and any
+ * certificate data which is sent during the handshake.
+ *
+ * Uncomment to set the maximum plaintext size of the outgoing I/O buffer
+ * independently of the incoming I/O buffer.
+ */
+//#define MBEDTLS_SSL_OUT_CONTENT_LEN             16384
+
+/** \def MBEDTLS_SSL_DTLS_MAX_BUFFERING
+ *
+ * Maximum number of heap-allocated bytes for the purpose of
+ * DTLS handshake message reassembly and future message buffering.
+ *
+ * This should be at least 9/8 * MBEDTLSSL_IN_CONTENT_LEN
+ * to account for a reassembled handshake message of maximum size,
+ * together with its reassembly bitmap.
+ *
+ * A value of 2 * MBEDTLS_SSL_IN_CONTENT_LEN (32768 by default)
+ * should be sufficient for all practical situations as it allows
+ * to reassembly a large handshake message (such as a certificate)
+ * while buffering multiple smaller handshake messages.
+ *
+ */
+//#define MBEDTLS_SSL_DTLS_MAX_BUFFERING             32768
+
+//#define MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME     86400 /**< Lifetime of session tickets (if enabled) */
+//#define MBEDTLS_PSK_MAX_LEN               32 /**< Max size of TLS pre-shared keys, in bytes (default 256 bits) */
+//#define MBEDTLS_SSL_COOKIE_TIMEOUT        60 /**< Default expiration delay of DTLS cookies, in seconds if HAVE_TIME, or in number of cookies issued */
+
+/**
+ * Complete list of ciphersuites to use, in order of preference.
+ *
+ * \warning No dependency checking is done on that field! This option can only
+ * be used to restrict the set of available ciphersuites. It is your
+ * responsibility to make sure the needed modules are active.
+ *
+ * Use this to save a few hundred bytes of ROM (default ordering of all
+ * available ciphersuites) and a few to a few hundred bytes of RAM.
+ *
+ * The value below is only an example, not the default.
+ */
+//#define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+
+/* X509 options */
+//#define MBEDTLS_X509_MAX_INTERMEDIATE_CA   8   /**< Maximum number of intermediate CAs in a verification chain. */
+//#define MBEDTLS_X509_MAX_FILE_PATH_LEN     512 /**< Maximum length of a path/filename string in bytes including the null terminator character ('\0'). */
+
+/**
+ * Allow SHA-1 in the default TLS configuration for certificate signing.
+ * Without this build-time option, SHA-1 support must be activated explicitly
+ * through mbedtls_ssl_conf_cert_profile. Turning on this option is not
+ * recommended because of it is possible to generate SHA-1 collisions, however
+ * this may be safe for legacy infrastructure where additional controls apply.
+ *
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. If possible, we recommend avoiding dependencies
+ *            on it, and considering stronger message digests instead.
+ *
+ */
+// #define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
+
+/**
+ * Allow SHA-1 in the default TLS configuration for TLS 1.2 handshake
+ * signature and ciphersuite selection. Without this build-time option, SHA-1
+ * support must be activated explicitly through mbedtls_ssl_conf_sig_hashes.
+ * The use of SHA-1 in TLS <= 1.1 and in HMAC-SHA-1 is always allowed by
+ * default. At the time of writing, there is no practical attack on the use
+ * of SHA-1 in handshake signatures, hence this option is turned on by default
+ * to preserve compatibility with existing peers, but the general
+ * warning applies nonetheless:
+ *
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. If possible, we recommend avoiding dependencies
+ *            on it, and considering stronger message digests instead.
+ *
+ */
+#define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_KEY_EXCHANGE
+
+/**
+ * Uncomment the macro to let mbed TLS use your alternate implementation of
+ * mbedtls_platform_zeroize(). This replaces the default implementation in
+ * platform_util.c.
+ *
+ * mbedtls_platform_zeroize() is a widely used function across the library to
+ * zero a block of memory. The implementation is expected to be secure in the
+ * sense that it has been written to prevent the compiler from removing calls
+ * to mbedtls_platform_zeroize() as part of redundant code elimination
+ * optimizations. However, it is difficult to guarantee that calls to
+ * mbedtls_platform_zeroize() will not be optimized by the compiler as older
+ * versions of the C language standards do not provide a secure implementation
+ * of memset(). Therefore, MBEDTLS_PLATFORM_ZEROIZE_ALT enables users to
+ * configure their own implementation of mbedtls_platform_zeroize(), for
+ * example by using directives specific to their compiler, features from newer
+ * C standards (e.g using memset_s() in C11) or calling a secure memset() from
+ * their system (e.g explicit_bzero() in BSD).
+ */
+//#define MBEDTLS_PLATFORM_ZEROIZE_ALT
+
+/**
+ * Uncomment the macro to let Mbed TLS use your alternate implementation of
+ * mbedtls_platform_gmtime_r(). This replaces the default implementation in
+ * platform_util.c.
+ *
+ * gmtime() is not a thread-safe function as defined in the C standard. The
+ * library will try to use safer implementations of this function, such as
+ * gmtime_r() when available. However, if Mbed TLS cannot identify the target
+ * system, the implementation of mbedtls_platform_gmtime_r() will default to
+ * using the standard gmtime(). In this case, calls from the library to
+ * gmtime() will be guarded by the global mutex mbedtls_threading_gmtime_mutex
+ * if MBEDTLS_THREADING_C is enabled. We recommend that calls from outside the
+ * library are also guarded with this mutex to avoid race conditions. However,
+ * if the macro MBEDTLS_PLATFORM_GMTIME_R_ALT is defined, Mbed TLS will
+ * unconditionally use the implementation for mbedtls_platform_gmtime_r()
+ * supplied at compile time.
+ */
+//#define MBEDTLS_PLATFORM_GMTIME_R_ALT
+
+/* \} name SECTION: Customisation configuration options */
+
+/* Target and application specific configurations
+ *
+ * Allow user to override any previous default.
+ *
+ */
+#if defined(MBEDTLS_USER_CONFIG_FILE)
+#include MBEDTLS_USER_CONFIG_FILE
+#endif
+
+#include "check_config.h"
+
+#endif /* MBEDTLS_CONFIG_H */
+
+#define MBEDTLS_RSA_NO_CRT

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/des.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/des.h
@@ -1,0 +1,356 @@
+/**
+ * \file des.h
+ *
+ * \brief DES block cipher
+ *
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers
+ *            instead.
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ *
+ */
+#ifndef MBEDTLS_DES_H
+#define MBEDTLS_DES_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include <stddef.h>
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdint.h>
+#endif
+
+#define MBEDTLS_DES_ENCRYPT     1
+#define MBEDTLS_DES_DECRYPT     0
+
+#define MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH              -0x0032  /**< The data input has an invalid length. */
+
+/* MBEDTLS_ERR_DES_HW_ACCEL_FAILED is deprecated and should not be used. */
+#define MBEDTLS_ERR_DES_HW_ACCEL_FAILED                   -0x0033  /**< DES hardware accelerator failed. */
+
+#define MBEDTLS_DES_KEY_SIZE    8
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(MBEDTLS_DES_ALT)
+// Regular implementation
+//
+
+/**
+ * \brief          DES context structure
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ */
+typedef struct mbedtls_des_context
+{
+    uint32_t sk[32];            /*!<  DES subkeys       */
+}
+mbedtls_des_context;
+
+/**
+ * \brief          Triple-DES context structure
+ */
+typedef struct mbedtls_des3_context
+{
+    uint32_t sk[96];            /*!<  3DES subkeys      */
+}
+mbedtls_des3_context;
+
+#else  /* MBEDTLS_DES_ALT */
+#include "des_alt.h"
+#endif /* MBEDTLS_DES_ALT */
+
+/**
+ * \brief          Initialize DES context
+ *
+ * \param ctx      DES context to be initialized
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ */
+void mbedtls_des_init( mbedtls_des_context *ctx );
+
+/**
+ * \brief          Clear DES context
+ *
+ * \param ctx      DES context to be cleared
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ */
+void mbedtls_des_free( mbedtls_des_context *ctx );
+
+/**
+ * \brief          Initialize Triple-DES context
+ *
+ * \param ctx      DES3 context to be initialized
+ */
+void mbedtls_des3_init( mbedtls_des3_context *ctx );
+
+/**
+ * \brief          Clear Triple-DES context
+ *
+ * \param ctx      DES3 context to be cleared
+ */
+void mbedtls_des3_free( mbedtls_des3_context *ctx );
+
+/**
+ * \brief          Set key parity on the given key to odd.
+ *
+ *                 DES keys are 56 bits long, but each byte is padded with
+ *                 a parity bit to allow verification.
+ *
+ * \param key      8-byte secret key
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ */
+void mbedtls_des_key_set_parity( unsigned char key[MBEDTLS_DES_KEY_SIZE] );
+
+/**
+ * \brief          Check that key parity on the given key is odd.
+ *
+ *                 DES keys are 56 bits long, but each byte is padded with
+ *                 a parity bit to allow verification.
+ *
+ * \param key      8-byte secret key
+ *
+ * \return         0 is parity was ok, 1 if parity was not correct.
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ */
+int mbedtls_des_key_check_key_parity( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
+
+/**
+ * \brief          Check that key is not a weak or semi-weak DES key
+ *
+ * \param key      8-byte secret key
+ *
+ * \return         0 if no weak key was found, 1 if a weak key was identified.
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ */
+int mbedtls_des_key_check_weak( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
+
+/**
+ * \brief          DES key schedule (56-bit, encryption)
+ *
+ * \param ctx      DES context to be initialized
+ * \param key      8-byte secret key
+ *
+ * \return         0
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ */
+int mbedtls_des_setkey_enc( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
+
+/**
+ * \brief          DES key schedule (56-bit, decryption)
+ *
+ * \param ctx      DES context to be initialized
+ * \param key      8-byte secret key
+ *
+ * \return         0
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ */
+int mbedtls_des_setkey_dec( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
+
+/**
+ * \brief          Triple-DES key schedule (112-bit, encryption)
+ *
+ * \param ctx      3DES context to be initialized
+ * \param key      16-byte secret key
+ *
+ * \return         0
+ */
+int mbedtls_des3_set2key_enc( mbedtls_des3_context *ctx,
+                      const unsigned char key[MBEDTLS_DES_KEY_SIZE * 2] );
+
+/**
+ * \brief          Triple-DES key schedule (112-bit, decryption)
+ *
+ * \param ctx      3DES context to be initialized
+ * \param key      16-byte secret key
+ *
+ * \return         0
+ */
+int mbedtls_des3_set2key_dec( mbedtls_des3_context *ctx,
+                      const unsigned char key[MBEDTLS_DES_KEY_SIZE * 2] );
+
+/**
+ * \brief          Triple-DES key schedule (168-bit, encryption)
+ *
+ * \param ctx      3DES context to be initialized
+ * \param key      24-byte secret key
+ *
+ * \return         0
+ */
+int mbedtls_des3_set3key_enc( mbedtls_des3_context *ctx,
+                      const unsigned char key[MBEDTLS_DES_KEY_SIZE * 3] );
+
+/**
+ * \brief          Triple-DES key schedule (168-bit, decryption)
+ *
+ * \param ctx      3DES context to be initialized
+ * \param key      24-byte secret key
+ *
+ * \return         0
+ */
+int mbedtls_des3_set3key_dec( mbedtls_des3_context *ctx,
+                      const unsigned char key[MBEDTLS_DES_KEY_SIZE * 3] );
+
+/**
+ * \brief          DES-ECB block encryption/decryption
+ *
+ * \param ctx      DES context
+ * \param input    64-bit input block
+ * \param output   64-bit output block
+ *
+ * \return         0 if successful
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ */
+int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
+                    const unsigned char input[8],
+                    unsigned char output[8] );
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+/**
+ * \brief          DES-CBC buffer encryption/decryption
+ *
+ * \note           Upon exit, the content of the IV is updated so that you can
+ *                 call the function same function again on the following
+ *                 block(s) of data and get the same result as if it was
+ *                 encrypted in one call. This allows a "streaming" usage.
+ *                 If on the other hand you need to retain the contents of the
+ *                 IV, you should either save it manually or use the cipher
+ *                 module instead.
+ *
+ * \param ctx      DES context
+ * \param mode     MBEDTLS_DES_ENCRYPT or MBEDTLS_DES_DECRYPT
+ * \param length   length of the input data
+ * \param iv       initialization vector (updated after use)
+ * \param input    buffer holding the input data
+ * \param output   buffer holding the output data
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ */
+int mbedtls_des_crypt_cbc( mbedtls_des_context *ctx,
+                    int mode,
+                    size_t length,
+                    unsigned char iv[8],
+                    const unsigned char *input,
+                    unsigned char *output );
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+/**
+ * \brief          3DES-ECB block encryption/decryption
+ *
+ * \param ctx      3DES context
+ * \param input    64-bit input block
+ * \param output   64-bit output block
+ *
+ * \return         0 if successful
+ */
+int mbedtls_des3_crypt_ecb( mbedtls_des3_context *ctx,
+                     const unsigned char input[8],
+                     unsigned char output[8] );
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+/**
+ * \brief          3DES-CBC buffer encryption/decryption
+ *
+ * \note           Upon exit, the content of the IV is updated so that you can
+ *                 call the function same function again on the following
+ *                 block(s) of data and get the same result as if it was
+ *                 encrypted in one call. This allows a "streaming" usage.
+ *                 If on the other hand you need to retain the contents of the
+ *                 IV, you should either save it manually or use the cipher
+ *                 module instead.
+ *
+ * \param ctx      3DES context
+ * \param mode     MBEDTLS_DES_ENCRYPT or MBEDTLS_DES_DECRYPT
+ * \param length   length of the input data
+ * \param iv       initialization vector (updated after use)
+ * \param input    buffer holding the input data
+ * \param output   buffer holding the output data
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH
+ */
+int mbedtls_des3_crypt_cbc( mbedtls_des3_context *ctx,
+                     int mode,
+                     size_t length,
+                     unsigned char iv[8],
+                     const unsigned char *input,
+                     unsigned char *output );
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+/**
+ * \brief          Internal function for key expansion.
+ *                 (Only exposed to allow overriding it,
+ *                 see MBEDTLS_DES_SETKEY_ALT)
+ *
+ * \param SK       Round keys
+ * \param key      Base key
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ */
+void mbedtls_des_setkey( uint32_t SK[32],
+                         const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
+
+/**
+ * \brief          Checkup routine
+ *
+ * \return         0 if successful, or 1 if the test failed
+ */
+int mbedtls_des_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* des.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/error.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/error.h
@@ -1,0 +1,123 @@
+/**
+ * \file error.h
+ *
+ * \brief Error to string translation
+ */
+/*
+ *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_ERROR_H
+#define MBEDTLS_ERROR_H
+
+#include <stddef.h>
+
+/**
+ * Error code layout.
+ *
+ * Currently we try to keep all error codes within the negative space of 16
+ * bits signed integers to support all platforms (-0x0001 - -0x7FFF). In
+ * addition we'd like to give two layers of information on the error if
+ * possible.
+ *
+ * For that purpose the error codes are segmented in the following manner:
+ *
+ * 16 bit error code bit-segmentation
+ *
+ * 1 bit  - Unused (sign bit)
+ * 3 bits - High level module ID
+ * 5 bits - Module-dependent error code
+ * 7 bits - Low level module errors
+ *
+ * For historical reasons, low-level error codes are divided in even and odd,
+ * even codes were assigned first, and -1 is reserved for other errors.
+ *
+ * Low-level module errors (0x0002-0x007E, 0x0003-0x007F)
+ *
+ * Module   Nr  Codes assigned
+ * MPI       7  0x0002-0x0010
+ * GCM       3  0x0012-0x0014   0x0013-0x0013
+ * BLOWFISH  3  0x0016-0x0018   0x0017-0x0017
+ * THREADING 3  0x001A-0x001E
+ * AES       5  0x0020-0x0022   0x0021-0x0025
+ * CAMELLIA  3  0x0024-0x0026   0x0027-0x0027
+ * XTEA      2  0x0028-0x0028   0x0029-0x0029
+ * BASE64    2  0x002A-0x002C
+ * OID       1  0x002E-0x002E   0x000B-0x000B
+ * PADLOCK   1  0x0030-0x0030
+ * DES       2  0x0032-0x0032   0x0033-0x0033
+ * CTR_DBRG  4  0x0034-0x003A
+ * ENTROPY   3  0x003C-0x0040   0x003D-0x003F
+ * NET      13  0x0042-0x0052   0x0043-0x0049
+ * ARIA      4  0x0058-0x005E
+ * ASN1      7  0x0060-0x006C
+ * CMAC      1  0x007A-0x007A
+ * PBKDF2    1  0x007C-0x007C
+ * HMAC_DRBG 4                  0x0003-0x0009
+ * CCM       3                  0x000D-0x0011
+ * ARC4      1                  0x0019-0x0019
+ * MD2       1                  0x002B-0x002B
+ * MD4       1                  0x002D-0x002D
+ * MD5       1                  0x002F-0x002F
+ * RIPEMD160 1                  0x0031-0x0031
+ * SHA1      1                  0x0035-0x0035 0x0073-0x0073
+ * SHA256    1                  0x0037-0x0037 0x0074-0x0074
+ * SHA512    1                  0x0039-0x0039 0x0075-0x0075
+ * CHACHA20  3                  0x0051-0x0055
+ * POLY1305  3                  0x0057-0x005B
+ * CHACHAPOLY 2 0x0054-0x0056
+ * PLATFORM  1  0x0070-0x0072
+ *
+ * High-level module nr (3 bits - 0x0...-0x7...)
+ * Name      ID  Nr of Errors
+ * PEM       1   9
+ * PKCS#12   1   4 (Started from top)
+ * X509      2   20
+ * PKCS5     2   4 (Started from top)
+ * DHM       3   11
+ * PK        3   15 (Started from top)
+ * RSA       4   11
+ * ECP       4   10 (Started from top)
+ * MD        5   5
+ * HKDF      5   1 (Started from top)
+ * CIPHER    6   8
+ * SSL       6   23 (Started from top)
+ * SSL       7   32
+ *
+ * Module dependent error code (5 bits 0x.00.-0x.F8.)
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief Translate a mbed TLS error code into a string representation,
+ *        Result is truncated if necessary and always includes a terminating
+ *        null byte.
+ *
+ * \param errnum    error code
+ * \param buffer    buffer to place representation in
+ * \param buflen    length of the buffer
+ */
+void mbedtls_strerror( int errnum, char *buffer, size_t buflen );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* error.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/gcm.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/gcm.h
@@ -1,0 +1,319 @@
+/**
+ * \file gcm.h
+ *
+ * \brief This file contains GCM definitions and functions.
+ *
+ * The Galois/Counter Mode (GCM) for 128-bit block ciphers is defined
+ * in <em>D. McGrew, J. Viega, The Galois/Counter Mode of Operation
+ * (GCM), Natl. Inst. Stand. Technol.</em>
+ *
+ * For more information on GCM, see <em>NIST SP 800-38D: Recommendation for
+ * Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC</em>.
+ *
+ */
+/*
+ *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_GCM_H
+#define MBEDTLS_GCM_H
+
+#include "cipher.h"
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdint.h>
+#endif
+
+#define MBEDTLS_GCM_ENCRYPT     1
+#define MBEDTLS_GCM_DECRYPT     0
+
+#define MBEDTLS_ERR_GCM_AUTH_FAILED                       -0x0012  /**< Authenticated decryption failed. */
+
+/* MBEDTLS_ERR_GCM_HW_ACCEL_FAILED is deprecated and should not be used. */
+#define MBEDTLS_ERR_GCM_HW_ACCEL_FAILED                   -0x0013  /**< GCM hardware accelerator failed. */
+
+#define MBEDTLS_ERR_GCM_BAD_INPUT                         -0x0014  /**< Bad input parameters to function. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(MBEDTLS_GCM_ALT)
+
+/**
+ * \brief          The GCM context structure.
+ */
+typedef struct mbedtls_gcm_context
+{
+    mbedtls_cipher_context_t cipher_ctx;  /*!< The cipher context used. */
+    uint64_t HL[16];                      /*!< Precalculated HTable low. */
+    uint64_t HH[16];                      /*!< Precalculated HTable high. */
+    uint64_t len;                         /*!< The total length of the encrypted data. */
+    uint64_t add_len;                     /*!< The total length of the additional data. */
+    unsigned char base_ectr[16];          /*!< The first ECTR for tag. */
+    unsigned char y[16];                  /*!< The Y working value. */
+    unsigned char buf[16];                /*!< The buf working value. */
+    int mode;                             /*!< The operation to perform:
+                                               #MBEDTLS_GCM_ENCRYPT or
+                                               #MBEDTLS_GCM_DECRYPT. */
+}
+mbedtls_gcm_context;
+
+#else  /* !MBEDTLS_GCM_ALT */
+#include "gcm_alt.h"
+#endif /* !MBEDTLS_GCM_ALT */
+
+/**
+ * \brief           This function initializes the specified GCM context,
+ *                  to make references valid, and prepares the context
+ *                  for mbedtls_gcm_setkey() or mbedtls_gcm_free().
+ *
+ *                  The function does not bind the GCM context to a particular
+ *                  cipher, nor set the key. For this purpose, use
+ *                  mbedtls_gcm_setkey().
+ *
+ * \param ctx       The GCM context to initialize. This must not be \c NULL.
+ */
+void mbedtls_gcm_init( mbedtls_gcm_context *ctx );
+
+/**
+ * \brief           This function associates a GCM context with a
+ *                  cipher algorithm and a key.
+ *
+ * \param ctx       The GCM context. This must be initialized.
+ * \param cipher    The 128-bit block cipher to use.
+ * \param key       The encryption key. This must be a readable buffer of at
+ *                  least \p keybits bits.
+ * \param keybits   The key size in bits. Valid options are:
+ *                  <ul><li>128 bits</li>
+ *                  <li>192 bits</li>
+ *                  <li>256 bits</li></ul>
+ *
+ * \return          \c 0 on success.
+ * \return          A cipher-specific error code on failure.
+ */
+int mbedtls_gcm_setkey( mbedtls_gcm_context *ctx,
+                        mbedtls_cipher_id_t cipher,
+                        const unsigned char *key,
+                        unsigned int keybits );
+
+/**
+ * \brief           This function performs GCM encryption or decryption of a buffer.
+ *
+ * \note            For encryption, the output buffer can be the same as the
+ *                  input buffer. For decryption, the output buffer cannot be
+ *                  the same as input buffer. If the buffers overlap, the output
+ *                  buffer must trail at least 8 Bytes behind the input buffer.
+ *
+ * \warning         When this function performs a decryption, it outputs the
+ *                  authentication tag and does not verify that the data is
+ *                  authentic. You should use this function to perform encryption
+ *                  only. For decryption, use mbedtls_gcm_auth_decrypt() instead.
+ *
+ * \param ctx       The GCM context to use for encryption or decryption. This
+ *                  must be initialized.
+ * \param mode      The operation to perform:
+ *                  - #MBEDTLS_GCM_ENCRYPT to perform authenticated encryption.
+ *                    The ciphertext is written to \p output and the
+ *                    authentication tag is written to \p tag.
+ *                  - #MBEDTLS_GCM_DECRYPT to perform decryption.
+ *                    The plaintext is written to \p output and the
+ *                    authentication tag is written to \p tag.
+ *                    Note that this mode is not recommended, because it does
+ *                    not verify the authenticity of the data. For this reason,
+ *                    you should use mbedtls_gcm_auth_decrypt() instead of
+ *                    calling this function in decryption mode.
+ * \param length    The length of the input data, which is equal to the length
+ *                  of the output data.
+ * \param iv        The initialization vector. This must be a readable buffer of
+ *                  at least \p iv_len Bytes.
+ * \param iv_len    The length of the IV.
+ * \param add       The buffer holding the additional data. This must be of at
+ *                  least that size in Bytes.
+ * \param add_len   The length of the additional data.
+ * \param input     The buffer holding the input data. If \p length is greater
+ *                  than zero, this must be a readable buffer of at least that
+ *                  size in Bytes.
+ * \param output    The buffer for holding the output data. If \p length is greater
+ *                  than zero, this must be a writable buffer of at least that
+ *                  size in Bytes.
+ * \param tag_len   The length of the tag to generate.
+ * \param tag       The buffer for holding the tag. This must be a readable
+ *                  buffer of at least \p tag_len Bytes.
+ *
+ * \return          \c 0 if the encryption or decryption was performed
+ *                  successfully. Note that in #MBEDTLS_GCM_DECRYPT mode,
+ *                  this does not indicate that the data is authentic.
+ * \return          #MBEDTLS_ERR_GCM_BAD_INPUT if the lengths or pointers are
+ *                  not valid or a cipher-specific error code if the encryption
+ *                  or decryption failed.
+ */
+int mbedtls_gcm_crypt_and_tag( mbedtls_gcm_context *ctx,
+                       int mode,
+                       size_t length,
+                       const unsigned char *iv,
+                       size_t iv_len,
+                       const unsigned char *add,
+                       size_t add_len,
+                       const unsigned char *input,
+                       unsigned char *output,
+                       size_t tag_len,
+                       unsigned char *tag );
+
+/**
+ * \brief           This function performs a GCM authenticated decryption of a
+ *                  buffer.
+ *
+ * \note            For decryption, the output buffer cannot be the same as
+ *                  input buffer. If the buffers overlap, the output buffer
+ *                  must trail at least 8 Bytes behind the input buffer.
+ *
+ * \param ctx       The GCM context. This must be initialized.
+ * \param length    The length of the ciphertext to decrypt, which is also
+ *                  the length of the decrypted plaintext.
+ * \param iv        The initialization vector. This must be a readable buffer
+ *                  of at least \p iv_len Bytes.
+ * \param iv_len    The length of the IV.
+ * \param add       The buffer holding the additional data. This must be of at
+ *                  least that size in Bytes.
+ * \param add_len   The length of the additional data.
+ * \param tag       The buffer holding the tag to verify. This must be a
+ *                  readable buffer of at least \p tag_len Bytes.
+ * \param tag_len   The length of the tag to verify.
+ * \param input     The buffer holding the ciphertext. If \p length is greater
+ *                  than zero, this must be a readable buffer of at least that
+ *                  size.
+ * \param output    The buffer for holding the decrypted plaintext. If \p length
+ *                  is greater than zero, this must be a writable buffer of at
+ *                  least that size.
+ *
+ * \return          \c 0 if successful and authenticated.
+ * \return          #MBEDTLS_ERR_GCM_AUTH_FAILED if the tag does not match.
+ * \return          #MBEDTLS_ERR_GCM_BAD_INPUT if the lengths or pointers are
+ *                  not valid or a cipher-specific error code if the decryption
+ *                  failed.
+ */
+int mbedtls_gcm_auth_decrypt( mbedtls_gcm_context *ctx,
+                      size_t length,
+                      const unsigned char *iv,
+                      size_t iv_len,
+                      const unsigned char *add,
+                      size_t add_len,
+                      const unsigned char *tag,
+                      size_t tag_len,
+                      const unsigned char *input,
+                      unsigned char *output );
+
+/**
+ * \brief           This function starts a GCM encryption or decryption
+ *                  operation.
+ *
+ * \param ctx       The GCM context. This must be initialized.
+ * \param mode      The operation to perform: #MBEDTLS_GCM_ENCRYPT or
+ *                  #MBEDTLS_GCM_DECRYPT.
+ * \param iv        The initialization vector. This must be a readable buffer of
+ *                  at least \p iv_len Bytes.
+ * \param iv_len    The length of the IV.
+ * \param add       The buffer holding the additional data, or \c NULL
+ *                  if \p add_len is \c 0.
+ * \param add_len   The length of the additional data. If \c 0,
+ *                  \p add may be \c NULL.
+ *
+ * \return          \c 0 on success.
+ */
+int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
+                int mode,
+                const unsigned char *iv,
+                size_t iv_len,
+                const unsigned char *add,
+                size_t add_len );
+
+/**
+ * \brief           This function feeds an input buffer into an ongoing GCM
+ *                  encryption or decryption operation.
+ *
+ *    `             The function expects input to be a multiple of 16
+ *                  Bytes. Only the last call before calling
+ *                  mbedtls_gcm_finish() can be less than 16 Bytes.
+ *
+ * \note            For decryption, the output buffer cannot be the same as
+ *                  input buffer. If the buffers overlap, the output buffer
+ *                  must trail at least 8 Bytes behind the input buffer.
+ *
+ * \param ctx       The GCM context. This must be initialized.
+ * \param length    The length of the input data. This must be a multiple of
+ *                  16 except in the last call before mbedtls_gcm_finish().
+ * \param input     The buffer holding the input data. If \p length is greater
+ *                  than zero, this must be a readable buffer of at least that
+ *                  size in Bytes.
+ * \param output    The buffer for holding the output data. If \p length is
+ *                  greater than zero, this must be a writable buffer of at
+ *                  least that size in Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_GCM_BAD_INPUT on failure.
+ */
+int mbedtls_gcm_update( mbedtls_gcm_context *ctx,
+                size_t length,
+                const unsigned char *input,
+                unsigned char *output );
+
+/**
+ * \brief           This function finishes the GCM operation and generates
+ *                  the authentication tag.
+ *
+ *                  It wraps up the GCM stream, and generates the
+ *                  tag. The tag can have a maximum length of 16 Bytes.
+ *
+ * \param ctx       The GCM context. This must be initialized.
+ * \param tag       The buffer for holding the tag. This must be a readable
+ *                  buffer of at least \p tag_len Bytes.
+ * \param tag_len   The length of the tag to generate. This must be at least
+ *                  four.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_GCM_BAD_INPUT on failure.
+ */
+int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
+                unsigned char *tag,
+                size_t tag_len );
+
+/**
+ * \brief           This function clears a GCM context and the underlying
+ *                  cipher sub-context.
+ *
+ * \param ctx       The GCM context to clear. If this is \c NULL, the call has
+ *                  no effect. Otherwise, this must be initialized.
+ */
+void mbedtls_gcm_free( mbedtls_gcm_context *ctx );
+
+/**
+ * \brief          The GCM checkup routine.
+ *
+ * \return         \c 0 on success.
+ * \return         \c 1 on failure.
+ */
+int mbedtls_gcm_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* gcm.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/md.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/md.h
@@ -1,0 +1,464 @@
+ /**
+ * \file md.h
+ *
+ * \brief This file contains the generic message-digest wrapper.
+ *
+ * \author Adriaan de Jong <dejong@fox-it.com>
+ */
+/*
+ *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_MD_H
+#define MBEDTLS_MD_H
+
+#include <stddef.h>
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#define MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE                -0x5080  /**< The selected feature is not available. */
+#define MBEDTLS_ERR_MD_BAD_INPUT_DATA                     -0x5100  /**< Bad input parameters to function. */
+#define MBEDTLS_ERR_MD_ALLOC_FAILED                       -0x5180  /**< Failed to allocate memory. */
+#define MBEDTLS_ERR_MD_FILE_IO_ERROR                      -0x5200  /**< Opening or reading of file failed. */
+
+/* MBEDTLS_ERR_MD_HW_ACCEL_FAILED is deprecated and should not be used. */
+#define MBEDTLS_ERR_MD_HW_ACCEL_FAILED                    -0x5280  /**< MD hardware accelerator failed. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief     Supported message digests.
+ *
+ * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests and
+ *            their use constitutes a security risk. We recommend considering
+ *            stronger message digests instead.
+ *
+ */
+typedef enum {
+    MBEDTLS_MD_NONE=0,    /**< None. */
+    MBEDTLS_MD_MD2,       /**< The MD2 message digest. */
+    MBEDTLS_MD_MD4,       /**< The MD4 message digest. */
+    MBEDTLS_MD_MD5,       /**< The MD5 message digest. */
+    MBEDTLS_MD_SHA1,      /**< The SHA-1 message digest. */
+    MBEDTLS_MD_SHA224,    /**< The SHA-224 message digest. */
+    MBEDTLS_MD_SHA256,    /**< The SHA-256 message digest. */
+    MBEDTLS_MD_SHA384,    /**< The SHA-384 message digest. */
+    MBEDTLS_MD_SHA512,    /**< The SHA-512 message digest. */
+    MBEDTLS_MD_RIPEMD160, /**< The RIPEMD-160 message digest. */
+} mbedtls_md_type_t;
+
+#define MBEDTLS_MD_MAX_SIZE         64  /* longest known is SHA512 */
+
+/**
+ * Opaque struct defined in md_internal.h.
+ */
+typedef struct mbedtls_md_info_t mbedtls_md_info_t;
+
+/**
+ * The generic message-digest context.
+ */
+typedef struct mbedtls_md_context_t
+{
+    /** Information about the associated message digest. */
+    const mbedtls_md_info_t *md_info;
+
+    /** The digest-specific context. */
+    void *md_ctx;
+
+    /** The HMAC part of the context. */
+    void *hmac_ctx;
+} mbedtls_md_context_t;
+
+/**
+ * \brief           This function returns the list of digests supported by the
+ *                  generic digest module.
+ *
+ * \return          A statically allocated array of digests. Each element
+ *                  in the returned list is an integer belonging to the
+ *                  message-digest enumeration #mbedtls_md_type_t.
+ *                  The last entry is 0.
+ */
+const int *mbedtls_md_list( void );
+
+/**
+ * \brief           This function returns the message-digest information
+ *                  associated with the given digest name.
+ *
+ * \param md_name   The name of the digest to search for.
+ *
+ * \return          The message-digest information associated with \p md_name.
+ * \return          NULL if the associated message-digest information is not found.
+ */
+const mbedtls_md_info_t *mbedtls_md_info_from_string( const char *md_name );
+
+/**
+ * \brief           This function returns the message-digest information
+ *                  associated with the given digest type.
+ *
+ * \param md_type   The type of digest to search for.
+ *
+ * \return          The message-digest information associated with \p md_type.
+ * \return          NULL if the associated message-digest information is not found.
+ */
+const mbedtls_md_info_t *mbedtls_md_info_from_type( mbedtls_md_type_t md_type );
+
+/**
+ * \brief           This function initializes a message-digest context without
+ *                  binding it to a particular message-digest algorithm.
+ *
+ *                  This function should always be called first. It prepares the
+ *                  context for mbedtls_md_setup() for binding it to a
+ *                  message-digest algorithm.
+ */
+void mbedtls_md_init( mbedtls_md_context_t *ctx );
+
+/**
+ * \brief           This function clears the internal structure of \p ctx and
+ *                  frees any embedded internal structure, but does not free
+ *                  \p ctx itself.
+ *
+ *                  If you have called mbedtls_md_setup() on \p ctx, you must
+ *                  call mbedtls_md_free() when you are no longer using the
+ *                  context.
+ *                  Calling this function if you have previously
+ *                  called mbedtls_md_init() and nothing else is optional.
+ *                  You must not call this function if you have not called
+ *                  mbedtls_md_init().
+ */
+void mbedtls_md_free( mbedtls_md_context_t *ctx );
+
+#if ! defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED    __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief           This function selects the message digest algorithm to use,
+ *                  and allocates internal structures.
+ *
+ *                  It should be called after mbedtls_md_init() or mbedtls_md_free().
+ *                  Makes it necessary to call mbedtls_md_free() later.
+ *
+ * \deprecated      Superseded by mbedtls_md_setup() in 2.0.0
+ *
+ * \param ctx       The context to set up.
+ * \param md_info   The information structure of the message-digest algorithm
+ *                  to use.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
+ *                  failure.
+ * \return          #MBEDTLS_ERR_MD_ALLOC_FAILED on memory-allocation failure.
+ */
+int mbedtls_md_init_ctx( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info ) MBEDTLS_DEPRECATED;
+#undef MBEDTLS_DEPRECATED
+#endif /* MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief           This function selects the message digest algorithm to use,
+ *                  and allocates internal structures.
+ *
+ *                  It should be called after mbedtls_md_init() or
+ *                  mbedtls_md_free(). Makes it necessary to call
+ *                  mbedtls_md_free() later.
+ *
+ * \param ctx       The context to set up.
+ * \param md_info   The information structure of the message-digest algorithm
+ *                  to use.
+ * \param hmac      Defines if HMAC is used. 0: HMAC is not used (saves some memory),
+ *                  or non-zero: HMAC is used with this context.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
+ *                  failure.
+ * \return          #MBEDTLS_ERR_MD_ALLOC_FAILED on memory-allocation failure.
+ */
+int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info, int hmac );
+
+/**
+ * \brief           This function clones the state of an message-digest
+ *                  context.
+ *
+ * \note            You must call mbedtls_md_setup() on \c dst before calling
+ *                  this function.
+ *
+ * \note            The two contexts must have the same type,
+ *                  for example, both are SHA-256.
+ *
+ * \warning         This function clones the message-digest state, not the
+ *                  HMAC state.
+ *
+ * \param dst       The destination context.
+ * \param src       The context to be cloned.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification failure.
+ */
+int mbedtls_md_clone( mbedtls_md_context_t *dst,
+                      const mbedtls_md_context_t *src );
+
+/**
+ * \brief           This function extracts the message-digest size from the
+ *                  message-digest information structure.
+ *
+ * \param md_info   The information structure of the message-digest algorithm
+ *                  to use.
+ *
+ * \return          The size of the message-digest output in Bytes.
+ */
+unsigned char mbedtls_md_get_size( const mbedtls_md_info_t *md_info );
+
+/**
+ * \brief           This function extracts the message-digest type from the
+ *                  message-digest information structure.
+ *
+ * \param md_info   The information structure of the message-digest algorithm
+ *                  to use.
+ *
+ * \return          The type of the message digest.
+ */
+mbedtls_md_type_t mbedtls_md_get_type( const mbedtls_md_info_t *md_info );
+
+/**
+ * \brief           This function extracts the message-digest name from the
+ *                  message-digest information structure.
+ *
+ * \param md_info   The information structure of the message-digest algorithm
+ *                  to use.
+ *
+ * \return          The name of the message digest.
+ */
+const char *mbedtls_md_get_name( const mbedtls_md_info_t *md_info );
+
+/**
+ * \brief           This function starts a message-digest computation.
+ *
+ *                  You must call this function after setting up the context
+ *                  with mbedtls_md_setup(), and before passing data with
+ *                  mbedtls_md_update().
+ *
+ * \param ctx       The generic message-digest context.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
+ *                  failure.
+ */
+int mbedtls_md_starts( mbedtls_md_context_t *ctx );
+
+/**
+ * \brief           This function feeds an input buffer into an ongoing
+ *                  message-digest computation.
+ *
+ *                  You must call mbedtls_md_starts() before calling this
+ *                  function. You may call this function multiple times.
+ *                  Afterwards, call mbedtls_md_finish().
+ *
+ * \param ctx       The generic message-digest context.
+ * \param input     The buffer holding the input data.
+ * \param ilen      The length of the input data.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
+ *                  failure.
+ */
+int mbedtls_md_update( mbedtls_md_context_t *ctx, const unsigned char *input, size_t ilen );
+
+/**
+ * \brief           This function finishes the digest operation,
+ *                  and writes the result to the output buffer.
+ *
+ *                  Call this function after a call to mbedtls_md_starts(),
+ *                  followed by any number of calls to mbedtls_md_update().
+ *                  Afterwards, you may either clear the context with
+ *                  mbedtls_md_free(), or call mbedtls_md_starts() to reuse
+ *                  the context for another digest operation with the same
+ *                  algorithm.
+ *
+ * \param ctx       The generic message-digest context.
+ * \param output    The buffer for the generic message-digest checksum result.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
+ *                  failure.
+ */
+int mbedtls_md_finish( mbedtls_md_context_t *ctx, unsigned char *output );
+
+/**
+ * \brief          This function calculates the message-digest of a buffer,
+ *                 with respect to a configurable message-digest algorithm
+ *                 in a single call.
+ *
+ *                 The result is calculated as
+ *                 Output = message_digest(input buffer).
+ *
+ * \param md_info  The information structure of the message-digest algorithm
+ *                 to use.
+ * \param input    The buffer holding the data.
+ * \param ilen     The length of the input data.
+ * \param output   The generic message-digest checksum result.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
+ *                 failure.
+ */
+int mbedtls_md( const mbedtls_md_info_t *md_info, const unsigned char *input, size_t ilen,
+        unsigned char *output );
+
+#if defined(MBEDTLS_FS_IO)
+/**
+ * \brief          This function calculates the message-digest checksum
+ *                 result of the contents of the provided file.
+ *
+ *                 The result is calculated as
+ *                 Output = message_digest(file contents).
+ *
+ * \param md_info  The information structure of the message-digest algorithm
+ *                 to use.
+ * \param path     The input file name.
+ * \param output   The generic message-digest checksum result.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_MD_FILE_IO_ERROR on an I/O error accessing
+ *                 the file pointed by \p path.
+ * \return         #MBEDTLS_ERR_MD_BAD_INPUT_DATA if \p md_info was NULL.
+ */
+int mbedtls_md_file( const mbedtls_md_info_t *md_info, const char *path,
+                     unsigned char *output );
+#endif /* MBEDTLS_FS_IO */
+
+/**
+ * \brief           This function sets the HMAC key and prepares to
+ *                  authenticate a new message.
+ *
+ *                  Call this function after mbedtls_md_setup(), to use
+ *                  the MD context for an HMAC calculation, then call
+ *                  mbedtls_md_hmac_update() to provide the input data, and
+ *                  mbedtls_md_hmac_finish() to get the HMAC value.
+ *
+ * \param ctx       The message digest context containing an embedded HMAC
+ *                  context.
+ * \param key       The HMAC secret key.
+ * \param keylen    The length of the HMAC key in Bytes.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
+ *                  failure.
+ */
+int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key,
+                    size_t keylen );
+
+/**
+ * \brief           This function feeds an input buffer into an ongoing HMAC
+ *                  computation.
+ *
+ *                  Call mbedtls_md_hmac_starts() or mbedtls_md_hmac_reset()
+ *                  before calling this function.
+ *                  You may call this function multiple times to pass the
+ *                  input piecewise.
+ *                  Afterwards, call mbedtls_md_hmac_finish().
+ *
+ * \param ctx       The message digest context containing an embedded HMAC
+ *                  context.
+ * \param input     The buffer holding the input data.
+ * \param ilen      The length of the input data.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
+ *                  failure.
+ */
+int mbedtls_md_hmac_update( mbedtls_md_context_t *ctx, const unsigned char *input,
+                    size_t ilen );
+
+/**
+ * \brief           This function finishes the HMAC operation, and writes
+ *                  the result to the output buffer.
+ *
+ *                  Call this function after mbedtls_md_hmac_starts() and
+ *                  mbedtls_md_hmac_update() to get the HMAC value. Afterwards
+ *                  you may either call mbedtls_md_free() to clear the context,
+ *                  or call mbedtls_md_hmac_reset() to reuse the context with
+ *                  the same HMAC key.
+ *
+ * \param ctx       The message digest context containing an embedded HMAC
+ *                  context.
+ * \param output    The generic HMAC checksum result.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
+ *                  failure.
+ */
+int mbedtls_md_hmac_finish( mbedtls_md_context_t *ctx, unsigned char *output);
+
+/**
+ * \brief           This function prepares to authenticate a new message with
+ *                  the same key as the previous HMAC operation.
+ *
+ *                  You may call this function after mbedtls_md_hmac_finish().
+ *                  Afterwards call mbedtls_md_hmac_update() to pass the new
+ *                  input.
+ *
+ * \param ctx       The message digest context containing an embedded HMAC
+ *                  context.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
+ *                  failure.
+ */
+int mbedtls_md_hmac_reset( mbedtls_md_context_t *ctx );
+
+/**
+ * \brief          This function calculates the full generic HMAC
+ *                 on the input buffer with the provided key.
+ *
+ *                 The function allocates the context, performs the
+ *                 calculation, and frees the context.
+ *
+ *                 The HMAC result is calculated as
+ *                 output = generic HMAC(hmac key, input buffer).
+ *
+ * \param md_info  The information structure of the message-digest algorithm
+ *                 to use.
+ * \param key      The HMAC secret key.
+ * \param keylen   The length of the HMAC secret key in Bytes.
+ * \param input    The buffer holding the input data.
+ * \param ilen     The length of the input data.
+ * \param output   The generic HMAC result.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
+ *                 failure.
+ */
+int mbedtls_md_hmac( const mbedtls_md_info_t *md_info, const unsigned char *key, size_t keylen,
+                const unsigned char *input, size_t ilen,
+                unsigned char *output );
+
+/* Internal use */
+int mbedtls_md_process( mbedtls_md_context_t *ctx, const unsigned char *data );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_MD_H */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/md_internal.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/md_internal.h
@@ -1,0 +1,115 @@
+/**
+ * \file md_internal.h
+ *
+ * \brief Message digest wrappers.
+ *
+ * \warning This in an internal header. Do not include directly.
+ *
+ * \author Adriaan de Jong <dejong@fox-it.com>
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_MD_WRAP_H
+#define MBEDTLS_MD_WRAP_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include "md.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Message digest information.
+ * Allows message digest functions to be called in a generic way.
+ */
+struct mbedtls_md_info_t
+{
+    /** Digest identifier */
+    mbedtls_md_type_t type;
+
+    /** Name of the message digest */
+    const char * name;
+
+    /** Output length of the digest function in bytes */
+    int size;
+
+    /** Block length of the digest function in bytes */
+    int block_size;
+
+    /** Digest initialisation function */
+    int (*starts_func)( void *ctx );
+
+    /** Digest update function */
+    int (*update_func)( void *ctx, const unsigned char *input, size_t ilen );
+
+    /** Digest finalisation function */
+    int (*finish_func)( void *ctx, unsigned char *output );
+
+    /** Generic digest function */
+    int (*digest_func)( const unsigned char *input, size_t ilen,
+                        unsigned char *output );
+
+    /** Allocate a new context */
+    void * (*ctx_alloc_func)( void );
+
+    /** Free the given context */
+    void (*ctx_free_func)( void *ctx );
+
+    /** Clone state from a context */
+    void (*clone_func)( void *dst, const void *src );
+
+    /** Internal use only */
+    int (*process_func)( void *ctx, const unsigned char *input );
+};
+
+#if defined(MBEDTLS_MD2_C)
+extern const mbedtls_md_info_t mbedtls_md2_info;
+#endif
+#if defined(MBEDTLS_MD4_C)
+extern const mbedtls_md_info_t mbedtls_md4_info;
+#endif
+#if defined(MBEDTLS_MD5_C)
+extern const mbedtls_md_info_t mbedtls_md5_info;
+#endif
+#if defined(MBEDTLS_RIPEMD160_C)
+extern const mbedtls_md_info_t mbedtls_ripemd160_info;
+#endif
+#if defined(MBEDTLS_SHA1_C)
+extern const mbedtls_md_info_t mbedtls_sha1_info;
+#endif
+#if defined(MBEDTLS_SHA256_C)
+extern const mbedtls_md_info_t mbedtls_sha224_info;
+extern const mbedtls_md_info_t mbedtls_sha256_info;
+#endif
+#if defined(MBEDTLS_SHA512_C)
+extern const mbedtls_md_info_t mbedtls_sha384_info;
+extern const mbedtls_md_info_t mbedtls_sha512_info;
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_MD_WRAP_H */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/oid.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/oid.h
@@ -1,0 +1,605 @@
+/**
+ * \file oid.h
+ *
+ * \brief Object Identifier (OID) database
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_OID_H
+#define MBEDTLS_OID_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include "asn1.h"
+#include "pk.h"
+
+#include <stddef.h>
+
+#if defined(MBEDTLS_CIPHER_C)
+#include "cipher.h"
+#endif
+
+#if defined(MBEDTLS_MD_C)
+#include "md.h"
+#endif
+
+#if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)
+#include "x509.h"
+#endif
+
+#define MBEDTLS_ERR_OID_NOT_FOUND                         -0x002E  /**< OID is not found. */
+#define MBEDTLS_ERR_OID_BUF_TOO_SMALL                     -0x000B  /**< output buffer is too small */
+
+/*
+ * Top level OID tuples
+ */
+#define MBEDTLS_OID_ISO_MEMBER_BODIES           "\x2a"          /* {iso(1) member-body(2)} */
+#define MBEDTLS_OID_ISO_IDENTIFIED_ORG          "\x2b"          /* {iso(1) identified-organization(3)} */
+#define MBEDTLS_OID_ISO_CCITT_DS                "\x55"          /* {joint-iso-ccitt(2) ds(5)} */
+#define MBEDTLS_OID_ISO_ITU_COUNTRY             "\x60"          /* {joint-iso-itu-t(2) country(16)} */
+
+/*
+ * ISO Member bodies OID parts
+ */
+#define MBEDTLS_OID_COUNTRY_US                  "\x86\x48"      /* {us(840)} */
+#define MBEDTLS_OID_ORG_RSA_DATA_SECURITY       "\x86\xf7\x0d"  /* {rsadsi(113549)} */
+#define MBEDTLS_OID_RSA_COMPANY                 MBEDTLS_OID_ISO_MEMBER_BODIES MBEDTLS_OID_COUNTRY_US \
+                                        MBEDTLS_OID_ORG_RSA_DATA_SECURITY /* {iso(1) member-body(2) us(840) rsadsi(113549)} */
+#define MBEDTLS_OID_ORG_ANSI_X9_62              "\xce\x3d" /* ansi-X9-62(10045) */
+#define MBEDTLS_OID_ANSI_X9_62                  MBEDTLS_OID_ISO_MEMBER_BODIES MBEDTLS_OID_COUNTRY_US \
+                                        MBEDTLS_OID_ORG_ANSI_X9_62
+
+/*
+ * ISO Identified organization OID parts
+ */
+#define MBEDTLS_OID_ORG_DOD                     "\x06"          /* {dod(6)} */
+#define MBEDTLS_OID_ORG_OIW                     "\x0e"
+#define MBEDTLS_OID_OIW_SECSIG                  MBEDTLS_OID_ORG_OIW "\x03"
+#define MBEDTLS_OID_OIW_SECSIG_ALG              MBEDTLS_OID_OIW_SECSIG "\x02"
+#define MBEDTLS_OID_OIW_SECSIG_SHA1             MBEDTLS_OID_OIW_SECSIG_ALG "\x1a"
+#define MBEDTLS_OID_ORG_CERTICOM                "\x81\x04"  /* certicom(132) */
+#define MBEDTLS_OID_CERTICOM                    MBEDTLS_OID_ISO_IDENTIFIED_ORG MBEDTLS_OID_ORG_CERTICOM
+#define MBEDTLS_OID_ORG_TELETRUST               "\x24" /* teletrust(36) */
+#define MBEDTLS_OID_TELETRUST                   MBEDTLS_OID_ISO_IDENTIFIED_ORG MBEDTLS_OID_ORG_TELETRUST
+
+/*
+ * ISO ITU OID parts
+ */
+#define MBEDTLS_OID_ORGANIZATION                "\x01"          /* {organization(1)} */
+#define MBEDTLS_OID_ISO_ITU_US_ORG              MBEDTLS_OID_ISO_ITU_COUNTRY MBEDTLS_OID_COUNTRY_US MBEDTLS_OID_ORGANIZATION /* {joint-iso-itu-t(2) country(16) us(840) organization(1)} */
+
+#define MBEDTLS_OID_ORG_GOV                     "\x65"          /* {gov(101)} */
+#define MBEDTLS_OID_GOV                         MBEDTLS_OID_ISO_ITU_US_ORG MBEDTLS_OID_ORG_GOV /* {joint-iso-itu-t(2) country(16) us(840) organization(1) gov(101)} */
+
+#define MBEDTLS_OID_ORG_NETSCAPE                "\x86\xF8\x42"  /* {netscape(113730)} */
+#define MBEDTLS_OID_NETSCAPE                    MBEDTLS_OID_ISO_ITU_US_ORG MBEDTLS_OID_ORG_NETSCAPE /* Netscape OID {joint-iso-itu-t(2) country(16) us(840) organization(1) netscape(113730)} */
+
+/* ISO arc for standard certificate and CRL extensions */
+#define MBEDTLS_OID_ID_CE                       MBEDTLS_OID_ISO_CCITT_DS "\x1D" /**< id-ce OBJECT IDENTIFIER  ::=  {joint-iso-ccitt(2) ds(5) 29} */
+
+#define MBEDTLS_OID_NIST_ALG                    MBEDTLS_OID_GOV "\x03\x04" /** { joint-iso-itu-t(2) country(16) us(840) organization(1) gov(101) csor(3) nistAlgorithm(4) */
+
+/**
+ * Private Internet Extensions
+ * { iso(1) identified-organization(3) dod(6) internet(1)
+ *                      security(5) mechanisms(5) pkix(7) }
+ */
+#define MBEDTLS_OID_PKIX                        MBEDTLS_OID_ISO_IDENTIFIED_ORG MBEDTLS_OID_ORG_DOD "\x01\x05\x05\x07"
+
+/*
+ * Arc for standard naming attributes
+ */
+#define MBEDTLS_OID_AT                          MBEDTLS_OID_ISO_CCITT_DS "\x04" /**< id-at OBJECT IDENTIFIER ::= {joint-iso-ccitt(2) ds(5) 4} */
+#define MBEDTLS_OID_AT_CN                       MBEDTLS_OID_AT "\x03" /**< id-at-commonName AttributeType:= {id-at 3} */
+#define MBEDTLS_OID_AT_SUR_NAME                 MBEDTLS_OID_AT "\x04" /**< id-at-surName AttributeType:= {id-at 4} */
+#define MBEDTLS_OID_AT_SERIAL_NUMBER            MBEDTLS_OID_AT "\x05" /**< id-at-serialNumber AttributeType:= {id-at 5} */
+#define MBEDTLS_OID_AT_COUNTRY                  MBEDTLS_OID_AT "\x06" /**< id-at-countryName AttributeType:= {id-at 6} */
+#define MBEDTLS_OID_AT_LOCALITY                 MBEDTLS_OID_AT "\x07" /**< id-at-locality AttributeType:= {id-at 7} */
+#define MBEDTLS_OID_AT_STATE                    MBEDTLS_OID_AT "\x08" /**< id-at-state AttributeType:= {id-at 8} */
+#define MBEDTLS_OID_AT_ORGANIZATION             MBEDTLS_OID_AT "\x0A" /**< id-at-organizationName AttributeType:= {id-at 10} */
+#define MBEDTLS_OID_AT_ORG_UNIT                 MBEDTLS_OID_AT "\x0B" /**< id-at-organizationalUnitName AttributeType:= {id-at 11} */
+#define MBEDTLS_OID_AT_TITLE                    MBEDTLS_OID_AT "\x0C" /**< id-at-title AttributeType:= {id-at 12} */
+#define MBEDTLS_OID_AT_POSTAL_ADDRESS           MBEDTLS_OID_AT "\x10" /**< id-at-postalAddress AttributeType:= {id-at 16} */
+#define MBEDTLS_OID_AT_POSTAL_CODE              MBEDTLS_OID_AT "\x11" /**< id-at-postalCode AttributeType:= {id-at 17} */
+#define MBEDTLS_OID_AT_GIVEN_NAME               MBEDTLS_OID_AT "\x2A" /**< id-at-givenName AttributeType:= {id-at 42} */
+#define MBEDTLS_OID_AT_INITIALS                 MBEDTLS_OID_AT "\x2B" /**< id-at-initials AttributeType:= {id-at 43} */
+#define MBEDTLS_OID_AT_GENERATION_QUALIFIER     MBEDTLS_OID_AT "\x2C" /**< id-at-generationQualifier AttributeType:= {id-at 44} */
+#define MBEDTLS_OID_AT_UNIQUE_IDENTIFIER        MBEDTLS_OID_AT "\x2D" /**< id-at-uniqueIdentifier AttributType:= {id-at 45} */
+#define MBEDTLS_OID_AT_DN_QUALIFIER             MBEDTLS_OID_AT "\x2E" /**< id-at-dnQualifier AttributeType:= {id-at 46} */
+#define MBEDTLS_OID_AT_PSEUDONYM                MBEDTLS_OID_AT "\x41" /**< id-at-pseudonym AttributeType:= {id-at 65} */
+
+#define MBEDTLS_OID_DOMAIN_COMPONENT            "\x09\x92\x26\x89\x93\xF2\x2C\x64\x01\x19" /** id-domainComponent AttributeType:= {itu-t(0) data(9) pss(2342) ucl(19200300) pilot(100) pilotAttributeType(1) domainComponent(25)} */
+
+/*
+ * OIDs for standard certificate extensions
+ */
+#define MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER    MBEDTLS_OID_ID_CE "\x23" /**< id-ce-authorityKeyIdentifier OBJECT IDENTIFIER ::=  { id-ce 35 } */
+#define MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER      MBEDTLS_OID_ID_CE "\x0E" /**< id-ce-subjectKeyIdentifier OBJECT IDENTIFIER ::=  { id-ce 14 } */
+#define MBEDTLS_OID_KEY_USAGE                   MBEDTLS_OID_ID_CE "\x0F" /**< id-ce-keyUsage OBJECT IDENTIFIER ::=  { id-ce 15 } */
+#define MBEDTLS_OID_CERTIFICATE_POLICIES        MBEDTLS_OID_ID_CE "\x20" /**< id-ce-certificatePolicies OBJECT IDENTIFIER ::=  { id-ce 32 } */
+#define MBEDTLS_OID_POLICY_MAPPINGS             MBEDTLS_OID_ID_CE "\x21" /**< id-ce-policyMappings OBJECT IDENTIFIER ::=  { id-ce 33 } */
+#define MBEDTLS_OID_SUBJECT_ALT_NAME            MBEDTLS_OID_ID_CE "\x11" /**< id-ce-subjectAltName OBJECT IDENTIFIER ::=  { id-ce 17 } */
+#define MBEDTLS_OID_ISSUER_ALT_NAME             MBEDTLS_OID_ID_CE "\x12" /**< id-ce-issuerAltName OBJECT IDENTIFIER ::=  { id-ce 18 } */
+#define MBEDTLS_OID_SUBJECT_DIRECTORY_ATTRS     MBEDTLS_OID_ID_CE "\x09" /**< id-ce-subjectDirectoryAttributes OBJECT IDENTIFIER ::=  { id-ce 9 } */
+#define MBEDTLS_OID_BASIC_CONSTRAINTS           MBEDTLS_OID_ID_CE "\x13" /**< id-ce-basicConstraints OBJECT IDENTIFIER ::=  { id-ce 19 } */
+#define MBEDTLS_OID_NAME_CONSTRAINTS            MBEDTLS_OID_ID_CE "\x1E" /**< id-ce-nameConstraints OBJECT IDENTIFIER ::=  { id-ce 30 } */
+#define MBEDTLS_OID_POLICY_CONSTRAINTS          MBEDTLS_OID_ID_CE "\x24" /**< id-ce-policyConstraints OBJECT IDENTIFIER ::=  { id-ce 36 } */
+#define MBEDTLS_OID_EXTENDED_KEY_USAGE          MBEDTLS_OID_ID_CE "\x25" /**< id-ce-extKeyUsage OBJECT IDENTIFIER ::= { id-ce 37 } */
+#define MBEDTLS_OID_CRL_DISTRIBUTION_POINTS     MBEDTLS_OID_ID_CE "\x1F" /**< id-ce-cRLDistributionPoints OBJECT IDENTIFIER ::=  { id-ce 31 } */
+#define MBEDTLS_OID_INIHIBIT_ANYPOLICY          MBEDTLS_OID_ID_CE "\x36" /**< id-ce-inhibitAnyPolicy OBJECT IDENTIFIER ::=  { id-ce 54 } */
+#define MBEDTLS_OID_FRESHEST_CRL                MBEDTLS_OID_ID_CE "\x2E" /**< id-ce-freshestCRL OBJECT IDENTIFIER ::=  { id-ce 46 } */
+
+/*
+ * Netscape certificate extensions
+ */
+#define MBEDTLS_OID_NS_CERT                 MBEDTLS_OID_NETSCAPE "\x01"
+#define MBEDTLS_OID_NS_CERT_TYPE            MBEDTLS_OID_NS_CERT  "\x01"
+#define MBEDTLS_OID_NS_BASE_URL             MBEDTLS_OID_NS_CERT  "\x02"
+#define MBEDTLS_OID_NS_REVOCATION_URL       MBEDTLS_OID_NS_CERT  "\x03"
+#define MBEDTLS_OID_NS_CA_REVOCATION_URL    MBEDTLS_OID_NS_CERT  "\x04"
+#define MBEDTLS_OID_NS_RENEWAL_URL          MBEDTLS_OID_NS_CERT  "\x07"
+#define MBEDTLS_OID_NS_CA_POLICY_URL        MBEDTLS_OID_NS_CERT  "\x08"
+#define MBEDTLS_OID_NS_SSL_SERVER_NAME      MBEDTLS_OID_NS_CERT  "\x0C"
+#define MBEDTLS_OID_NS_COMMENT              MBEDTLS_OID_NS_CERT  "\x0D"
+#define MBEDTLS_OID_NS_DATA_TYPE            MBEDTLS_OID_NETSCAPE "\x02"
+#define MBEDTLS_OID_NS_CERT_SEQUENCE        MBEDTLS_OID_NS_DATA_TYPE "\x05"
+
+/*
+ * OIDs for CRL extensions
+ */
+#define MBEDTLS_OID_PRIVATE_KEY_USAGE_PERIOD    MBEDTLS_OID_ID_CE "\x10"
+#define MBEDTLS_OID_CRL_NUMBER                  MBEDTLS_OID_ID_CE "\x14" /**< id-ce-cRLNumber OBJECT IDENTIFIER ::= { id-ce 20 } */
+
+/*
+ * X.509 v3 Extended key usage OIDs
+ */
+#define MBEDTLS_OID_ANY_EXTENDED_KEY_USAGE      MBEDTLS_OID_EXTENDED_KEY_USAGE "\x00" /**< anyExtendedKeyUsage OBJECT IDENTIFIER ::= { id-ce-extKeyUsage 0 } */
+
+#define MBEDTLS_OID_KP                          MBEDTLS_OID_PKIX "\x03" /**< id-kp OBJECT IDENTIFIER ::= { id-pkix 3 } */
+#define MBEDTLS_OID_SERVER_AUTH                 MBEDTLS_OID_KP "\x01" /**< id-kp-serverAuth OBJECT IDENTIFIER ::= { id-kp 1 } */
+#define MBEDTLS_OID_CLIENT_AUTH                 MBEDTLS_OID_KP "\x02" /**< id-kp-clientAuth OBJECT IDENTIFIER ::= { id-kp 2 } */
+#define MBEDTLS_OID_CODE_SIGNING                MBEDTLS_OID_KP "\x03" /**< id-kp-codeSigning OBJECT IDENTIFIER ::= { id-kp 3 } */
+#define MBEDTLS_OID_EMAIL_PROTECTION            MBEDTLS_OID_KP "\x04" /**< id-kp-emailProtection OBJECT IDENTIFIER ::= { id-kp 4 } */
+#define MBEDTLS_OID_TIME_STAMPING               MBEDTLS_OID_KP "\x08" /**< id-kp-timeStamping OBJECT IDENTIFIER ::= { id-kp 8 } */
+#define MBEDTLS_OID_OCSP_SIGNING                MBEDTLS_OID_KP "\x09" /**< id-kp-OCSPSigning OBJECT IDENTIFIER ::= { id-kp 9 } */
+
+/*
+ * PKCS definition OIDs
+ */
+
+#define MBEDTLS_OID_PKCS                MBEDTLS_OID_RSA_COMPANY "\x01" /**< pkcs OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) 1 } */
+#define MBEDTLS_OID_PKCS1               MBEDTLS_OID_PKCS "\x01" /**< pkcs-1 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 1 } */
+#define MBEDTLS_OID_PKCS5               MBEDTLS_OID_PKCS "\x05" /**< pkcs-5 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 5 } */
+#define MBEDTLS_OID_PKCS9               MBEDTLS_OID_PKCS "\x09" /**< pkcs-9 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 9 } */
+#define MBEDTLS_OID_PKCS12              MBEDTLS_OID_PKCS "\x0c" /**< pkcs-12 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 12 } */
+
+/*
+ * PKCS#1 OIDs
+ */
+#define MBEDTLS_OID_PKCS1_RSA           MBEDTLS_OID_PKCS1 "\x01" /**< rsaEncryption OBJECT IDENTIFIER ::= { pkcs-1 1 } */
+#define MBEDTLS_OID_PKCS1_MD2           MBEDTLS_OID_PKCS1 "\x02" /**< md2WithRSAEncryption ::= { pkcs-1 2 } */
+#define MBEDTLS_OID_PKCS1_MD4           MBEDTLS_OID_PKCS1 "\x03" /**< md4WithRSAEncryption ::= { pkcs-1 3 } */
+#define MBEDTLS_OID_PKCS1_MD5           MBEDTLS_OID_PKCS1 "\x04" /**< md5WithRSAEncryption ::= { pkcs-1 4 } */
+#define MBEDTLS_OID_PKCS1_SHA1          MBEDTLS_OID_PKCS1 "\x05" /**< sha1WithRSAEncryption ::= { pkcs-1 5 } */
+#define MBEDTLS_OID_PKCS1_SHA224        MBEDTLS_OID_PKCS1 "\x0e" /**< sha224WithRSAEncryption ::= { pkcs-1 14 } */
+#define MBEDTLS_OID_PKCS1_SHA256        MBEDTLS_OID_PKCS1 "\x0b" /**< sha256WithRSAEncryption ::= { pkcs-1 11 } */
+#define MBEDTLS_OID_PKCS1_SHA384        MBEDTLS_OID_PKCS1 "\x0c" /**< sha384WithRSAEncryption ::= { pkcs-1 12 } */
+#define MBEDTLS_OID_PKCS1_SHA512        MBEDTLS_OID_PKCS1 "\x0d" /**< sha512WithRSAEncryption ::= { pkcs-1 13 } */
+
+#define MBEDTLS_OID_RSA_SHA_OBS         "\x2B\x0E\x03\x02\x1D"
+
+#define MBEDTLS_OID_PKCS9_EMAIL         MBEDTLS_OID_PKCS9 "\x01" /**< emailAddress AttributeType ::= { pkcs-9 1 } */
+
+/* RFC 4055 */
+#define MBEDTLS_OID_RSASSA_PSS          MBEDTLS_OID_PKCS1 "\x0a" /**< id-RSASSA-PSS ::= { pkcs-1 10 } */
+#define MBEDTLS_OID_MGF1                MBEDTLS_OID_PKCS1 "\x08" /**< id-mgf1 ::= { pkcs-1 8 } */
+
+/*
+ * Digest algorithms
+ */
+#define MBEDTLS_OID_DIGEST_ALG_MD2              MBEDTLS_OID_RSA_COMPANY "\x02\x02" /**< id-mbedtls_md2 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) digestAlgorithm(2) 2 } */
+#define MBEDTLS_OID_DIGEST_ALG_MD4              MBEDTLS_OID_RSA_COMPANY "\x02\x04" /**< id-mbedtls_md4 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) digestAlgorithm(2) 4 } */
+#define MBEDTLS_OID_DIGEST_ALG_MD5              MBEDTLS_OID_RSA_COMPANY "\x02\x05" /**< id-mbedtls_md5 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) digestAlgorithm(2) 5 } */
+#define MBEDTLS_OID_DIGEST_ALG_SHA1             MBEDTLS_OID_ISO_IDENTIFIED_ORG MBEDTLS_OID_OIW_SECSIG_SHA1 /**< id-mbedtls_sha1 OBJECT IDENTIFIER ::= { iso(1) identified-organization(3) oiw(14) secsig(3) algorithms(2) 26 } */
+#define MBEDTLS_OID_DIGEST_ALG_SHA224           MBEDTLS_OID_NIST_ALG "\x02\x04" /**< id-sha224 OBJECT IDENTIFIER ::= { joint-iso-itu-t(2) country(16) us(840) organization(1) gov(101) csor(3) nistalgorithm(4) hashalgs(2) 4 } */
+#define MBEDTLS_OID_DIGEST_ALG_SHA256           MBEDTLS_OID_NIST_ALG "\x02\x01" /**< id-mbedtls_sha256 OBJECT IDENTIFIER ::= { joint-iso-itu-t(2) country(16) us(840) organization(1) gov(101) csor(3) nistalgorithm(4) hashalgs(2) 1 } */
+
+#define MBEDTLS_OID_DIGEST_ALG_SHA384           MBEDTLS_OID_NIST_ALG "\x02\x02" /**< id-sha384 OBJECT IDENTIFIER ::= { joint-iso-itu-t(2) country(16) us(840) organization(1) gov(101) csor(3) nistalgorithm(4) hashalgs(2) 2 } */
+
+#define MBEDTLS_OID_DIGEST_ALG_SHA512           MBEDTLS_OID_NIST_ALG "\x02\x03" /**< id-mbedtls_sha512 OBJECT IDENTIFIER ::= { joint-iso-itu-t(2) country(16) us(840) organization(1) gov(101) csor(3) nistalgorithm(4) hashalgs(2) 3 } */
+
+#define MBEDTLS_OID_HMAC_SHA1                   MBEDTLS_OID_RSA_COMPANY "\x02\x07" /**< id-hmacWithSHA1 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) digestAlgorithm(2) 7 } */
+
+#define MBEDTLS_OID_HMAC_SHA224                 MBEDTLS_OID_RSA_COMPANY "\x02\x08" /**< id-hmacWithSHA224 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) digestAlgorithm(2) 8 } */
+
+#define MBEDTLS_OID_HMAC_SHA256                 MBEDTLS_OID_RSA_COMPANY "\x02\x09" /**< id-hmacWithSHA256 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) digestAlgorithm(2) 9 } */
+
+#define MBEDTLS_OID_HMAC_SHA384                 MBEDTLS_OID_RSA_COMPANY "\x02\x0A" /**< id-hmacWithSHA384 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) digestAlgorithm(2) 10 } */
+
+#define MBEDTLS_OID_HMAC_SHA512                 MBEDTLS_OID_RSA_COMPANY "\x02\x0B" /**< id-hmacWithSHA512 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) digestAlgorithm(2) 11 } */
+
+/*
+ * Encryption algorithms
+ */
+#define MBEDTLS_OID_DES_CBC                     MBEDTLS_OID_ISO_IDENTIFIED_ORG MBEDTLS_OID_OIW_SECSIG_ALG "\x07" /**< desCBC OBJECT IDENTIFIER ::= { iso(1) identified-organization(3) oiw(14) secsig(3) algorithms(2) 7 } */
+#define MBEDTLS_OID_DES_EDE3_CBC                MBEDTLS_OID_RSA_COMPANY "\x03\x07" /**< des-ede3-cbc OBJECT IDENTIFIER ::= { iso(1) member-body(2) -- us(840) rsadsi(113549) encryptionAlgorithm(3) 7 } */
+#define MBEDTLS_OID_AES                         MBEDTLS_OID_NIST_ALG "\x01" /** aes OBJECT IDENTIFIER ::= { joint-iso-itu-t(2) country(16) us(840) organization(1) gov(101) csor(3) nistAlgorithm(4) 1 } */
+
+/*
+ * Key Wrapping algorithms
+ */
+/*
+ * RFC 5649
+ */
+#define MBEDTLS_OID_AES128_KW                   MBEDTLS_OID_AES "\x05" /** id-aes128-wrap     OBJECT IDENTIFIER ::= { aes 5 } */
+#define MBEDTLS_OID_AES128_KWP                  MBEDTLS_OID_AES "\x08" /** id-aes128-wrap-pad OBJECT IDENTIFIER ::= { aes 8 } */
+#define MBEDTLS_OID_AES192_KW                   MBEDTLS_OID_AES "\x19" /** id-aes192-wrap     OBJECT IDENTIFIER ::= { aes 25 } */
+#define MBEDTLS_OID_AES192_KWP                  MBEDTLS_OID_AES "\x1c" /** id-aes192-wrap-pad OBJECT IDENTIFIER ::= { aes 28 } */
+#define MBEDTLS_OID_AES256_KW                   MBEDTLS_OID_AES "\x2d" /** id-aes256-wrap     OBJECT IDENTIFIER ::= { aes 45 } */
+#define MBEDTLS_OID_AES256_KWP                  MBEDTLS_OID_AES "\x30" /** id-aes256-wrap-pad OBJECT IDENTIFIER ::= { aes 48 } */
+/*
+ * PKCS#5 OIDs
+ */
+#define MBEDTLS_OID_PKCS5_PBKDF2                MBEDTLS_OID_PKCS5 "\x0c" /**< id-PBKDF2 OBJECT IDENTIFIER ::= {pkcs-5 12} */
+#define MBEDTLS_OID_PKCS5_PBES2                 MBEDTLS_OID_PKCS5 "\x0d" /**< id-PBES2 OBJECT IDENTIFIER ::= {pkcs-5 13} */
+#define MBEDTLS_OID_PKCS5_PBMAC1                MBEDTLS_OID_PKCS5 "\x0e" /**< id-PBMAC1 OBJECT IDENTIFIER ::= {pkcs-5 14} */
+
+/*
+ * PKCS#5 PBES1 algorithms
+ */
+#define MBEDTLS_OID_PKCS5_PBE_MD2_DES_CBC       MBEDTLS_OID_PKCS5 "\x01" /**< pbeWithMD2AndDES-CBC OBJECT IDENTIFIER ::= {pkcs-5 1} */
+#define MBEDTLS_OID_PKCS5_PBE_MD2_RC2_CBC       MBEDTLS_OID_PKCS5 "\x04" /**< pbeWithMD2AndRC2-CBC OBJECT IDENTIFIER ::= {pkcs-5 4} */
+#define MBEDTLS_OID_PKCS5_PBE_MD5_DES_CBC       MBEDTLS_OID_PKCS5 "\x03" /**< pbeWithMD5AndDES-CBC OBJECT IDENTIFIER ::= {pkcs-5 3} */
+#define MBEDTLS_OID_PKCS5_PBE_MD5_RC2_CBC       MBEDTLS_OID_PKCS5 "\x06" /**< pbeWithMD5AndRC2-CBC OBJECT IDENTIFIER ::= {pkcs-5 6} */
+#define MBEDTLS_OID_PKCS5_PBE_SHA1_DES_CBC      MBEDTLS_OID_PKCS5 "\x0a" /**< pbeWithSHA1AndDES-CBC OBJECT IDENTIFIER ::= {pkcs-5 10} */
+#define MBEDTLS_OID_PKCS5_PBE_SHA1_RC2_CBC      MBEDTLS_OID_PKCS5 "\x0b" /**< pbeWithSHA1AndRC2-CBC OBJECT IDENTIFIER ::= {pkcs-5 11} */
+
+/*
+ * PKCS#8 OIDs
+ */
+#define MBEDTLS_OID_PKCS9_CSR_EXT_REQ           MBEDTLS_OID_PKCS9 "\x0e" /**< extensionRequest OBJECT IDENTIFIER ::= {pkcs-9 14} */
+
+/*
+ * PKCS#12 PBE OIDs
+ */
+#define MBEDTLS_OID_PKCS12_PBE                      MBEDTLS_OID_PKCS12 "\x01" /**< pkcs-12PbeIds OBJECT IDENTIFIER ::= {pkcs-12 1} */
+
+#define MBEDTLS_OID_PKCS12_PBE_SHA1_RC4_128         MBEDTLS_OID_PKCS12_PBE "\x01" /**< pbeWithSHAAnd128BitRC4 OBJECT IDENTIFIER ::= {pkcs-12PbeIds 1} */
+#define MBEDTLS_OID_PKCS12_PBE_SHA1_RC4_40          MBEDTLS_OID_PKCS12_PBE "\x02" /**< pbeWithSHAAnd40BitRC4 OBJECT IDENTIFIER ::= {pkcs-12PbeIds 2} */
+#define MBEDTLS_OID_PKCS12_PBE_SHA1_DES3_EDE_CBC    MBEDTLS_OID_PKCS12_PBE "\x03" /**< pbeWithSHAAnd3-KeyTripleDES-CBC OBJECT IDENTIFIER ::= {pkcs-12PbeIds 3} */
+#define MBEDTLS_OID_PKCS12_PBE_SHA1_DES2_EDE_CBC    MBEDTLS_OID_PKCS12_PBE "\x04" /**< pbeWithSHAAnd2-KeyTripleDES-CBC OBJECT IDENTIFIER ::= {pkcs-12PbeIds 4} */
+#define MBEDTLS_OID_PKCS12_PBE_SHA1_RC2_128_CBC     MBEDTLS_OID_PKCS12_PBE "\x05" /**< pbeWithSHAAnd128BitRC2-CBC OBJECT IDENTIFIER ::= {pkcs-12PbeIds 5} */
+#define MBEDTLS_OID_PKCS12_PBE_SHA1_RC2_40_CBC      MBEDTLS_OID_PKCS12_PBE "\x06" /**< pbeWithSHAAnd40BitRC2-CBC OBJECT IDENTIFIER ::= {pkcs-12PbeIds 6} */
+
+/*
+ * EC key algorithms from RFC 5480
+ */
+
+/* id-ecPublicKey OBJECT IDENTIFIER ::= {
+ *       iso(1) member-body(2) us(840) ansi-X9-62(10045) keyType(2) 1 } */
+#define MBEDTLS_OID_EC_ALG_UNRESTRICTED         MBEDTLS_OID_ANSI_X9_62 "\x02\01"
+
+/*   id-ecDH OBJECT IDENTIFIER ::= {
+ *     iso(1) identified-organization(3) certicom(132)
+ *     schemes(1) ecdh(12) } */
+#define MBEDTLS_OID_EC_ALG_ECDH                 MBEDTLS_OID_CERTICOM "\x01\x0c"
+
+/*
+ * ECParameters namedCurve identifiers, from RFC 5480, RFC 5639, and SEC2
+ */
+
+/* secp192r1 OBJECT IDENTIFIER ::= {
+ *   iso(1) member-body(2) us(840) ansi-X9-62(10045) curves(3) prime(1) 1 } */
+#define MBEDTLS_OID_EC_GRP_SECP192R1        MBEDTLS_OID_ANSI_X9_62 "\x03\x01\x01"
+
+/* secp224r1 OBJECT IDENTIFIER ::= {
+ *   iso(1) identified-organization(3) certicom(132) curve(0) 33 } */
+#define MBEDTLS_OID_EC_GRP_SECP224R1        MBEDTLS_OID_CERTICOM "\x00\x21"
+
+/* secp256r1 OBJECT IDENTIFIER ::= {
+ *   iso(1) member-body(2) us(840) ansi-X9-62(10045) curves(3) prime(1) 7 } */
+#define MBEDTLS_OID_EC_GRP_SECP256R1        MBEDTLS_OID_ANSI_X9_62 "\x03\x01\x07"
+
+/* secp384r1 OBJECT IDENTIFIER ::= {
+ *   iso(1) identified-organization(3) certicom(132) curve(0) 34 } */
+#define MBEDTLS_OID_EC_GRP_SECP384R1        MBEDTLS_OID_CERTICOM "\x00\x22"
+
+/* secp521r1 OBJECT IDENTIFIER ::= {
+ *   iso(1) identified-organization(3) certicom(132) curve(0) 35 } */
+#define MBEDTLS_OID_EC_GRP_SECP521R1        MBEDTLS_OID_CERTICOM "\x00\x23"
+
+/* secp192k1 OBJECT IDENTIFIER ::= {
+ *   iso(1) identified-organization(3) certicom(132) curve(0) 31 } */
+#define MBEDTLS_OID_EC_GRP_SECP192K1        MBEDTLS_OID_CERTICOM "\x00\x1f"
+
+/* secp224k1 OBJECT IDENTIFIER ::= {
+ *   iso(1) identified-organization(3) certicom(132) curve(0) 32 } */
+#define MBEDTLS_OID_EC_GRP_SECP224K1        MBEDTLS_OID_CERTICOM "\x00\x20"
+
+/* secp256k1 OBJECT IDENTIFIER ::= {
+ *   iso(1) identified-organization(3) certicom(132) curve(0) 10 } */
+#define MBEDTLS_OID_EC_GRP_SECP256K1        MBEDTLS_OID_CERTICOM "\x00\x0a"
+
+/* RFC 5639 4.1
+ * ecStdCurvesAndGeneration OBJECT IDENTIFIER::= {iso(1)
+ * identified-organization(3) teletrust(36) algorithm(3) signature-
+ * algorithm(3) ecSign(2) 8}
+ * ellipticCurve OBJECT IDENTIFIER ::= {ecStdCurvesAndGeneration 1}
+ * versionOne OBJECT IDENTIFIER ::= {ellipticCurve 1} */
+#define MBEDTLS_OID_EC_BRAINPOOL_V1         MBEDTLS_OID_TELETRUST "\x03\x03\x02\x08\x01\x01"
+
+/* brainpoolP256r1 OBJECT IDENTIFIER ::= {versionOne 7} */
+#define MBEDTLS_OID_EC_GRP_BP256R1          MBEDTLS_OID_EC_BRAINPOOL_V1 "\x07"
+
+/* brainpoolP384r1 OBJECT IDENTIFIER ::= {versionOne 11} */
+#define MBEDTLS_OID_EC_GRP_BP384R1          MBEDTLS_OID_EC_BRAINPOOL_V1 "\x0B"
+
+/* brainpoolP512r1 OBJECT IDENTIFIER ::= {versionOne 13} */
+#define MBEDTLS_OID_EC_GRP_BP512R1          MBEDTLS_OID_EC_BRAINPOOL_V1 "\x0D"
+
+/*
+ * SEC1 C.1
+ *
+ * prime-field OBJECT IDENTIFIER ::= { id-fieldType 1 }
+ * id-fieldType OBJECT IDENTIFIER ::= { ansi-X9-62 fieldType(1)}
+ */
+#define MBEDTLS_OID_ANSI_X9_62_FIELD_TYPE   MBEDTLS_OID_ANSI_X9_62 "\x01"
+#define MBEDTLS_OID_ANSI_X9_62_PRIME_FIELD  MBEDTLS_OID_ANSI_X9_62_FIELD_TYPE "\x01"
+
+/*
+ * ECDSA signature identifiers, from RFC 5480
+ */
+#define MBEDTLS_OID_ANSI_X9_62_SIG          MBEDTLS_OID_ANSI_X9_62 "\x04" /* signatures(4) */
+#define MBEDTLS_OID_ANSI_X9_62_SIG_SHA2     MBEDTLS_OID_ANSI_X9_62_SIG "\x03" /* ecdsa-with-SHA2(3) */
+
+/* ecdsa-with-SHA1 OBJECT IDENTIFIER ::= {
+ *   iso(1) member-body(2) us(840) ansi-X9-62(10045) signatures(4) 1 } */
+#define MBEDTLS_OID_ECDSA_SHA1              MBEDTLS_OID_ANSI_X9_62_SIG "\x01"
+
+/* ecdsa-with-SHA224 OBJECT IDENTIFIER ::= {
+ *   iso(1) member-body(2) us(840) ansi-X9-62(10045) signatures(4)
+ *   ecdsa-with-SHA2(3) 1 } */
+#define MBEDTLS_OID_ECDSA_SHA224            MBEDTLS_OID_ANSI_X9_62_SIG_SHA2 "\x01"
+
+/* ecdsa-with-SHA256 OBJECT IDENTIFIER ::= {
+ *   iso(1) member-body(2) us(840) ansi-X9-62(10045) signatures(4)
+ *   ecdsa-with-SHA2(3) 2 } */
+#define MBEDTLS_OID_ECDSA_SHA256            MBEDTLS_OID_ANSI_X9_62_SIG_SHA2 "\x02"
+
+/* ecdsa-with-SHA384 OBJECT IDENTIFIER ::= {
+ *   iso(1) member-body(2) us(840) ansi-X9-62(10045) signatures(4)
+ *   ecdsa-with-SHA2(3) 3 } */
+#define MBEDTLS_OID_ECDSA_SHA384            MBEDTLS_OID_ANSI_X9_62_SIG_SHA2 "\x03"
+
+/* ecdsa-with-SHA512 OBJECT IDENTIFIER ::= {
+ *   iso(1) member-body(2) us(840) ansi-X9-62(10045) signatures(4)
+ *   ecdsa-with-SHA2(3) 4 } */
+#define MBEDTLS_OID_ECDSA_SHA512            MBEDTLS_OID_ANSI_X9_62_SIG_SHA2 "\x04"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief Base OID descriptor structure
+ */
+typedef struct mbedtls_oid_descriptor_t
+{
+    const char *asn1;               /*!< OID ASN.1 representation       */
+    size_t asn1_len;                /*!< length of asn1                 */
+    const char *name;               /*!< official name (e.g. from RFC)  */
+    const char *description;        /*!< human friendly description     */
+} mbedtls_oid_descriptor_t;
+
+/**
+ * \brief           Translate an ASN.1 OID into its numeric representation
+ *                  (e.g. "\x2A\x86\x48\x86\xF7\x0D" into "1.2.840.113549")
+ *
+ * \param buf       buffer to put representation in
+ * \param size      size of the buffer
+ * \param oid       OID to translate
+ *
+ * \return          Length of the string written (excluding final NULL) or
+ *                  MBEDTLS_ERR_OID_BUF_TOO_SMALL in case of error
+ */
+int mbedtls_oid_get_numeric_string( char *buf, size_t size, const mbedtls_asn1_buf *oid );
+
+#if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)
+/**
+ * \brief          Translate an X.509 extension OID into local values
+ *
+ * \param oid      OID to use
+ * \param ext_type place to store the extension type
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_x509_ext_type( const mbedtls_asn1_buf *oid, int *ext_type );
+#endif
+
+/**
+ * \brief          Translate an X.509 attribute type OID into the short name
+ *                 (e.g. the OID for an X520 Common Name into "CN")
+ *
+ * \param oid      OID to use
+ * \param short_name    place to store the string pointer
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_attr_short_name( const mbedtls_asn1_buf *oid, const char **short_name );
+
+/**
+ * \brief          Translate PublicKeyAlgorithm OID into pk_type
+ *
+ * \param oid      OID to use
+ * \param pk_alg   place to store public key algorithm
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_pk_alg( const mbedtls_asn1_buf *oid, mbedtls_pk_type_t *pk_alg );
+
+/**
+ * \brief          Translate pk_type into PublicKeyAlgorithm OID
+ *
+ * \param pk_alg   Public key type to look for
+ * \param oid      place to store ASN.1 OID string pointer
+ * \param olen     length of the OID
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_oid_by_pk_alg( mbedtls_pk_type_t pk_alg,
+                           const char **oid, size_t *olen );
+
+#if defined(MBEDTLS_ECP_C)
+/**
+ * \brief          Translate NamedCurve OID into an EC group identifier
+ *
+ * \param oid      OID to use
+ * \param grp_id   place to store group id
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_ec_grp( const mbedtls_asn1_buf *oid, mbedtls_ecp_group_id *grp_id );
+
+/**
+ * \brief          Translate EC group identifier into NamedCurve OID
+ *
+ * \param grp_id   EC group identifier
+ * \param oid      place to store ASN.1 OID string pointer
+ * \param olen     length of the OID
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_oid_by_ec_grp( mbedtls_ecp_group_id grp_id,
+                           const char **oid, size_t *olen );
+#endif /* MBEDTLS_ECP_C */
+
+#if defined(MBEDTLS_MD_C)
+/**
+ * \brief          Translate SignatureAlgorithm OID into md_type and pk_type
+ *
+ * \param oid      OID to use
+ * \param md_alg   place to store message digest algorithm
+ * \param pk_alg   place to store public key algorithm
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_sig_alg( const mbedtls_asn1_buf *oid,
+                     mbedtls_md_type_t *md_alg, mbedtls_pk_type_t *pk_alg );
+
+/**
+ * \brief          Translate SignatureAlgorithm OID into description
+ *
+ * \param oid      OID to use
+ * \param desc     place to store string pointer
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_sig_alg_desc( const mbedtls_asn1_buf *oid, const char **desc );
+
+/**
+ * \brief          Translate md_type and pk_type into SignatureAlgorithm OID
+ *
+ * \param md_alg   message digest algorithm
+ * \param pk_alg   public key algorithm
+ * \param oid      place to store ASN.1 OID string pointer
+ * \param olen     length of the OID
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_oid_by_sig_alg( mbedtls_pk_type_t pk_alg, mbedtls_md_type_t md_alg,
+                            const char **oid, size_t *olen );
+
+/**
+ * \brief          Translate hash algorithm OID into md_type
+ *
+ * \param oid      OID to use
+ * \param md_alg   place to store message digest algorithm
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_md_alg( const mbedtls_asn1_buf *oid, mbedtls_md_type_t *md_alg );
+
+/**
+ * \brief          Translate hmac algorithm OID into md_type
+ *
+ * \param oid      OID to use
+ * \param md_hmac  place to store message hmac algorithm
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_md_hmac( const mbedtls_asn1_buf *oid, mbedtls_md_type_t *md_hmac );
+#endif /* MBEDTLS_MD_C */
+
+/**
+ * \brief          Translate Extended Key Usage OID into description
+ *
+ * \param oid      OID to use
+ * \param desc     place to store string pointer
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_extended_key_usage( const mbedtls_asn1_buf *oid, const char **desc );
+
+/**
+ * \brief          Translate md_type into hash algorithm OID
+ *
+ * \param md_alg   message digest algorithm
+ * \param oid      place to store ASN.1 OID string pointer
+ * \param olen     length of the OID
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_oid_by_md( mbedtls_md_type_t md_alg, const char **oid, size_t *olen );
+
+#if defined(MBEDTLS_CIPHER_C)
+/**
+ * \brief          Translate encryption algorithm OID into cipher_type
+ *
+ * \param oid           OID to use
+ * \param cipher_alg    place to store cipher algorithm
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_cipher_alg( const mbedtls_asn1_buf *oid, mbedtls_cipher_type_t *cipher_alg );
+#endif /* MBEDTLS_CIPHER_C */
+
+#if defined(MBEDTLS_PKCS12_C)
+/**
+ * \brief          Translate PKCS#12 PBE algorithm OID into md_type and
+ *                 cipher_type
+ *
+ * \param oid           OID to use
+ * \param md_alg        place to store message digest algorithm
+ * \param cipher_alg    place to store cipher algorithm
+ *
+ * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
+ */
+int mbedtls_oid_get_pkcs12_pbe_alg( const mbedtls_asn1_buf *oid, mbedtls_md_type_t *md_alg,
+                            mbedtls_cipher_type_t *cipher_alg );
+#endif /* MBEDTLS_PKCS12_C */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* oid.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/pk.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/pk.h
@@ -1,0 +1,747 @@
+/**
+ * \file pk.h
+ *
+ * \brief Public Key abstraction layer
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_PK_H
+#define MBEDTLS_PK_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include "md.h"
+
+#if defined(MBEDTLS_RSA_C)
+#include "rsa.h"
+#endif
+
+#if defined(MBEDTLS_ECP_C)
+#include "ecp.h"
+#endif
+
+#if defined(MBEDTLS_ECDSA_C)
+#include "ecdsa.h"
+#endif
+
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
+#define MBEDTLS_ERR_PK_ALLOC_FAILED        -0x3F80  /**< Memory allocation failed. */
+#define MBEDTLS_ERR_PK_TYPE_MISMATCH       -0x3F00  /**< Type mismatch, eg attempt to encrypt with an ECDSA key */
+#define MBEDTLS_ERR_PK_BAD_INPUT_DATA      -0x3E80  /**< Bad input parameters to function. */
+#define MBEDTLS_ERR_PK_FILE_IO_ERROR       -0x3E00  /**< Read/write of file failed. */
+#define MBEDTLS_ERR_PK_KEY_INVALID_VERSION -0x3D80  /**< Unsupported key version */
+#define MBEDTLS_ERR_PK_KEY_INVALID_FORMAT  -0x3D00  /**< Invalid key tag or value. */
+#define MBEDTLS_ERR_PK_UNKNOWN_PK_ALG      -0x3C80  /**< Key algorithm is unsupported (only RSA and EC are supported). */
+#define MBEDTLS_ERR_PK_PASSWORD_REQUIRED   -0x3C00  /**< Private key password can't be empty. */
+#define MBEDTLS_ERR_PK_PASSWORD_MISMATCH   -0x3B80  /**< Given private key password does not allow for correct decryption. */
+#define MBEDTLS_ERR_PK_INVALID_PUBKEY      -0x3B00  /**< The pubkey tag or value is invalid (only RSA and EC are supported). */
+#define MBEDTLS_ERR_PK_INVALID_ALG         -0x3A80  /**< The algorithm tag or value is invalid. */
+#define MBEDTLS_ERR_PK_UNKNOWN_NAMED_CURVE -0x3A00  /**< Elliptic curve is unsupported (only NIST curves are supported). */
+#define MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE -0x3980  /**< Unavailable feature, e.g. RSA disabled for RSA key. */
+#define MBEDTLS_ERR_PK_SIG_LEN_MISMATCH    -0x3900  /**< The buffer contains a valid signature followed by more data. */
+
+/* MBEDTLS_ERR_PK_HW_ACCEL_FAILED is deprecated and should not be used. */
+#define MBEDTLS_ERR_PK_HW_ACCEL_FAILED     -0x3880  /**< PK hardware accelerator failed. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief          Public key types
+ */
+typedef enum {
+    MBEDTLS_PK_NONE=0,
+    MBEDTLS_PK_RSA,
+    MBEDTLS_PK_ECKEY,
+    MBEDTLS_PK_ECKEY_DH,
+    MBEDTLS_PK_ECDSA,
+    MBEDTLS_PK_RSA_ALT,
+    MBEDTLS_PK_RSASSA_PSS,
+} mbedtls_pk_type_t;
+
+/**
+ * \brief           Options for RSASSA-PSS signature verification.
+ *                  See \c mbedtls_rsa_rsassa_pss_verify_ext()
+ */
+typedef struct mbedtls_pk_rsassa_pss_options
+{
+    mbedtls_md_type_t mgf1_hash_id;
+    int expected_salt_len;
+
+} mbedtls_pk_rsassa_pss_options;
+
+/**
+ * \brief           Types for interfacing with the debug module
+ */
+typedef enum
+{
+    MBEDTLS_PK_DEBUG_NONE = 0,
+    MBEDTLS_PK_DEBUG_MPI,
+    MBEDTLS_PK_DEBUG_ECP,
+} mbedtls_pk_debug_type;
+
+/**
+ * \brief           Item to send to the debug module
+ */
+typedef struct mbedtls_pk_debug_item
+{
+    mbedtls_pk_debug_type type;
+    const char *name;
+    void *value;
+} mbedtls_pk_debug_item;
+
+/** Maximum number of item send for debugging, plus 1 */
+#define MBEDTLS_PK_DEBUG_MAX_ITEMS 3
+
+/**
+ * \brief           Public key information and operations
+ */
+typedef struct mbedtls_pk_info_t mbedtls_pk_info_t;
+
+/**
+ * \brief           Public key container
+ */
+typedef struct mbedtls_pk_context
+{
+    const mbedtls_pk_info_t *   pk_info; /**< Public key information         */
+    void *                      pk_ctx;  /**< Underlying public key context  */
+} mbedtls_pk_context;
+
+#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
+/**
+ * \brief           Context for resuming operations
+ */
+typedef struct
+{
+    const mbedtls_pk_info_t *   pk_info; /**< Public key information         */
+    void *                      rs_ctx;  /**< Underlying restart context     */
+} mbedtls_pk_restart_ctx;
+#else /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+/* Now we can declare functions that take a pointer to that */
+typedef void mbedtls_pk_restart_ctx;
+#endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+
+#if defined(MBEDTLS_RSA_C)
+/**
+ * Quick access to an RSA context inside a PK context.
+ *
+ * \warning You must make sure the PK context actually holds an RSA context
+ * before using this function!
+ */
+static inline mbedtls_rsa_context *mbedtls_pk_rsa( const mbedtls_pk_context pk )
+{
+    return( (mbedtls_rsa_context *) (pk).pk_ctx );
+}
+#endif /* MBEDTLS_RSA_C */
+
+#if defined(MBEDTLS_ECP_C)
+/**
+ * Quick access to an EC context inside a PK context.
+ *
+ * \warning You must make sure the PK context actually holds an EC context
+ * before using this function!
+ */
+static inline mbedtls_ecp_keypair *mbedtls_pk_ec( const mbedtls_pk_context pk )
+{
+    return( (mbedtls_ecp_keypair *) (pk).pk_ctx );
+}
+#endif /* MBEDTLS_ECP_C */
+
+#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+/**
+ * \brief           Types for RSA-alt abstraction
+ */
+typedef int (*mbedtls_pk_rsa_alt_decrypt_func)( void *ctx, int mode, size_t *olen,
+                    const unsigned char *input, unsigned char *output,
+                    size_t output_max_len );
+typedef int (*mbedtls_pk_rsa_alt_sign_func)( void *ctx,
+                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
+                    int mode, mbedtls_md_type_t md_alg, unsigned int hashlen,
+                    const unsigned char *hash, unsigned char *sig );
+typedef size_t (*mbedtls_pk_rsa_alt_key_len_func)( void *ctx );
+#endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
+
+/**
+ * \brief           Return information associated with the given PK type
+ *
+ * \param pk_type   PK type to search for.
+ *
+ * \return          The PK info associated with the type or NULL if not found.
+ */
+const mbedtls_pk_info_t *mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type );
+
+/**
+ * \brief           Initialize a #mbedtls_pk_context (as NONE).
+ *
+ * \param ctx       The context to initialize.
+ *                  This must not be \c NULL.
+ */
+void mbedtls_pk_init( mbedtls_pk_context *ctx );
+
+/**
+ * \brief           Free the components of a #mbedtls_pk_context.
+ *
+ * \param ctx       The context to clear. It must have been initialized.
+ *                  If this is \c NULL, this function does nothing.
+ */
+void mbedtls_pk_free( mbedtls_pk_context *ctx );
+
+#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
+/**
+ * \brief           Initialize a restart context
+ *
+ * \param ctx       The context to initialize.
+ *                  This must not be \c NULL.
+ */
+void mbedtls_pk_restart_init( mbedtls_pk_restart_ctx *ctx );
+
+/**
+ * \brief           Free the components of a restart context
+ *
+ * \param ctx       The context to clear. It must have been initialized.
+ *                  If this is \c NULL, this function does nothing.
+ */
+void mbedtls_pk_restart_free( mbedtls_pk_restart_ctx *ctx );
+#endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+
+/**
+ * \brief           Initialize a PK context with the information given
+ *                  and allocates the type-specific PK subcontext.
+ *
+ * \param ctx       Context to initialize. It must not have been set
+ *                  up yet (type #MBEDTLS_PK_NONE).
+ * \param info      Information to use
+ *
+ * \return          0 on success,
+ *                  MBEDTLS_ERR_PK_BAD_INPUT_DATA on invalid input,
+ *                  MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
+ *
+ * \note            For contexts holding an RSA-alt key, use
+ *                  \c mbedtls_pk_setup_rsa_alt() instead.
+ */
+int mbedtls_pk_setup( mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info );
+
+#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+/**
+ * \brief           Initialize an RSA-alt context
+ *
+ * \param ctx       Context to initialize. It must not have been set
+ *                  up yet (type #MBEDTLS_PK_NONE).
+ * \param key       RSA key pointer
+ * \param decrypt_func  Decryption function
+ * \param sign_func     Signing function
+ * \param key_len_func  Function returning key length in bytes
+ *
+ * \return          0 on success, or MBEDTLS_ERR_PK_BAD_INPUT_DATA if the
+ *                  context wasn't already initialized as RSA_ALT.
+ *
+ * \note            This function replaces \c mbedtls_pk_setup() for RSA-alt.
+ */
+int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
+                         mbedtls_pk_rsa_alt_decrypt_func decrypt_func,
+                         mbedtls_pk_rsa_alt_sign_func sign_func,
+                         mbedtls_pk_rsa_alt_key_len_func key_len_func );
+#endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
+
+/**
+ * \brief           Get the size in bits of the underlying key
+ *
+ * \param ctx       The context to query. It must have been initialized.
+ *
+ * \return          Key size in bits, or 0 on error
+ */
+size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx );
+
+/**
+ * \brief           Get the length in bytes of the underlying key
+ *
+ * \param ctx       The context to query. It must have been initialized.
+ *
+ * \return          Key length in bytes, or 0 on error
+ */
+static inline size_t mbedtls_pk_get_len( const mbedtls_pk_context *ctx )
+{
+    return( ( mbedtls_pk_get_bitlen( ctx ) + 7 ) / 8 );
+}
+
+/**
+ * \brief           Tell if a context can do the operation given by type
+ *
+ * \param ctx       The context to query. It must have been initialized.
+ * \param type      The desired type.
+ *
+ * \return          1 if the context can do operations on the given type.
+ * \return          0 if the context cannot do the operations on the given
+ *                  type. This is always the case for a context that has
+ *                  been initialized but not set up, or that has been
+ *                  cleared with mbedtls_pk_free().
+ */
+int mbedtls_pk_can_do( const mbedtls_pk_context *ctx, mbedtls_pk_type_t type );
+
+/**
+ * \brief           Verify signature (including padding if relevant).
+ *
+ * \param ctx       The PK context to use. It must have been set up.
+ * \param md_alg    Hash algorithm used (see notes)
+ * \param hash      Hash of the message to sign
+ * \param hash_len  Hash length or 0 (see notes)
+ * \param sig       Signature to verify
+ * \param sig_len   Signature length
+ *
+ * \return          0 on success (signature is valid),
+ *                  #MBEDTLS_ERR_PK_SIG_LEN_MISMATCH if there is a valid
+ *                  signature in sig but its length is less than \p siglen,
+ *                  or a specific error code.
+ *
+ * \note            For RSA keys, the default padding type is PKCS#1 v1.5.
+ *                  Use \c mbedtls_pk_verify_ext( MBEDTLS_PK_RSASSA_PSS, ... )
+ *                  to verify RSASSA_PSS signatures.
+ *
+ * \note            If hash_len is 0, then the length associated with md_alg
+ *                  is used instead, or an error returned if it is invalid.
+ *
+ * \note            md_alg may be MBEDTLS_MD_NONE, only if hash_len != 0
+ */
+int mbedtls_pk_verify( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
+               const unsigned char *hash, size_t hash_len,
+               const unsigned char *sig, size_t sig_len );
+
+/**
+ * \brief           Restartable version of \c mbedtls_pk_verify()
+ *
+ * \note            Performs the same job as \c mbedtls_pk_verify(), but can
+ *                  return early and restart according to the limit set with
+ *                  \c mbedtls_ecp_set_max_ops() to reduce blocking for ECC
+ *                  operations. For RSA, same as \c mbedtls_pk_verify().
+ *
+ * \param ctx       The PK context to use. It must have been set up.
+ * \param md_alg    Hash algorithm used (see notes)
+ * \param hash      Hash of the message to sign
+ * \param hash_len  Hash length or 0 (see notes)
+ * \param sig       Signature to verify
+ * \param sig_len   Signature length
+ * \param rs_ctx    Restart context (NULL to disable restart)
+ *
+ * \return          See \c mbedtls_pk_verify(), or
+ * \return          #MBEDTLS_ERR_ECP_IN_PROGRESS if maximum number of
+ *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
+ */
+int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
+               mbedtls_md_type_t md_alg,
+               const unsigned char *hash, size_t hash_len,
+               const unsigned char *sig, size_t sig_len,
+               mbedtls_pk_restart_ctx *rs_ctx );
+
+/**
+ * \brief           Verify signature, with options.
+ *                  (Includes verification of the padding depending on type.)
+ *
+ * \param type      Signature type (inc. possible padding type) to verify
+ * \param options   Pointer to type-specific options, or NULL
+ * \param ctx       The PK context to use. It must have been set up.
+ * \param md_alg    Hash algorithm used (see notes)
+ * \param hash      Hash of the message to sign
+ * \param hash_len  Hash length or 0 (see notes)
+ * \param sig       Signature to verify
+ * \param sig_len   Signature length
+ *
+ * \return          0 on success (signature is valid),
+ *                  #MBEDTLS_ERR_PK_TYPE_MISMATCH if the PK context can't be
+ *                  used for this type of signatures,
+ *                  #MBEDTLS_ERR_PK_SIG_LEN_MISMATCH if there is a valid
+ *                  signature in sig but its length is less than \p siglen,
+ *                  or a specific error code.
+ *
+ * \note            If hash_len is 0, then the length associated with md_alg
+ *                  is used instead, or an error returned if it is invalid.
+ *
+ * \note            md_alg may be MBEDTLS_MD_NONE, only if hash_len != 0
+ *
+ * \note            If type is MBEDTLS_PK_RSASSA_PSS, then options must point
+ *                  to a mbedtls_pk_rsassa_pss_options structure,
+ *                  otherwise it must be NULL.
+ */
+int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
+                   mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
+                   const unsigned char *hash, size_t hash_len,
+                   const unsigned char *sig, size_t sig_len );
+
+/**
+ * \brief           Make signature, including padding if relevant.
+ *
+ * \param ctx       The PK context to use. It must have been set up
+ *                  with a private key.
+ * \param md_alg    Hash algorithm used (see notes)
+ * \param hash      Hash of the message to sign
+ * \param hash_len  Hash length or 0 (see notes)
+ * \param sig       Place to write the signature
+ * \param sig_len   Number of bytes written
+ * \param f_rng     RNG function
+ * \param p_rng     RNG parameter
+ *
+ * \return          0 on success, or a specific error code.
+ *
+ * \note            For RSA keys, the default padding type is PKCS#1 v1.5.
+ *                  There is no interface in the PK module to make RSASSA-PSS
+ *                  signatures yet.
+ *
+ * \note            If hash_len is 0, then the length associated with md_alg
+ *                  is used instead, or an error returned if it is invalid.
+ *
+ * \note            For RSA, md_alg may be MBEDTLS_MD_NONE if hash_len != 0.
+ *                  For ECDSA, md_alg may never be MBEDTLS_MD_NONE.
+ */
+int mbedtls_pk_sign( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
+             const unsigned char *hash, size_t hash_len,
+             unsigned char *sig, size_t *sig_len,
+             int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
+
+/**
+ * \brief           Restartable version of \c mbedtls_pk_sign()
+ *
+ * \note            Performs the same job as \c mbedtls_pk_sign(), but can
+ *                  return early and restart according to the limit set with
+ *                  \c mbedtls_ecp_set_max_ops() to reduce blocking for ECC
+ *                  operations. For RSA, same as \c mbedtls_pk_sign().
+ *
+ * \param ctx       The PK context to use. It must have been set up
+ *                  with a private key.
+ * \param md_alg    Hash algorithm used (see notes)
+ * \param hash      Hash of the message to sign
+ * \param hash_len  Hash length or 0 (see notes)
+ * \param sig       Place to write the signature
+ * \param sig_len   Number of bytes written
+ * \param f_rng     RNG function
+ * \param p_rng     RNG parameter
+ * \param rs_ctx    Restart context (NULL to disable restart)
+ *
+ * \return          See \c mbedtls_pk_sign(), or
+ * \return          #MBEDTLS_ERR_ECP_IN_PROGRESS if maximum number of
+ *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
+ */
+int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
+             mbedtls_md_type_t md_alg,
+             const unsigned char *hash, size_t hash_len,
+             unsigned char *sig, size_t *sig_len,
+             int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
+             mbedtls_pk_restart_ctx *rs_ctx );
+
+/**
+ * \brief           Decrypt message (including padding if relevant).
+ *
+ * \param ctx       The PK context to use. It must have been set up
+ *                  with a private key.
+ * \param input     Input to decrypt
+ * \param ilen      Input size
+ * \param output    Decrypted output
+ * \param olen      Decrypted message length
+ * \param osize     Size of the output buffer
+ * \param f_rng     RNG function
+ * \param p_rng     RNG parameter
+ *
+ * \note            For RSA keys, the default padding type is PKCS#1 v1.5.
+ *
+ * \return          0 on success, or a specific error code.
+ */
+int mbedtls_pk_decrypt( mbedtls_pk_context *ctx,
+                const unsigned char *input, size_t ilen,
+                unsigned char *output, size_t *olen, size_t osize,
+                int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
+
+/**
+ * \brief           Encrypt message (including padding if relevant).
+ *
+ * \param ctx       The PK context to use. It must have been set up.
+ * \param input     Message to encrypt
+ * \param ilen      Message size
+ * \param output    Encrypted output
+ * \param olen      Encrypted output length
+ * \param osize     Size of the output buffer
+ * \param f_rng     RNG function
+ * \param p_rng     RNG parameter
+ *
+ * \note            For RSA keys, the default padding type is PKCS#1 v1.5.
+ *
+ * \return          0 on success, or a specific error code.
+ */
+int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
+                const unsigned char *input, size_t ilen,
+                unsigned char *output, size_t *olen, size_t osize,
+                int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
+
+/**
+ * \brief           Check if a public-private pair of keys matches.
+ *
+ * \param pub       Context holding a public key.
+ * \param prv       Context holding a private (and public) key.
+ *
+ * \return          0 on success or MBEDTLS_ERR_PK_BAD_INPUT_DATA
+ */
+int mbedtls_pk_check_pair( const mbedtls_pk_context *pub, const mbedtls_pk_context *prv );
+
+/**
+ * \brief           Export debug information
+ *
+ * \param ctx       The PK context to use. It must have been initialized.
+ * \param items     Place to write debug items
+ *
+ * \return          0 on success or MBEDTLS_ERR_PK_BAD_INPUT_DATA
+ */
+int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items );
+
+/**
+ * \brief           Access the type name
+ *
+ * \param ctx       The PK context to use. It must have been initialized.
+ *
+ * \return          Type name on success, or "invalid PK"
+ */
+const char * mbedtls_pk_get_name( const mbedtls_pk_context *ctx );
+
+/**
+ * \brief           Get the key type
+ *
+ * \param ctx       The PK context to use. It must have been initialized.
+ *
+ * \return          Type on success.
+ * \return          #MBEDTLS_PK_NONE for a context that has not been set up.
+ */
+mbedtls_pk_type_t mbedtls_pk_get_type( const mbedtls_pk_context *ctx );
+
+#if defined(MBEDTLS_PK_PARSE_C)
+/** \ingroup pk_module */
+/**
+ * \brief           Parse a private key in PEM or DER format
+ *
+ * \param ctx       The PK context to fill. It must have been initialized
+ *                  but not set up.
+ * \param key       Input buffer to parse.
+ *                  The buffer must contain the input exactly, with no
+ *                  extra trailing material. For PEM, the buffer must
+ *                  contain a null-terminated string.
+ * \param keylen    Size of \b key in bytes.
+ *                  For PEM data, this includes the terminating null byte,
+ *                  so \p keylen must be equal to `strlen(key) + 1`.
+ * \param pwd       Optional password for decryption.
+ *                  Pass \c NULL if expecting a non-encrypted key.
+ *                  Pass a string of \p pwdlen bytes if expecting an encrypted
+ *                  key; a non-encrypted key will also be accepted.
+ *                  The empty password is not supported.
+ * \param pwdlen    Size of the password in bytes.
+ *                  Ignored if \p pwd is \c NULL.
+ *
+ * \note            On entry, ctx must be empty, either freshly initialised
+ *                  with mbedtls_pk_init() or reset with mbedtls_pk_free(). If you need a
+ *                  specific key type, check the result with mbedtls_pk_can_do().
+ *
+ * \note            The key is also checked for correctness.
+ *
+ * \return          0 if successful, or a specific PK or PEM error code
+ */
+int mbedtls_pk_parse_key( mbedtls_pk_context *ctx,
+                  const unsigned char *key, size_t keylen,
+                  const unsigned char *pwd, size_t pwdlen );
+
+/** \ingroup pk_module */
+/**
+ * \brief           Parse a public key in PEM or DER format
+ *
+ * \param ctx       The PK context to fill. It must have been initialized
+ *                  but not set up.
+ * \param key       Input buffer to parse.
+ *                  The buffer must contain the input exactly, with no
+ *                  extra trailing material. For PEM, the buffer must
+ *                  contain a null-terminated string.
+ * \param keylen    Size of \b key in bytes.
+ *                  For PEM data, this includes the terminating null byte,
+ *                  so \p keylen must be equal to `strlen(key) + 1`.
+ *
+ * \note            On entry, ctx must be empty, either freshly initialised
+ *                  with mbedtls_pk_init() or reset with mbedtls_pk_free(). If you need a
+ *                  specific key type, check the result with mbedtls_pk_can_do().
+ *
+ * \note            The key is also checked for correctness.
+ *
+ * \return          0 if successful, or a specific PK or PEM error code
+ */
+int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
+                         const unsigned char *key, size_t keylen );
+
+#if defined(MBEDTLS_FS_IO)
+/** \ingroup pk_module */
+/**
+ * \brief           Load and parse a private key
+ *
+ * \param ctx       The PK context to fill. It must have been initialized
+ *                  but not set up.
+ * \param path      filename to read the private key from
+ * \param password  Optional password to decrypt the file.
+ *                  Pass \c NULL if expecting a non-encrypted key.
+ *                  Pass a null-terminated string if expecting an encrypted
+ *                  key; a non-encrypted key will also be accepted.
+ *                  The empty password is not supported.
+ *
+ * \note            On entry, ctx must be empty, either freshly initialised
+ *                  with mbedtls_pk_init() or reset with mbedtls_pk_free(). If you need a
+ *                  specific key type, check the result with mbedtls_pk_can_do().
+ *
+ * \note            The key is also checked for correctness.
+ *
+ * \return          0 if successful, or a specific PK or PEM error code
+ */
+int mbedtls_pk_parse_keyfile( mbedtls_pk_context *ctx,
+                      const char *path, const char *password );
+
+/** \ingroup pk_module */
+/**
+ * \brief           Load and parse a public key
+ *
+ * \param ctx       The PK context to fill. It must have been initialized
+ *                  but not set up.
+ * \param path      filename to read the public key from
+ *
+ * \note            On entry, ctx must be empty, either freshly initialised
+ *                  with mbedtls_pk_init() or reset with mbedtls_pk_free(). If
+ *                  you need a specific key type, check the result with
+ *                  mbedtls_pk_can_do().
+ *
+ * \note            The key is also checked for correctness.
+ *
+ * \return          0 if successful, or a specific PK or PEM error code
+ */
+int mbedtls_pk_parse_public_keyfile( mbedtls_pk_context *ctx, const char *path );
+#endif /* MBEDTLS_FS_IO */
+#endif /* MBEDTLS_PK_PARSE_C */
+
+#if defined(MBEDTLS_PK_WRITE_C)
+/**
+ * \brief           Write a private key to a PKCS#1 or SEC1 DER structure
+ *                  Note: data is written at the end of the buffer! Use the
+ *                        return value to determine where you should start
+ *                        using the buffer
+ *
+ * \param ctx       PK context which must contain a valid private key.
+ * \param buf       buffer to write to
+ * \param size      size of the buffer
+ *
+ * \return          length of data written if successful, or a specific
+ *                  error code
+ */
+int mbedtls_pk_write_key_der( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
+
+/**
+ * \brief           Write a public key to a SubjectPublicKeyInfo DER structure
+ *                  Note: data is written at the end of the buffer! Use the
+ *                        return value to determine where you should start
+ *                        using the buffer
+ *
+ * \param ctx       PK context which must contain a valid public or private key.
+ * \param buf       buffer to write to
+ * \param size      size of the buffer
+ *
+ * \return          length of data written if successful, or a specific
+ *                  error code
+ */
+int mbedtls_pk_write_pubkey_der( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
+
+#if defined(MBEDTLS_PEM_WRITE_C)
+/**
+ * \brief           Write a public key to a PEM string
+ *
+ * \param ctx       PK context which must contain a valid public or private key.
+ * \param buf       Buffer to write to. The output includes a
+ *                  terminating null byte.
+ * \param size      Size of the buffer in bytes.
+ *
+ * \return          0 if successful, or a specific error code
+ */
+int mbedtls_pk_write_pubkey_pem( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
+
+/**
+ * \brief           Write a private key to a PKCS#1 or SEC1 PEM string
+ *
+ * \param ctx       PK context which must contain a valid private key.
+ * \param buf       Buffer to write to. The output includes a
+ *                  terminating null byte.
+ * \param size      Size of the buffer in bytes.
+ *
+ * \return          0 if successful, or a specific error code
+ */
+int mbedtls_pk_write_key_pem( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
+#endif /* MBEDTLS_PEM_WRITE_C */
+#endif /* MBEDTLS_PK_WRITE_C */
+
+/*
+ * WARNING: Low-level functions. You probably do not want to use these unless
+ *          you are certain you do ;)
+ */
+
+#if defined(MBEDTLS_PK_PARSE_C)
+/**
+ * \brief           Parse a SubjectPublicKeyInfo DER structure
+ *
+ * \param p         the position in the ASN.1 data
+ * \param end       end of the buffer
+ * \param pk        The PK context to fill. It must have been initialized
+ *                  but not set up.
+ *
+ * \return          0 if successful, or a specific PK error code
+ */
+int mbedtls_pk_parse_subpubkey( unsigned char **p, const unsigned char *end,
+                        mbedtls_pk_context *pk );
+#endif /* MBEDTLS_PK_PARSE_C */
+
+#if defined(MBEDTLS_PK_WRITE_C)
+/**
+ * \brief           Write a subjectPublicKey to ASN.1 data
+ *                  Note: function works backwards in data buffer
+ *
+ * \param p         reference to current position pointer
+ * \param start     start of the buffer (for bounds-checking)
+ * \param key       PK context which must contain a valid public or private key.
+ *
+ * \return          the length written or a negative error code
+ */
+int mbedtls_pk_write_pubkey( unsigned char **p, unsigned char *start,
+                     const mbedtls_pk_context *key );
+#endif /* MBEDTLS_PK_WRITE_C */
+
+/*
+ * Internal module functions. You probably do not want to use these unless you
+ * know you do.
+ */
+#if defined(MBEDTLS_FS_IO)
+int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n );
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_PK_H */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/pkcs5.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/pkcs5.h
@@ -1,0 +1,99 @@
+/**
+ * \file pkcs5.h
+ *
+ * \brief PKCS#5 functions
+ *
+ * \author Mathias Olsson <mathias@kompetensum.com>
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_PKCS5_H
+#define MBEDTLS_PKCS5_H
+
+#include "asn1.h"
+#include "md.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define MBEDTLS_ERR_PKCS5_BAD_INPUT_DATA                  -0x2f80  /**< Bad input parameters to function. */
+#define MBEDTLS_ERR_PKCS5_INVALID_FORMAT                  -0x2f00  /**< Unexpected ASN.1 data. */
+#define MBEDTLS_ERR_PKCS5_FEATURE_UNAVAILABLE             -0x2e80  /**< Requested encryption or digest alg not available. */
+#define MBEDTLS_ERR_PKCS5_PASSWORD_MISMATCH               -0x2e00  /**< Given private key password does not allow for correct decryption. */
+
+#define MBEDTLS_PKCS5_DECRYPT      0
+#define MBEDTLS_PKCS5_ENCRYPT      1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(MBEDTLS_ASN1_PARSE_C)
+
+/**
+ * \brief          PKCS#5 PBES2 function
+ *
+ * \param pbe_params the ASN.1 algorithm parameters
+ * \param mode       either MBEDTLS_PKCS5_DECRYPT or MBEDTLS_PKCS5_ENCRYPT
+ * \param pwd        password to use when generating key
+ * \param pwdlen     length of password
+ * \param data       data to process
+ * \param datalen    length of data
+ * \param output     output buffer
+ *
+ * \returns        0 on success, or a MBEDTLS_ERR_XXX code if verification fails.
+ */
+int mbedtls_pkcs5_pbes2( const mbedtls_asn1_buf *pbe_params, int mode,
+                 const unsigned char *pwd,  size_t pwdlen,
+                 const unsigned char *data, size_t datalen,
+                 unsigned char *output );
+
+#endif /* MBEDTLS_ASN1_PARSE_C */
+
+/**
+ * \brief          PKCS#5 PBKDF2 using HMAC
+ *
+ * \param ctx      Generic HMAC context
+ * \param password Password to use when generating key
+ * \param plen     Length of password
+ * \param salt     Salt to use when generating key
+ * \param slen     Length of salt
+ * \param iteration_count       Iteration count
+ * \param key_length            Length of generated key in bytes
+ * \param output   Generated key. Must be at least as big as key_length
+ *
+ * \returns        0 on success, or a MBEDTLS_ERR_XXX code if verification fails.
+ */
+int mbedtls_pkcs5_pbkdf2_hmac( mbedtls_md_context_t *ctx, const unsigned char *password,
+                       size_t plen, const unsigned char *salt, size_t slen,
+                       unsigned int iteration_count,
+                       uint32_t key_length, unsigned char *output );
+
+/**
+ * \brief          Checkup routine
+ *
+ * \return         0 if successful, or 1 if the test failed
+ */
+int mbedtls_pkcs5_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* pkcs5.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/platform.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/platform.h
@@ -1,0 +1,404 @@
+/**
+ * \file platform.h
+ *
+ * \brief This file contains the definitions and functions of the
+ *        Mbed TLS platform abstraction layer.
+ *
+ *        The platform abstraction layer removes the need for the library
+ *        to directly link to standard C library functions or operating
+ *        system services, making the library easier to port and embed.
+ *        Application developers and users of the library can provide their own
+ *        implementations of these functions, or implementations specific to
+ *        their platform, which can be statically linked to the library or
+ *        dynamically configured at runtime.
+ */
+/*
+ *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_PLATFORM_H
+#define MBEDTLS_PLATFORM_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include "drv_osal_lib.h"
+
+#if defined(MBEDTLS_HAVE_TIME)
+#include "platform_time.h"
+#endif
+
+#define MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED     -0x0070 /**< Hardware accelerator failed */
+#define MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED -0x0072 /**< The requested feature is not supported by the platform */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed char int8_t;
+typedef short     int16_t;
+typedef int       int32_t;
+typedef long long int64_t;
+
+typedef int8_t int_least8_t;
+typedef int16_t int_least16_t;
+typedef int32_t int_least32_t;
+typedef int64_t int_least64_t;
+typedef uint8_t uint_least8_t;
+typedef uint16_t uint_least16_t;
+typedef uint32_t uint_least32_t;
+typedef uint64_t uint_least64_t;
+
+#ifndef __HuaweiLite__
+typedef int8_t int_fast8_t;
+typedef int16_t int_fast16_t;
+typedef int32_t int_fast32_t;
+typedef int64_t int_fast64_t;
+typedef uint8_t uint_fast8_t;
+typedef uint16_t uint_fast16_t;
+typedef uint32_t uint_fast32_t;
+typedef uint64_t uint_fast64_t;
+
+typedef long intptr_t;
+typedef unsigned long uintptr_t;
+#endif
+
+typedef long long intmax_t;
+typedef unsigned long long uintmax_t;
+
+/**
+ * \name SECTION: Module settings
+ *
+ * The configuration options you can set for this module are in this section.
+ * Either change them in config.h or define them on the compiler command line.
+ * \{
+ */
+
+#if !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS)
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#if !defined(MBEDTLS_PLATFORM_STD_SNPRINTF)
+#if defined(_WIN32)
+#define MBEDTLS_PLATFORM_STD_SNPRINTF   mbedtls_platform_win32_snprintf /**< The default \c snprintf function to use.  */
+#else
+#define MBEDTLS_PLATFORM_STD_SNPRINTF   snprintf /**< The default \c snprintf function to use.  */
+#endif
+#endif
+#if !defined(MBEDTLS_PLATFORM_STD_PRINTF)
+#define MBEDTLS_PLATFORM_STD_PRINTF   printf /**< The default \c printf function to use. */
+#endif
+#if !defined(MBEDTLS_PLATFORM_STD_FPRINTF)
+#define MBEDTLS_PLATFORM_STD_FPRINTF fprintf /**< The default \c fprintf function to use. */
+#endif
+#if !defined(MBEDTLS_PLATFORM_STD_CALLOC)
+#define MBEDTLS_PLATFORM_STD_CALLOC   calloc /**< The default \c calloc function to use. */
+#endif
+#if !defined(MBEDTLS_PLATFORM_STD_FREE)
+#define MBEDTLS_PLATFORM_STD_FREE       free /**< The default \c free function to use. */
+#endif
+#if !defined(MBEDTLS_PLATFORM_STD_EXIT)
+#define MBEDTLS_PLATFORM_STD_EXIT      exit /**< The default \c exit function to use. */
+#endif
+#if !defined(MBEDTLS_PLATFORM_STD_TIME)
+#define MBEDTLS_PLATFORM_STD_TIME       time    /**< The default \c time function to use. */
+#endif
+#if !defined(MBEDTLS_PLATFORM_STD_EXIT_SUCCESS)
+#define MBEDTLS_PLATFORM_STD_EXIT_SUCCESS  EXIT_SUCCESS /**< The default exit value to use. */
+#endif
+#if !defined(MBEDTLS_PLATFORM_STD_EXIT_FAILURE)
+#define MBEDTLS_PLATFORM_STD_EXIT_FAILURE  EXIT_FAILURE /**< The default exit value to use. */
+#endif
+#if defined(MBEDTLS_FS_IO)
+#if !defined(MBEDTLS_PLATFORM_STD_NV_SEED_READ)
+#define MBEDTLS_PLATFORM_STD_NV_SEED_READ   mbedtls_platform_std_nv_seed_read
+#endif
+#if !defined(MBEDTLS_PLATFORM_STD_NV_SEED_WRITE)
+#define MBEDTLS_PLATFORM_STD_NV_SEED_WRITE  mbedtls_platform_std_nv_seed_write
+#endif
+#if !defined(MBEDTLS_PLATFORM_STD_NV_SEED_FILE)
+#define MBEDTLS_PLATFORM_STD_NV_SEED_FILE   "seedfile"
+#endif
+#endif /* MBEDTLS_FS_IO */
+#else /* MBEDTLS_PLATFORM_NO_STD_FUNCTIONS */
+#if defined(MBEDTLS_PLATFORM_STD_MEM_HDR)
+#include MBEDTLS_PLATFORM_STD_MEM_HDR
+#endif
+#endif /* MBEDTLS_PLATFORM_NO_STD_FUNCTIONS */
+
+
+/* \} name SECTION: Module settings */
+
+/*
+ * The function pointers for calloc and free.
+ */
+#if defined(MBEDTLS_PLATFORM_MEMORY)
+#if defined(MBEDTLS_PLATFORM_FREE_MACRO) && \
+    defined(MBEDTLS_PLATFORM_CALLOC_MACRO)
+#define mbedtls_free       MBEDTLS_PLATFORM_FREE_MACRO
+#define mbedtls_calloc     MBEDTLS_PLATFORM_CALLOC_MACRO
+#else
+/* For size_t */
+#include <stddef.h>
+extern void *mbedtls_calloc( size_t n, size_t size );
+extern void mbedtls_free( void *ptr );
+
+/**
+ * \brief               This function dynamically sets the memory-management
+ *                      functions used by the library, during runtime.
+ *
+ * \param calloc_func   The \c calloc function implementation.
+ * \param free_func     The \c free function implementation.
+ *
+ * \return              \c 0.
+ */
+int mbedtls_platform_set_calloc_free( void * (*calloc_func)( size_t, size_t ),
+                              void (*free_func)( void * ) );
+#endif /* MBEDTLS_PLATFORM_FREE_MACRO && MBEDTLS_PLATFORM_CALLOC_MACRO */
+#else /* !MBEDTLS_PLATFORM_MEMORY */
+#define mbedtls_free       free
+#define mbedtls_calloc     calloc
+#endif /* MBEDTLS_PLATFORM_MEMORY && !MBEDTLS_PLATFORM_{FREE,CALLOC}_MACRO */
+
+/*
+ * The function pointers for fprintf
+ */
+#if defined(MBEDTLS_PLATFORM_FPRINTF_ALT)
+/* We need FILE * */
+#include <stdio.h>
+extern int (*mbedtls_fprintf)( FILE *stream, const char *format, ... );
+
+/**
+ * \brief                This function dynamically configures the fprintf
+ *                       function that is called when the
+ *                       mbedtls_fprintf() function is invoked by the library.
+ *
+ * \param fprintf_func   The \c fprintf function implementation.
+ *
+ * \return               \c 0.
+ */
+int mbedtls_platform_set_fprintf( int (*fprintf_func)( FILE *stream, const char *,
+                                               ... ) );
+#else
+#if defined(MBEDTLS_PLATFORM_FPRINTF_MACRO)
+#define mbedtls_fprintf    MBEDTLS_PLATFORM_FPRINTF_MACRO
+#else
+#define mbedtls_fprintf    fprintf
+#endif /* MBEDTLS_PLATFORM_FPRINTF_MACRO */
+#endif /* MBEDTLS_PLATFORM_FPRINTF_ALT */
+
+/*
+ * The function pointers for printf
+ */
+#if defined(MBEDTLS_PLATFORM_PRINTF_ALT)
+extern int (*mbedtls_printf)( const char *format, ... );
+
+/**
+ * \brief               This function dynamically configures the snprintf
+ *                      function that is called when the mbedtls_snprintf()
+ *                      function is invoked by the library.
+ *
+ * \param printf_func   The \c printf function implementation.
+ *
+ * \return              \c 0 on success.
+ */
+int mbedtls_platform_set_printf( int (*printf_func)( const char *, ... ) );
+#else /* !MBEDTLS_PLATFORM_PRINTF_ALT */
+#if defined(MBEDTLS_PLATFORM_PRINTF_MACRO)
+#define mbedtls_printf     MBEDTLS_PLATFORM_PRINTF_MACRO
+#else
+#define mbedtls_printf     printf
+#endif /* MBEDTLS_PLATFORM_PRINTF_MACRO */
+#endif /* MBEDTLS_PLATFORM_PRINTF_ALT */
+
+/*
+ * The function pointers for snprintf
+ *
+ * The snprintf implementation should conform to C99:
+ * - it *must* always correctly zero-terminate the buffer
+ *   (except when n == 0, then it must leave the buffer untouched)
+ * - however it is acceptable to return -1 instead of the required length when
+ *   the destination buffer is too short.
+ */
+#if defined(_WIN32)
+/* For Windows (inc. MSYS2), we provide our own fixed implementation */
+int mbedtls_platform_win32_snprintf( char *s, size_t n, const char *fmt, ... );
+#endif
+
+#if defined(MBEDTLS_PLATFORM_SNPRINTF_ALT)
+extern int (*mbedtls_snprintf)( char * s, size_t n, const char * format, ... );
+
+/**
+ * \brief                 This function allows configuring a custom
+ *                        \c snprintf function pointer.
+ *
+ * \param snprintf_func   The \c snprintf function implementation.
+ *
+ * \return                \c 0 on success.
+ */
+int mbedtls_platform_set_snprintf( int (*snprintf_func)( char * s, size_t n,
+                                                 const char * format, ... ) );
+#else /* MBEDTLS_PLATFORM_SNPRINTF_ALT */
+#if defined(MBEDTLS_PLATFORM_SNPRINTF_MACRO)
+#define mbedtls_snprintf   MBEDTLS_PLATFORM_SNPRINTF_MACRO
+#else
+#define mbedtls_snprintf   MBEDTLS_PLATFORM_STD_SNPRINTF
+#endif /* MBEDTLS_PLATFORM_SNPRINTF_MACRO */
+#endif /* MBEDTLS_PLATFORM_SNPRINTF_ALT */
+
+/*
+ * The function pointers for exit
+ */
+#if defined(MBEDTLS_PLATFORM_EXIT_ALT)
+extern void (*mbedtls_exit)( int status );
+
+/**
+ * \brief             This function dynamically configures the exit
+ *                    function that is called when the mbedtls_exit()
+ *                    function is invoked by the library.
+ *
+ * \param exit_func   The \c exit function implementation.
+ *
+ * \return            \c 0 on success.
+ */
+int mbedtls_platform_set_exit( void (*exit_func)( int status ) );
+#else
+#if defined(MBEDTLS_PLATFORM_EXIT_MACRO)
+#define mbedtls_exit   MBEDTLS_PLATFORM_EXIT_MACRO
+#else
+#define mbedtls_exit   exit
+#endif /* MBEDTLS_PLATFORM_EXIT_MACRO */
+#endif /* MBEDTLS_PLATFORM_EXIT_ALT */
+
+/*
+ * The default exit values
+ */
+#if defined(MBEDTLS_PLATFORM_STD_EXIT_SUCCESS)
+#define MBEDTLS_EXIT_SUCCESS MBEDTLS_PLATFORM_STD_EXIT_SUCCESS
+#else
+#define MBEDTLS_EXIT_SUCCESS 0
+#endif
+#if defined(MBEDTLS_PLATFORM_STD_EXIT_FAILURE)
+#define MBEDTLS_EXIT_FAILURE MBEDTLS_PLATFORM_STD_EXIT_FAILURE
+#else
+#define MBEDTLS_EXIT_FAILURE 1
+#endif
+
+/*
+ * The function pointers for reading from and writing a seed file to
+ * Non-Volatile storage (NV) in a platform-independent way
+ *
+ * Only enabled when the NV seed entropy source is enabled
+ */
+#if defined(MBEDTLS_ENTROPY_NV_SEED)
+#if !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS) && defined(MBEDTLS_FS_IO)
+/* Internal standard platform definitions */
+int mbedtls_platform_std_nv_seed_read( unsigned char *buf, size_t buf_len );
+int mbedtls_platform_std_nv_seed_write( unsigned char *buf, size_t buf_len );
+#endif
+
+#if defined(MBEDTLS_PLATFORM_NV_SEED_ALT)
+extern int (*mbedtls_nv_seed_read)( unsigned char *buf, size_t buf_len );
+extern int (*mbedtls_nv_seed_write)( unsigned char *buf, size_t buf_len );
+
+/**
+ * \brief   This function allows configuring custom seed file writing and
+ *          reading functions.
+ *
+ * \param   nv_seed_read_func   The seed reading function implementation.
+ * \param   nv_seed_write_func  The seed writing function implementation.
+ *
+ * \return  \c 0 on success.
+ */
+int mbedtls_platform_set_nv_seed(
+            int (*nv_seed_read_func)( unsigned char *buf, size_t buf_len ),
+            int (*nv_seed_write_func)( unsigned char *buf, size_t buf_len )
+            );
+#else
+#if defined(MBEDTLS_PLATFORM_NV_SEED_READ_MACRO) && \
+    defined(MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO)
+#define mbedtls_nv_seed_read    MBEDTLS_PLATFORM_NV_SEED_READ_MACRO
+#define mbedtls_nv_seed_write   MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO
+#else
+#define mbedtls_nv_seed_read    mbedtls_platform_std_nv_seed_read
+#define mbedtls_nv_seed_write   mbedtls_platform_std_nv_seed_write
+#endif
+#endif /* MBEDTLS_PLATFORM_NV_SEED_ALT */
+#endif /* MBEDTLS_ENTROPY_NV_SEED */
+
+#if !defined(MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT)
+
+/**
+ * \brief   The platform context structure.
+ *
+ * \note    This structure may be used to assist platform-specific
+ *          setup or teardown operations.
+ */
+typedef struct mbedtls_platform_context
+{
+    char dummy; /**< A placeholder member, as empty structs are not portable. */
+}
+mbedtls_platform_context;
+
+#else
+#include "platform_alt.h"
+#endif /* !MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT */
+
+/**
+ * \brief   This function performs any platform-specific initialization
+ *          operations.
+ *
+ * \note    This function should be called before any other library functions.
+ *
+ *          Its implementation is platform-specific, and unless
+ *          platform-specific code is provided, it does nothing.
+ *
+ * \note    The usage and necessity of this function is dependent on the platform.
+ *
+ * \param   ctx     The platform context.
+ *
+ * \return  \c 0 on success.
+ */
+int mbedtls_platform_setup( mbedtls_platform_context *ctx );
+/**
+ * \brief   This function performs any platform teardown operations.
+ *
+ * \note    This function should be called after every other Mbed TLS module
+ *          has been correctly freed using the appropriate free function.
+ *
+ *          Its implementation is platform-specific, and unless
+ *          platform-specific code is provided, it does nothing.
+ *
+ * \note    The usage and necessity of this function is dependent on the platform.
+ *
+ * \param   ctx     The platform context.
+ *
+ */
+void mbedtls_platform_teardown( mbedtls_platform_context *ctx );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* platform.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/platform_util.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/platform_util.h
@@ -1,0 +1,185 @@
+/**
+ * \file platform_util.h
+ *
+ * \brief Common and shared functions used by multiple modules in the Mbed TLS
+ *        library.
+ */
+/*
+ *  Copyright (C) 2018, Arm Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_PLATFORM_UTIL_H
+#define MBEDTLS_PLATFORM_UTIL_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include <stddef.h>
+#if defined(MBEDTLS_HAVE_TIME_DATE)
+#include "mbedtls/platform_time.h"
+#include <time.h>
+#endif /* MBEDTLS_HAVE_TIME_DATE */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(MBEDTLS_CHECK_PARAMS)
+
+#if defined(MBEDTLS_PARAM_FAILED)
+/** An alternative definition of MBEDTLS_PARAM_FAILED has been set in config.h.
+ *
+ * This flag can be used to check whether it is safe to assume that
+ * MBEDTLS_PARAM_FAILED() will expand to a call to mbedtls_param_failed().
+ */
+#define MBEDTLS_PARAM_FAILED_ALT
+#else /* MBEDTLS_PARAM_FAILED */
+#define MBEDTLS_PARAM_FAILED( cond ) \
+    mbedtls_param_failed( #cond, __FILE__, __LINE__ )
+
+/**
+ * \brief       User supplied callback function for parameter validation failure.
+ *              See #MBEDTLS_CHECK_PARAMS for context.
+ *
+ *              This function will be called unless an alternative treatement
+ *              is defined through the #MBEDTLS_PARAM_FAILED macro.
+ *
+ *              This function can return, and the operation will be aborted, or
+ *              alternatively, through use of setjmp()/longjmp() can resume
+ *              execution in the application code.
+ *
+ * \param failure_condition The assertion that didn't hold.
+ * \param file  The file where the assertion failed.
+ * \param line  The line in the file where the assertion failed.
+ */
+void mbedtls_param_failed( const char *failure_condition,
+                           const char *file,
+                           int line );
+#endif /* MBEDTLS_PARAM_FAILED */
+
+/* Internal macro meant to be called only from within the library. */
+#define MBEDTLS_INTERNAL_VALIDATE_RET( cond, ret )  \
+    do {                                            \
+        if( !(cond) )                               \
+        {                                           \
+            MBEDTLS_PARAM_FAILED( cond );           \
+            return( ret );                          \
+        }                                           \
+    } while( 0 )
+
+/* Internal macro meant to be called only from within the library. */
+#define MBEDTLS_INTERNAL_VALIDATE( cond )           \
+    do {                                            \
+        if( !(cond) )                               \
+        {                                           \
+            MBEDTLS_PARAM_FAILED( cond );           \
+            return;                                 \
+        }                                           \
+    } while( 0 )
+
+#else /* MBEDTLS_CHECK_PARAMS */
+
+/* Internal macros meant to be called only from within the library. */
+#define MBEDTLS_INTERNAL_VALIDATE_RET( cond, ret )  do { } while( 0 )
+#define MBEDTLS_INTERNAL_VALIDATE( cond )           do { } while( 0 )
+
+#endif /* MBEDTLS_CHECK_PARAMS */
+
+/* Internal helper macros for deprecating API constants. */
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+/* Deliberately don't (yet) export MBEDTLS_DEPRECATED here
+ * to avoid conflict with other headers which define and use
+ * it, too. We might want to move all these definitions here at
+ * some point for uniformity. */
+#define MBEDTLS_DEPRECATED __attribute__((deprecated))
+MBEDTLS_DEPRECATED typedef char const * mbedtls_deprecated_string_constant_t;
+#define MBEDTLS_DEPRECATED_STRING_CONSTANT( VAL )       \
+    ( (mbedtls_deprecated_string_constant_t) ( VAL ) )
+MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
+#define MBEDTLS_DEPRECATED_NUMERIC_CONSTANT( VAL )       \
+    ( (mbedtls_deprecated_numeric_constant_t) ( VAL ) )
+#undef MBEDTLS_DEPRECATED
+#else /* MBEDTLS_DEPRECATED_WARNING */
+#define MBEDTLS_DEPRECATED_STRING_CONSTANT( VAL ) VAL
+#define MBEDTLS_DEPRECATED_NUMERIC_CONSTANT( VAL ) VAL
+#endif /* MBEDTLS_DEPRECATED_WARNING */
+#endif /* MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief       Securely zeroize a buffer
+ *
+ *              The function is meant to wipe the data contained in a buffer so
+ *              that it can no longer be recovered even if the program memory
+ *              is later compromised. Call this function on sensitive data
+ *              stored on the stack before returning from a function, and on
+ *              sensitive data stored on the heap before freeing the heap
+ *              object.
+ *
+ *              It is extremely difficult to guarantee that calls to
+ *              mbedtls_platform_zeroize() are not removed by aggressive
+ *              compiler optimizations in a portable way. For this reason, Mbed
+ *              TLS provides the configuration option
+ *              MBEDTLS_PLATFORM_ZEROIZE_ALT, which allows users to configure
+ *              mbedtls_platform_zeroize() to use a suitable implementation for
+ *              their platform and needs
+ *
+ * \param buf   Buffer to be zeroized
+ * \param len   Length of the buffer in bytes
+ *
+ */
+void mbedtls_platform_zeroize( void *buf, size_t len );
+
+#if defined(MBEDTLS_HAVE_TIME_DATE)
+/**
+ * \brief      Platform-specific implementation of gmtime_r()
+ *
+ *             The function is a thread-safe abstraction that behaves
+ *             similarly to the gmtime_r() function from Unix/POSIX.
+ *
+ *             Mbed TLS will try to identify the underlying platform and
+ *             make use of an appropriate underlying implementation (e.g.
+ *             gmtime_r() for POSIX and gmtime_s() for Windows). If this is
+ *             not possible, then gmtime() will be used. In this case, calls
+ *             from the library to gmtime() will be guarded by the mutex
+ *             mbedtls_threading_gmtime_mutex if MBEDTLS_THREADING_C is
+ *             enabled. It is recommended that calls from outside the library
+ *             are also guarded by this mutex.
+ *
+ *             If MBEDTLS_PLATFORM_GMTIME_R_ALT is defined, then Mbed TLS will
+ *             unconditionally use the alternative implementation for
+ *             mbedtls_platform_gmtime_r() supplied by the user at compile time.
+ *
+ * \param tt     Pointer to an object containing time (in seconds) since the
+ *               epoch to be converted
+ * \param tm_buf Pointer to an object where the results will be stored
+ *
+ * \return      Pointer to an object of type struct tm on success, otherwise
+ *              NULL
+ */
+struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
+                                      struct tm *tm_buf );
+#endif /* MBEDTLS_HAVE_TIME_DATE */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_PLATFORM_UTIL_H */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/rsa.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/rsa.h
@@ -1,0 +1,1267 @@
+/**
+ * \file rsa.h
+ *
+ * \brief This file provides an API for the RSA public-key cryptosystem.
+ *
+ * The RSA public-key cryptosystem is defined in <em>Public-Key
+ * Cryptography Standards (PKCS) #1 v1.5: RSA Encryption</em>
+ * and <em>Public-Key Cryptography Standards (PKCS) #1 v2.1:
+ * RSA Cryptography Specifications</em>.
+ *
+ */
+/*
+ *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_RSA_H
+#define MBEDTLS_RSA_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include "bignum.h"
+#include "md.h"
+
+#if defined(MBEDTLS_THREADING_C)
+#include "threading.h"
+#endif
+
+/*
+ * RSA Error codes
+ */
+#define MBEDTLS_ERR_RSA_BAD_INPUT_DATA                    -0x4080  /**< Bad input parameters to function. */
+#define MBEDTLS_ERR_RSA_INVALID_PADDING                   -0x4100  /**< Input data contains invalid padding and is rejected. */
+#define MBEDTLS_ERR_RSA_KEY_GEN_FAILED                    -0x4180  /**< Something failed during generation of a key. */
+#define MBEDTLS_ERR_RSA_KEY_CHECK_FAILED                  -0x4200  /**< Key failed to pass the validity check of the library. */
+#define MBEDTLS_ERR_RSA_PUBLIC_FAILED                     -0x4280  /**< The public key operation failed. */
+#define MBEDTLS_ERR_RSA_PRIVATE_FAILED                    -0x4300  /**< The private key operation failed. */
+#define MBEDTLS_ERR_RSA_VERIFY_FAILED                     -0x4380  /**< The PKCS#1 verification failed. */
+#define MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE                  -0x4400  /**< The output buffer for decryption is not large enough. */
+#define MBEDTLS_ERR_RSA_RNG_FAILED                        -0x4480  /**< The random generator failed to generate non-zeros. */
+
+/* MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION is deprecated and should not be used.
+ */
+#define MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION             -0x4500  /**< The implementation does not offer the requested operation, for example, because of security violations or lack of functionality. */
+
+/* MBEDTLS_ERR_RSA_HW_ACCEL_FAILED is deprecated and should not be used. */
+#define MBEDTLS_ERR_RSA_HW_ACCEL_FAILED                   -0x4580  /**< RSA hardware accelerator failed. */
+
+/*
+ * RSA constants
+ */
+#define MBEDTLS_RSA_PUBLIC      0 /**< Request private key operation. */
+#define MBEDTLS_RSA_PRIVATE     1 /**< Request public key operation. */
+
+#define MBEDTLS_RSA_PKCS_V15    0 /**< Use PKCS#1 v1.5 encoding. */
+#define MBEDTLS_RSA_PKCS_V21    1 /**< Use PKCS#1 v2.1 encoding. */
+
+#define MBEDTLS_RSA_SIGN        1 /**< Identifier for RSA signature operations. */
+#define MBEDTLS_RSA_CRYPT       2 /**< Identifier for RSA encryption and decryption operations. */
+
+#define MBEDTLS_RSA_SALT_LEN_ANY    -1
+
+/*
+ * The above constants may be used even if the RSA module is compile out,
+ * eg for alternative (PKCS#11) RSA implemenations in the PK layers.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(MBEDTLS_RSA_ALT)
+// Regular implementation
+//
+
+/**
+ * \brief   The RSA context structure.
+ *
+ * \note    Direct manipulation of the members of this structure
+ *          is deprecated. All manipulation should instead be done through
+ *          the public interface functions.
+ */
+typedef struct mbedtls_rsa_context
+{
+    int ver;                    /*!<  Always 0.*/
+    size_t len;                 /*!<  The size of \p N in Bytes. */
+
+    mbedtls_mpi N;              /*!<  The public modulus. */
+    mbedtls_mpi E;              /*!<  The public exponent. */
+
+    mbedtls_mpi D;              /*!<  The private exponent. */
+    mbedtls_mpi P;              /*!<  The first prime factor. */
+    mbedtls_mpi Q;              /*!<  The second prime factor. */
+
+    mbedtls_mpi DP;             /*!<  <code>D % (P - 1)</code>. */
+    mbedtls_mpi DQ;             /*!<  <code>D % (Q - 1)</code>. */
+    mbedtls_mpi QP;             /*!<  <code>1 / (Q % P)</code>. */
+
+    mbedtls_mpi RN;             /*!<  cached <code>R^2 mod N</code>. */
+
+    mbedtls_mpi RP;             /*!<  cached <code>R^2 mod P</code>. */
+    mbedtls_mpi RQ;             /*!<  cached <code>R^2 mod Q</code>. */
+
+    mbedtls_mpi Vi;             /*!<  The cached blinding value. */
+    mbedtls_mpi Vf;             /*!<  The cached un-blinding value. */
+
+    int padding;                /*!< Selects padding mode:
+                                     #MBEDTLS_RSA_PKCS_V15 for 1.5 padding and
+                                     #MBEDTLS_RSA_PKCS_V21 for OAEP or PSS. */
+    int hash_id;                /*!< Hash identifier of mbedtls_md_type_t type,
+                                     as specified in md.h for use in the MGF
+                                     mask generating function used in the
+                                     EME-OAEP and EMSA-PSS encodings. */
+#if defined(MBEDTLS_THREADING_C)
+    mbedtls_threading_mutex_t mutex;    /*!<  Thread-safety mutex. */
+#endif
+}
+mbedtls_rsa_context;
+
+#else  /* MBEDTLS_RSA_ALT */
+#include "rsa_alt.h"
+#endif /* MBEDTLS_RSA_ALT */
+
+/**
+ * \brief          This function initializes an RSA context.
+ *
+ * \note           Set padding to #MBEDTLS_RSA_PKCS_V21 for the RSAES-OAEP
+ *                 encryption scheme and the RSASSA-PSS signature scheme.
+ *
+ * \note           The \p hash_id parameter is ignored when using
+ *                 #MBEDTLS_RSA_PKCS_V15 padding.
+ *
+ * \note           The choice of padding mode is strictly enforced for private key
+ *                 operations, since there might be security concerns in
+ *                 mixing padding modes. For public key operations it is
+ *                 a default value, which can be overriden by calling specific
+ *                 \c rsa_rsaes_xxx or \c rsa_rsassa_xxx functions.
+ *
+ * \note           The hash selected in \p hash_id is always used for OEAP
+ *                 encryption. For PSS signatures, it is always used for
+ *                 making signatures, but can be overriden for verifying them.
+ *                 If set to #MBEDTLS_MD_NONE, it is always overriden.
+ *
+ * \param ctx      The RSA context to initialize. This must not be \c NULL.
+ * \param padding  The padding mode to use. This must be either
+ *                 #MBEDTLS_RSA_PKCS_V15 or #MBEDTLS_RSA_PKCS_V21.
+ * \param hash_id  The hash identifier of ::mbedtls_md_type_t type, if
+ *                 \p padding is #MBEDTLS_RSA_PKCS_V21. It is unused
+ *                 otherwise.
+ */
+void mbedtls_rsa_init( mbedtls_rsa_context *ctx,
+                       int padding,
+                       int hash_id );
+
+/**
+ * \brief          This function imports a set of core parameters into an
+ *                 RSA context.
+ *
+ * \note           This function can be called multiple times for successive
+ *                 imports, if the parameters are not simultaneously present.
+ *
+ *                 Any sequence of calls to this function should be followed
+ *                 by a call to mbedtls_rsa_complete(), which checks and
+ *                 completes the provided information to a ready-for-use
+ *                 public or private RSA key.
+ *
+ * \note           See mbedtls_rsa_complete() for more information on which
+ *                 parameters are necessary to set up a private or public
+ *                 RSA key.
+ *
+ * \note           The imported parameters are copied and need not be preserved
+ *                 for the lifetime of the RSA context being set up.
+ *
+ * \param ctx      The initialized RSA context to store the parameters in.
+ * \param N        The RSA modulus. This may be \c NULL.
+ * \param P        The first prime factor of \p N. This may be \c NULL.
+ * \param Q        The second prime factor of \p N. This may be \c NULL.
+ * \param D        The private exponent. This may be \c NULL.
+ * \param E        The public exponent. This may be \c NULL.
+ *
+ * \return         \c 0 on success.
+ * \return         A non-zero error code on failure.
+ */
+int mbedtls_rsa_import( mbedtls_rsa_context *ctx,
+                        const mbedtls_mpi *N,
+                        const mbedtls_mpi *P, const mbedtls_mpi *Q,
+                        const mbedtls_mpi *D, const mbedtls_mpi *E );
+
+/**
+ * \brief          This function imports core RSA parameters, in raw big-endian
+ *                 binary format, into an RSA context.
+ *
+ * \note           This function can be called multiple times for successive
+ *                 imports, if the parameters are not simultaneously present.
+ *
+ *                 Any sequence of calls to this function should be followed
+ *                 by a call to mbedtls_rsa_complete(), which checks and
+ *                 completes the provided information to a ready-for-use
+ *                 public or private RSA key.
+ *
+ * \note           See mbedtls_rsa_complete() for more information on which
+ *                 parameters are necessary to set up a private or public
+ *                 RSA key.
+ *
+ * \note           The imported parameters are copied and need not be preserved
+ *                 for the lifetime of the RSA context being set up.
+ *
+ * \param ctx      The initialized RSA context to store the parameters in.
+ * \param N        The RSA modulus. This may be \c NULL.
+ * \param N_len    The Byte length of \p N; it is ignored if \p N == NULL.
+ * \param P        The first prime factor of \p N. This may be \c NULL.
+ * \param P_len    The Byte length of \p P; it ns ignored if \p P == NULL.
+ * \param Q        The second prime factor of \p N. This may be \c NULL.
+ * \param Q_len    The Byte length of \p Q; it is ignored if \p Q == NULL.
+ * \param D        The private exponent. This may be \c NULL.
+ * \param D_len    The Byte length of \p D; it is ignored if \p D == NULL.
+ * \param E        The public exponent. This may be \c NULL.
+ * \param E_len    The Byte length of \p E; it is ignored if \p E == NULL.
+ *
+ * \return         \c 0 on success.
+ * \return         A non-zero error code on failure.
+ */
+int mbedtls_rsa_import_raw( mbedtls_rsa_context *ctx,
+                            unsigned char const *N, size_t N_len,
+                            unsigned char const *P, size_t P_len,
+                            unsigned char const *Q, size_t Q_len,
+                            unsigned char const *D, size_t D_len,
+                            unsigned char const *E, size_t E_len );
+
+/**
+ * \brief          This function completes an RSA context from
+ *                 a set of imported core parameters.
+ *
+ *                 To setup an RSA public key, precisely \p N and \p E
+ *                 must have been imported.
+ *
+ *                 To setup an RSA private key, sufficient information must
+ *                 be present for the other parameters to be derivable.
+ *
+ *                 The default implementation supports the following:
+ *                 <ul><li>Derive \p P, \p Q from \p N, \p D, \p E.</li>
+ *                 <li>Derive \p N, \p D from \p P, \p Q, \p E.</li></ul>
+ *                 Alternative implementations need not support these.
+ *
+ *                 If this function runs successfully, it guarantees that
+ *                 the RSA context can be used for RSA operations without
+ *                 the risk of failure or crash.
+ *
+ * \warning        This function need not perform consistency checks
+ *                 for the imported parameters. In particular, parameters that
+ *                 are not needed by the implementation might be silently
+ *                 discarded and left unchecked. To check the consistency
+ *                 of the key material, see mbedtls_rsa_check_privkey().
+ *
+ * \param ctx      The initialized RSA context holding imported parameters.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_RSA_BAD_INPUT_DATA if the attempted derivations
+ *                 failed.
+ *
+ */
+int mbedtls_rsa_complete( mbedtls_rsa_context *ctx );
+
+/**
+ * \brief          This function exports the core parameters of an RSA key.
+ *
+ *                 If this function runs successfully, the non-NULL buffers
+ *                 pointed to by \p N, \p P, \p Q, \p D, and \p E are fully
+ *                 written, with additional unused space filled leading by
+ *                 zero Bytes.
+ *
+ *                 Possible reasons for returning
+ *                 #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED:<ul>
+ *                 <li>An alternative RSA implementation is in use, which
+ *                 stores the key externally, and either cannot or should
+ *                 not export it into RAM.</li>
+ *                 <li>A SW or HW implementation might not support a certain
+ *                 deduction. For example, \p P, \p Q from \p N, \p D,
+ *                 and \p E if the former are not part of the
+ *                 implementation.</li></ul>
+ *
+ *                 If the function fails due to an unsupported operation,
+ *                 the RSA context stays intact and remains usable.
+ *
+ * \param ctx      The initialized RSA context.
+ * \param N        The MPI to hold the RSA modulus.
+ *                 This may be \c NULL if this field need not be exported.
+ * \param P        The MPI to hold the first prime factor of \p N.
+ *                 This may be \c NULL if this field need not be exported.
+ * \param Q        The MPI to hold the second prime factor of \p N.
+ *                 This may be \c NULL if this field need not be exported.
+ * \param D        The MPI to hold the private exponent.
+ *                 This may be \c NULL if this field need not be exported.
+ * \param E        The MPI to hold the public exponent.
+ *                 This may be \c NULL if this field need not be exported.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED if exporting the
+ *                 requested parameters cannot be done due to missing
+ *                 functionality or because of security policies.
+ * \return         A non-zero return code on any other failure.
+ *
+ */
+int mbedtls_rsa_export( const mbedtls_rsa_context *ctx,
+                        mbedtls_mpi *N, mbedtls_mpi *P, mbedtls_mpi *Q,
+                        mbedtls_mpi *D, mbedtls_mpi *E );
+
+/**
+ * \brief          This function exports core parameters of an RSA key
+ *                 in raw big-endian binary format.
+ *
+ *                 If this function runs successfully, the non-NULL buffers
+ *                 pointed to by \p N, \p P, \p Q, \p D, and \p E are fully
+ *                 written, with additional unused space filled leading by
+ *                 zero Bytes.
+ *
+ *                 Possible reasons for returning
+ *                 #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED:<ul>
+ *                 <li>An alternative RSA implementation is in use, which
+ *                 stores the key externally, and either cannot or should
+ *                 not export it into RAM.</li>
+ *                 <li>A SW or HW implementation might not support a certain
+ *                 deduction. For example, \p P, \p Q from \p N, \p D,
+ *                 and \p E if the former are not part of the
+ *                 implementation.</li></ul>
+ *                 If the function fails due to an unsupported operation,
+ *                 the RSA context stays intact and remains usable.
+ *
+ * \note           The length parameters are ignored if the corresponding
+ *                 buffer pointers are NULL.
+ *
+ * \param ctx      The initialized RSA context.
+ * \param N        The Byte array to store the RSA modulus,
+ *                 or \c NULL if this field need not be exported.
+ * \param N_len    The size of the buffer for the modulus.
+ * \param P        The Byte array to hold the first prime factor of \p N,
+ *                 or \c NULL if this field need not be exported.
+ * \param P_len    The size of the buffer for the first prime factor.
+ * \param Q        The Byte array to hold the second prime factor of \p N,
+ *                 or \c NULL if this field need not be exported.
+ * \param Q_len    The size of the buffer for the second prime factor.
+ * \param D        The Byte array to hold the private exponent,
+ *                 or \c NULL if this field need not be exported.
+ * \param D_len    The size of the buffer for the private exponent.
+ * \param E        The Byte array to hold the public exponent,
+ *                 or \c NULL if this field need not be exported.
+ * \param E_len    The size of the buffer for the public exponent.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED if exporting the
+ *                 requested parameters cannot be done due to missing
+ *                 functionality or because of security policies.
+ * \return         A non-zero return code on any other failure.
+ */
+int mbedtls_rsa_export_raw( const mbedtls_rsa_context *ctx,
+                            unsigned char *N, size_t N_len,
+                            unsigned char *P, size_t P_len,
+                            unsigned char *Q, size_t Q_len,
+                            unsigned char *D, size_t D_len,
+                            unsigned char *E, size_t E_len );
+
+/**
+ * \brief          This function exports CRT parameters of a private RSA key.
+ *
+ * \note           Alternative RSA implementations not using CRT-parameters
+ *                 internally can implement this function based on
+ *                 mbedtls_rsa_deduce_opt().
+ *
+ * \param ctx      The initialized RSA context.
+ * \param DP       The MPI to hold \c D modulo `P-1`,
+ *                 or \c NULL if it need not be exported.
+ * \param DQ       The MPI to hold \c D modulo `Q-1`,
+ *                 or \c NULL if it need not be exported.
+ * \param QP       The MPI to hold modular inverse of \c Q modulo \c P,
+ *                 or \c NULL if it need not be exported.
+ *
+ * \return         \c 0 on success.
+ * \return         A non-zero error code on failure.
+ *
+ */
+int mbedtls_rsa_export_crt( const mbedtls_rsa_context *ctx,
+                            mbedtls_mpi *DP, mbedtls_mpi *DQ, mbedtls_mpi *QP );
+
+/**
+ * \brief          This function sets padding for an already initialized RSA
+ *                 context. See mbedtls_rsa_init() for details.
+ *
+ * \param ctx      The initialized RSA context to be configured.
+ * \param padding  The padding mode to use. This must be either
+ *                 #MBEDTLS_RSA_PKCS_V15 or #MBEDTLS_RSA_PKCS_V21.
+ * \param hash_id  The #MBEDTLS_RSA_PKCS_V21 hash identifier.
+ */
+void mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
+                              int hash_id );
+
+/**
+ * \brief          This function retrieves the length of RSA modulus in Bytes.
+ *
+ * \param ctx      The initialized RSA context.
+ *
+ * \return         The length of the RSA modulus in Bytes.
+ *
+ */
+size_t mbedtls_rsa_get_len( const mbedtls_rsa_context *ctx );
+
+/**
+ * \brief          This function generates an RSA keypair.
+ *
+ * \note           mbedtls_rsa_init() must be called before this function,
+ *                 to set up the RSA context.
+ *
+ * \param ctx      The initialized RSA context used to hold the key.
+ * \param f_rng    The RNG function to be used for key generation.
+ *                 This must not be \c NULL.
+ * \param p_rng    The RNG context to be passed to \p f_rng.
+ *                 This may be \c NULL if \p f_rng doesn't need a context.
+ * \param nbits    The size of the public key in bits.
+ * \param exponent The public exponent to use. For example, \c 65537.
+ *                 This must be odd and greater than \c 1.
+ *
+ * \return         \c 0 on success.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_gen_key( mbedtls_rsa_context *ctx,
+                         int (*f_rng)(void *, unsigned char *, size_t),
+                         void *p_rng,
+                         unsigned int nbits, int exponent );
+
+/**
+ * \brief          This function checks if a context contains at least an RSA
+ *                 public key.
+ *
+ *                 If the function runs successfully, it is guaranteed that
+ *                 enough information is present to perform an RSA public key
+ *                 operation using mbedtls_rsa_public().
+ *
+ * \param ctx      The initialized RSA context to check.
+ *
+ * \return         \c 0 on success.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ *
+ */
+int mbedtls_rsa_check_pubkey( const mbedtls_rsa_context *ctx );
+
+/**
+ * \brief      This function checks if a context contains an RSA private key
+ *             and perform basic consistency checks.
+ *
+ * \note       The consistency checks performed by this function not only
+ *             ensure that mbedtls_rsa_private() can be called successfully
+ *             on the given context, but that the various parameters are
+ *             mutually consistent with high probability, in the sense that
+ *             mbedtls_rsa_public() and mbedtls_rsa_private() are inverses.
+ *
+ * \warning    This function should catch accidental misconfigurations
+ *             like swapping of parameters, but it cannot establish full
+ *             trust in neither the quality nor the consistency of the key
+ *             material that was used to setup the given RSA context:
+ *             <ul><li>Consistency: Imported parameters that are irrelevant
+ *             for the implementation might be silently dropped. If dropped,
+ *             the current function does not have access to them,
+ *             and therefore cannot check them. See mbedtls_rsa_complete().
+ *             If you want to check the consistency of the entire
+ *             content of an PKCS1-encoded RSA private key, for example, you
+ *             should use mbedtls_rsa_validate_params() before setting
+ *             up the RSA context.
+ *             Additionally, if the implementation performs empirical checks,
+ *             these checks substantiate but do not guarantee consistency.</li>
+ *             <li>Quality: This function is not expected to perform
+ *             extended quality assessments like checking that the prime
+ *             factors are safe. Additionally, it is the responsibility of the
+ *             user to ensure the trustworthiness of the source of his RSA
+ *             parameters, which goes beyond what is effectively checkable
+ *             by the library.</li></ul>
+ *
+ * \param ctx  The initialized RSA context to check.
+ *
+ * \return     \c 0 on success.
+ * \return     An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_check_privkey( const mbedtls_rsa_context *ctx );
+
+/**
+ * \brief          This function checks a public-private RSA key pair.
+ *
+ *                 It checks each of the contexts, and makes sure they match.
+ *
+ * \param pub      The initialized RSA context holding the public key.
+ * \param prv      The initialized RSA context holding the private key.
+ *
+ * \return         \c 0 on success.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_check_pub_priv( const mbedtls_rsa_context *pub,
+                                const mbedtls_rsa_context *prv );
+
+/**
+ * \brief          This function performs an RSA public key operation.
+ *
+ * \param ctx      The initialized RSA context to use.
+ * \param input    The input buffer. This must be a readable buffer
+ *                 of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ * \param output   The output buffer. This must be a writable buffer
+ *                 of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ *
+ * \note           This function does not handle message padding.
+ *
+ * \note           Make sure to set \p input[0] = 0 or ensure that
+ *                 input is smaller than \p N.
+ *
+ * \return         \c 0 on success.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_public( mbedtls_rsa_context *ctx,
+                const unsigned char *input,
+                unsigned char *output );
+
+/**
+ * \brief          This function performs an RSA private key operation.
+ *
+ * \note           Blinding is used if and only if a PRNG is provided.
+ *
+ * \note           If blinding is used, both the base of exponentation
+ *                 and the exponent are blinded, providing protection
+ *                 against some side-channel attacks.
+ *
+ * \warning        It is deprecated and a security risk to not provide
+ *                 a PRNG here and thereby prevent the use of blinding.
+ *                 Future versions of the library may enforce the presence
+ *                 of a PRNG.
+ *
+ * \param ctx      The initialized RSA context to use.
+ * \param f_rng    The RNG function, used for blinding. It is discouraged
+ *                 and deprecated to pass \c NULL here, in which case
+ *                 blinding will be omitted.
+ * \param p_rng    The RNG context to pass to \p f_rng. This may be \c NULL
+ *                 if \p f_rng is \c NULL or if \p f_rng doesn't need a context.
+ * \param input    The input buffer. This must be a readable buffer
+ *                 of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ * \param output   The output buffer. This must be a writable buffer
+ *                 of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ *
+ * \return         \c 0 on success.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ *
+ */
+int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
+                 int (*f_rng)(void *, unsigned char *, size_t),
+                 void *p_rng,
+                 const unsigned char *input,
+                 unsigned char *output );
+
+/**
+ * \brief          This function adds the message padding, then performs an RSA
+ *                 operation.
+ *
+ *                 It is the generic wrapper for performing a PKCS#1 encryption
+ *                 operation using the \p mode from the context.
+ *
+ * \deprecated     It is deprecated and discouraged to call this function
+ *                 in #MBEDTLS_RSA_PRIVATE mode. Future versions of the library
+ *                 are likely to remove the \p mode argument and have it
+ *                 implicitly set to #MBEDTLS_RSA_PUBLIC.
+ *
+ * \note           Alternative implementations of RSA need not support
+ *                 mode being set to #MBEDTLS_RSA_PRIVATE and might instead
+ *                 return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx      The initialized RSA context to use.
+ * \param f_rng    The RNG to use. It is mandatory for PKCS#1 v2.1 padding
+ *                 encoding, and for PKCS#1 v1.5 padding encoding when used
+ *                 with \p mode set to #MBEDTLS_RSA_PUBLIC. For PKCS#1 v1.5
+ *                 padding encoding and \p mode set to #MBEDTLS_RSA_PRIVATE,
+ *                 it is used for blinding and should be provided in this
+ *                 case; see mbedtls_rsa_private() for more.
+ * \param p_rng    The RNG context to be passed to \p f_rng. May be
+ *                 \c NULL if \p f_rng is \c NULL or if \p f_rng doesn't
+ *                 need a context argument.
+ * \param mode     The mode of operation. This must be either
+ *                 #MBEDTLS_RSA_PUBLIC or #MBEDTLS_RSA_PRIVATE (deprecated).
+ * \param ilen     The length of the plaintext in Bytes.
+ * \param input    The input data to encrypt. This must be a readable
+ *                 buffer of size \p ilen Bytes. This must not be \c NULL.
+ * \param output   The output buffer. This must be a writable buffer
+ *                 of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ *
+ * \return         \c 0 on success.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_pkcs1_encrypt( mbedtls_rsa_context *ctx,
+                       int (*f_rng)(void *, unsigned char *, size_t),
+                       void *p_rng,
+                       int mode, size_t ilen,
+                       const unsigned char *input,
+                       unsigned char *output );
+
+/**
+ * \brief          This function performs a PKCS#1 v1.5 encryption operation
+ *                 (RSAES-PKCS1-v1_5-ENCRYPT).
+ *
+ * \deprecated     It is deprecated and discouraged to call this function
+ *                 in #MBEDTLS_RSA_PRIVATE mode. Future versions of the library
+ *                 are likely to remove the \p mode argument and have it
+ *                 implicitly set to #MBEDTLS_RSA_PUBLIC.
+ *
+ * \note           Alternative implementations of RSA need not support
+ *                 mode being set to #MBEDTLS_RSA_PRIVATE and might instead
+ *                 return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx      The initialized RSA context to use.
+ * \param f_rng    The RNG function to use. It is needed for padding generation
+ *                 if \p mode is #MBEDTLS_RSA_PUBLIC. If \p mode is
+ *                 #MBEDTLS_RSA_PRIVATE (discouraged), it is used for
+ *                 blinding and should be provided; see mbedtls_rsa_private().
+ * \param p_rng    The RNG context to be passed to \p f_rng. This may
+ *                 be \c NULL if \p f_rng is \c NULL or if \p f_rng
+ *                 doesn't need a context argument.
+ * \param mode     The mode of operation. This must be either
+ *                 #MBEDTLS_RSA_PUBLIC or #MBEDTLS_RSA_PRIVATE (deprecated).
+ * \param ilen     The length of the plaintext in Bytes.
+ * \param input    The input data to encrypt. This must be a readable
+ *                 buffer of size \p ilen Bytes. This must not be \c NULL.
+ * \param output   The output buffer. This must be a writable buffer
+ *                 of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ *
+ * \return         \c 0 on success.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_rsaes_pkcs1_v15_encrypt( mbedtls_rsa_context *ctx,
+                                 int (*f_rng)(void *, unsigned char *, size_t),
+                                 void *p_rng,
+                                 int mode, size_t ilen,
+                                 const unsigned char *input,
+                                 unsigned char *output );
+
+/**
+ * \brief            This function performs a PKCS#1 v2.1 OAEP encryption
+ *                   operation (RSAES-OAEP-ENCRYPT).
+ *
+ * \note             The output buffer must be as large as the size
+ *                   of ctx->N. For example, 128 Bytes if RSA-1024 is used.
+ *
+ * \deprecated       It is deprecated and discouraged to call this function
+ *                   in #MBEDTLS_RSA_PRIVATE mode. Future versions of the library
+ *                   are likely to remove the \p mode argument and have it
+ *                   implicitly set to #MBEDTLS_RSA_PUBLIC.
+ *
+ * \note             Alternative implementations of RSA need not support
+ *                   mode being set to #MBEDTLS_RSA_PRIVATE and might instead
+ *                   return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx        The initnialized RSA context to use.
+ * \param f_rng      The RNG function to use. This is needed for padding
+ *                   generation and must be provided.
+ * \param p_rng      The RNG context to be passed to \p f_rng. This may
+ *                   be \c NULL if \p f_rng doesn't need a context argument.
+ * \param mode       The mode of operation. This must be either
+ *                   #MBEDTLS_RSA_PUBLIC or #MBEDTLS_RSA_PRIVATE (deprecated).
+ * \param label      The buffer holding the custom label to use.
+ *                   This must be a readable buffer of length \p label_len
+ *                   Bytes. It may be \c NULL if \p label_len is \c 0.
+ * \param label_len  The length of the label in Bytes.
+ * \param ilen       The length of the plaintext buffer \p input in Bytes.
+ * \param input      The input data to encrypt. This must be a readable
+ *                   buffer of size \p ilen Bytes. This must not be \c NULL.
+ * \param output     The output buffer. This must be a writable buffer
+ *                   of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                   for an 2048-bit RSA modulus.
+ *
+ * \return           \c 0 on success.
+ * \return           An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
+                            int (*f_rng)(void *, unsigned char *, size_t),
+                            void *p_rng,
+                            int mode,
+                            const unsigned char *label, size_t label_len,
+                            size_t ilen,
+                            const unsigned char *input,
+                            unsigned char *output );
+
+/**
+ * \brief          This function performs an RSA operation, then removes the
+ *                 message padding.
+ *
+ *                 It is the generic wrapper for performing a PKCS#1 decryption
+ *                 operation using the \p mode from the context.
+ *
+ * \note           The output buffer length \c output_max_len should be
+ *                 as large as the size \p ctx->len of \p ctx->N (for example,
+ *                 128 Bytes if RSA-1024 is used) to be able to hold an
+ *                 arbitrary decrypted message. If it is not large enough to
+ *                 hold the decryption of the particular ciphertext provided,
+ *                 the function returns \c MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE.
+ *
+ * \deprecated     It is deprecated and discouraged to call this function
+ *                 in #MBEDTLS_RSA_PUBLIC mode. Future versions of the library
+ *                 are likely to remove the \p mode argument and have it
+ *                 implicitly set to #MBEDTLS_RSA_PRIVATE.
+ *
+ * \note           Alternative implementations of RSA need not support
+ *                 mode being set to #MBEDTLS_RSA_PUBLIC and might instead
+ *                 return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx      The initialized RSA context to use.
+ * \param f_rng    The RNG function. If \p mode is #MBEDTLS_RSA_PRIVATE,
+ *                 this is used for blinding and should be provided; see
+ *                 mbedtls_rsa_private() for more. If \p mode is
+ *                 #MBEDTLS_RSA_PUBLIC, it is ignored.
+ * \param p_rng    The RNG context to be passed to \p f_rng. This may be
+ *                 \c NULL if \p f_rng is \c NULL or doesn't need a context.
+ * \param mode     The mode of operation. This must be either
+ *                 #MBEDTLS_RSA_PRIVATE or #MBEDTLS_RSA_PUBLIC (deprecated).
+ * \param olen     The address at which to store the length of
+ *                 the plaintext. This must not be \c NULL.
+ * \param input    The ciphertext buffer. This must be a readable buffer
+ *                 of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ * \param output   The buffer used to hold the plaintext. This must
+ *                 be a writable buffer of length \p output_max_len Bytes.
+ * \param output_max_len The length in Bytes of the output buffer \p output.
+ *
+ * \return         \c 0 on success.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_pkcs1_decrypt( mbedtls_rsa_context *ctx,
+                       int (*f_rng)(void *, unsigned char *, size_t),
+                       void *p_rng,
+                       int mode, size_t *olen,
+                       const unsigned char *input,
+                       unsigned char *output,
+                       size_t output_max_len );
+
+/**
+ * \brief          This function performs a PKCS#1 v1.5 decryption
+ *                 operation (RSAES-PKCS1-v1_5-DECRYPT).
+ *
+ * \note           The output buffer length \c output_max_len should be
+ *                 as large as the size \p ctx->len of \p ctx->N, for example,
+ *                 128 Bytes if RSA-1024 is used, to be able to hold an
+ *                 arbitrary decrypted message. If it is not large enough to
+ *                 hold the decryption of the particular ciphertext provided,
+ *                 the function returns #MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE.
+ *
+ * \deprecated     It is deprecated and discouraged to call this function
+ *                 in #MBEDTLS_RSA_PUBLIC mode. Future versions of the library
+ *                 are likely to remove the \p mode argument and have it
+ *                 implicitly set to #MBEDTLS_RSA_PRIVATE.
+ *
+ * \note           Alternative implementations of RSA need not support
+ *                 mode being set to #MBEDTLS_RSA_PUBLIC and might instead
+ *                 return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx      The initialized RSA context to use.
+ * \param f_rng    The RNG function. If \p mode is #MBEDTLS_RSA_PRIVATE,
+ *                 this is used for blinding and should be provided; see
+ *                 mbedtls_rsa_private() for more. If \p mode is
+ *                 #MBEDTLS_RSA_PUBLIC, it is ignored.
+ * \param p_rng    The RNG context to be passed to \p f_rng. This may be
+ *                 \c NULL if \p f_rng is \c NULL or doesn't need a context.
+ * \param mode     The mode of operation. This must be either
+ *                 #MBEDTLS_RSA_PRIVATE or #MBEDTLS_RSA_PUBLIC (deprecated).
+ * \param olen     The address at which to store the length of
+ *                 the plaintext. This must not be \c NULL.
+ * \param input    The ciphertext buffer. This must be a readable buffer
+ *                 of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ * \param output   The buffer used to hold the plaintext. This must
+ *                 be a writable buffer of length \p output_max_len Bytes.
+ * \param output_max_len The length in Bytes of the output buffer \p output.
+ *
+ * \return         \c 0 on success.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ *
+ */
+int mbedtls_rsa_rsaes_pkcs1_v15_decrypt( mbedtls_rsa_context *ctx,
+                                 int (*f_rng)(void *, unsigned char *, size_t),
+                                 void *p_rng,
+                                 int mode, size_t *olen,
+                                 const unsigned char *input,
+                                 unsigned char *output,
+                                 size_t output_max_len );
+
+/**
+ * \brief            This function performs a PKCS#1 v2.1 OAEP decryption
+ *                   operation (RSAES-OAEP-DECRYPT).
+ *
+ * \note             The output buffer length \c output_max_len should be
+ *                   as large as the size \p ctx->len of \p ctx->N, for
+ *                   example, 128 Bytes if RSA-1024 is used, to be able to
+ *                   hold an arbitrary decrypted message. If it is not
+ *                   large enough to hold the decryption of the particular
+ *                   ciphertext provided, the function returns
+ *                   #MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE.
+ *
+ * \deprecated       It is deprecated and discouraged to call this function
+ *                   in #MBEDTLS_RSA_PUBLIC mode. Future versions of the library
+ *                   are likely to remove the \p mode argument and have it
+ *                   implicitly set to #MBEDTLS_RSA_PRIVATE.
+ *
+ * \note             Alternative implementations of RSA need not support
+ *                   mode being set to #MBEDTLS_RSA_PUBLIC and might instead
+ *                   return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx        The initialized RSA context to use.
+ * \param f_rng      The RNG function. If \p mode is #MBEDTLS_RSA_PRIVATE,
+ *                   this is used for blinding and should be provided; see
+ *                   mbedtls_rsa_private() for more. If \p mode is
+ *                   #MBEDTLS_RSA_PUBLIC, it is ignored.
+ * \param p_rng      The RNG context to be passed to \p f_rng. This may be
+ *                   \c NULL if \p f_rng is \c NULL or doesn't need a context.
+ * \param mode       The mode of operation. This must be either
+ *                   #MBEDTLS_RSA_PRIVATE or #MBEDTLS_RSA_PUBLIC (deprecated).
+ * \param label      The buffer holding the custom label to use.
+ *                   This must be a readable buffer of length \p label_len
+ *                   Bytes. It may be \c NULL if \p label_len is \c 0.
+ * \param label_len  The length of the label in Bytes.
+ * \param olen       The address at which to store the length of
+ *                   the plaintext. This must not be \c NULL.
+ * \param input      The ciphertext buffer. This must be a readable buffer
+ *                   of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                   for an 2048-bit RSA modulus.
+ * \param output     The buffer used to hold the plaintext. This must
+ *                   be a writable buffer of length \p output_max_len Bytes.
+ * \param output_max_len The length in Bytes of the output buffer \p output.
+ *
+ * \return         \c 0 on success.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
+                            int (*f_rng)(void *, unsigned char *, size_t),
+                            void *p_rng,
+                            int mode,
+                            const unsigned char *label, size_t label_len,
+                            size_t *olen,
+                            const unsigned char *input,
+                            unsigned char *output,
+                            size_t output_max_len );
+
+/**
+ * \brief          This function performs a private RSA operation to sign
+ *                 a message digest using PKCS#1.
+ *
+ *                 It is the generic wrapper for performing a PKCS#1
+ *                 signature using the \p mode from the context.
+ *
+ * \note           The \p sig buffer must be as large as the size
+ *                 of \p ctx->N. For example, 128 Bytes if RSA-1024 is used.
+ *
+ * \note           For PKCS#1 v2.1 encoding, see comments on
+ *                 mbedtls_rsa_rsassa_pss_sign() for details on
+ *                 \p md_alg and \p hash_id.
+ *
+ * \deprecated     It is deprecated and discouraged to call this function
+ *                 in #MBEDTLS_RSA_PUBLIC mode. Future versions of the library
+ *                 are likely to remove the \p mode argument and have it
+ *                 implicitly set to #MBEDTLS_RSA_PRIVATE.
+ *
+ * \note           Alternative implementations of RSA need not support
+ *                 mode being set to #MBEDTLS_RSA_PUBLIC and might instead
+ *                 return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx      The initialized RSA context to use.
+ * \param f_rng    The RNG function to use. If the padding mode is PKCS#1 v2.1,
+ *                 this must be provided. If the padding mode is PKCS#1 v1.5 and
+ *                 \p mode is #MBEDTLS_RSA_PRIVATE, it is used for blinding
+ *                 and should be provided; see mbedtls_rsa_private() for more
+ *                 more. It is ignored otherwise.
+ * \param p_rng    The RNG context to be passed to \p f_rng. This may be \c NULL
+ *                 if \p f_rng is \c NULL or doesn't need a context argument.
+ * \param mode     The mode of operation. This must be either
+ *                 #MBEDTLS_RSA_PRIVATE or #MBEDTLS_RSA_PUBLIC (deprecated).
+ * \param md_alg   The message-digest algorithm used to hash the original data.
+ *                 Use #MBEDTLS_MD_NONE for signing raw data.
+ * \param hashlen  The length of the message digest.
+ *                 Ths is only used if \p md_alg is #MBEDTLS_MD_NONE.
+ * \param hash     The buffer holding the message digest or raw data.
+ *                 If \p md_alg is #MBEDTLS_MD_NONE, this must be a readable
+ *                 buffer of length \p hashlen Bytes. If \p md_alg is not
+ *                 #MBEDTLS_MD_NONE, it must be a readable buffer of length
+ *                 the size of the hash corresponding to \p md_alg.
+ * \param sig      The buffer to hold the signature. This must be a writable
+ *                 buffer of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ *
+ * \return         \c 0 if the signing operation was successful.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_pkcs1_sign( mbedtls_rsa_context *ctx,
+                    int (*f_rng)(void *, unsigned char *, size_t),
+                    void *p_rng,
+                    int mode,
+                    mbedtls_md_type_t md_alg,
+                    unsigned int hashlen,
+                    const unsigned char *hash,
+                    unsigned char *sig );
+
+/**
+ * \brief          This function performs a PKCS#1 v1.5 signature
+ *                 operation (RSASSA-PKCS1-v1_5-SIGN).
+ *
+ * \deprecated     It is deprecated and discouraged to call this function
+ *                 in #MBEDTLS_RSA_PUBLIC mode. Future versions of the library
+ *                 are likely to remove the \p mode argument and have it
+ *                 implicitly set to #MBEDTLS_RSA_PRIVATE.
+ *
+ * \note           Alternative implementations of RSA need not support
+ *                 mode being set to #MBEDTLS_RSA_PUBLIC and might instead
+ *                 return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx      The initialized RSA context to use.
+ * \param f_rng    The RNG function. If \p mode is #MBEDTLS_RSA_PRIVATE,
+ *                 this is used for blinding and should be provided; see
+ *                 mbedtls_rsa_private() for more. If \p mode is
+ *                 #MBEDTLS_RSA_PUBLIC, it is ignored.
+ * \param p_rng    The RNG context to be passed to \p f_rng. This may be \c NULL
+ *                 if \p f_rng is \c NULL or doesn't need a context argument.
+ * \param mode     The mode of operation. This must be either
+ *                 #MBEDTLS_RSA_PRIVATE or #MBEDTLS_RSA_PUBLIC (deprecated).
+ * \param md_alg   The message-digest algorithm used to hash the original data.
+ *                 Use #MBEDTLS_MD_NONE for signing raw data.
+ * \param hashlen  The length of the message digest.
+ *                 Ths is only used if \p md_alg is #MBEDTLS_MD_NONE.
+ * \param hash     The buffer holding the message digest or raw data.
+ *                 If \p md_alg is #MBEDTLS_MD_NONE, this must be a readable
+ *                 buffer of length \p hashlen Bytes. If \p md_alg is not
+ *                 #MBEDTLS_MD_NONE, it must be a readable buffer of length
+ *                 the size of the hash corresponding to \p md_alg.
+ * \param sig      The buffer to hold the signature. This must be a writable
+ *                 buffer of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ *
+ * \return         \c 0 if the signing operation was successful.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_rsassa_pkcs1_v15_sign( mbedtls_rsa_context *ctx,
+                               int (*f_rng)(void *, unsigned char *, size_t),
+                               void *p_rng,
+                               int mode,
+                               mbedtls_md_type_t md_alg,
+                               unsigned int hashlen,
+                               const unsigned char *hash,
+                               unsigned char *sig );
+
+/**
+ * \brief          This function performs a PKCS#1 v2.1 PSS signature
+ *                 operation (RSASSA-PSS-SIGN).
+ *
+ * \note           The \p hash_id in the RSA context is the one used for the
+ *                 encoding. \p md_alg in the function call is the type of hash
+ *                 that is encoded. According to <em>RFC-3447: Public-Key
+ *                 Cryptography Standards (PKCS) #1 v2.1: RSA Cryptography
+ *                 Specifications</em> it is advised to keep both hashes the
+ *                 same.
+ *
+ * \note           This function always uses the maximum possible salt size,
+ *                 up to the length of the payload hash. This choice of salt
+ *                 size complies with FIPS 186-4.5.5 (e) and RFC 8017 (PKCS#1
+ *                 v2.2) 9.1.1 step 3. Furthermore this function enforces a
+ *                 minimum salt size which is the hash size minus 2 bytes. If
+ *                 this minimum size is too large given the key size (the salt
+ *                 size, plus the hash size, plus 2 bytes must be no more than
+ *                 the key size in bytes), this function returns
+ *                 #MBEDTLS_ERR_RSA_BAD_INPUT_DATA.
+ *
+ * \deprecated     It is deprecated and discouraged to call this function
+ *                 in #MBEDTLS_RSA_PUBLIC mode. Future versions of the library
+ *                 are likely to remove the \p mode argument and have it
+ *                 implicitly set to #MBEDTLS_RSA_PRIVATE.
+ *
+ * \note           Alternative implementations of RSA need not support
+ *                 mode being set to #MBEDTLS_RSA_PUBLIC and might instead
+ *                 return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx      The initialized RSA context to use.
+ * \param f_rng    The RNG function. It must not be \c NULL.
+ * \param p_rng    The RNG context to be passed to \p f_rng. This may be \c NULL
+ *                 if \p f_rng doesn't need a context argument.
+ * \param mode     The mode of operation. This must be either
+ *                 #MBEDTLS_RSA_PRIVATE or #MBEDTLS_RSA_PUBLIC (deprecated).
+ * \param md_alg   The message-digest algorithm used to hash the original data.
+ *                 Use #MBEDTLS_MD_NONE for signing raw data.
+ * \param hashlen  The length of the message digest.
+ *                 Ths is only used if \p md_alg is #MBEDTLS_MD_NONE.
+ * \param hash     The buffer holding the message digest or raw data.
+ *                 If \p md_alg is #MBEDTLS_MD_NONE, this must be a readable
+ *                 buffer of length \p hashlen Bytes. If \p md_alg is not
+ *                 #MBEDTLS_MD_NONE, it must be a readable buffer of length
+ *                 the size of the hash corresponding to \p md_alg.
+ * \param sig      The buffer to hold the signature. This must be a writable
+ *                 buffer of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ *
+ * \return         \c 0 if the signing operation was successful.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
+                         int (*f_rng)(void *, unsigned char *, size_t),
+                         void *p_rng,
+                         int mode,
+                         mbedtls_md_type_t md_alg,
+                         unsigned int hashlen,
+                         const unsigned char *hash,
+                         unsigned char *sig );
+
+/**
+ * \brief          This function performs a public RSA operation and checks
+ *                 the message digest.
+ *
+ *                 This is the generic wrapper for performing a PKCS#1
+ *                 verification using the mode from the context.
+ *
+ * \note           For PKCS#1 v2.1 encoding, see comments on
+ *                 mbedtls_rsa_rsassa_pss_verify() about \p md_alg and
+ *                 \p hash_id.
+ *
+ * \deprecated     It is deprecated and discouraged to call this function
+ *                 in #MBEDTLS_RSA_PRIVATE mode. Future versions of the library
+ *                 are likely to remove the \p mode argument and have it
+ *                 set to #MBEDTLS_RSA_PUBLIC.
+ *
+ * \note           Alternative implementations of RSA need not support
+ *                 mode being set to #MBEDTLS_RSA_PRIVATE and might instead
+ *                 return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx      The initialized RSA public key context to use.
+ * \param f_rng    The RNG function to use. If \p mode is #MBEDTLS_RSA_PRIVATE,
+ *                 this is used for blinding and should be provided; see
+ *                 mbedtls_rsa_private() for more. Otherwise, it is ignored.
+ * \param p_rng    The RNG context to be passed to \p f_rng. This may be
+ *                 \c NULL if \p f_rng is \c NULL or doesn't need a context.
+ * \param mode     The mode of operation. This must be either
+ *                 #MBEDTLS_RSA_PUBLIC or #MBEDTLS_RSA_PRIVATE (deprecated).
+ * \param md_alg   The message-digest algorithm used to hash the original data.
+ *                 Use #MBEDTLS_MD_NONE for signing raw data.
+ * \param hashlen  The length of the message digest.
+ *                 This is only used if \p md_alg is #MBEDTLS_MD_NONE.
+ * \param hash     The buffer holding the message digest or raw data.
+ *                 If \p md_alg is #MBEDTLS_MD_NONE, this must be a readable
+ *                 buffer of length \p hashlen Bytes. If \p md_alg is not
+ *                 #MBEDTLS_MD_NONE, it must be a readable buffer of length
+ *                 the size of the hash corresponding to \p md_alg.
+ * \param sig      The buffer holding the signature. This must be a readable
+ *                 buffer of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ *
+ * \return         \c 0 if the verify operation was successful.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_pkcs1_verify( mbedtls_rsa_context *ctx,
+                      int (*f_rng)(void *, unsigned char *, size_t),
+                      void *p_rng,
+                      int mode,
+                      mbedtls_md_type_t md_alg,
+                      unsigned int hashlen,
+                      const unsigned char *hash,
+                      const unsigned char *sig );
+
+/**
+ * \brief          This function performs a PKCS#1 v1.5 verification
+ *                 operation (RSASSA-PKCS1-v1_5-VERIFY).
+ *
+ * \deprecated     It is deprecated and discouraged to call this function
+ *                 in #MBEDTLS_RSA_PRIVATE mode. Future versions of the library
+ *                 are likely to remove the \p mode argument and have it
+ *                 set to #MBEDTLS_RSA_PUBLIC.
+ *
+ * \note           Alternative implementations of RSA need not support
+ *                 mode being set to #MBEDTLS_RSA_PRIVATE and might instead
+ *                 return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx      The initialized RSA public key context to use.
+ * \param f_rng    The RNG function to use. If \p mode is #MBEDTLS_RSA_PRIVATE,
+ *                 this is used for blinding and should be provided; see
+ *                 mbedtls_rsa_private() for more. Otherwise, it is ignored.
+ * \param p_rng    The RNG context to be passed to \p f_rng. This may be
+ *                 \c NULL if \p f_rng is \c NULL or doesn't need a context.
+ * \param mode     The mode of operation. This must be either
+ *                 #MBEDTLS_RSA_PUBLIC or #MBEDTLS_RSA_PRIVATE (deprecated).
+ * \param md_alg   The message-digest algorithm used to hash the original data.
+ *                 Use #MBEDTLS_MD_NONE for signing raw data.
+ * \param hashlen  The length of the message digest.
+ *                 This is only used if \p md_alg is #MBEDTLS_MD_NONE.
+ * \param hash     The buffer holding the message digest or raw data.
+ *                 If \p md_alg is #MBEDTLS_MD_NONE, this must be a readable
+ *                 buffer of length \p hashlen Bytes. If \p md_alg is not
+ *                 #MBEDTLS_MD_NONE, it must be a readable buffer of length
+ *                 the size of the hash corresponding to \p md_alg.
+ * \param sig      The buffer holding the signature. This must be a readable
+ *                 buffer of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ *
+ * \return         \c 0 if the verify operation was successful.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_rsassa_pkcs1_v15_verify( mbedtls_rsa_context *ctx,
+                                 int (*f_rng)(void *, unsigned char *, size_t),
+                                 void *p_rng,
+                                 int mode,
+                                 mbedtls_md_type_t md_alg,
+                                 unsigned int hashlen,
+                                 const unsigned char *hash,
+                                 const unsigned char *sig );
+
+/**
+ * \brief          This function performs a PKCS#1 v2.1 PSS verification
+ *                 operation (RSASSA-PSS-VERIFY).
+ *
+ *                 The hash function for the MGF mask generating function
+ *                 is that specified in the RSA context.
+ *
+ * \note           The \p hash_id in the RSA context is the one used for the
+ *                 verification. \p md_alg in the function call is the type of
+ *                 hash that is verified. According to <em>RFC-3447: Public-Key
+ *                 Cryptography Standards (PKCS) #1 v2.1: RSA Cryptography
+ *                 Specifications</em> it is advised to keep both hashes the
+ *                 same. If \p hash_id in the RSA context is unset,
+ *                 the \p md_alg from the function call is used.
+ *
+ * \deprecated     It is deprecated and discouraged to call this function
+ *                 in #MBEDTLS_RSA_PRIVATE mode. Future versions of the library
+ *                 are likely to remove the \p mode argument and have it
+ *                 implicitly set to #MBEDTLS_RSA_PUBLIC.
+ *
+ * \note           Alternative implementations of RSA need not support
+ *                 mode being set to #MBEDTLS_RSA_PRIVATE and might instead
+ *                 return #MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+ *
+ * \param ctx      The initialized RSA public key context to use.
+ * \param f_rng    The RNG function to use. If \p mode is #MBEDTLS_RSA_PRIVATE,
+ *                 this is used for blinding and should be provided; see
+ *                 mbedtls_rsa_private() for more. Otherwise, it is ignored.
+ * \param p_rng    The RNG context to be passed to \p f_rng. This may be
+ *                 \c NULL if \p f_rng is \c NULL or doesn't need a context.
+ * \param mode     The mode of operation. This must be either
+ *                 #MBEDTLS_RSA_PUBLIC or #MBEDTLS_RSA_PRIVATE (deprecated).
+ * \param md_alg   The message-digest algorithm used to hash the original data.
+ *                 Use #MBEDTLS_MD_NONE for signing raw data.
+ * \param hashlen  The length of the message digest.
+ *                 This is only used if \p md_alg is #MBEDTLS_MD_NONE.
+ * \param hash     The buffer holding the message digest or raw data.
+ *                 If \p md_alg is #MBEDTLS_MD_NONE, this must be a readable
+ *                 buffer of length \p hashlen Bytes. If \p md_alg is not
+ *                 #MBEDTLS_MD_NONE, it must be a readable buffer of length
+ *                 the size of the hash corresponding to \p md_alg.
+ * \param sig      The buffer holding the signature. This must be a readable
+ *                 buffer of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ *
+ * \return         \c 0 if the verify operation was successful.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_rsassa_pss_verify( mbedtls_rsa_context *ctx,
+                           int (*f_rng)(void *, unsigned char *, size_t),
+                           void *p_rng,
+                           int mode,
+                           mbedtls_md_type_t md_alg,
+                           unsigned int hashlen,
+                           const unsigned char *hash,
+                           const unsigned char *sig );
+
+/**
+ * \brief          This function performs a PKCS#1 v2.1 PSS verification
+ *                 operation (RSASSA-PSS-VERIFY).
+ *
+ *                 The hash function for the MGF mask generating function
+ *                 is that specified in \p mgf1_hash_id.
+ *
+ * \note           The \p sig buffer must be as large as the size
+ *                 of \p ctx->N. For example, 128 Bytes if RSA-1024 is used.
+ *
+ * \note           The \p hash_id in the RSA context is ignored.
+ *
+ * \param ctx      The initialized RSA public key context to use.
+ * \param f_rng    The RNG function to use. If \p mode is #MBEDTLS_RSA_PRIVATE,
+ *                 this is used for blinding and should be provided; see
+ *                 mbedtls_rsa_private() for more. Otherwise, it is ignored.
+ * \param p_rng    The RNG context to be passed to \p f_rng. This may be
+ *                 \c NULL if \p f_rng is \c NULL or doesn't need a context.
+ * \param mode     The mode of operation. This must be either
+ *                 #MBEDTLS_RSA_PUBLIC or #MBEDTLS_RSA_PRIVATE.
+ * \param md_alg   The message-digest algorithm used to hash the original data.
+ *                 Use #MBEDTLS_MD_NONE for signing raw data.
+ * \param hashlen  The length of the message digest.
+ *                 This is only used if \p md_alg is #MBEDTLS_MD_NONE.
+ * \param hash     The buffer holding the message digest or raw data.
+ *                 If \p md_alg is #MBEDTLS_MD_NONE, this must be a readable
+ *                 buffer of length \p hashlen Bytes. If \p md_alg is not
+ *                 #MBEDTLS_MD_NONE, it must be a readable buffer of length
+ *                 the size of the hash corresponding to \p md_alg.
+ * \param mgf1_hash_id      The message digest used for mask generation.
+ * \param expected_salt_len The length of the salt used in padding. Use
+ *                          #MBEDTLS_RSA_SALT_LEN_ANY to accept any salt length.
+ * \param sig      The buffer holding the signature. This must be a readable
+ *                 buffer of length \c ctx->len Bytes. For example, \c 256 Bytes
+ *                 for an 2048-bit RSA modulus.
+ *
+ * \return         \c 0 if the verify operation was successful.
+ * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
+ */
+int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
+                               int (*f_rng)(void *, unsigned char *, size_t),
+                               void *p_rng,
+                               int mode,
+                               mbedtls_md_type_t md_alg,
+                               unsigned int hashlen,
+                               const unsigned char *hash,
+                               mbedtls_md_type_t mgf1_hash_id,
+                               int expected_salt_len,
+                               const unsigned char *sig );
+
+/**
+ * \brief          This function copies the components of an RSA context.
+ *
+ * \param dst      The destination context. This must be initialized.
+ * \param src      The source context. This must be initialized.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED on memory allocation failure.
+ */
+int mbedtls_rsa_copy( mbedtls_rsa_context *dst, const mbedtls_rsa_context *src );
+
+/**
+ * \brief          This function frees the components of an RSA key.
+ *
+ * \param ctx      The RSA context to free. May be \c NULL, in which case
+ *                 this function is a no-op. If it is not \c NULL, it must
+ *                 point to an initialized RSA context.
+ */
+void mbedtls_rsa_free( mbedtls_rsa_context *ctx );
+
+/**
+ * \brief          The RSA checkup routine.
+ *
+ * \return         \c 0 on success.
+ * \return         \c 1 on failure.
+ */
+int mbedtls_rsa_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* rsa.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/rsa_internal.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/rsa_internal.h
@@ -1,0 +1,226 @@
+/**
+ * \file rsa_internal.h
+ *
+ * \brief Context-independent RSA helper functions
+ *
+ *  This module declares some RSA-related helper functions useful when
+ *  implementing the RSA interface. These functions are provided in a separate
+ *  compilation unit in order to make it easy for designers of alternative RSA
+ *  implementations to use them in their own code, as it is conceived that the
+ *  functionality they provide will be necessary for most complete
+ *  implementations.
+ *
+ *  End-users of Mbed TLS who are not providing their own alternative RSA
+ *  implementations should not use these functions directly, and should instead
+ *  use only the functions declared in rsa.h.
+ *
+ *  The interface provided by this module will be maintained through LTS (Long
+ *  Term Support) branches of Mbed TLS, but may otherwise be subject to change,
+ *  and must be considered an internal interface of the library.
+ *
+ *  There are two classes of helper functions:
+ *
+ *  (1) Parameter-generating helpers. These are:
+ *      - mbedtls_rsa_deduce_primes
+ *      - mbedtls_rsa_deduce_private_exponent
+ *      - mbedtls_rsa_deduce_crt
+ *       Each of these functions takes a set of core RSA parameters and
+ *       generates some other, or CRT related parameters.
+ *
+ *  (2) Parameter-checking helpers. These are:
+ *      - mbedtls_rsa_validate_params
+ *      - mbedtls_rsa_validate_crt
+ *      They take a set of core or CRT related RSA parameters and check their
+ *      validity.
+ *
+ */
+/*
+ *  Copyright (C) 2006-2017, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ *
+ */
+
+#ifndef MBEDTLS_RSA_INTERNAL_H
+#define MBEDTLS_RSA_INTERNAL_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include "bignum.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * \brief          Compute RSA prime moduli P, Q from public modulus N=PQ
+ *                 and a pair of private and public key.
+ *
+ * \note           This is a 'static' helper function not operating on
+ *                 an RSA context. Alternative implementations need not
+ *                 overwrite it.
+ *
+ * \param N        RSA modulus N = PQ, with P, Q to be found
+ * \param E        RSA public exponent
+ * \param D        RSA private exponent
+ * \param P        Pointer to MPI holding first prime factor of N on success
+ * \param Q        Pointer to MPI holding second prime factor of N on success
+ *
+ * \return
+ *                 - 0 if successful. In this case, P and Q constitute a
+ *                   factorization of N.
+ *                 - A non-zero error code otherwise.
+ *
+ * \note           It is neither checked that P, Q are prime nor that
+ *                 D, E are modular inverses wrt. P-1 and Q-1. For that,
+ *                 use the helper function \c mbedtls_rsa_validate_params.
+ *
+ */
+int mbedtls_rsa_deduce_primes( mbedtls_mpi const *N, mbedtls_mpi const *E,
+                               mbedtls_mpi const *D,
+                               mbedtls_mpi *P, mbedtls_mpi *Q );
+
+/**
+ * \brief          Compute RSA private exponent from
+ *                 prime moduli and public key.
+ *
+ * \note           This is a 'static' helper function not operating on
+ *                 an RSA context. Alternative implementations need not
+ *                 overwrite it.
+ *
+ * \param P        First prime factor of RSA modulus
+ * \param Q        Second prime factor of RSA modulus
+ * \param E        RSA public exponent
+ * \param D        Pointer to MPI holding the private exponent on success.
+ *
+ * \return
+ *                 - 0 if successful. In this case, D is set to a simultaneous
+ *                   modular inverse of E modulo both P-1 and Q-1.
+ *                 - A non-zero error code otherwise.
+ *
+ * \note           This function does not check whether P and Q are primes.
+ *
+ */
+int mbedtls_rsa_deduce_private_exponent( mbedtls_mpi const *P,
+                                         mbedtls_mpi const *Q,
+                                         mbedtls_mpi const *E,
+                                         mbedtls_mpi *D );
+
+
+/**
+ * \brief          Generate RSA-CRT parameters
+ *
+ * \note           This is a 'static' helper function not operating on
+ *                 an RSA context. Alternative implementations need not
+ *                 overwrite it.
+ *
+ * \param P        First prime factor of N
+ * \param Q        Second prime factor of N
+ * \param D        RSA private exponent
+ * \param DP       Output variable for D modulo P-1
+ * \param DQ       Output variable for D modulo Q-1
+ * \param QP       Output variable for the modular inverse of Q modulo P.
+ *
+ * \return         0 on success, non-zero error code otherwise.
+ *
+ * \note           This function does not check whether P, Q are
+ *                 prime and whether D is a valid private exponent.
+ *
+ */
+int mbedtls_rsa_deduce_crt( const mbedtls_mpi *P, const mbedtls_mpi *Q,
+                            const mbedtls_mpi *D, mbedtls_mpi *DP,
+                            mbedtls_mpi *DQ, mbedtls_mpi *QP );
+
+
+/**
+ * \brief          Check validity of core RSA parameters
+ *
+ * \note           This is a 'static' helper function not operating on
+ *                 an RSA context. Alternative implementations need not
+ *                 overwrite it.
+ *
+ * \param N        RSA modulus N = PQ
+ * \param P        First prime factor of N
+ * \param Q        Second prime factor of N
+ * \param D        RSA private exponent
+ * \param E        RSA public exponent
+ * \param f_rng    PRNG to be used for primality check, or NULL
+ * \param p_rng    PRNG context for f_rng, or NULL
+ *
+ * \return
+ *                 - 0 if the following conditions are satisfied
+ *                   if all relevant parameters are provided:
+ *                    - P prime if f_rng != NULL (%)
+ *                    - Q prime if f_rng != NULL (%)
+ *                    - 1 < N = P * Q
+ *                    - 1 < D, E < N
+ *                    - D and E are modular inverses modulo P-1 and Q-1
+ *                   (%) This is only done if MBEDTLS_GENPRIME is defined.
+ *                 - A non-zero error code otherwise.
+ *
+ * \note           The function can be used with a restricted set of arguments
+ *                 to perform specific checks only. E.g., calling it with
+ *                 (-,P,-,-,-) and a PRNG amounts to a primality check for P.
+ */
+int mbedtls_rsa_validate_params( const mbedtls_mpi *N, const mbedtls_mpi *P,
+                                 const mbedtls_mpi *Q, const mbedtls_mpi *D,
+                                 const mbedtls_mpi *E,
+                                 int (*f_rng)(void *, unsigned char *, size_t),
+                                 void *p_rng );
+
+/**
+ * \brief          Check validity of RSA CRT parameters
+ *
+ * \note           This is a 'static' helper function not operating on
+ *                 an RSA context. Alternative implementations need not
+ *                 overwrite it.
+ *
+ * \param P        First prime factor of RSA modulus
+ * \param Q        Second prime factor of RSA modulus
+ * \param D        RSA private exponent
+ * \param DP       MPI to check for D modulo P-1
+ * \param DQ       MPI to check for D modulo P-1
+ * \param QP       MPI to check for the modular inverse of Q modulo P.
+ *
+ * \return
+ *                 - 0 if the following conditions are satisfied:
+ *                    - D = DP mod P-1 if P, D, DP != NULL
+ *                    - Q = DQ mod P-1 if P, D, DQ != NULL
+ *                    - QP = Q^-1 mod P if P, Q, QP != NULL
+ *                 - \c MBEDTLS_ERR_RSA_KEY_CHECK_FAILED if check failed,
+ *                   potentially including \c MBEDTLS_ERR_MPI_XXX if some
+ *                   MPI calculations failed.
+ *                 - \c MBEDTLS_ERR_RSA_BAD_INPUT_DATA if insufficient
+ *                   data was provided to check DP, DQ or QP.
+ *
+ * \note           The function can be used with a restricted set of arguments
+ *                 to perform specific checks only. E.g., calling it with the
+ *                 parameters (P, -, D, DP, -, -) will check DP = D mod P-1.
+ */
+int mbedtls_rsa_validate_crt( const mbedtls_mpi *P,  const mbedtls_mpi *Q,
+                              const mbedtls_mpi *D,  const mbedtls_mpi *DP,
+                              const mbedtls_mpi *DQ, const mbedtls_mpi *QP );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* rsa_internal.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/sha1.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/sha1.h
@@ -1,0 +1,349 @@
+/**
+ * \file sha1.h
+ *
+ * \brief This file contains SHA-1 definitions and functions.
+ *
+ * The Secure Hash Algorithm 1 (SHA-1) cryptographic hash function is defined in
+ * <em>FIPS 180-4: Secure Hash Standard (SHS)</em>.
+ *
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. We recommend considering stronger message
+ *            digests instead.
+ */
+/*
+ *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_SHA1_H
+#define MBEDTLS_SHA1_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#endif
+
+/* MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED is deprecated and should not be used. */
+#define MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED                  -0x0035  /**< SHA-1 hardware accelerator failed */
+#define MBEDTLS_ERR_SHA1_BAD_INPUT_DATA                   -0x0073  /**< SHA-1 input data was malformed. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(MBEDTLS_SHA1_ALT)
+// Regular implementation
+//
+
+/**
+ * \brief          The SHA-1 context structure.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ */
+typedef struct mbedtls_sha1_context
+{
+    uint32_t total[2];          /*!< The number of Bytes processed.  */
+    uint32_t state[5];          /*!< The intermediate digest state.  */
+    unsigned char buffer[64];   /*!< The data block being processed. */
+}
+mbedtls_sha1_context;
+
+#else  /* MBEDTLS_SHA1_ALT */
+#include "sha1_alt.h"
+#endif /* MBEDTLS_SHA1_ALT */
+
+/**
+ * \brief          This function initializes a SHA-1 context.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \param ctx      The SHA-1 context to initialize.
+ *                 This must not be \c NULL.
+ *
+ */
+void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
+
+/**
+ * \brief          This function clears a SHA-1 context.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \param ctx      The SHA-1 context to clear. This may be \c NULL,
+ *                 in which case this function does nothing. If it is
+ *                 not \c NULL, it must point to an initialized
+ *                 SHA-1 context.
+ *
+ */
+void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
+
+/**
+ * \brief          This function clones the state of a SHA-1 context.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \param dst      The SHA-1 context to clone to. This must be initialized.
+ * \param src      The SHA-1 context to clone from. This must be initialized.
+ *
+ */
+void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
+                         const mbedtls_sha1_context *src );
+
+/**
+ * \brief          This function starts a SHA-1 checksum calculation.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \param ctx      The SHA-1 context to initialize. This must be initialized.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ *
+ */
+int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx );
+
+/**
+ * \brief          This function feeds an input buffer into an ongoing SHA-1
+ *                 checksum calculation.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \param ctx      The SHA-1 context. This must be initialized
+ *                 and have a hash operation started.
+ * \param input    The buffer holding the input data.
+ *                 This must be a readable buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data \p input in Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
+                             const unsigned char *input,
+                             size_t ilen );
+
+/**
+ * \brief          This function finishes the SHA-1 operation, and writes
+ *                 the result to the output buffer.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \param ctx      The SHA-1 context to use. This must be initialized and
+ *                 have a hash operation started.
+ * \param output   The SHA-1 checksum result. This must be a writable
+ *                 buffer of length \c 20 Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
+                             unsigned char output[20] );
+
+/**
+ * \brief          SHA-1 process data block (internal use only).
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \param ctx      The SHA-1 context to use. This must be initialized.
+ * \param data     The data block being processed. This must be a
+ *                 readable buffer of length \c 64 Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ *
+ */
+int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
+                                   const unsigned char data[64] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          This function starts a SHA-1 checksum calculation.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \deprecated     Superseded by mbedtls_sha1_starts_ret() in 2.7.0.
+ *
+ * \param ctx      The SHA-1 context to initialize. This must be initialized.
+ *
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
+
+/**
+ * \brief          This function feeds an input buffer into an ongoing SHA-1
+ *                 checksum calculation.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \deprecated     Superseded by mbedtls_sha1_update_ret() in 2.7.0.
+ *
+ * \param ctx      The SHA-1 context. This must be initialized and
+ *                 have a hash operation started.
+ * \param input    The buffer holding the input data.
+ *                 This must be a readable buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data \p input in Bytes.
+ *
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha1_update( mbedtls_sha1_context *ctx,
+                                             const unsigned char *input,
+                                             size_t ilen );
+
+/**
+ * \brief          This function finishes the SHA-1 operation, and writes
+ *                 the result to the output buffer.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \deprecated     Superseded by mbedtls_sha1_finish_ret() in 2.7.0.
+ *
+ * \param ctx      The SHA-1 context. This must be initialized and
+ *                 have a hash operation started.
+ * \param output   The SHA-1 checksum result.
+ *                 This must be a writable buffer of length \c 20 Bytes.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha1_finish( mbedtls_sha1_context *ctx,
+                                             unsigned char output[20] );
+
+/**
+ * \brief          SHA-1 process data block (internal use only).
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \deprecated     Superseded by mbedtls_internal_sha1_process() in 2.7.0.
+ *
+ * \param ctx      The SHA-1 context. This must be initialized.
+ * \param data     The data block being processed.
+ *                 This must be a readable buffer of length \c 64 bytes.
+ *
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha1_process( mbedtls_sha1_context *ctx,
+                                              const unsigned char data[64] );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief          This function calculates the SHA-1 checksum of a buffer.
+ *
+ *                 The function allocates the context, performs the
+ *                 calculation, and frees the context.
+ *
+ *                 The SHA-1 result is calculated as
+ *                 output = SHA-1(input buffer).
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \param input    The buffer holding the input data.
+ *                 This must be a readable buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data \p input in Bytes.
+ * \param output   The SHA-1 checksum result.
+ *                 This must be a writable buffer of length \c 20 Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ *
+ */
+int mbedtls_sha1_ret( const unsigned char *input,
+                      size_t ilen,
+                      unsigned char output[20] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          This function calculates the SHA-1 checksum of a buffer.
+ *
+ *                 The function allocates the context, performs the
+ *                 calculation, and frees the context.
+ *
+ *                 The SHA-1 result is calculated as
+ *                 output = SHA-1(input buffer).
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \deprecated     Superseded by mbedtls_sha1_ret() in 2.7.0
+ *
+ * \param input    The buffer holding the input data.
+ *                 This must be a readable buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data \p input in Bytes.
+ * \param output   The SHA-1 checksum result. This must be a writable
+ *                 buffer of size \c 20 Bytes.
+ *
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha1( const unsigned char *input,
+                                      size_t ilen,
+                                      unsigned char output[20] );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief          The SHA-1 checkup routine.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ * \return         \c 0 on success.
+ * \return         \c 1 on failure.
+ *
+ */
+int mbedtls_sha1_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* mbedtls_sha1.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/sha256.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/sha256.h
@@ -1,0 +1,294 @@
+/**
+ * \file sha256.h
+ *
+ * \brief This file contains SHA-224 and SHA-256 definitions and functions.
+ *
+ * The Secure Hash Algorithms 224 and 256 (SHA-224 and SHA-256) cryptographic
+ * hash functions are defined in <em>FIPS 180-4: Secure Hash Standard (SHS)</em>.
+ */
+/*
+ *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_SHA256_H
+#define MBEDTLS_SHA256_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#endif
+
+/* MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED is deprecated and should not be used. */
+#define MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED                -0x0037  /**< SHA-256 hardware accelerator failed */
+#define MBEDTLS_ERR_SHA256_BAD_INPUT_DATA                 -0x0074  /**< SHA-256 input data was malformed. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(MBEDTLS_SHA256_ALT)
+// Regular implementation
+//
+
+/**
+ * \brief          The SHA-256 context structure.
+ *
+ *                 The structure is used both for SHA-256 and for SHA-224
+ *                 checksum calculations. The choice between these two is
+ *                 made in the call to mbedtls_sha256_starts_ret().
+ */
+typedef struct mbedtls_sha256_context
+{
+    uint32_t total[2];          /*!< The number of Bytes processed.  */
+    uint32_t state[8];          /*!< The intermediate digest state.  */
+    unsigned char buffer[64];   /*!< The data block being processed. */
+    int is224;                  /*!< Determines which function to use:
+                                     0: Use SHA-256, or 1: Use SHA-224. */
+}
+mbedtls_sha256_context;
+
+#else  /* MBEDTLS_SHA256_ALT */
+#include "sha256_alt.h"
+#endif /* MBEDTLS_SHA256_ALT */
+
+/**
+ * \brief          This function initializes a SHA-256 context.
+ *
+ * \param ctx      The SHA-256 context to initialize. This must not be \c NULL.
+ */
+void mbedtls_sha256_init( mbedtls_sha256_context *ctx );
+
+/**
+ * \brief          This function clears a SHA-256 context.
+ *
+ * \param ctx      The SHA-256 context to clear. This may be \c NULL, in which
+ *                 case this function returns immediately. If it is not \c NULL,
+ *                 it must point to an initialized SHA-256 context.
+ */
+void mbedtls_sha256_free( mbedtls_sha256_context *ctx );
+
+/**
+ * \brief          This function clones the state of a SHA-256 context.
+ *
+ * \param dst      The destination context. This must be initialized.
+ * \param src      The context to clone. This must be initialized.
+ */
+void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
+                           const mbedtls_sha256_context *src );
+
+/**
+ * \brief          This function starts a SHA-224 or SHA-256 checksum
+ *                 calculation.
+ *
+ * \param ctx      The context to use. This must be initialized.
+ * \param is224    This determines which function to use. This must be
+ *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 );
+
+/**
+ * \brief          This function feeds an input buffer into an ongoing
+ *                 SHA-256 checksum calculation.
+ *
+ * \param ctx      The SHA-256 context. This must be initialized
+ *                 and have a hash operation started.
+ * \param input    The buffer holding the data. This must be a readable
+ *                 buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data in Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
+                               const unsigned char *input,
+                               size_t ilen );
+
+/**
+ * \brief          This function finishes the SHA-256 operation, and writes
+ *                 the result to the output buffer.
+ *
+ * \param ctx      The SHA-256 context. This must be initialized
+ *                 and have a hash operation started.
+ * \param output   The SHA-224 or SHA-256 checksum result.
+ *                 This must be a writable buffer of length \c 32 Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
+                               unsigned char output[32] );
+
+/**
+ * \brief          This function processes a single data block within
+ *                 the ongoing SHA-256 computation. This function is for
+ *                 internal use only.
+ *
+ * \param ctx      The SHA-256 context. This must be initialized.
+ * \param data     The buffer holding one block of data. This must
+ *                 be a readable buffer of length \c 64 Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
+                                     const unsigned char data[64] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          This function starts a SHA-224 or SHA-256 checksum
+ *                 calculation.
+ *
+ * \deprecated     Superseded by mbedtls_sha256_starts_ret() in 2.7.0.
+ *
+ * \param ctx      The context to use. This must be initialized.
+ * \param is224    Determines which function to use. This must be
+ *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha256_starts( mbedtls_sha256_context *ctx,
+                                               int is224 );
+
+/**
+ * \brief          This function feeds an input buffer into an ongoing
+ *                 SHA-256 checksum calculation.
+ *
+ * \deprecated     Superseded by mbedtls_sha256_update_ret() in 2.7.0.
+ *
+ * \param ctx      The SHA-256 context to use. This must be
+ *                 initialized and have a hash operation started.
+ * \param input    The buffer holding the data. This must be a readable
+ *                 buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data in Bytes.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha256_update( mbedtls_sha256_context *ctx,
+                                               const unsigned char *input,
+                                               size_t ilen );
+
+/**
+ * \brief          This function finishes the SHA-256 operation, and writes
+ *                 the result to the output buffer.
+ *
+ * \deprecated     Superseded by mbedtls_sha256_finish_ret() in 2.7.0.
+ *
+ * \param ctx      The SHA-256 context. This must be initialized and
+ *                 have a hash operation started.
+ * \param output   The SHA-224 or SHA-256 checksum result. This must be
+ *                 a writable buffer of length \c 32 Bytes.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha256_finish( mbedtls_sha256_context *ctx,
+                                               unsigned char output[32] );
+
+/**
+ * \brief          This function processes a single data block within
+ *                 the ongoing SHA-256 computation. This function is for
+ *                 internal use only.
+ *
+ * \deprecated     Superseded by mbedtls_internal_sha256_process() in 2.7.0.
+ *
+ * \param ctx      The SHA-256 context. This must be initialized.
+ * \param data     The buffer holding one block of data. This must be
+ *                 a readable buffer of size \c 64 Bytes.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha256_process( mbedtls_sha256_context *ctx,
+                                                const unsigned char data[64] );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief          This function calculates the SHA-224 or SHA-256
+ *                 checksum of a buffer.
+ *
+ *                 The function allocates the context, performs the
+ *                 calculation, and frees the context.
+ *
+ *                 The SHA-256 result is calculated as
+ *                 output = SHA-256(input buffer).
+ *
+ * \param input    The buffer holding the data. This must be a readable
+ *                 buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data in Bytes.
+ * \param output   The SHA-224 or SHA-256 checksum result. This must
+ *                 be a writable buffer of length \c 32 Bytes.
+ * \param is224    Determines which function to use. This must be
+ *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
+ */
+int mbedtls_sha256_ret( const unsigned char *input,
+                        size_t ilen,
+                        unsigned char output[32],
+                        int is224 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+
+/**
+ * \brief          This function calculates the SHA-224 or SHA-256 checksum
+ *                 of a buffer.
+ *
+ *                 The function allocates the context, performs the
+ *                 calculation, and frees the context.
+ *
+ *                 The SHA-256 result is calculated as
+ *                 output = SHA-256(input buffer).
+ *
+ * \deprecated     Superseded by mbedtls_sha256_ret() in 2.7.0.
+ *
+ * \param input    The buffer holding the data. This must be a readable
+ *                 buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data in Bytes.
+ * \param output   The SHA-224 or SHA-256 checksum result. This must be
+ *                 a writable buffer of length \c 32 Bytes.
+ * \param is224    Determines which function to use. This must be either
+ *                 \c 0 for SHA-256, or \c 1 for SHA-224.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha256( const unsigned char *input,
+                                        size_t ilen,
+                                        unsigned char output[32],
+                                        int is224 );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief          The SHA-224 and SHA-256 checkup routine.
+ *
+ * \return         \c 0 on success.
+ * \return         \c 1 on failure.
+ */
+int mbedtls_sha256_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* mbedtls_sha256.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/sha512.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/sha512.h
@@ -1,0 +1,296 @@
+/**
+ * \file sha512.h
+ * \brief This file contains SHA-384 and SHA-512 definitions and functions.
+ *
+ * The Secure Hash Algorithms 384 and 512 (SHA-384 and SHA-512) cryptographic
+ * hash functions are defined in <em>FIPS 180-4: Secure Hash Standard (SHS)</em>.
+ */
+/*
+ *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_SHA512_H
+#define MBEDTLS_SHA512_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#endif
+
+/* MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED is deprecated and should not be used. */
+#define MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED                -0x0039  /**< SHA-512 hardware accelerator failed */
+#define MBEDTLS_ERR_SHA512_BAD_INPUT_DATA                 -0x0075  /**< SHA-512 input data was malformed. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(MBEDTLS_SHA512_ALT)
+// Regular implementation
+//
+
+/**
+ * \brief          The SHA-512 context structure.
+ *
+ *                 The structure is used both for SHA-384 and for SHA-512
+ *                 checksum calculations. The choice between these two is
+ *                 made in the call to mbedtls_sha512_starts_ret().
+ */
+typedef struct mbedtls_sha512_context
+{
+    uint64_t total[2];          /*!< The number of Bytes processed. */
+    uint64_t state[8];          /*!< The intermediate digest state. */
+    unsigned char buffer[128];  /*!< The data block being processed. */
+    int is384;                  /*!< Determines which function to use:
+                                     0: Use SHA-512, or 1: Use SHA-384. */
+}
+mbedtls_sha512_context;
+
+#else  /* MBEDTLS_SHA512_ALT */
+#include "sha512_alt.h"
+#endif /* MBEDTLS_SHA512_ALT */
+
+/**
+ * \brief          This function initializes a SHA-512 context.
+ *
+ * \param ctx      The SHA-512 context to initialize. This must
+ *                 not be \c NULL.
+ */
+void mbedtls_sha512_init( mbedtls_sha512_context *ctx );
+
+/**
+ * \brief          This function clears a SHA-512 context.
+ *
+ * \param ctx      The SHA-512 context to clear. This may be \c NULL,
+ *                 in which case this function does nothing. If it
+ *                 is not \c NULL, it must point to an initialized
+ *                 SHA-512 context.
+ */
+void mbedtls_sha512_free( mbedtls_sha512_context *ctx );
+
+/**
+ * \brief          This function clones the state of a SHA-512 context.
+ *
+ * \param dst      The destination context. This must be initialized.
+ * \param src      The context to clone. This must be initialized.
+ */
+void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
+                           const mbedtls_sha512_context *src );
+
+/**
+ * \brief          This function starts a SHA-384 or SHA-512 checksum
+ *                 calculation.
+ *
+ * \param ctx      The SHA-512 context to use. This must be initialized.
+ * \param is384    Determines which function to use. This must be
+ *                 either \c for SHA-512, or \c 1 for SHA-384.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha512_starts_ret( mbedtls_sha512_context *ctx, int is384 );
+
+/**
+ * \brief          This function feeds an input buffer into an ongoing
+ *                 SHA-512 checksum calculation.
+ *
+ * \param ctx      The SHA-512 context. This must be initialized
+ *                 and have a hash operation started.
+ * \param input    The buffer holding the input data. This must
+ *                 be a readable buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data in Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
+                    const unsigned char *input,
+                    size_t ilen );
+
+/**
+ * \brief          This function finishes the SHA-512 operation, and writes
+ *                 the result to the output buffer. This function is for
+ *                 internal use only.
+ *
+ * \param ctx      The SHA-512 context. This must be initialized
+ *                 and have a hash operation started.
+ * \param output   The SHA-384 or SHA-512 checksum result.
+ *                 This must be a writable buffer of length \c 64 Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
+                               unsigned char output[64] );
+
+/**
+ * \brief          This function processes a single data block within
+ *                 the ongoing SHA-512 computation.
+ *
+ * \param ctx      The SHA-512 context. This must be initialized.
+ * \param data     The buffer holding one block of data. This
+ *                 must be a readable buffer of length \c 128 Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
+                                     const unsigned char data[128] );
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          This function starts a SHA-384 or SHA-512 checksum
+ *                 calculation.
+ *
+ * \deprecated     Superseded by mbedtls_sha512_starts_ret() in 2.7.0
+ *
+ * \param ctx      The SHA-512 context to use. This must be initialized.
+ * \param is384    Determines which function to use. This must be either
+ *                 \c 0 for SHA-512 or \c 1 for SHA-384.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha512_starts( mbedtls_sha512_context *ctx,
+                                               int is384 );
+
+/**
+ * \brief          This function feeds an input buffer into an ongoing
+ *                 SHA-512 checksum calculation.
+ *
+ * \deprecated     Superseded by mbedtls_sha512_update_ret() in 2.7.0.
+ *
+ * \param ctx      The SHA-512 context. This must be initialized
+ *                 and have a hash operation started.
+ * \param input    The buffer holding the data. This must be a readable
+ *                 buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data in Bytes.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha512_update( mbedtls_sha512_context *ctx,
+                                               const unsigned char *input,
+                                               size_t ilen );
+
+/**
+ * \brief          This function finishes the SHA-512 operation, and writes
+ *                 the result to the output buffer.
+ *
+ * \deprecated     Superseded by mbedtls_sha512_finish_ret() in 2.7.0.
+ *
+ * \param ctx      The SHA-512 context. This must be initialized
+ *                 and have a hash operation started.
+ * \param output   The SHA-384 or SHA-512 checksum result. This must
+ *                 be a writable buffer of size \c 64 Bytes.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha512_finish( mbedtls_sha512_context *ctx,
+                                               unsigned char output[64] );
+
+/**
+ * \brief          This function processes a single data block within
+ *                 the ongoing SHA-512 computation. This function is for
+ *                 internal use only.
+ *
+ * \deprecated     Superseded by mbedtls_internal_sha512_process() in 2.7.0.
+ *
+ * \param ctx      The SHA-512 context. This must be initialized.
+ * \param data     The buffer holding one block of data. This must be
+ *                 a readable buffer of length \c 128 Bytes.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha512_process(
+                                            mbedtls_sha512_context *ctx,
+                                            const unsigned char data[128] );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief          This function calculates the SHA-512 or SHA-384
+ *                 checksum of a buffer.
+ *
+ *                 The function allocates the context, performs the
+ *                 calculation, and frees the context.
+ *
+ *                 The SHA-512 result is calculated as
+ *                 output = SHA-512(input buffer).
+ *
+ * \param input    The buffer holding the input data. This must be
+ *                 a readable buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data in Bytes.
+ * \param output   The SHA-384 or SHA-512 checksum result.
+ *                 This must be a writable buffer of length \c 64 Bytes.
+ * \param is384    Determines which function to use. This must be either
+ *                 \c 0 for SHA-512, or \c 1 for SHA-384.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha512_ret( const unsigned char *input,
+                        size_t ilen,
+                        unsigned char output[64],
+                        int is384 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          This function calculates the SHA-512 or SHA-384
+ *                 checksum of a buffer.
+ *
+ *                 The function allocates the context, performs the
+ *                 calculation, and frees the context.
+ *
+ *                 The SHA-512 result is calculated as
+ *                 output = SHA-512(input buffer).
+ *
+ * \deprecated     Superseded by mbedtls_sha512_ret() in 2.7.0
+ *
+ * \param input    The buffer holding the data. This must be a
+ *                 readable buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data in Bytes.
+ * \param output   The SHA-384 or SHA-512 checksum result. This must
+ *                 be a writable buffer of length \c 64 Bytes.
+ * \param is384    Determines which function to use. This must be either
+ *                 \c 0 for SHA-512, or \c 1 for SHA-384.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha512( const unsigned char *input,
+                                        size_t ilen,
+                                        unsigned char output[64],
+                                        int is384 );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+ /**
+ * \brief          The SHA-384 or SHA-512 checkup routine.
+ *
+ * \return         \c 0 on success.
+ * \return         \c 1 on failure.
+ */
+int mbedtls_sha512_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* mbedtls_sha512.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/version.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include/mbedtls/version.h
@@ -1,0 +1,112 @@
+/**
+ * \file version.h
+ *
+ * \brief Run-time version information
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+/*
+ * This set of compile-time defines and run-time variables can be used to
+ * determine the version number of the mbed TLS library used.
+ */
+#ifndef MBEDTLS_VERSION_H
+#define MBEDTLS_VERSION_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+/**
+ * The version number x.y.z is split into three parts.
+ * Major, Minor, Patchlevel
+ */
+#define MBEDTLS_VERSION_MAJOR  2
+#define MBEDTLS_VERSION_MINOR  16
+#define MBEDTLS_VERSION_PATCH  0
+
+/**
+ * The single version number has the following structure:
+ *    MMNNPP00
+ *    Major version | Minor version | Patch version
+ */
+#define MBEDTLS_VERSION_NUMBER         0x02100000
+#define MBEDTLS_VERSION_STRING         "2.16.0"
+#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.16.0"
+
+#if defined(MBEDTLS_VERSION_C)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Get the version number.
+ *
+ * \return          The constructed version number in the format
+ *                  MMNNPP00 (Major, Minor, Patch).
+ */
+unsigned int mbedtls_version_get_number( void );
+
+/**
+ * Get the version string ("x.y.z").
+ *
+ * \param string    The string that will receive the value.
+ *                  (Should be at least 9 bytes in size)
+ */
+void mbedtls_version_get_string( char *string );
+
+/**
+ * Get the full version string ("mbed TLS x.y.z").
+ *
+ * \param string    The string that will receive the value. The mbed TLS version
+ *                  string will use 18 bytes AT MOST including a terminating
+ *                  null byte.
+ *                  (So the buffer should be at least 18 bytes to receive this
+ *                  version string).
+ */
+void mbedtls_version_get_string_full( char *string );
+
+/**
+ * \brief           Check if support for a feature was compiled into this
+ *                  mbed TLS binary. This allows you to see at runtime if the
+ *                  library was for instance compiled with or without
+ *                  Multi-threading support.
+ *
+ * \note            only checks against defines in the sections "System
+ *                  support", "mbed TLS modules" and "mbed TLS feature
+ *                  support" in config.h
+ *
+ * \param feature   The string for the define to check (e.g. "MBEDTLS_AES_C")
+ *
+ * \return          0 if the feature is present,
+ *                  -1 if the feature is not present and
+ *                  -2 if support for feature checking as a whole was not
+ *                  compiled in.
+ */
+int mbedtls_version_check_feature( const char *feature );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_VERSION_C */
+
+#endif /* version.h */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/aes.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/aes.c
@@ -1,0 +1,2205 @@
+/*
+ *  FIPS-197 compliant AES implementation
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+/*
+ *  The AES block cipher was designed by Vincent Rijmen and Joan Daemen.
+ *
+ *  http://csrc.nist.gov/encryption/aes/rijndael/Rijndael.pdf
+ *  http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_AES_C)
+
+#include "mbedtls/aes.h"
+#include "mbedtls/platform.h"
+#include "mbedtls/platform_util.h"
+#if defined(MBEDTLS_PADLOCK_C)
+#include "mbedtls/padlock.h"
+#endif
+#if defined(MBEDTLS_AESNI_C)
+#include "mbedtls/aesni.h"
+#endif
+
+#if defined(MBEDTLS_SELF_TEST)
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#define mbedtls_printf printf
+#endif /* MBEDTLS_PLATFORM_C */
+#endif /* MBEDTLS_SELF_TEST */
+
+#if !defined(MBEDTLS_AES_ALT)
+
+/* Parameter validation macros based on platform_util.h */
+#define AES_VALIDATE_RET( cond )    \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_AES_BAD_INPUT_DATA )
+#define AES_VALIDATE( cond )        \
+    MBEDTLS_INTERNAL_VALIDATE( cond )
+
+/*
+ * 32-bit integer manipulation macros (little endian)
+ */
+#ifndef GET_UINT32_LE
+#define GET_UINT32_LE(n,b,i)                            \
+{                                                       \
+    (n) = ( (uint32_t) (b)[(i)    ]       )             \
+        | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
+        | ( (uint32_t) (b)[(i) + 2] << 16 )             \
+        | ( (uint32_t) (b)[(i) + 3] << 24 );            \
+}
+#endif
+
+#ifndef PUT_UINT32_LE
+#define PUT_UINT32_LE(n,b,i)                                    \
+{                                                               \
+    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
+    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
+    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
+    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
+}
+#endif
+
+#if defined(MBEDTLS_PADLOCK_C) &&                      \
+    ( defined(MBEDTLS_HAVE_X86) || defined(MBEDTLS_PADLOCK_ALIGN16) )
+static int aes_padlock_ace = -1;
+#endif
+
+#if defined(MBEDTLS_AES_ROM_TABLES)
+/*
+ * Forward S-box
+ */
+static const unsigned char FSb[256] =
+{
+    0x63, 0x7C, 0x77, 0x7B, 0xF2, 0x6B, 0x6F, 0xC5,
+    0x30, 0x01, 0x67, 0x2B, 0xFE, 0xD7, 0xAB, 0x76,
+    0xCA, 0x82, 0xC9, 0x7D, 0xFA, 0x59, 0x47, 0xF0,
+    0xAD, 0xD4, 0xA2, 0xAF, 0x9C, 0xA4, 0x72, 0xC0,
+    0xB7, 0xFD, 0x93, 0x26, 0x36, 0x3F, 0xF7, 0xCC,
+    0x34, 0xA5, 0xE5, 0xF1, 0x71, 0xD8, 0x31, 0x15,
+    0x04, 0xC7, 0x23, 0xC3, 0x18, 0x96, 0x05, 0x9A,
+    0x07, 0x12, 0x80, 0xE2, 0xEB, 0x27, 0xB2, 0x75,
+    0x09, 0x83, 0x2C, 0x1A, 0x1B, 0x6E, 0x5A, 0xA0,
+    0x52, 0x3B, 0xD6, 0xB3, 0x29, 0xE3, 0x2F, 0x84,
+    0x53, 0xD1, 0x00, 0xED, 0x20, 0xFC, 0xB1, 0x5B,
+    0x6A, 0xCB, 0xBE, 0x39, 0x4A, 0x4C, 0x58, 0xCF,
+    0xD0, 0xEF, 0xAA, 0xFB, 0x43, 0x4D, 0x33, 0x85,
+    0x45, 0xF9, 0x02, 0x7F, 0x50, 0x3C, 0x9F, 0xA8,
+    0x51, 0xA3, 0x40, 0x8F, 0x92, 0x9D, 0x38, 0xF5,
+    0xBC, 0xB6, 0xDA, 0x21, 0x10, 0xFF, 0xF3, 0xD2,
+    0xCD, 0x0C, 0x13, 0xEC, 0x5F, 0x97, 0x44, 0x17,
+    0xC4, 0xA7, 0x7E, 0x3D, 0x64, 0x5D, 0x19, 0x73,
+    0x60, 0x81, 0x4F, 0xDC, 0x22, 0x2A, 0x90, 0x88,
+    0x46, 0xEE, 0xB8, 0x14, 0xDE, 0x5E, 0x0B, 0xDB,
+    0xE0, 0x32, 0x3A, 0x0A, 0x49, 0x06, 0x24, 0x5C,
+    0xC2, 0xD3, 0xAC, 0x62, 0x91, 0x95, 0xE4, 0x79,
+    0xE7, 0xC8, 0x37, 0x6D, 0x8D, 0xD5, 0x4E, 0xA9,
+    0x6C, 0x56, 0xF4, 0xEA, 0x65, 0x7A, 0xAE, 0x08,
+    0xBA, 0x78, 0x25, 0x2E, 0x1C, 0xA6, 0xB4, 0xC6,
+    0xE8, 0xDD, 0x74, 0x1F, 0x4B, 0xBD, 0x8B, 0x8A,
+    0x70, 0x3E, 0xB5, 0x66, 0x48, 0x03, 0xF6, 0x0E,
+    0x61, 0x35, 0x57, 0xB9, 0x86, 0xC1, 0x1D, 0x9E,
+    0xE1, 0xF8, 0x98, 0x11, 0x69, 0xD9, 0x8E, 0x94,
+    0x9B, 0x1E, 0x87, 0xE9, 0xCE, 0x55, 0x28, 0xDF,
+    0x8C, 0xA1, 0x89, 0x0D, 0xBF, 0xE6, 0x42, 0x68,
+    0x41, 0x99, 0x2D, 0x0F, 0xB0, 0x54, 0xBB, 0x16
+};
+
+/*
+ * Forward tables
+ */
+#define FT \
+\
+    V(A5,63,63,C6), V(84,7C,7C,F8), V(99,77,77,EE), V(8D,7B,7B,F6), \
+    V(0D,F2,F2,FF), V(BD,6B,6B,D6), V(B1,6F,6F,DE), V(54,C5,C5,91), \
+    V(50,30,30,60), V(03,01,01,02), V(A9,67,67,CE), V(7D,2B,2B,56), \
+    V(19,FE,FE,E7), V(62,D7,D7,B5), V(E6,AB,AB,4D), V(9A,76,76,EC), \
+    V(45,CA,CA,8F), V(9D,82,82,1F), V(40,C9,C9,89), V(87,7D,7D,FA), \
+    V(15,FA,FA,EF), V(EB,59,59,B2), V(C9,47,47,8E), V(0B,F0,F0,FB), \
+    V(EC,AD,AD,41), V(67,D4,D4,B3), V(FD,A2,A2,5F), V(EA,AF,AF,45), \
+    V(BF,9C,9C,23), V(F7,A4,A4,53), V(96,72,72,E4), V(5B,C0,C0,9B), \
+    V(C2,B7,B7,75), V(1C,FD,FD,E1), V(AE,93,93,3D), V(6A,26,26,4C), \
+    V(5A,36,36,6C), V(41,3F,3F,7E), V(02,F7,F7,F5), V(4F,CC,CC,83), \
+    V(5C,34,34,68), V(F4,A5,A5,51), V(34,E5,E5,D1), V(08,F1,F1,F9), \
+    V(93,71,71,E2), V(73,D8,D8,AB), V(53,31,31,62), V(3F,15,15,2A), \
+    V(0C,04,04,08), V(52,C7,C7,95), V(65,23,23,46), V(5E,C3,C3,9D), \
+    V(28,18,18,30), V(A1,96,96,37), V(0F,05,05,0A), V(B5,9A,9A,2F), \
+    V(09,07,07,0E), V(36,12,12,24), V(9B,80,80,1B), V(3D,E2,E2,DF), \
+    V(26,EB,EB,CD), V(69,27,27,4E), V(CD,B2,B2,7F), V(9F,75,75,EA), \
+    V(1B,09,09,12), V(9E,83,83,1D), V(74,2C,2C,58), V(2E,1A,1A,34), \
+    V(2D,1B,1B,36), V(B2,6E,6E,DC), V(EE,5A,5A,B4), V(FB,A0,A0,5B), \
+    V(F6,52,52,A4), V(4D,3B,3B,76), V(61,D6,D6,B7), V(CE,B3,B3,7D), \
+    V(7B,29,29,52), V(3E,E3,E3,DD), V(71,2F,2F,5E), V(97,84,84,13), \
+    V(F5,53,53,A6), V(68,D1,D1,B9), V(00,00,00,00), V(2C,ED,ED,C1), \
+    V(60,20,20,40), V(1F,FC,FC,E3), V(C8,B1,B1,79), V(ED,5B,5B,B6), \
+    V(BE,6A,6A,D4), V(46,CB,CB,8D), V(D9,BE,BE,67), V(4B,39,39,72), \
+    V(DE,4A,4A,94), V(D4,4C,4C,98), V(E8,58,58,B0), V(4A,CF,CF,85), \
+    V(6B,D0,D0,BB), V(2A,EF,EF,C5), V(E5,AA,AA,4F), V(16,FB,FB,ED), \
+    V(C5,43,43,86), V(D7,4D,4D,9A), V(55,33,33,66), V(94,85,85,11), \
+    V(CF,45,45,8A), V(10,F9,F9,E9), V(06,02,02,04), V(81,7F,7F,FE), \
+    V(F0,50,50,A0), V(44,3C,3C,78), V(BA,9F,9F,25), V(E3,A8,A8,4B), \
+    V(F3,51,51,A2), V(FE,A3,A3,5D), V(C0,40,40,80), V(8A,8F,8F,05), \
+    V(AD,92,92,3F), V(BC,9D,9D,21), V(48,38,38,70), V(04,F5,F5,F1), \
+    V(DF,BC,BC,63), V(C1,B6,B6,77), V(75,DA,DA,AF), V(63,21,21,42), \
+    V(30,10,10,20), V(1A,FF,FF,E5), V(0E,F3,F3,FD), V(6D,D2,D2,BF), \
+    V(4C,CD,CD,81), V(14,0C,0C,18), V(35,13,13,26), V(2F,EC,EC,C3), \
+    V(E1,5F,5F,BE), V(A2,97,97,35), V(CC,44,44,88), V(39,17,17,2E), \
+    V(57,C4,C4,93), V(F2,A7,A7,55), V(82,7E,7E,FC), V(47,3D,3D,7A), \
+    V(AC,64,64,C8), V(E7,5D,5D,BA), V(2B,19,19,32), V(95,73,73,E6), \
+    V(A0,60,60,C0), V(98,81,81,19), V(D1,4F,4F,9E), V(7F,DC,DC,A3), \
+    V(66,22,22,44), V(7E,2A,2A,54), V(AB,90,90,3B), V(83,88,88,0B), \
+    V(CA,46,46,8C), V(29,EE,EE,C7), V(D3,B8,B8,6B), V(3C,14,14,28), \
+    V(79,DE,DE,A7), V(E2,5E,5E,BC), V(1D,0B,0B,16), V(76,DB,DB,AD), \
+    V(3B,E0,E0,DB), V(56,32,32,64), V(4E,3A,3A,74), V(1E,0A,0A,14), \
+    V(DB,49,49,92), V(0A,06,06,0C), V(6C,24,24,48), V(E4,5C,5C,B8), \
+    V(5D,C2,C2,9F), V(6E,D3,D3,BD), V(EF,AC,AC,43), V(A6,62,62,C4), \
+    V(A8,91,91,39), V(A4,95,95,31), V(37,E4,E4,D3), V(8B,79,79,F2), \
+    V(32,E7,E7,D5), V(43,C8,C8,8B), V(59,37,37,6E), V(B7,6D,6D,DA), \
+    V(8C,8D,8D,01), V(64,D5,D5,B1), V(D2,4E,4E,9C), V(E0,A9,A9,49), \
+    V(B4,6C,6C,D8), V(FA,56,56,AC), V(07,F4,F4,F3), V(25,EA,EA,CF), \
+    V(AF,65,65,CA), V(8E,7A,7A,F4), V(E9,AE,AE,47), V(18,08,08,10), \
+    V(D5,BA,BA,6F), V(88,78,78,F0), V(6F,25,25,4A), V(72,2E,2E,5C), \
+    V(24,1C,1C,38), V(F1,A6,A6,57), V(C7,B4,B4,73), V(51,C6,C6,97), \
+    V(23,E8,E8,CB), V(7C,DD,DD,A1), V(9C,74,74,E8), V(21,1F,1F,3E), \
+    V(DD,4B,4B,96), V(DC,BD,BD,61), V(86,8B,8B,0D), V(85,8A,8A,0F), \
+    V(90,70,70,E0), V(42,3E,3E,7C), V(C4,B5,B5,71), V(AA,66,66,CC), \
+    V(D8,48,48,90), V(05,03,03,06), V(01,F6,F6,F7), V(12,0E,0E,1C), \
+    V(A3,61,61,C2), V(5F,35,35,6A), V(F9,57,57,AE), V(D0,B9,B9,69), \
+    V(91,86,86,17), V(58,C1,C1,99), V(27,1D,1D,3A), V(B9,9E,9E,27), \
+    V(38,E1,E1,D9), V(13,F8,F8,EB), V(B3,98,98,2B), V(33,11,11,22), \
+    V(BB,69,69,D2), V(70,D9,D9,A9), V(89,8E,8E,07), V(A7,94,94,33), \
+    V(B6,9B,9B,2D), V(22,1E,1E,3C), V(92,87,87,15), V(20,E9,E9,C9), \
+    V(49,CE,CE,87), V(FF,55,55,AA), V(78,28,28,50), V(7A,DF,DF,A5), \
+    V(8F,8C,8C,03), V(F8,A1,A1,59), V(80,89,89,09), V(17,0D,0D,1A), \
+    V(DA,BF,BF,65), V(31,E6,E6,D7), V(C6,42,42,84), V(B8,68,68,D0), \
+    V(C3,41,41,82), V(B0,99,99,29), V(77,2D,2D,5A), V(11,0F,0F,1E), \
+    V(CB,B0,B0,7B), V(FC,54,54,A8), V(D6,BB,BB,6D), V(3A,16,16,2C)
+
+#define V(a,b,c,d) 0x##a##b##c##d
+static const uint32_t FT0[256] = { FT };
+#undef V
+
+#if !defined(MBEDTLS_AES_FEWER_TABLES)
+
+#define V(a,b,c,d) 0x##b##c##d##a
+static const uint32_t FT1[256] = { FT };
+#undef V
+
+#define V(a,b,c,d) 0x##c##d##a##b
+static const uint32_t FT2[256] = { FT };
+#undef V
+
+#define V(a,b,c,d) 0x##d##a##b##c
+static const uint32_t FT3[256] = { FT };
+#undef V
+
+#endif /* !MBEDTLS_AES_FEWER_TABLES */
+
+#undef FT
+
+/*
+ * Reverse S-box
+ */
+static const unsigned char RSb[256] =
+{
+    0x52, 0x09, 0x6A, 0xD5, 0x30, 0x36, 0xA5, 0x38,
+    0xBF, 0x40, 0xA3, 0x9E, 0x81, 0xF3, 0xD7, 0xFB,
+    0x7C, 0xE3, 0x39, 0x82, 0x9B, 0x2F, 0xFF, 0x87,
+    0x34, 0x8E, 0x43, 0x44, 0xC4, 0xDE, 0xE9, 0xCB,
+    0x54, 0x7B, 0x94, 0x32, 0xA6, 0xC2, 0x23, 0x3D,
+    0xEE, 0x4C, 0x95, 0x0B, 0x42, 0xFA, 0xC3, 0x4E,
+    0x08, 0x2E, 0xA1, 0x66, 0x28, 0xD9, 0x24, 0xB2,
+    0x76, 0x5B, 0xA2, 0x49, 0x6D, 0x8B, 0xD1, 0x25,
+    0x72, 0xF8, 0xF6, 0x64, 0x86, 0x68, 0x98, 0x16,
+    0xD4, 0xA4, 0x5C, 0xCC, 0x5D, 0x65, 0xB6, 0x92,
+    0x6C, 0x70, 0x48, 0x50, 0xFD, 0xED, 0xB9, 0xDA,
+    0x5E, 0x15, 0x46, 0x57, 0xA7, 0x8D, 0x9D, 0x84,
+    0x90, 0xD8, 0xAB, 0x00, 0x8C, 0xBC, 0xD3, 0x0A,
+    0xF7, 0xE4, 0x58, 0x05, 0xB8, 0xB3, 0x45, 0x06,
+    0xD0, 0x2C, 0x1E, 0x8F, 0xCA, 0x3F, 0x0F, 0x02,
+    0xC1, 0xAF, 0xBD, 0x03, 0x01, 0x13, 0x8A, 0x6B,
+    0x3A, 0x91, 0x11, 0x41, 0x4F, 0x67, 0xDC, 0xEA,
+    0x97, 0xF2, 0xCF, 0xCE, 0xF0, 0xB4, 0xE6, 0x73,
+    0x96, 0xAC, 0x74, 0x22, 0xE7, 0xAD, 0x35, 0x85,
+    0xE2, 0xF9, 0x37, 0xE8, 0x1C, 0x75, 0xDF, 0x6E,
+    0x47, 0xF1, 0x1A, 0x71, 0x1D, 0x29, 0xC5, 0x89,
+    0x6F, 0xB7, 0x62, 0x0E, 0xAA, 0x18, 0xBE, 0x1B,
+    0xFC, 0x56, 0x3E, 0x4B, 0xC6, 0xD2, 0x79, 0x20,
+    0x9A, 0xDB, 0xC0, 0xFE, 0x78, 0xCD, 0x5A, 0xF4,
+    0x1F, 0xDD, 0xA8, 0x33, 0x88, 0x07, 0xC7, 0x31,
+    0xB1, 0x12, 0x10, 0x59, 0x27, 0x80, 0xEC, 0x5F,
+    0x60, 0x51, 0x7F, 0xA9, 0x19, 0xB5, 0x4A, 0x0D,
+    0x2D, 0xE5, 0x7A, 0x9F, 0x93, 0xC9, 0x9C, 0xEF,
+    0xA0, 0xE0, 0x3B, 0x4D, 0xAE, 0x2A, 0xF5, 0xB0,
+    0xC8, 0xEB, 0xBB, 0x3C, 0x83, 0x53, 0x99, 0x61,
+    0x17, 0x2B, 0x04, 0x7E, 0xBA, 0x77, 0xD6, 0x26,
+    0xE1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0C, 0x7D
+};
+
+/*
+ * Reverse tables
+ */
+#define RT \
+\
+    V(50,A7,F4,51), V(53,65,41,7E), V(C3,A4,17,1A), V(96,5E,27,3A), \
+    V(CB,6B,AB,3B), V(F1,45,9D,1F), V(AB,58,FA,AC), V(93,03,E3,4B), \
+    V(55,FA,30,20), V(F6,6D,76,AD), V(91,76,CC,88), V(25,4C,02,F5), \
+    V(FC,D7,E5,4F), V(D7,CB,2A,C5), V(80,44,35,26), V(8F,A3,62,B5), \
+    V(49,5A,B1,DE), V(67,1B,BA,25), V(98,0E,EA,45), V(E1,C0,FE,5D), \
+    V(02,75,2F,C3), V(12,F0,4C,81), V(A3,97,46,8D), V(C6,F9,D3,6B), \
+    V(E7,5F,8F,03), V(95,9C,92,15), V(EB,7A,6D,BF), V(DA,59,52,95), \
+    V(2D,83,BE,D4), V(D3,21,74,58), V(29,69,E0,49), V(44,C8,C9,8E), \
+    V(6A,89,C2,75), V(78,79,8E,F4), V(6B,3E,58,99), V(DD,71,B9,27), \
+    V(B6,4F,E1,BE), V(17,AD,88,F0), V(66,AC,20,C9), V(B4,3A,CE,7D), \
+    V(18,4A,DF,63), V(82,31,1A,E5), V(60,33,51,97), V(45,7F,53,62), \
+    V(E0,77,64,B1), V(84,AE,6B,BB), V(1C,A0,81,FE), V(94,2B,08,F9), \
+    V(58,68,48,70), V(19,FD,45,8F), V(87,6C,DE,94), V(B7,F8,7B,52), \
+    V(23,D3,73,AB), V(E2,02,4B,72), V(57,8F,1F,E3), V(2A,AB,55,66), \
+    V(07,28,EB,B2), V(03,C2,B5,2F), V(9A,7B,C5,86), V(A5,08,37,D3), \
+    V(F2,87,28,30), V(B2,A5,BF,23), V(BA,6A,03,02), V(5C,82,16,ED), \
+    V(2B,1C,CF,8A), V(92,B4,79,A7), V(F0,F2,07,F3), V(A1,E2,69,4E), \
+    V(CD,F4,DA,65), V(D5,BE,05,06), V(1F,62,34,D1), V(8A,FE,A6,C4), \
+    V(9D,53,2E,34), V(A0,55,F3,A2), V(32,E1,8A,05), V(75,EB,F6,A4), \
+    V(39,EC,83,0B), V(AA,EF,60,40), V(06,9F,71,5E), V(51,10,6E,BD), \
+    V(F9,8A,21,3E), V(3D,06,DD,96), V(AE,05,3E,DD), V(46,BD,E6,4D), \
+    V(B5,8D,54,91), V(05,5D,C4,71), V(6F,D4,06,04), V(FF,15,50,60), \
+    V(24,FB,98,19), V(97,E9,BD,D6), V(CC,43,40,89), V(77,9E,D9,67), \
+    V(BD,42,E8,B0), V(88,8B,89,07), V(38,5B,19,E7), V(DB,EE,C8,79), \
+    V(47,0A,7C,A1), V(E9,0F,42,7C), V(C9,1E,84,F8), V(00,00,00,00), \
+    V(83,86,80,09), V(48,ED,2B,32), V(AC,70,11,1E), V(4E,72,5A,6C), \
+    V(FB,FF,0E,FD), V(56,38,85,0F), V(1E,D5,AE,3D), V(27,39,2D,36), \
+    V(64,D9,0F,0A), V(21,A6,5C,68), V(D1,54,5B,9B), V(3A,2E,36,24), \
+    V(B1,67,0A,0C), V(0F,E7,57,93), V(D2,96,EE,B4), V(9E,91,9B,1B), \
+    V(4F,C5,C0,80), V(A2,20,DC,61), V(69,4B,77,5A), V(16,1A,12,1C), \
+    V(0A,BA,93,E2), V(E5,2A,A0,C0), V(43,E0,22,3C), V(1D,17,1B,12), \
+    V(0B,0D,09,0E), V(AD,C7,8B,F2), V(B9,A8,B6,2D), V(C8,A9,1E,14), \
+    V(85,19,F1,57), V(4C,07,75,AF), V(BB,DD,99,EE), V(FD,60,7F,A3), \
+    V(9F,26,01,F7), V(BC,F5,72,5C), V(C5,3B,66,44), V(34,7E,FB,5B), \
+    V(76,29,43,8B), V(DC,C6,23,CB), V(68,FC,ED,B6), V(63,F1,E4,B8), \
+    V(CA,DC,31,D7), V(10,85,63,42), V(40,22,97,13), V(20,11,C6,84), \
+    V(7D,24,4A,85), V(F8,3D,BB,D2), V(11,32,F9,AE), V(6D,A1,29,C7), \
+    V(4B,2F,9E,1D), V(F3,30,B2,DC), V(EC,52,86,0D), V(D0,E3,C1,77), \
+    V(6C,16,B3,2B), V(99,B9,70,A9), V(FA,48,94,11), V(22,64,E9,47), \
+    V(C4,8C,FC,A8), V(1A,3F,F0,A0), V(D8,2C,7D,56), V(EF,90,33,22), \
+    V(C7,4E,49,87), V(C1,D1,38,D9), V(FE,A2,CA,8C), V(36,0B,D4,98), \
+    V(CF,81,F5,A6), V(28,DE,7A,A5), V(26,8E,B7,DA), V(A4,BF,AD,3F), \
+    V(E4,9D,3A,2C), V(0D,92,78,50), V(9B,CC,5F,6A), V(62,46,7E,54), \
+    V(C2,13,8D,F6), V(E8,B8,D8,90), V(5E,F7,39,2E), V(F5,AF,C3,82), \
+    V(BE,80,5D,9F), V(7C,93,D0,69), V(A9,2D,D5,6F), V(B3,12,25,CF), \
+    V(3B,99,AC,C8), V(A7,7D,18,10), V(6E,63,9C,E8), V(7B,BB,3B,DB), \
+    V(09,78,26,CD), V(F4,18,59,6E), V(01,B7,9A,EC), V(A8,9A,4F,83), \
+    V(65,6E,95,E6), V(7E,E6,FF,AA), V(08,CF,BC,21), V(E6,E8,15,EF), \
+    V(D9,9B,E7,BA), V(CE,36,6F,4A), V(D4,09,9F,EA), V(D6,7C,B0,29), \
+    V(AF,B2,A4,31), V(31,23,3F,2A), V(30,94,A5,C6), V(C0,66,A2,35), \
+    V(37,BC,4E,74), V(A6,CA,82,FC), V(B0,D0,90,E0), V(15,D8,A7,33), \
+    V(4A,98,04,F1), V(F7,DA,EC,41), V(0E,50,CD,7F), V(2F,F6,91,17), \
+    V(8D,D6,4D,76), V(4D,B0,EF,43), V(54,4D,AA,CC), V(DF,04,96,E4), \
+    V(E3,B5,D1,9E), V(1B,88,6A,4C), V(B8,1F,2C,C1), V(7F,51,65,46), \
+    V(04,EA,5E,9D), V(5D,35,8C,01), V(73,74,87,FA), V(2E,41,0B,FB), \
+    V(5A,1D,67,B3), V(52,D2,DB,92), V(33,56,10,E9), V(13,47,D6,6D), \
+    V(8C,61,D7,9A), V(7A,0C,A1,37), V(8E,14,F8,59), V(89,3C,13,EB), \
+    V(EE,27,A9,CE), V(35,C9,61,B7), V(ED,E5,1C,E1), V(3C,B1,47,7A), \
+    V(59,DF,D2,9C), V(3F,73,F2,55), V(79,CE,14,18), V(BF,37,C7,73), \
+    V(EA,CD,F7,53), V(5B,AA,FD,5F), V(14,6F,3D,DF), V(86,DB,44,78), \
+    V(81,F3,AF,CA), V(3E,C4,68,B9), V(2C,34,24,38), V(5F,40,A3,C2), \
+    V(72,C3,1D,16), V(0C,25,E2,BC), V(8B,49,3C,28), V(41,95,0D,FF), \
+    V(71,01,A8,39), V(DE,B3,0C,08), V(9C,E4,B4,D8), V(90,C1,56,64), \
+    V(61,84,CB,7B), V(70,B6,32,D5), V(74,5C,6C,48), V(42,57,B8,D0)
+
+#define V(a,b,c,d) 0x##a##b##c##d
+static const uint32_t RT0[256] = { RT };
+#undef V
+
+#if !defined(MBEDTLS_AES_FEWER_TABLES)
+
+#define V(a,b,c,d) 0x##b##c##d##a
+static const uint32_t RT1[256] = { RT };
+#undef V
+
+#define V(a,b,c,d) 0x##c##d##a##b
+static const uint32_t RT2[256] = { RT };
+#undef V
+
+#define V(a,b,c,d) 0x##d##a##b##c
+static const uint32_t RT3[256] = { RT };
+#undef V
+
+#endif /* !MBEDTLS_AES_FEWER_TABLES */
+
+#undef RT
+
+/*
+ * Round constants
+ */
+static const uint32_t RCON[10] =
+{
+    0x00000001, 0x00000002, 0x00000004, 0x00000008,
+    0x00000010, 0x00000020, 0x00000040, 0x00000080,
+    0x0000001B, 0x00000036
+};
+
+#else /* MBEDTLS_AES_ROM_TABLES */
+
+/*
+ * Forward S-box & tables
+ */
+static unsigned char FSb[256];
+static uint32_t FT0[256];
+#if !defined(MBEDTLS_AES_FEWER_TABLES)
+static uint32_t FT1[256];
+static uint32_t FT2[256];
+static uint32_t FT3[256];
+#endif /* !MBEDTLS_AES_FEWER_TABLES */
+
+/*
+ * Reverse S-box & tables
+ */
+static unsigned char RSb[256];
+static uint32_t RT0[256];
+#if !defined(MBEDTLS_AES_FEWER_TABLES)
+static uint32_t RT1[256];
+static uint32_t RT2[256];
+static uint32_t RT3[256];
+#endif /* !MBEDTLS_AES_FEWER_TABLES */
+
+/*
+ * Round constants
+ */
+static uint32_t RCON[10];
+
+/*
+ * Tables generation code
+ */
+#define ROTL8(x) ( ( x << 8 ) & 0xFFFFFFFF ) | ( x >> 24 )
+#define XTIME(x) ( ( x << 1 ) ^ ( ( x & 0x80 ) ? 0x1B : 0x00 ) )
+#define MUL(x,y) ( ( x && y ) ? pow[(log[x]+log[y]) % 255] : 0 )
+
+static int aes_init_done = 0;
+
+static void aes_gen_tables( void )
+{
+    int i, x, y, z;
+    static int pow[256];
+    static int log[256];
+
+    /*
+     * compute pow and log tables over GF(2^8)
+     */
+    for( i = 0, x = 1; i < 256; i++ )
+    {
+        pow[i] = x;
+        log[x] = i;
+        x = ( x ^ XTIME( x ) ) & 0xFF;
+    }
+
+    /*
+     * calculate the round constants
+     */
+    for( i = 0, x = 1; i < 10; i++ )
+    {
+        RCON[i] = (uint32_t) x;
+        x = XTIME( x ) & 0xFF;
+    }
+
+    /*
+     * generate the forward and reverse S-boxes
+     */
+    FSb[0x00] = 0x63;
+    RSb[0x63] = 0x00;
+
+    for( i = 1; i < 256; i++ )
+    {
+        x = pow[255 - log[i]];
+
+        y  = x; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
+        x ^= y; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
+        x ^= y; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
+        x ^= y; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
+        x ^= y ^ 0x63;
+
+        FSb[i] = (unsigned char) x;
+        RSb[x] = (unsigned char) i;
+    }
+
+    /*
+     * generate the forward and reverse tables
+     */
+    for( i = 0; i < 256; i++ )
+    {
+        x = FSb[i];
+        y = XTIME( x ) & 0xFF;
+        z =  ( y ^ x ) & 0xFF;
+
+        FT0[i] = ( (uint32_t) y       ) ^
+                 ( (uint32_t) x <<  8 ) ^
+                 ( (uint32_t) x << 16 ) ^
+                 ( (uint32_t) z << 24 );
+
+#if !defined(MBEDTLS_AES_FEWER_TABLES)
+        FT1[i] = ROTL8( FT0[i] );
+        FT2[i] = ROTL8( FT1[i] );
+        FT3[i] = ROTL8( FT2[i] );
+#endif /* !MBEDTLS_AES_FEWER_TABLES */
+
+        x = RSb[i];
+
+        RT0[i] = ( (uint32_t) MUL( 0x0E, x )       ) ^
+                 ( (uint32_t) MUL( 0x09, x ) <<  8 ) ^
+                 ( (uint32_t) MUL( 0x0D, x ) << 16 ) ^
+                 ( (uint32_t) MUL( 0x0B, x ) << 24 );
+
+#if !defined(MBEDTLS_AES_FEWER_TABLES)
+        RT1[i] = ROTL8( RT0[i] );
+        RT2[i] = ROTL8( RT1[i] );
+        RT3[i] = ROTL8( RT2[i] );
+#endif /* !MBEDTLS_AES_FEWER_TABLES */
+    }
+}
+
+#undef ROTL8
+
+#endif /* MBEDTLS_AES_ROM_TABLES */
+
+#if defined(MBEDTLS_AES_FEWER_TABLES)
+
+#define ROTL8(x)  ( (uint32_t)( ( x ) <<  8 ) + (uint32_t)( ( x ) >> 24 ) )
+#define ROTL16(x) ( (uint32_t)( ( x ) << 16 ) + (uint32_t)( ( x ) >> 16 ) )
+#define ROTL24(x) ( (uint32_t)( ( x ) << 24 ) + (uint32_t)( ( x ) >>  8 ) )
+
+#define AES_RT0(idx) RT0[idx]
+#define AES_RT1(idx) ROTL8(  RT0[idx] )
+#define AES_RT2(idx) ROTL16( RT0[idx] )
+#define AES_RT3(idx) ROTL24( RT0[idx] )
+
+#define AES_FT0(idx) FT0[idx]
+#define AES_FT1(idx) ROTL8(  FT0[idx] )
+#define AES_FT2(idx) ROTL16( FT0[idx] )
+#define AES_FT3(idx) ROTL24( FT0[idx] )
+
+#else /* MBEDTLS_AES_FEWER_TABLES */
+
+#define AES_RT0(idx) RT0[idx]
+#define AES_RT1(idx) RT1[idx]
+#define AES_RT2(idx) RT2[idx]
+#define AES_RT3(idx) RT3[idx]
+
+#define AES_FT0(idx) FT0[idx]
+#define AES_FT1(idx) FT1[idx]
+#define AES_FT2(idx) FT2[idx]
+#define AES_FT3(idx) FT3[idx]
+
+#endif /* MBEDTLS_AES_FEWER_TABLES */
+
+void mbedtls_aes_init( mbedtls_aes_context *ctx )
+{
+    AES_VALIDATE( ctx != NULL );
+
+    memset( ctx, 0, sizeof( mbedtls_aes_context ) );
+}
+
+void mbedtls_aes_free( mbedtls_aes_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_aes_context ) );
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+void mbedtls_aes_xts_init( mbedtls_aes_xts_context *ctx )
+{
+    AES_VALIDATE( ctx != NULL );
+
+    mbedtls_aes_init( &ctx->crypt );
+    mbedtls_aes_init( &ctx->tweak );
+}
+
+void mbedtls_aes_xts_free( mbedtls_aes_xts_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    mbedtls_aes_free( &ctx->crypt );
+    mbedtls_aes_free( &ctx->tweak );
+}
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+/*
+ * AES key schedule (encryption)
+ */
+#if !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
+int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
+                    unsigned int keybits )
+{
+    unsigned int i;
+    uint32_t *RK;
+
+    AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( key != NULL );
+
+    switch( keybits )
+    {
+        case 128: ctx->nr = 10; break;
+        case 192: ctx->nr = 12; break;
+        case 256: ctx->nr = 14; break;
+        default : return( MBEDTLS_ERR_AES_INVALID_KEY_LENGTH );
+    }
+
+#if !defined(MBEDTLS_AES_ROM_TABLES)
+    if( aes_init_done == 0 )
+    {
+        aes_gen_tables();
+        aes_init_done = 1;
+    }
+#endif
+
+#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_PADLOCK_ALIGN16)
+    if( aes_padlock_ace == -1 )
+        aes_padlock_ace = mbedtls_padlock_has_support( MBEDTLS_PADLOCK_ACE );
+
+    if( aes_padlock_ace )
+        ctx->rk = RK = MBEDTLS_PADLOCK_ALIGN16( ctx->buf );
+    else
+#endif
+    ctx->rk = RK = ctx->buf;
+
+#if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
+    if( mbedtls_aesni_has_support( MBEDTLS_AESNI_AES ) )
+        return( mbedtls_aesni_setkey_enc( (unsigned char *) ctx->rk, key, keybits ) );
+#endif
+
+    for( i = 0; i < ( keybits >> 5 ); i++ )
+    {
+        GET_UINT32_LE( RK[i], key, i << 2 );
+    }
+
+    switch( ctx->nr )
+    {
+        case 10:
+
+            for( i = 0; i < 10; i++, RK += 4 )
+            {
+                RK[4]  = RK[0] ^ RCON[i] ^
+                ( (uint32_t) FSb[ ( RK[3] >>  8 ) & 0xFF ]       ) ^
+                ( (uint32_t) FSb[ ( RK[3] >> 16 ) & 0xFF ] <<  8 ) ^
+                ( (uint32_t) FSb[ ( RK[3] >> 24 ) & 0xFF ] << 16 ) ^
+                ( (uint32_t) FSb[ ( RK[3]       ) & 0xFF ] << 24 );
+
+                RK[5]  = RK[1] ^ RK[4];
+                RK[6]  = RK[2] ^ RK[5];
+                RK[7]  = RK[3] ^ RK[6];
+            }
+            break;
+
+        case 12:
+
+            for( i = 0; i < 8; i++, RK += 6 )
+            {
+                RK[6]  = RK[0] ^ RCON[i] ^
+                ( (uint32_t) FSb[ ( RK[5] >>  8 ) & 0xFF ]       ) ^
+                ( (uint32_t) FSb[ ( RK[5] >> 16 ) & 0xFF ] <<  8 ) ^
+                ( (uint32_t) FSb[ ( RK[5] >> 24 ) & 0xFF ] << 16 ) ^
+                ( (uint32_t) FSb[ ( RK[5]       ) & 0xFF ] << 24 );
+
+                RK[7]  = RK[1] ^ RK[6];
+                RK[8]  = RK[2] ^ RK[7];
+                RK[9]  = RK[3] ^ RK[8];
+                RK[10] = RK[4] ^ RK[9];
+                RK[11] = RK[5] ^ RK[10];
+            }
+            break;
+
+        case 14:
+
+            for( i = 0; i < 7; i++, RK += 8 )
+            {
+                RK[8]  = RK[0] ^ RCON[i] ^
+                ( (uint32_t) FSb[ ( RK[7] >>  8 ) & 0xFF ]       ) ^
+                ( (uint32_t) FSb[ ( RK[7] >> 16 ) & 0xFF ] <<  8 ) ^
+                ( (uint32_t) FSb[ ( RK[7] >> 24 ) & 0xFF ] << 16 ) ^
+                ( (uint32_t) FSb[ ( RK[7]       ) & 0xFF ] << 24 );
+
+                RK[9]  = RK[1] ^ RK[8];
+                RK[10] = RK[2] ^ RK[9];
+                RK[11] = RK[3] ^ RK[10];
+
+                RK[12] = RK[4] ^
+                ( (uint32_t) FSb[ ( RK[11]       ) & 0xFF ]       ) ^
+                ( (uint32_t) FSb[ ( RK[11] >>  8 ) & 0xFF ] <<  8 ) ^
+                ( (uint32_t) FSb[ ( RK[11] >> 16 ) & 0xFF ] << 16 ) ^
+                ( (uint32_t) FSb[ ( RK[11] >> 24 ) & 0xFF ] << 24 );
+
+                RK[13] = RK[5] ^ RK[12];
+                RK[14] = RK[6] ^ RK[13];
+                RK[15] = RK[7] ^ RK[14];
+            }
+            break;
+    }
+
+    return( 0 );
+}
+#endif /* !MBEDTLS_AES_SETKEY_ENC_ALT */
+
+/*
+ * AES key schedule (decryption)
+ */
+#if !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
+int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
+                    unsigned int keybits )
+{
+    int i, j, ret;
+    mbedtls_aes_context cty;
+    uint32_t *RK;
+    uint32_t *SK;
+
+    AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( key != NULL );
+
+    mbedtls_aes_init( &cty );
+
+#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_PADLOCK_ALIGN16)
+    if( aes_padlock_ace == -1 )
+        aes_padlock_ace = mbedtls_padlock_has_support( MBEDTLS_PADLOCK_ACE );
+
+    if( aes_padlock_ace )
+        ctx->rk = RK = MBEDTLS_PADLOCK_ALIGN16( ctx->buf );
+    else
+#endif
+    ctx->rk = RK = ctx->buf;
+
+    /* Also checks keybits */
+    if( ( ret = mbedtls_aes_setkey_enc( &cty, key, keybits ) ) != 0 )
+        goto exit;
+
+    ctx->nr = cty.nr;
+
+#if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
+    if( mbedtls_aesni_has_support( MBEDTLS_AESNI_AES ) )
+    {
+        mbedtls_aesni_inverse_key( (unsigned char *) ctx->rk,
+                           (const unsigned char *) cty.rk, ctx->nr );
+        goto exit;
+    }
+#endif
+
+    SK = cty.rk + cty.nr * 4;
+
+    *RK++ = *SK++;
+    *RK++ = *SK++;
+    *RK++ = *SK++;
+    *RK++ = *SK++;
+
+    for( i = ctx->nr - 1, SK -= 8; i > 0; i--, SK -= 8 )
+    {
+        for( j = 0; j < 4; j++, SK++ )
+        {
+            *RK++ = AES_RT0( FSb[ ( *SK       ) & 0xFF ] ) ^
+                    AES_RT1( FSb[ ( *SK >>  8 ) & 0xFF ] ) ^
+                    AES_RT2( FSb[ ( *SK >> 16 ) & 0xFF ] ) ^
+                    AES_RT3( FSb[ ( *SK >> 24 ) & 0xFF ] );
+        }
+    }
+
+    *RK++ = *SK++;
+    *RK++ = *SK++;
+    *RK++ = *SK++;
+    *RK++ = *SK++;
+
+exit:
+    mbedtls_aes_free( &cty );
+
+    return( ret );
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+static int mbedtls_aes_xts_decode_keys( const unsigned char *key,
+                                        unsigned int keybits,
+                                        const unsigned char **key1,
+                                        unsigned int *key1bits,
+                                        const unsigned char **key2,
+                                        unsigned int *key2bits )
+{
+    const unsigned int half_keybits = keybits / 2;
+    const unsigned int half_keybytes = half_keybits / 8;
+
+    switch( keybits )
+    {
+        case 256: break;
+        case 512: break;
+        default : return( MBEDTLS_ERR_AES_INVALID_KEY_LENGTH );
+    }
+
+    *key1bits = half_keybits;
+    *key2bits = half_keybits;
+    *key1 = &key[0];
+    *key2 = &key[half_keybytes];
+
+    return 0;
+}
+
+int mbedtls_aes_xts_setkey_enc( mbedtls_aes_xts_context *ctx,
+                                const unsigned char *key,
+                                unsigned int keybits)
+{
+    int ret;
+    const unsigned char *key1, *key2;
+    unsigned int key1bits, key2bits;
+
+    AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( key != NULL );
+
+    ret = mbedtls_aes_xts_decode_keys( key, keybits, &key1, &key1bits,
+                                       &key2, &key2bits );
+    if( ret != 0 )
+        return( ret );
+
+    /* Set the tweak key. Always set tweak key for the encryption mode. */
+    ret = mbedtls_aes_setkey_enc( &ctx->tweak, key2, key2bits );
+    if( ret != 0 )
+        return( ret );
+
+    /* Set crypt key for encryption. */
+    return mbedtls_aes_setkey_enc( &ctx->crypt, key1, key1bits );
+}
+
+int mbedtls_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
+                                const unsigned char *key,
+                                unsigned int keybits)
+{
+    int ret;
+    const unsigned char *key1, *key2;
+    unsigned int key1bits, key2bits;
+
+    AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( key != NULL );
+
+    ret = mbedtls_aes_xts_decode_keys( key, keybits, &key1, &key1bits,
+                                       &key2, &key2bits );
+    if( ret != 0 )
+        return( ret );
+
+    /* Set the tweak key. Always set tweak key for encryption. */
+    ret = mbedtls_aes_setkey_enc( &ctx->tweak, key2, key2bits );
+    if( ret != 0 )
+        return( ret );
+
+    /* Set crypt key for decryption. */
+    return mbedtls_aes_setkey_dec( &ctx->crypt, key1, key1bits );
+}
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+#endif /* !MBEDTLS_AES_SETKEY_DEC_ALT */
+
+#define AES_FROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)         \
+{                                                   \
+    X0 = *RK++ ^ AES_FT0( ( Y0       ) & 0xFF ) ^   \
+                 AES_FT1( ( Y1 >>  8 ) & 0xFF ) ^   \
+                 AES_FT2( ( Y2 >> 16 ) & 0xFF ) ^   \
+                 AES_FT3( ( Y3 >> 24 ) & 0xFF );    \
+                                                    \
+    X1 = *RK++ ^ AES_FT0( ( Y1       ) & 0xFF ) ^   \
+                 AES_FT1( ( Y2 >>  8 ) & 0xFF ) ^   \
+                 AES_FT2( ( Y3 >> 16 ) & 0xFF ) ^   \
+                 AES_FT3( ( Y0 >> 24 ) & 0xFF );    \
+                                                    \
+    X2 = *RK++ ^ AES_FT0( ( Y2       ) & 0xFF ) ^   \
+                 AES_FT1( ( Y3 >>  8 ) & 0xFF ) ^   \
+                 AES_FT2( ( Y0 >> 16 ) & 0xFF ) ^   \
+                 AES_FT3( ( Y1 >> 24 ) & 0xFF );    \
+                                                    \
+    X3 = *RK++ ^ AES_FT0( ( Y3       ) & 0xFF ) ^   \
+                 AES_FT1( ( Y0 >>  8 ) & 0xFF ) ^   \
+                 AES_FT2( ( Y1 >> 16 ) & 0xFF ) ^   \
+                 AES_FT3( ( Y2 >> 24 ) & 0xFF );    \
+}
+
+#define AES_RROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)         \
+{                                                   \
+    X0 = *RK++ ^ AES_RT0( ( Y0       ) & 0xFF ) ^   \
+                 AES_RT1( ( Y3 >>  8 ) & 0xFF ) ^   \
+                 AES_RT2( ( Y2 >> 16 ) & 0xFF ) ^   \
+                 AES_RT3( ( Y1 >> 24 ) & 0xFF );    \
+                                                    \
+    X1 = *RK++ ^ AES_RT0( ( Y1       ) & 0xFF ) ^   \
+                 AES_RT1( ( Y0 >>  8 ) & 0xFF ) ^   \
+                 AES_RT2( ( Y3 >> 16 ) & 0xFF ) ^   \
+                 AES_RT3( ( Y2 >> 24 ) & 0xFF );    \
+                                                    \
+    X2 = *RK++ ^ AES_RT0( ( Y2       ) & 0xFF ) ^   \
+                 AES_RT1( ( Y1 >>  8 ) & 0xFF ) ^   \
+                 AES_RT2( ( Y0 >> 16 ) & 0xFF ) ^   \
+                 AES_RT3( ( Y3 >> 24 ) & 0xFF );    \
+                                                    \
+    X3 = *RK++ ^ AES_RT0( ( Y3       ) & 0xFF ) ^   \
+                 AES_RT1( ( Y2 >>  8 ) & 0xFF ) ^   \
+                 AES_RT2( ( Y1 >> 16 ) & 0xFF ) ^   \
+                 AES_RT3( ( Y0 >> 24 ) & 0xFF );    \
+}
+
+/*
+ * AES-ECB block encryption
+ */
+#if !defined(MBEDTLS_AES_ENCRYPT_ALT)
+int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
+                                  const unsigned char input[16],
+                                  unsigned char output[16] )
+{
+    int i;
+    uint32_t *RK, X0, X1, X2, X3, Y0, Y1, Y2, Y3;
+
+    RK = ctx->rk;
+
+    GET_UINT32_LE( X0, input,  0 ); X0 ^= *RK++;
+    GET_UINT32_LE( X1, input,  4 ); X1 ^= *RK++;
+    GET_UINT32_LE( X2, input,  8 ); X2 ^= *RK++;
+    GET_UINT32_LE( X3, input, 12 ); X3 ^= *RK++;
+
+    for( i = ( ctx->nr >> 1 ) - 1; i > 0; i-- )
+    {
+        AES_FROUND( Y0, Y1, Y2, Y3, X0, X1, X2, X3 );
+        AES_FROUND( X0, X1, X2, X3, Y0, Y1, Y2, Y3 );
+    }
+
+    AES_FROUND( Y0, Y1, Y2, Y3, X0, X1, X2, X3 );
+
+    X0 = *RK++ ^ \
+            ( (uint32_t) FSb[ ( Y0       ) & 0xFF ]       ) ^
+            ( (uint32_t) FSb[ ( Y1 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) FSb[ ( Y2 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) FSb[ ( Y3 >> 24 ) & 0xFF ] << 24 );
+
+    X1 = *RK++ ^ \
+            ( (uint32_t) FSb[ ( Y1       ) & 0xFF ]       ) ^
+            ( (uint32_t) FSb[ ( Y2 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) FSb[ ( Y3 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) FSb[ ( Y0 >> 24 ) & 0xFF ] << 24 );
+
+    X2 = *RK++ ^ \
+            ( (uint32_t) FSb[ ( Y2       ) & 0xFF ]       ) ^
+            ( (uint32_t) FSb[ ( Y3 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) FSb[ ( Y0 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) FSb[ ( Y1 >> 24 ) & 0xFF ] << 24 );
+
+    X3 = *RK++ ^ \
+            ( (uint32_t) FSb[ ( Y3       ) & 0xFF ]       ) ^
+            ( (uint32_t) FSb[ ( Y0 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) FSb[ ( Y1 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) FSb[ ( Y2 >> 24 ) & 0xFF ] << 24 );
+
+    PUT_UINT32_LE( X0, output,  0 );
+    PUT_UINT32_LE( X1, output,  4 );
+    PUT_UINT32_LE( X2, output,  8 );
+    PUT_UINT32_LE( X3, output, 12 );
+
+    return( 0 );
+}
+#endif /* !MBEDTLS_AES_ENCRYPT_ALT */
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_aes_encrypt( mbedtls_aes_context *ctx,
+                          const unsigned char input[16],
+                          unsigned char output[16] )
+{
+    mbedtls_internal_aes_encrypt( ctx, input, output );
+}
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/*
+ * AES-ECB block decryption
+ */
+#if !defined(MBEDTLS_AES_DECRYPT_ALT)
+int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
+                                  const unsigned char input[16],
+                                  unsigned char output[16] )
+{
+    int i;
+    uint32_t *RK, X0, X1, X2, X3, Y0, Y1, Y2, Y3;
+
+    RK = ctx->rk;
+
+    GET_UINT32_LE( X0, input,  0 ); X0 ^= *RK++;
+    GET_UINT32_LE( X1, input,  4 ); X1 ^= *RK++;
+    GET_UINT32_LE( X2, input,  8 ); X2 ^= *RK++;
+    GET_UINT32_LE( X3, input, 12 ); X3 ^= *RK++;
+
+    for( i = ( ctx->nr >> 1 ) - 1; i > 0; i-- )
+    {
+        AES_RROUND( Y0, Y1, Y2, Y3, X0, X1, X2, X3 );
+        AES_RROUND( X0, X1, X2, X3, Y0, Y1, Y2, Y3 );
+    }
+
+    AES_RROUND( Y0, Y1, Y2, Y3, X0, X1, X2, X3 );
+
+    X0 = *RK++ ^ \
+            ( (uint32_t) RSb[ ( Y0       ) & 0xFF ]       ) ^
+            ( (uint32_t) RSb[ ( Y3 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) RSb[ ( Y2 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) RSb[ ( Y1 >> 24 ) & 0xFF ] << 24 );
+
+    X1 = *RK++ ^ \
+            ( (uint32_t) RSb[ ( Y1       ) & 0xFF ]       ) ^
+            ( (uint32_t) RSb[ ( Y0 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) RSb[ ( Y3 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) RSb[ ( Y2 >> 24 ) & 0xFF ] << 24 );
+
+    X2 = *RK++ ^ \
+            ( (uint32_t) RSb[ ( Y2       ) & 0xFF ]       ) ^
+            ( (uint32_t) RSb[ ( Y1 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) RSb[ ( Y0 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) RSb[ ( Y3 >> 24 ) & 0xFF ] << 24 );
+
+    X3 = *RK++ ^ \
+            ( (uint32_t) RSb[ ( Y3       ) & 0xFF ]       ) ^
+            ( (uint32_t) RSb[ ( Y2 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) RSb[ ( Y1 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) RSb[ ( Y0 >> 24 ) & 0xFF ] << 24 );
+
+    PUT_UINT32_LE( X0, output,  0 );
+    PUT_UINT32_LE( X1, output,  4 );
+    PUT_UINT32_LE( X2, output,  8 );
+    PUT_UINT32_LE( X3, output, 12 );
+
+    return( 0 );
+}
+#endif /* !MBEDTLS_AES_DECRYPT_ALT */
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_aes_decrypt( mbedtls_aes_context *ctx,
+                          const unsigned char input[16],
+                          unsigned char output[16] )
+{
+    mbedtls_internal_aes_decrypt( ctx, input, output );
+}
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/*
+ * AES-ECB block encryption/decryption
+ */
+int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
+                           int mode,
+                           const unsigned char input[16],
+                           unsigned char output[16] )
+{
+    AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( input != NULL );
+    AES_VALIDATE_RET( output != NULL );
+    AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
+                      mode == MBEDTLS_AES_DECRYPT );
+
+#if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
+    if( mbedtls_aesni_has_support( MBEDTLS_AESNI_AES ) )
+        return( mbedtls_aesni_crypt_ecb( ctx, mode, input, output ) );
+#endif
+
+#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+    if( aes_padlock_ace )
+    {
+        if( mbedtls_padlock_xcryptecb( ctx, mode, input, output ) == 0 )
+            return( 0 );
+
+        // If padlock data misaligned, we just fall back to
+        // unaccelerated mode
+        //
+    }
+#endif
+
+    if( mode == MBEDTLS_AES_ENCRYPT )
+        return( mbedtls_internal_aes_encrypt( ctx, input, output ) );
+    else
+        return( mbedtls_internal_aes_decrypt( ctx, input, output ) );
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+/*
+ * AES-CBC buffer encryption/decryption
+ */
+int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
+                    int mode,
+                    size_t length,
+                    unsigned char iv[16],
+                    const unsigned char *input,
+                    unsigned char *output )
+{
+    int i;
+    unsigned char temp[16];
+
+    AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
+                      mode == MBEDTLS_AES_DECRYPT );
+    AES_VALIDATE_RET( iv != NULL );
+    AES_VALIDATE_RET( input != NULL );
+    AES_VALIDATE_RET( output != NULL );
+
+    if( length % 16 )
+        return( MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH );
+
+#if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
+    if( aes_padlock_ace )
+    {
+        if( mbedtls_padlock_xcryptcbc( ctx, mode, length, iv, input, output ) == 0 )
+            return( 0 );
+
+        // If padlock data misaligned, we just fall back to
+        // unaccelerated mode
+        //
+    }
+#endif
+
+    if( mode == MBEDTLS_AES_DECRYPT )
+    {
+        while( length > 0 )
+        {
+            memcpy( temp, input, 16 );
+            mbedtls_aes_crypt_ecb( ctx, mode, input, output );
+
+            for( i = 0; i < 16; i++ )
+                output[i] = (unsigned char)( output[i] ^ iv[i] );
+
+            memcpy( iv, temp, 16 );
+
+            input  += 16;
+            output += 16;
+            length -= 16;
+        }
+    }
+    else
+    {
+        while( length > 0 )
+        {
+            for( i = 0; i < 16; i++ )
+                output[i] = (unsigned char)( input[i] ^ iv[i] );
+
+            mbedtls_aes_crypt_ecb( ctx, mode, output, output );
+            memcpy( iv, output, 16 );
+
+            input  += 16;
+            output += 16;
+            length -= 16;
+        }
+    }
+
+    return( 0 );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+
+/* Endianess with 64 bits values */
+#ifndef GET_UINT64_LE
+#define GET_UINT64_LE(n,b,i)                            \
+{                                                       \
+    (n) = ( (uint64_t) (b)[(i) + 7] << 56 )             \
+        | ( (uint64_t) (b)[(i) + 6] << 48 )             \
+        | ( (uint64_t) (b)[(i) + 5] << 40 )             \
+        | ( (uint64_t) (b)[(i) + 4] << 32 )             \
+        | ( (uint64_t) (b)[(i) + 3] << 24 )             \
+        | ( (uint64_t) (b)[(i) + 2] << 16 )             \
+        | ( (uint64_t) (b)[(i) + 1] <<  8 )             \
+        | ( (uint64_t) (b)[(i)    ]       );            \
+}
+#endif
+
+#ifndef PUT_UINT64_LE
+#define PUT_UINT64_LE(n,b,i)                            \
+{                                                       \
+    (b)[(i) + 7] = (unsigned char) ( (n) >> 56 );       \
+    (b)[(i) + 6] = (unsigned char) ( (n) >> 48 );       \
+    (b)[(i) + 5] = (unsigned char) ( (n) >> 40 );       \
+    (b)[(i) + 4] = (unsigned char) ( (n) >> 32 );       \
+    (b)[(i) + 3] = (unsigned char) ( (n) >> 24 );       \
+    (b)[(i) + 2] = (unsigned char) ( (n) >> 16 );       \
+    (b)[(i) + 1] = (unsigned char) ( (n) >>  8 );       \
+    (b)[(i)    ] = (unsigned char) ( (n)       );       \
+}
+#endif
+
+typedef unsigned char mbedtls_be128[16];
+
+/*
+ * GF(2^128) multiplication function
+ *
+ * This function multiplies a field element by x in the polynomial field
+ * representation. It uses 64-bit word operations to gain speed but compensates
+ * for machine endianess and hence works correctly on both big and little
+ * endian machines.
+ */
+static void mbedtls_gf128mul_x_ble( unsigned char r[16],
+                                    const unsigned char x[16] )
+{
+    uint64_t a, b, ra, rb;
+
+    GET_UINT64_LE( a, x, 0 );
+    GET_UINT64_LE( b, x, 8 );
+
+    ra = ( a << 1 )  ^ 0x0087 >> ( 8 - ( ( b >> 63 ) << 3 ) );
+    rb = ( a >> 63 ) | ( b << 1 );
+
+    PUT_UINT64_LE( ra, r, 0 );
+    PUT_UINT64_LE( rb, r, 8 );
+}
+
+/*
+ * AES-XTS buffer encryption/decryption
+ */
+int mbedtls_aes_crypt_xts( mbedtls_aes_xts_context *ctx,
+                           int mode,
+                           size_t length,
+                           const unsigned char data_unit[16],
+                           const unsigned char *input,
+                           unsigned char *output )
+{
+    int ret;
+    size_t blocks = length / 16;
+    size_t leftover = length % 16;
+    unsigned char tweak[16];
+    unsigned char prev_tweak[16];
+    unsigned char tmp[16];
+
+    AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
+                      mode == MBEDTLS_AES_DECRYPT );
+    AES_VALIDATE_RET( data_unit != NULL );
+    AES_VALIDATE_RET( input != NULL );
+    AES_VALIDATE_RET( output != NULL );
+
+    /* Data units must be at least 16 bytes long. */
+    if( length < 16 )
+        return MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH;
+
+    /* NIST SP 800-38E disallows data units larger than 2**20 blocks. */
+    if( length > ( 1 << 20 ) * 16 )
+        return MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH;
+
+    /* Compute the tweak. */
+    ret = mbedtls_aes_crypt_ecb( &ctx->tweak, MBEDTLS_AES_ENCRYPT,
+                                 data_unit, tweak );
+    if( ret != 0 )
+        return( ret );
+
+    while( blocks-- )
+    {
+        size_t i;
+
+        if( leftover && ( mode == MBEDTLS_AES_DECRYPT ) && blocks == 0 )
+        {
+            /* We are on the last block in a decrypt operation that has
+             * leftover bytes, so we need to use the next tweak for this block,
+             * and this tweak for the lefover bytes. Save the current tweak for
+             * the leftovers and then update the current tweak for use on this,
+             * the last full block. */
+            memcpy( prev_tweak, tweak, sizeof( tweak ) );
+            mbedtls_gf128mul_x_ble( tweak, tweak );
+        }
+
+        for( i = 0; i < 16; i++ )
+            tmp[i] = input[i] ^ tweak[i];
+
+        ret = mbedtls_aes_crypt_ecb( &ctx->crypt, mode, tmp, tmp );
+        if( ret != 0 )
+            return( ret );
+
+        for( i = 0; i < 16; i++ )
+            output[i] = tmp[i] ^ tweak[i];
+
+        /* Update the tweak for the next block. */
+        mbedtls_gf128mul_x_ble( tweak, tweak );
+
+        output += 16;
+        input += 16;
+    }
+
+    if( leftover )
+    {
+        /* If we are on the leftover bytes in a decrypt operation, we need to
+         * use the previous tweak for these bytes (as saved in prev_tweak). */
+        unsigned char *t = mode == MBEDTLS_AES_DECRYPT ? prev_tweak : tweak;
+
+        /* We are now on the final part of the data unit, which doesn't divide
+         * evenly by 16. It's time for ciphertext stealing. */
+        size_t i;
+        unsigned char *prev_output = output - 16;
+
+        /* Copy ciphertext bytes from the previous block to our output for each
+         * byte of cyphertext we won't steal. At the same time, copy the
+         * remainder of the input for this final round (since the loop bounds
+         * are the same). */
+        for( i = 0; i < leftover; i++ )
+        {
+            output[i] = prev_output[i];
+            tmp[i] = input[i] ^ t[i];
+        }
+
+        /* Copy ciphertext bytes from the previous block for input in this
+         * round. */
+        for( ; i < 16; i++ )
+            tmp[i] = prev_output[i] ^ t[i];
+
+        ret = mbedtls_aes_crypt_ecb( &ctx->crypt, mode, tmp, tmp );
+        if( ret != 0 )
+            return ret;
+
+        /* Write the result back to the previous block, overriding the previous
+         * output we copied. */
+        for( i = 0; i < 16; i++ )
+            prev_output[i] = tmp[i] ^ t[i];
+    }
+
+    return( 0 );
+}
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+/*
+ * AES-CFB128 buffer encryption/decryption
+ */
+int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
+                       int mode,
+                       size_t length,
+                       size_t *iv_off,
+                       unsigned char iv[16],
+                       const unsigned char *input,
+                       unsigned char *output )
+{
+    int c;
+    size_t n;
+
+    AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
+                      mode == MBEDTLS_AES_DECRYPT );
+    AES_VALIDATE_RET( iv_off != NULL );
+    AES_VALIDATE_RET( iv != NULL );
+    AES_VALIDATE_RET( input != NULL );
+    AES_VALIDATE_RET( output != NULL );
+
+    n = *iv_off;
+
+    if( n > 15 )
+        return( MBEDTLS_ERR_AES_BAD_INPUT_DATA );
+
+    if( mode == MBEDTLS_AES_DECRYPT )
+    {
+        while( length-- )
+        {
+            if( n == 0 )
+                mbedtls_aes_crypt_ecb( ctx, MBEDTLS_AES_ENCRYPT, iv, iv );
+
+            c = *input++;
+            *output++ = (unsigned char)( c ^ iv[n] );
+            iv[n] = (unsigned char) c;
+
+            n = ( n + 1 ) & 0x0F;
+        }
+    }
+    else
+    {
+        while( length-- )
+        {
+            if( n == 0 )
+                mbedtls_aes_crypt_ecb( ctx, MBEDTLS_AES_ENCRYPT, iv, iv );
+
+            iv[n] = *output++ = (unsigned char)( iv[n] ^ *input++ );
+
+            n = ( n + 1 ) & 0x0F;
+        }
+    }
+
+    *iv_off = n;
+
+    return( 0 );
+}
+
+/*
+ * AES-CFB8 buffer encryption/decryption
+ */
+int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
+                            int mode,
+                            size_t length,
+                            unsigned char iv[16],
+                            const unsigned char *input,
+                            unsigned char *output )
+{
+    unsigned char c;
+    unsigned char ov[17];
+
+    AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
+                      mode == MBEDTLS_AES_DECRYPT );
+    AES_VALIDATE_RET( iv != NULL );
+    AES_VALIDATE_RET( input != NULL );
+    AES_VALIDATE_RET( output != NULL );
+    while( length-- )
+    {
+        memcpy( ov, iv, 16 );
+        mbedtls_aes_crypt_ecb( ctx, MBEDTLS_AES_ENCRYPT, iv, iv );
+
+        if( mode == MBEDTLS_AES_DECRYPT )
+            ov[16] = *input;
+
+        c = *output++ = (unsigned char)( iv[0] ^ *input++ );
+
+        if( mode == MBEDTLS_AES_ENCRYPT )
+            ov[16] = c;
+
+        memcpy( iv, ov + 1, 16 );
+    }
+
+    return( 0 );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+/*
+ * AES-OFB (Output Feedback Mode) buffer encryption/decryption
+ */
+int mbedtls_aes_crypt_ofb( mbedtls_aes_context *ctx,
+                           size_t length,
+                           size_t *iv_off,
+                           unsigned char iv[16],
+                           const unsigned char *input,
+                           unsigned char *output )
+{
+    int ret = 0;
+    size_t n;
+
+    AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( iv_off != NULL );
+    AES_VALIDATE_RET( iv != NULL );
+    AES_VALIDATE_RET( input != NULL );
+    AES_VALIDATE_RET( output != NULL );
+
+    n = *iv_off;
+
+    if( n > 15 )
+        return( MBEDTLS_ERR_AES_BAD_INPUT_DATA );
+
+    while( length-- )
+    {
+        if( n == 0 )
+        {
+            ret = mbedtls_aes_crypt_ecb( ctx, MBEDTLS_AES_ENCRYPT, iv, iv );
+            if( ret != 0 )
+                goto exit;
+        }
+        *output++ =  *input++ ^ iv[n];
+
+        n = ( n + 1 ) & 0x0F;
+    }
+
+    *iv_off = n;
+
+exit:
+    return( ret );
+}
+#endif /* MBEDTLS_CIPHER_MODE_OFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+/*
+ * AES-CTR buffer encryption/decryption
+ */
+int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
+                       size_t length,
+                       size_t *nc_off,
+                       unsigned char nonce_counter[16],
+                       unsigned char stream_block[16],
+                       const unsigned char *input,
+                       unsigned char *output )
+{
+    int c, i;
+    size_t n;
+
+    AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( nc_off != NULL );
+    AES_VALIDATE_RET( nonce_counter != NULL );
+    AES_VALIDATE_RET( stream_block != NULL );
+    AES_VALIDATE_RET( input != NULL );
+    AES_VALIDATE_RET( output != NULL );
+
+    n = *nc_off;
+
+    if ( n > 0x0F )
+        return( MBEDTLS_ERR_AES_BAD_INPUT_DATA );
+
+    while( length-- )
+    {
+        if( n == 0 ) {
+            mbedtls_aes_crypt_ecb( ctx, MBEDTLS_AES_ENCRYPT, nonce_counter, stream_block );
+
+            for( i = 16; i > 0; i-- )
+                if( ++nonce_counter[i - 1] != 0 )
+                    break;
+        }
+        c = *input++;
+        *output++ = (unsigned char)( c ^ stream_block[n] );
+
+        n = ( n + 1 ) & 0x0F;
+    }
+
+    *nc_off = n;
+
+    return( 0 );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+#endif /* !MBEDTLS_AES_ALT */
+
+#if defined(MBEDTLS_SELF_TEST)
+/*
+ * AES test vectors from:
+ *
+ * http://csrc.nist.gov/archive/aes/rijndael/rijndael-vals.zip
+ */
+static const unsigned char aes_test_ecb_dec[3][16] =
+{
+    { 0x44, 0x41, 0x6A, 0xC2, 0xD1, 0xF5, 0x3C, 0x58,
+      0x33, 0x03, 0x91, 0x7E, 0x6B, 0xE9, 0xEB, 0xE0 },
+    { 0x48, 0xE3, 0x1E, 0x9E, 0x25, 0x67, 0x18, 0xF2,
+      0x92, 0x29, 0x31, 0x9C, 0x19, 0xF1, 0x5B, 0xA4 },
+    { 0x05, 0x8C, 0xCF, 0xFD, 0xBB, 0xCB, 0x38, 0x2D,
+      0x1F, 0x6F, 0x56, 0x58, 0x5D, 0x8A, 0x4A, 0xDE }
+};
+
+static const unsigned char aes_test_ecb_enc[3][16] =
+{
+    { 0xC3, 0x4C, 0x05, 0x2C, 0xC0, 0xDA, 0x8D, 0x73,
+      0x45, 0x1A, 0xFE, 0x5F, 0x03, 0xBE, 0x29, 0x7F },
+    { 0xF3, 0xF6, 0x75, 0x2A, 0xE8, 0xD7, 0x83, 0x11,
+      0x38, 0xF0, 0x41, 0x56, 0x06, 0x31, 0xB1, 0x14 },
+    { 0x8B, 0x79, 0xEE, 0xCC, 0x93, 0xA0, 0xEE, 0x5D,
+      0xFF, 0x30, 0xB4, 0xEA, 0x21, 0x63, 0x6D, 0xA4 }
+};
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static const unsigned char aes_test_cbc_dec[3][16] =
+{
+    { 0xFA, 0xCA, 0x37, 0xE0, 0xB0, 0xC8, 0x53, 0x73,
+      0xDF, 0x70, 0x6E, 0x73, 0xF7, 0xC9, 0xAF, 0x86 },
+    { 0x5D, 0xF6, 0x78, 0xDD, 0x17, 0xBA, 0x4E, 0x75,
+      0xB6, 0x17, 0x68, 0xC6, 0xAD, 0xEF, 0x7C, 0x7B },
+    { 0x48, 0x04, 0xE1, 0x81, 0x8F, 0xE6, 0x29, 0x75,
+      0x19, 0xA3, 0xE8, 0x8C, 0x57, 0x31, 0x04, 0x13 }
+};
+
+static const unsigned char aes_test_cbc_enc[3][16] =
+{
+    { 0x8A, 0x05, 0xFC, 0x5E, 0x09, 0x5A, 0xF4, 0x84,
+      0x8A, 0x08, 0xD3, 0x28, 0xD3, 0x68, 0x8E, 0x3D },
+    { 0x7B, 0xD9, 0x66, 0xD5, 0x3A, 0xD8, 0xC1, 0xBB,
+      0x85, 0xD2, 0xAD, 0xFA, 0xE8, 0x7B, 0xB1, 0x04 },
+    { 0xFE, 0x3C, 0x53, 0x65, 0x3E, 0x2F, 0x45, 0xB5,
+      0x6F, 0xCD, 0x88, 0xB2, 0xCC, 0x89, 0x8F, 0xF0 }
+};
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+/*
+ * AES-CFB128 test vectors from:
+ *
+ * http://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf
+ */
+static const unsigned char aes_test_cfb128_key[3][32] =
+{
+    { 0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6,
+      0xAB, 0xF7, 0x15, 0x88, 0x09, 0xCF, 0x4F, 0x3C },
+    { 0x8E, 0x73, 0xB0, 0xF7, 0xDA, 0x0E, 0x64, 0x52,
+      0xC8, 0x10, 0xF3, 0x2B, 0x80, 0x90, 0x79, 0xE5,
+      0x62, 0xF8, 0xEA, 0xD2, 0x52, 0x2C, 0x6B, 0x7B },
+    { 0x60, 0x3D, 0xEB, 0x10, 0x15, 0xCA, 0x71, 0xBE,
+      0x2B, 0x73, 0xAE, 0xF0, 0x85, 0x7D, 0x77, 0x81,
+      0x1F, 0x35, 0x2C, 0x07, 0x3B, 0x61, 0x08, 0xD7,
+      0x2D, 0x98, 0x10, 0xA3, 0x09, 0x14, 0xDF, 0xF4 }
+};
+
+static const unsigned char aes_test_cfb128_iv[16] =
+{
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+};
+
+static const unsigned char aes_test_cfb128_pt[64] =
+{
+    0x6B, 0xC1, 0xBE, 0xE2, 0x2E, 0x40, 0x9F, 0x96,
+    0xE9, 0x3D, 0x7E, 0x11, 0x73, 0x93, 0x17, 0x2A,
+    0xAE, 0x2D, 0x8A, 0x57, 0x1E, 0x03, 0xAC, 0x9C,
+    0x9E, 0xB7, 0x6F, 0xAC, 0x45, 0xAF, 0x8E, 0x51,
+    0x30, 0xC8, 0x1C, 0x46, 0xA3, 0x5C, 0xE4, 0x11,
+    0xE5, 0xFB, 0xC1, 0x19, 0x1A, 0x0A, 0x52, 0xEF,
+    0xF6, 0x9F, 0x24, 0x45, 0xDF, 0x4F, 0x9B, 0x17,
+    0xAD, 0x2B, 0x41, 0x7B, 0xE6, 0x6C, 0x37, 0x10
+};
+
+static const unsigned char aes_test_cfb128_ct[3][64] =
+{
+    { 0x3B, 0x3F, 0xD9, 0x2E, 0xB7, 0x2D, 0xAD, 0x20,
+      0x33, 0x34, 0x49, 0xF8, 0xE8, 0x3C, 0xFB, 0x4A,
+      0xC8, 0xA6, 0x45, 0x37, 0xA0, 0xB3, 0xA9, 0x3F,
+      0xCD, 0xE3, 0xCD, 0xAD, 0x9F, 0x1C, 0xE5, 0x8B,
+      0x26, 0x75, 0x1F, 0x67, 0xA3, 0xCB, 0xB1, 0x40,
+      0xB1, 0x80, 0x8C, 0xF1, 0x87, 0xA4, 0xF4, 0xDF,
+      0xC0, 0x4B, 0x05, 0x35, 0x7C, 0x5D, 0x1C, 0x0E,
+      0xEA, 0xC4, 0xC6, 0x6F, 0x9F, 0xF7, 0xF2, 0xE6 },
+    { 0xCD, 0xC8, 0x0D, 0x6F, 0xDD, 0xF1, 0x8C, 0xAB,
+      0x34, 0xC2, 0x59, 0x09, 0xC9, 0x9A, 0x41, 0x74,
+      0x67, 0xCE, 0x7F, 0x7F, 0x81, 0x17, 0x36, 0x21,
+      0x96, 0x1A, 0x2B, 0x70, 0x17, 0x1D, 0x3D, 0x7A,
+      0x2E, 0x1E, 0x8A, 0x1D, 0xD5, 0x9B, 0x88, 0xB1,
+      0xC8, 0xE6, 0x0F, 0xED, 0x1E, 0xFA, 0xC4, 0xC9,
+      0xC0, 0x5F, 0x9F, 0x9C, 0xA9, 0x83, 0x4F, 0xA0,
+      0x42, 0xAE, 0x8F, 0xBA, 0x58, 0x4B, 0x09, 0xFF },
+    { 0xDC, 0x7E, 0x84, 0xBF, 0xDA, 0x79, 0x16, 0x4B,
+      0x7E, 0xCD, 0x84, 0x86, 0x98, 0x5D, 0x38, 0x60,
+      0x39, 0xFF, 0xED, 0x14, 0x3B, 0x28, 0xB1, 0xC8,
+      0x32, 0x11, 0x3C, 0x63, 0x31, 0xE5, 0x40, 0x7B,
+      0xDF, 0x10, 0x13, 0x24, 0x15, 0xE5, 0x4B, 0x92,
+      0xA1, 0x3E, 0xD0, 0xA8, 0x26, 0x7A, 0xE2, 0xF9,
+      0x75, 0xA3, 0x85, 0x74, 0x1A, 0xB9, 0xCE, 0xF8,
+      0x20, 0x31, 0x62, 0x3D, 0x55, 0xB1, 0xE4, 0x71 }
+};
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+/*
+ * AES-OFB test vectors from:
+ *
+ * https://csrc.nist.gov/publications/detail/sp/800-38a/final
+ */
+static const unsigned char aes_test_ofb_key[3][32] =
+{
+    { 0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6,
+      0xAB, 0xF7, 0x15, 0x88, 0x09, 0xCF, 0x4F, 0x3C },
+    { 0x8E, 0x73, 0xB0, 0xF7, 0xDA, 0x0E, 0x64, 0x52,
+      0xC8, 0x10, 0xF3, 0x2B, 0x80, 0x90, 0x79, 0xE5,
+      0x62, 0xF8, 0xEA, 0xD2, 0x52, 0x2C, 0x6B, 0x7B },
+    { 0x60, 0x3D, 0xEB, 0x10, 0x15, 0xCA, 0x71, 0xBE,
+      0x2B, 0x73, 0xAE, 0xF0, 0x85, 0x7D, 0x77, 0x81,
+      0x1F, 0x35, 0x2C, 0x07, 0x3B, 0x61, 0x08, 0xD7,
+      0x2D, 0x98, 0x10, 0xA3, 0x09, 0x14, 0xDF, 0xF4 }
+};
+
+static const unsigned char aes_test_ofb_iv[16] =
+{
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+};
+
+static const unsigned char aes_test_ofb_pt[64] =
+{
+    0x6B, 0xC1, 0xBE, 0xE2, 0x2E, 0x40, 0x9F, 0x96,
+    0xE9, 0x3D, 0x7E, 0x11, 0x73, 0x93, 0x17, 0x2A,
+    0xAE, 0x2D, 0x8A, 0x57, 0x1E, 0x03, 0xAC, 0x9C,
+    0x9E, 0xB7, 0x6F, 0xAC, 0x45, 0xAF, 0x8E, 0x51,
+    0x30, 0xC8, 0x1C, 0x46, 0xA3, 0x5C, 0xE4, 0x11,
+    0xE5, 0xFB, 0xC1, 0x19, 0x1A, 0x0A, 0x52, 0xEF,
+    0xF6, 0x9F, 0x24, 0x45, 0xDF, 0x4F, 0x9B, 0x17,
+    0xAD, 0x2B, 0x41, 0x7B, 0xE6, 0x6C, 0x37, 0x10
+};
+
+static const unsigned char aes_test_ofb_ct[3][64] =
+{
+    { 0x3B, 0x3F, 0xD9, 0x2E, 0xB7, 0x2D, 0xAD, 0x20,
+      0x33, 0x34, 0x49, 0xF8, 0xE8, 0x3C, 0xFB, 0x4A,
+      0x77, 0x89, 0x50, 0x8d, 0x16, 0x91, 0x8f, 0x03,
+      0xf5, 0x3c, 0x52, 0xda, 0xc5, 0x4e, 0xd8, 0x25,
+      0x97, 0x40, 0x05, 0x1e, 0x9c, 0x5f, 0xec, 0xf6,
+      0x43, 0x44, 0xf7, 0xa8, 0x22, 0x60, 0xed, 0xcc,
+      0x30, 0x4c, 0x65, 0x28, 0xf6, 0x59, 0xc7, 0x78,
+      0x66, 0xa5, 0x10, 0xd9, 0xc1, 0xd6, 0xae, 0x5e },
+    { 0xCD, 0xC8, 0x0D, 0x6F, 0xDD, 0xF1, 0x8C, 0xAB,
+      0x34, 0xC2, 0x59, 0x09, 0xC9, 0x9A, 0x41, 0x74,
+      0xfc, 0xc2, 0x8b, 0x8d, 0x4c, 0x63, 0x83, 0x7c,
+      0x09, 0xe8, 0x17, 0x00, 0xc1, 0x10, 0x04, 0x01,
+      0x8d, 0x9a, 0x9a, 0xea, 0xc0, 0xf6, 0x59, 0x6f,
+      0x55, 0x9c, 0x6d, 0x4d, 0xaf, 0x59, 0xa5, 0xf2,
+      0x6d, 0x9f, 0x20, 0x08, 0x57, 0xca, 0x6c, 0x3e,
+      0x9c, 0xac, 0x52, 0x4b, 0xd9, 0xac, 0xc9, 0x2a },
+    { 0xDC, 0x7E, 0x84, 0xBF, 0xDA, 0x79, 0x16, 0x4B,
+      0x7E, 0xCD, 0x84, 0x86, 0x98, 0x5D, 0x38, 0x60,
+      0x4f, 0xeb, 0xdc, 0x67, 0x40, 0xd2, 0x0b, 0x3a,
+      0xc8, 0x8f, 0x6a, 0xd8, 0x2a, 0x4f, 0xb0, 0x8d,
+      0x71, 0xab, 0x47, 0xa0, 0x86, 0xe8, 0x6e, 0xed,
+      0xf3, 0x9d, 0x1c, 0x5b, 0xba, 0x97, 0xc4, 0x08,
+      0x01, 0x26, 0x14, 0x1d, 0x67, 0xf3, 0x7b, 0xe8,
+      0x53, 0x8f, 0x5a, 0x8b, 0xe7, 0x40, 0xe4, 0x84 }
+};
+#endif /* MBEDTLS_CIPHER_MODE_OFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+/*
+ * AES-CTR test vectors from:
+ *
+ * http://www.faqs.org/rfcs/rfc3686.html
+ */
+
+static const unsigned char aes_test_ctr_key[3][16] =
+{
+    { 0xAE, 0x68, 0x52, 0xF8, 0x12, 0x10, 0x67, 0xCC,
+      0x4B, 0xF7, 0xA5, 0x76, 0x55, 0x77, 0xF3, 0x9E },
+    { 0x7E, 0x24, 0x06, 0x78, 0x17, 0xFA, 0xE0, 0xD7,
+      0x43, 0xD6, 0xCE, 0x1F, 0x32, 0x53, 0x91, 0x63 },
+    { 0x76, 0x91, 0xBE, 0x03, 0x5E, 0x50, 0x20, 0xA8,
+      0xAC, 0x6E, 0x61, 0x85, 0x29, 0xF9, 0xA0, 0xDC }
+};
+
+static const unsigned char aes_test_ctr_nonce_counter[3][16] =
+{
+    { 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 },
+    { 0x00, 0x6C, 0xB6, 0xDB, 0xC0, 0x54, 0x3B, 0x59,
+      0xDA, 0x48, 0xD9, 0x0B, 0x00, 0x00, 0x00, 0x01 },
+    { 0x00, 0xE0, 0x01, 0x7B, 0x27, 0x77, 0x7F, 0x3F,
+      0x4A, 0x17, 0x86, 0xF0, 0x00, 0x00, 0x00, 0x01 }
+};
+
+static const unsigned char aes_test_ctr_pt[3][48] =
+{
+    { 0x53, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20, 0x62,
+      0x6C, 0x6F, 0x63, 0x6B, 0x20, 0x6D, 0x73, 0x67 },
+
+    { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+      0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+      0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+      0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F },
+
+    { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+      0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+      0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+      0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+      0x20, 0x21, 0x22, 0x23 }
+};
+
+static const unsigned char aes_test_ctr_ct[3][48] =
+{
+    { 0xE4, 0x09, 0x5D, 0x4F, 0xB7, 0xA7, 0xB3, 0x79,
+      0x2D, 0x61, 0x75, 0xA3, 0x26, 0x13, 0x11, 0xB8 },
+    { 0x51, 0x04, 0xA1, 0x06, 0x16, 0x8A, 0x72, 0xD9,
+      0x79, 0x0D, 0x41, 0xEE, 0x8E, 0xDA, 0xD3, 0x88,
+      0xEB, 0x2E, 0x1E, 0xFC, 0x46, 0xDA, 0x57, 0xC8,
+      0xFC, 0xE6, 0x30, 0xDF, 0x91, 0x41, 0xBE, 0x28 },
+    { 0xC1, 0xCF, 0x48, 0xA8, 0x9F, 0x2F, 0xFD, 0xD9,
+      0xCF, 0x46, 0x52, 0xE9, 0xEF, 0xDB, 0x72, 0xD7,
+      0x45, 0x40, 0xA4, 0x2B, 0xDE, 0x6D, 0x78, 0x36,
+      0xD5, 0x9A, 0x5C, 0xEA, 0xAE, 0xF3, 0x10, 0x53,
+      0x25, 0xB2, 0x07, 0x2F }
+};
+
+static const int aes_test_ctr_len[3] =
+    { 16, 32, 36 };
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+/*
+ * AES-XTS test vectors from:
+ *
+ * IEEE P1619/D16 Annex B
+ * https://web.archive.org/web/20150629024421/http://grouper.ieee.org/groups/1619/email/pdf00086.pdf
+ * (Archived from original at http://grouper.ieee.org/groups/1619/email/pdf00086.pdf)
+ */
+static const unsigned char aes_test_xts_key[][32] =
+{
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    { 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+      0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+      0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+      0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22 },
+    { 0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8,
+      0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf2, 0xf1, 0xf0,
+      0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+      0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22 },
+};
+
+static const unsigned char aes_test_xts_pt32[][32] =
+{
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    { 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+      0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+      0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+      0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44 },
+    { 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+      0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+      0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+      0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44 },
+};
+
+static const unsigned char aes_test_xts_ct32[][32] =
+{
+    { 0x91, 0x7c, 0xf6, 0x9e, 0xbd, 0x68, 0xb2, 0xec,
+      0x9b, 0x9f, 0xe9, 0xa3, 0xea, 0xdd, 0xa6, 0x92,
+      0xcd, 0x43, 0xd2, 0xf5, 0x95, 0x98, 0xed, 0x85,
+      0x8c, 0x02, 0xc2, 0x65, 0x2f, 0xbf, 0x92, 0x2e },
+    { 0xc4, 0x54, 0x18, 0x5e, 0x6a, 0x16, 0x93, 0x6e,
+      0x39, 0x33, 0x40, 0x38, 0xac, 0xef, 0x83, 0x8b,
+      0xfb, 0x18, 0x6f, 0xff, 0x74, 0x80, 0xad, 0xc4,
+      0x28, 0x93, 0x82, 0xec, 0xd6, 0xd3, 0x94, 0xf0 },
+    { 0xaf, 0x85, 0x33, 0x6b, 0x59, 0x7a, 0xfc, 0x1a,
+      0x90, 0x0b, 0x2e, 0xb2, 0x1e, 0xc9, 0x49, 0xd2,
+      0x92, 0xdf, 0x4c, 0x04, 0x7e, 0x0b, 0x21, 0x53,
+      0x21, 0x86, 0xa5, 0x97, 0x1a, 0x22, 0x7a, 0x89 },
+};
+
+static const unsigned char aes_test_xts_data_unit[][16] =
+{
+   { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+   { 0x33, 0x33, 0x33, 0x33, 0x33, 0x00, 0x00, 0x00,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+   { 0x33, 0x33, 0x33, 0x33, 0x33, 0x00, 0x00, 0x00,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+};
+
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+/*
+ * Checkup routine
+ */
+int mbedtls_aes_self_test( int verbose )
+{
+    int ret = 0, i, j, u, mode;
+    unsigned int keybits;
+    unsigned char key[32];
+    unsigned char buf[64];
+    const unsigned char *aes_tests;
+#if defined(MBEDTLS_CIPHER_MODE_CBC) || defined(MBEDTLS_CIPHER_MODE_CFB)
+    unsigned char iv[16];
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    unsigned char prv[16];
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR) || defined(MBEDTLS_CIPHER_MODE_CFB) || \
+    defined(MBEDTLS_CIPHER_MODE_OFB)
+    size_t offset;
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR) || defined(MBEDTLS_CIPHER_MODE_XTS)
+    int len;
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    unsigned char nonce_counter[16];
+    unsigned char stream_block[16];
+#endif
+    mbedtls_aes_context ctx;
+
+    memset( key, 0, 32 );
+    mbedtls_aes_init( &ctx );
+
+    /*
+     * ECB mode
+     */
+    for( i = 0; i < 6; i++ )
+    {
+        u = i >> 1;
+        keybits = 128 + u * 64;
+        mode = i & 1;
+
+        if( verbose != 0 )
+            mbedtls_printf( "  AES-ECB-%3d (%s): ", keybits,
+                            ( mode == MBEDTLS_AES_DECRYPT ) ? "dec" : "enc" );
+
+        memset( buf, 0, 16 );
+
+        if( mode == MBEDTLS_AES_DECRYPT )
+        {
+            ret = mbedtls_aes_setkey_dec( &ctx, key, keybits );
+            aes_tests = aes_test_ecb_dec[u];
+        }
+        else
+        {
+            ret = mbedtls_aes_setkey_enc( &ctx, key, keybits );
+            aes_tests = aes_test_ecb_enc[u];
+        }
+
+        /*
+         * AES-192 is an optional feature that may be unavailable when
+         * there is an alternative underlying implementation i.e. when
+         * MBEDTLS_AES_ALT is defined.
+         */
+        if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED && keybits == 192 )
+        {
+            mbedtls_printf( "skipped\n" );
+            continue;
+        }
+        else if( ret != 0 )
+        {
+            goto exit;
+        }
+
+        for( j = 0; j < 10000; j++ )
+        {
+            ret = mbedtls_aes_crypt_ecb( &ctx, mode, buf, buf );
+            if( ret != 0 )
+                goto exit;
+        }
+
+        if( memcmp( buf, aes_tests, 16 ) != 0 )
+        {
+            ret = 1;
+            goto exit;
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    /*
+     * CBC mode
+     */
+    for( i = 0; i < 6; i++ )
+    {
+        u = i >> 1;
+        keybits = 128 + u * 64;
+        mode = i & 1;
+
+        if( verbose != 0 )
+            mbedtls_printf( "  AES-CBC-%3d (%s): ", keybits,
+                            ( mode == MBEDTLS_AES_DECRYPT ) ? "dec" : "enc" );
+
+        memset( iv , 0, 16 );
+        memset( prv, 0, 16 );
+        memset( buf, 0, 16 );
+
+        if( mode == MBEDTLS_AES_DECRYPT )
+        {
+            ret = mbedtls_aes_setkey_dec( &ctx, key, keybits );
+            aes_tests = aes_test_cbc_dec[u];
+        }
+        else
+        {
+            ret = mbedtls_aes_setkey_enc( &ctx, key, keybits );
+            aes_tests = aes_test_cbc_enc[u];
+        }
+
+        /*
+         * AES-192 is an optional feature that may be unavailable when
+         * there is an alternative underlying implementation i.e. when
+         * MBEDTLS_AES_ALT is defined.
+         */
+        if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED && keybits == 192 )
+        {
+            mbedtls_printf( "skipped\n" );
+            continue;
+        }
+        else if( ret != 0 )
+        {
+            goto exit;
+        }
+
+        for( j = 0; j < 10000; j++ )
+        {
+            if( mode == MBEDTLS_AES_ENCRYPT )
+            {
+                unsigned char tmp[16];
+
+                memcpy( tmp, prv, 16 );
+                memcpy( prv, buf, 16 );
+                memcpy( buf, tmp, 16 );
+            }
+
+            ret = mbedtls_aes_crypt_cbc( &ctx, mode, 16, iv, buf, buf );
+            if( ret != 0 )
+                goto exit;
+
+        }
+
+        if( memcmp( buf, aes_tests, 16 ) != 0 )
+        {
+            ret = 1;
+            goto exit;
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    /*
+     * CFB128 mode
+     */
+    for( i = 0; i < 6; i++ )
+    {
+        u = i >> 1;
+        keybits = 128 + u * 64;
+        mode = i & 1;
+
+        if( verbose != 0 )
+            mbedtls_printf( "  AES-CFB128-%3d (%s): ", keybits,
+                            ( mode == MBEDTLS_AES_DECRYPT ) ? "dec" : "enc" );
+
+        memcpy( iv,  aes_test_cfb128_iv, 16 );
+        memcpy( key, aes_test_cfb128_key[u], keybits / 8 );
+
+        offset = 0;
+        ret = mbedtls_aes_setkey_enc( &ctx, key, keybits );
+        /*
+         * AES-192 is an optional feature that may be unavailable when
+         * there is an alternative underlying implementation i.e. when
+         * MBEDTLS_AES_ALT is defined.
+         */
+        if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED && keybits == 192 )
+        {
+            mbedtls_printf( "skipped\n" );
+            continue;
+        }
+        else if( ret != 0 )
+        {
+            goto exit;
+        }
+
+        if( mode == MBEDTLS_AES_DECRYPT )
+        {
+            memcpy( buf, aes_test_cfb128_ct[u], 64 );
+            aes_tests = aes_test_cfb128_pt;
+        }
+        else
+        {
+            memcpy( buf, aes_test_cfb128_pt, 64 );
+            aes_tests = aes_test_cfb128_ct[u];
+        }
+
+        ret = mbedtls_aes_crypt_cfb128( &ctx, mode, 64, &offset, iv, buf, buf );
+        if( ret != 0 )
+            goto exit;
+
+        if( memcmp( buf, aes_tests, 64 ) != 0 )
+        {
+            ret = 1;
+            goto exit;
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    /*
+     * OFB mode
+     */
+    for( i = 0; i < 6; i++ )
+    {
+        u = i >> 1;
+        keybits = 128 + u * 64;
+        mode = i & 1;
+
+        if( verbose != 0 )
+            mbedtls_printf( "  AES-OFB-%3d (%s): ", keybits,
+                            ( mode == MBEDTLS_AES_DECRYPT ) ? "dec" : "enc" );
+
+        memcpy( iv,  aes_test_ofb_iv, 16 );
+        memcpy( key, aes_test_ofb_key[u], keybits / 8 );
+
+        offset = 0;
+        ret = mbedtls_aes_setkey_enc( &ctx, key, keybits );
+        /*
+         * AES-192 is an optional feature that may be unavailable when
+         * there is an alternative underlying implementation i.e. when
+         * MBEDTLS_AES_ALT is defined.
+         */
+        if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED && keybits == 192 )
+        {
+            mbedtls_printf( "skipped\n" );
+            continue;
+        }
+        else if( ret != 0 )
+        {
+            goto exit;
+        }
+
+        if( mode == MBEDTLS_AES_DECRYPT )
+        {
+            memcpy( buf, aes_test_ofb_ct[u], 64 );
+            aes_tests = aes_test_ofb_pt;
+        }
+        else
+        {
+            memcpy( buf, aes_test_ofb_pt, 64 );
+            aes_tests = aes_test_ofb_ct[u];
+        }
+
+        ret = mbedtls_aes_crypt_ofb( &ctx, 64, &offset, iv, buf, buf );
+        if( ret != 0 )
+            goto exit;
+
+        if( memcmp( buf, aes_tests, 64 ) != 0 )
+        {
+            ret = 1;
+            goto exit;
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+#endif /* MBEDTLS_CIPHER_MODE_OFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    /*
+     * CTR mode
+     */
+    for( i = 0; i < 6; i++ )
+    {
+        u = i >> 1;
+        mode = i & 1;
+
+        if( verbose != 0 )
+            mbedtls_printf( "  AES-CTR-128 (%s): ",
+                            ( mode == MBEDTLS_AES_DECRYPT ) ? "dec" : "enc" );
+
+        memcpy( nonce_counter, aes_test_ctr_nonce_counter[u], 16 );
+        memcpy( key, aes_test_ctr_key[u], 16 );
+
+        offset = 0;
+        if( ( ret = mbedtls_aes_setkey_enc( &ctx, key, 128 ) ) != 0 )
+            goto exit;
+
+        len = aes_test_ctr_len[u];
+
+        if( mode == MBEDTLS_AES_DECRYPT )
+        {
+            memcpy( buf, aes_test_ctr_ct[u], len );
+            aes_tests = aes_test_ctr_pt[u];
+        }
+        else
+        {
+            memcpy( buf, aes_test_ctr_pt[u], len );
+            aes_tests = aes_test_ctr_ct[u];
+        }
+
+        ret = mbedtls_aes_crypt_ctr( &ctx, len, &offset, nonce_counter,
+                                     stream_block, buf, buf );
+        if( ret != 0 )
+            goto exit;
+
+        if( memcmp( buf, aes_tests, len ) != 0 )
+        {
+            ret = 1;
+            goto exit;
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    {
+    static const int num_tests =
+        sizeof(aes_test_xts_key) / sizeof(*aes_test_xts_key);
+    mbedtls_aes_xts_context ctx_xts;
+
+    /*
+     * XTS mode
+     */
+    mbedtls_aes_xts_init( &ctx_xts );
+
+    for( i = 0; i < num_tests << 1; i++ )
+    {
+        const unsigned char *data_unit;
+        u = i >> 1;
+        mode = i & 1;
+
+        if( verbose != 0 )
+            mbedtls_printf( "  AES-XTS-128 (%s): ",
+                            ( mode == MBEDTLS_AES_DECRYPT ) ? "dec" : "enc" );
+
+        memset( key, 0, sizeof( key ) );
+        memcpy( key, aes_test_xts_key[u], 32 );
+        data_unit = aes_test_xts_data_unit[u];
+
+        len = sizeof( *aes_test_xts_ct32 );
+
+        if( mode == MBEDTLS_AES_DECRYPT )
+        {
+            ret = mbedtls_aes_xts_setkey_dec( &ctx_xts, key, 256 );
+            if( ret != 0)
+                goto exit;
+            memcpy( buf, aes_test_xts_ct32[u], len );
+            aes_tests = aes_test_xts_pt32[u];
+        }
+        else
+        {
+            ret = mbedtls_aes_xts_setkey_enc( &ctx_xts, key, 256 );
+            if( ret != 0)
+                goto exit;
+            memcpy( buf, aes_test_xts_pt32[u], len );
+            aes_tests = aes_test_xts_ct32[u];
+        }
+
+
+        ret = mbedtls_aes_crypt_xts( &ctx_xts, mode, len, data_unit,
+                                     buf, buf );
+        if( ret != 0 )
+            goto exit;
+
+        if( memcmp( buf, aes_tests, len ) != 0 )
+        {
+            ret = 1;
+            goto exit;
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+
+    mbedtls_aes_xts_free( &ctx_xts );
+    }
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+    ret = 0;
+
+exit:
+    if( ret != 0 && verbose != 0 )
+        mbedtls_printf( "failed\n" );
+
+    mbedtls_aes_free( &ctx );
+
+    return( ret );
+}
+
+#endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_AES_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/asn1parse.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/asn1parse.c
@@ -1,0 +1,399 @@
+/*
+ *  Generic ASN.1 parsing
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_ASN1_PARSE_C)
+
+#include "mbedtls/asn1.h"
+#include "mbedtls/platform_util.h"
+
+#if defined(MBEDTLS_BIGNUM_C)
+#include "mbedtls/bignum.h"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdlib.h>
+#define mbedtls_calloc    calloc
+#define mbedtls_free       free
+#endif
+
+#define MBEDTLS_MPI_TAG_MAX_LEN 4096
+
+/*
+ * ASN.1 DER decoding routines
+ */
+
+int mbedtls_asn1_get_len( unsigned char **p,
+                  const unsigned char *end,
+                  size_t *len )
+{
+    if( ( end - *p ) < 1 )
+        return( MBEDTLS_ERR_ASN1_OUT_OF_DATA );
+
+    if( ( **p & 0x80 ) == 0 )
+        *len = *(*p)++;
+    else
+    {
+        switch( **p & 0x7F )
+        {
+        case 1:
+            if( ( end - *p ) < 2 )
+                return( MBEDTLS_ERR_ASN1_OUT_OF_DATA );
+
+            *len = (*p)[1];
+            (*p) += 2;
+            break;
+
+        case 2:
+            if( ( end - *p ) < 3 )
+                return( MBEDTLS_ERR_ASN1_OUT_OF_DATA );
+
+            *len = ( (size_t)(*p)[1] << 8 ) | (*p)[2];
+            (*p) += 3;
+            break;
+
+        case 3:
+            if( ( end - *p ) < 4 )
+                return( MBEDTLS_ERR_ASN1_OUT_OF_DATA );
+
+            *len = ( (size_t)(*p)[1] << 16 ) |
+                   ( (size_t)(*p)[2] << 8  ) | (*p)[3];
+            (*p) += 4;
+            break;
+
+        case 4:
+            if( ( end - *p ) < 5 )
+                return( MBEDTLS_ERR_ASN1_OUT_OF_DATA );
+
+            *len = ( (size_t)(*p)[1] << 24 ) | ( (size_t)(*p)[2] << 16 ) |
+                   ( (size_t)(*p)[3] << 8  ) |           (*p)[4];
+            (*p) += 5;
+            break;
+
+        default:
+            return( MBEDTLS_ERR_ASN1_INVALID_LENGTH );
+        }
+    }
+
+    if( *len > (size_t) ( end - *p ) )
+        return( MBEDTLS_ERR_ASN1_OUT_OF_DATA );
+
+    return( 0 );
+}
+
+int mbedtls_asn1_get_tag( unsigned char **p,
+                  const unsigned char *end,
+                  size_t *len, int tag )
+{
+    if( ( end - *p ) < 1 )
+        return( MBEDTLS_ERR_ASN1_OUT_OF_DATA );
+
+    if( **p != tag )
+        return( MBEDTLS_ERR_ASN1_UNEXPECTED_TAG );
+
+    (*p)++;
+
+    return( mbedtls_asn1_get_len( p, end, len ) );
+}
+
+#if defined(MBEDTLS_HI_NO_CUT)
+int mbedtls_asn1_get_bool( unsigned char **p,
+                   const unsigned char *end,
+                   int *val )
+{
+    int ret;
+    size_t len;
+
+    if( ( ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_BOOLEAN ) ) != 0 )
+        return( ret );
+
+    if( len != 1 )
+        return( MBEDTLS_ERR_ASN1_INVALID_LENGTH );
+
+    *val = ( **p != 0 ) ? 1 : 0;
+    (*p)++;
+
+    return( 0 );
+}
+
+int mbedtls_asn1_get_int( unsigned char **p,
+                  const unsigned char *end,
+                  int *val )
+{
+    int ret;
+    size_t len;
+
+    if( ( ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_INTEGER ) ) != 0 )
+        return( ret );
+
+    if( len == 0 || len > sizeof( int ) || ( **p & 0x80 ) != 0 )
+        return( MBEDTLS_ERR_ASN1_INVALID_LENGTH );
+
+    *val = 0;
+
+    while( len-- > 0 )
+    {
+        *val = ( *val << 8 ) | **p;
+        (*p)++;
+    }
+
+    return( 0 );
+}
+
+#if defined(MBEDTLS_BIGNUM_C)
+int mbedtls_asn1_get_mpi( unsigned char **p,
+                  const unsigned char *end,
+                  mbedtls_mpi *X )
+{
+    int ret;
+    size_t len;
+
+    if( ( ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_INTEGER ) ) != 0 )
+        return( ret );
+
+    if(MBEDTLS_MPI_TAG_MAX_LEN < len)
+    {
+        return MBEDTLS_ERR_ASN1_INVALID_LENGTH;
+    }
+
+    ret = mbedtls_mpi_read_binary( X, *p, len );
+
+    *p += len;
+
+    return( ret );
+}
+#endif /* MBEDTLS_BIGNUM_C */
+
+int mbedtls_asn1_get_bitstring( unsigned char **p, const unsigned char *end,
+                        mbedtls_asn1_bitstring *bs)
+{
+    int ret;
+
+    /* Certificate type is a single byte bitstring */
+    if( ( ret = mbedtls_asn1_get_tag( p, end, &bs->len, MBEDTLS_ASN1_BIT_STRING ) ) != 0 )
+        return( ret );
+
+    /* Check length, subtract one for actual bit string length */
+    if( bs->len < 1 )
+        return( MBEDTLS_ERR_ASN1_OUT_OF_DATA );
+    bs->len -= 1;
+
+    /* Get number of unused bits, ensure unused bits <= 7 */
+    bs->unused_bits = **p;
+    if( bs->unused_bits > 7 )
+        return( MBEDTLS_ERR_ASN1_INVALID_LENGTH );
+    (*p)++;
+
+    /* Get actual bitstring */
+    bs->p = *p;
+    *p += bs->len;
+
+    if( *p != end )
+        return( MBEDTLS_ERR_ASN1_LENGTH_MISMATCH );
+
+    return( 0 );
+}
+
+/*
+ * Get a bit string without unused bits
+ */
+int mbedtls_asn1_get_bitstring_null( unsigned char **p, const unsigned char *end,
+                             size_t *len )
+{
+    int ret;
+
+    if( ( ret = mbedtls_asn1_get_tag( p, end, len, MBEDTLS_ASN1_BIT_STRING ) ) != 0 )
+        return( ret );
+
+    if( (*len)-- < 2 || *(*p)++ != 0 )
+        return( MBEDTLS_ERR_ASN1_INVALID_DATA );
+
+    return( 0 );
+}
+
+
+
+/*
+ *  Parses and splits an ASN.1 "SEQUENCE OF <tag>"
+ */
+int mbedtls_asn1_get_sequence_of( unsigned char **p,
+                          const unsigned char *end,
+                          mbedtls_asn1_sequence *cur,
+                          int tag)
+{
+    int ret;
+    size_t len;
+    mbedtls_asn1_buf *buf;
+
+    /* Get main sequence tag */
+    if( ( ret = mbedtls_asn1_get_tag( p, end, &len,
+            MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE ) ) != 0 )
+        return( ret );
+
+    if( *p + len != end )
+        return( MBEDTLS_ERR_ASN1_LENGTH_MISMATCH );
+
+    while( *p < end )
+    {
+        buf = &(cur->buf);
+        buf->tag = **p;
+
+        if( ( ret = mbedtls_asn1_get_tag( p, end, &buf->len, tag ) ) != 0 )
+            return( ret );
+
+        buf->p = *p;
+        *p += buf->len;
+
+        /* Allocate and assign next pointer */
+        if( *p < end )
+        {
+            cur->next = (mbedtls_asn1_sequence*)mbedtls_calloc( 1,
+                                            sizeof( mbedtls_asn1_sequence ) );
+
+            if( cur->next == NULL )
+                return( MBEDTLS_ERR_ASN1_ALLOC_FAILED );
+
+            cur = cur->next;
+        }
+    }
+
+    /* Set final sequence entry's next pointer to NULL */
+    cur->next = NULL;
+
+    if( *p != end )
+        return( MBEDTLS_ERR_ASN1_LENGTH_MISMATCH );
+
+    return( 0 );
+}
+
+int mbedtls_asn1_get_alg( unsigned char **p,
+                  const unsigned char *end,
+                  mbedtls_asn1_buf *alg, mbedtls_asn1_buf *params )
+{
+    int ret;
+    size_t len;
+
+    if( ( ret = mbedtls_asn1_get_tag( p, end, &len,
+            MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE ) ) != 0 )
+        return( ret );
+
+    if( ( end - *p ) < 1 )
+        return( MBEDTLS_ERR_ASN1_OUT_OF_DATA );
+
+    alg->tag = **p;
+    end = *p + len;
+
+    if( ( ret = mbedtls_asn1_get_tag( p, end, &alg->len, MBEDTLS_ASN1_OID ) ) != 0 )
+        return( ret );
+
+    alg->p = *p;
+    *p += alg->len;
+
+    if( *p == end )
+    {
+        mbedtls_platform_zeroize( params, sizeof(mbedtls_asn1_buf) );
+        return( 0 );
+    }
+
+    params->tag = **p;
+    (*p)++;
+
+    if( ( ret = mbedtls_asn1_get_len( p, end, &params->len ) ) != 0 )
+        return( ret );
+
+    params->p = *p;
+    *p += params->len;
+
+    if( *p != end )
+        return( MBEDTLS_ERR_ASN1_LENGTH_MISMATCH );
+
+    return( 0 );
+}
+
+int mbedtls_asn1_get_alg_null( unsigned char **p,
+                       const unsigned char *end,
+                       mbedtls_asn1_buf *alg )
+{
+    int ret;
+    mbedtls_asn1_buf params;
+
+    memset( &params, 0, sizeof(mbedtls_asn1_buf) );
+
+    if( ( ret = mbedtls_asn1_get_alg( p, end, alg, &params ) ) != 0 )
+        return( ret );
+
+    if( ( params.tag != MBEDTLS_ASN1_NULL && params.tag != 0 ) || params.len != 0 )
+        return( MBEDTLS_ERR_ASN1_INVALID_DATA );
+
+    return( 0 );
+}
+
+void mbedtls_asn1_free_named_data( mbedtls_asn1_named_data *cur )
+{
+    if( cur == NULL )
+        return;
+
+    mbedtls_free( cur->oid.p );
+    cur->oid.p = NULL;
+    mbedtls_free( cur->val.p );
+    cur->val.p = NULL;
+
+    mbedtls_platform_zeroize( cur, sizeof( mbedtls_asn1_named_data ) );
+}
+
+void mbedtls_asn1_free_named_data_list( mbedtls_asn1_named_data **head )
+{
+    mbedtls_asn1_named_data *cur;
+
+    while( ( cur = *head ) != NULL )
+    {
+        *head = cur->next;
+        mbedtls_asn1_free_named_data( cur );
+        mbedtls_free( cur );
+        cur = NULL;
+    }
+}
+
+mbedtls_asn1_named_data *mbedtls_asn1_find_named_data( mbedtls_asn1_named_data *list,
+                                       const char *oid, size_t len )
+{
+    while( list != NULL )
+    {
+        if( list->oid.len == len &&
+            memcmp( list->oid.p, oid, len ) == 0 )
+        {
+            break;
+        }
+
+        list = list->next;
+    }
+
+    return( list );
+}
+#endif
+#endif /* MBEDTLS_ASN1_PARSE_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/bignum.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/bignum.c
@@ -1,0 +1,2670 @@
+/*
+ *  Multi-precision integer library
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+/*
+ *  The following sources were referenced in the design of this Multi-precision
+ *  Integer library:
+ *
+ *  [1] Handbook of Applied Cryptography - 1997
+ *      Menezes, van Oorschot and Vanstone
+ *
+ *  [2] Multi-Precision Math
+ *      Tom St Denis
+ *      https://github.com/libtom/libtommath/blob/develop/tommath.pdf
+ *
+ *  [3] GNU Multi-Precision Arithmetic Library
+ *      https://gmplib.org/manual/index.html
+ *
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_BIGNUM_C)
+
+#include "mbedtls/bignum.h"
+#include "mbedtls/bn_mul.h"
+#include "mbedtls/platform_util.h"
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#define mbedtls_printf     printf
+#define mbedtls_calloc    calloc
+#define mbedtls_free       free
+#endif
+
+#define MPI_VALIDATE_RET( cond )                                       \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_MPI_BAD_INPUT_DATA )
+#define MPI_VALIDATE( cond )                                           \
+    MBEDTLS_INTERNAL_VALIDATE( cond )
+
+#define ciL    (sizeof(mbedtls_mpi_uint))         /* chars in limb  */
+#define biL    (ciL << 3)               /* bits  in limb  */
+#define biH    (ciL << 2)               /* half limb size */
+
+#define MPI_SIZE_T_MAX  ( (size_t) -1 ) /* SIZE_T_MAX is not standard */
+
+/*
+ * Convert between bits/chars and number of limbs
+ * Divide first in order to avoid potential overflows
+ */
+#define BITS_TO_LIMBS(i)  ( (i) / biL + ( (i) % biL != 0 ) )
+#define CHARS_TO_LIMBS(i) ( (i) / ciL + ( (i) % ciL != 0 ) )
+
+/* Implementation that should never be optimized out by the compiler */
+static void mbedtls_mpi_zeroize( mbedtls_mpi_uint *v, size_t n )
+{
+    mbedtls_platform_zeroize( v, ciL * n );
+}
+
+/*
+ * Initialize one MPI
+ */
+void mbedtls_mpi_init( mbedtls_mpi *X )
+{
+    MPI_VALIDATE( X != NULL );
+
+    X->s = 1;
+    X->n = 0;
+    X->p = NULL;
+}
+
+/*
+ * Unallocate one MPI
+ */
+void mbedtls_mpi_free( mbedtls_mpi *X )
+{
+    if( X == NULL )
+        return;
+
+    if( X->p != NULL )
+    {
+        mbedtls_mpi_zeroize( X->p, X->n );
+        mbedtls_free( X->p );
+    }
+
+    X->s = 1;
+    X->n = 0;
+    X->p = NULL;
+}
+
+/*
+ * Enlarge to the specified number of limbs
+ */
+int mbedtls_mpi_grow( mbedtls_mpi *X, size_t nblimbs )
+{
+    mbedtls_mpi_uint *p;
+    MPI_VALIDATE_RET( X != NULL );
+
+    if( nblimbs > MBEDTLS_MPI_MAX_LIMBS )
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+
+    if( X->n < nblimbs )
+    {
+        if( ( p = (mbedtls_mpi_uint*)mbedtls_calloc( nblimbs, ciL ) ) == NULL )
+            return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+
+        if( X->p != NULL )
+        {
+            memcpy( p, X->p, X->n * ciL );
+            mbedtls_mpi_zeroize( X->p, X->n );
+            mbedtls_free( X->p );
+        }
+
+        X->n = nblimbs;
+        X->p = p;
+    }
+
+    return( 0 );
+}
+
+#if defined(MBEDTLS_GENPRIME)
+/*
+ * Resize down as much as possible,
+ * while keeping at least the specified number of limbs
+ */
+int mbedtls_mpi_shrink( mbedtls_mpi *X, size_t nblimbs )
+{
+    mbedtls_mpi_uint *p;
+    size_t i;
+    MPI_VALIDATE_RET( X != NULL );
+
+    if( nblimbs > MBEDTLS_MPI_MAX_LIMBS )
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+
+    /* Actually resize up in this case */
+    if( X->n <= nblimbs )
+        return( mbedtls_mpi_grow( X, nblimbs ) );
+
+    for( i = X->n - 1; i > 0; i-- )
+        if( X->p[i] != 0 )
+            break;
+    i++;
+
+    if( i < nblimbs )
+        i = nblimbs;
+
+    if( ( p = (mbedtls_mpi_uint*)mbedtls_calloc( i, ciL ) ) == NULL )
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+
+    if( X->p != NULL )
+    {
+        memcpy( p, X->p, i * ciL );
+        mbedtls_mpi_zeroize( X->p, X->n );
+        mbedtls_free( X->p );
+    }
+
+    X->n = i;
+    X->p = p;
+
+    return( 0 );
+}
+#endif
+
+/*
+ * Copy the contents of Y into X
+ */
+int mbedtls_mpi_copy( mbedtls_mpi *X, const mbedtls_mpi *Y )
+{
+    int ret = 0;
+    size_t i;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( Y != NULL );
+
+    if( X == Y )
+        return( 0 );
+
+    if( Y->p == NULL )
+    {
+        mbedtls_mpi_free( X );
+        return( 0 );
+    }
+
+    for( i = Y->n - 1; i > 0; i-- )
+        if( Y->p[i] != 0 )
+            break;
+    i++;
+
+    X->s = Y->s;
+
+    if( X->n < i )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, i ) );
+    }
+    else
+    {
+        memset( X->p + i, 0, ( X->n - i ) * ciL );
+    }
+
+    memcpy( X->p, Y->p, i * ciL );
+
+cleanup:
+
+    return( ret );
+}
+
+#if defined(MBEDTLS_GENPRIME)
+/*
+ * Swap the contents of X and Y
+ */
+void mbedtls_mpi_swap( mbedtls_mpi *X, mbedtls_mpi *Y )
+{
+    mbedtls_mpi T;
+    MPI_VALIDATE( X != NULL );
+    MPI_VALIDATE( Y != NULL );
+
+    memcpy( &T,  X, sizeof( mbedtls_mpi ) );
+    memcpy(  X,  Y, sizeof( mbedtls_mpi ) );
+    memcpy(  Y, &T, sizeof( mbedtls_mpi ) );
+}
+
+/*
+ * Conditionally assign X = Y, without leaking information
+ * about whether the assignment was made or not.
+ * (Leaking information about the respective sizes of X and Y is ok however.)
+ */
+int mbedtls_mpi_safe_cond_assign( mbedtls_mpi *X, const mbedtls_mpi *Y, unsigned char assign )
+{
+    int ret = 0;
+    size_t i;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( Y != NULL );
+
+    /* make sure assign is 0 or 1 in a time-constant manner */
+    assign = (assign | (unsigned char)-assign) >> 7;
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, Y->n ) );
+
+    X->s = X->s * ( 1 - assign ) + Y->s * assign;
+
+    for( i = 0; i < Y->n; i++ )
+        X->p[i] = X->p[i] * ( 1 - assign ) + Y->p[i] * assign;
+
+    for( ; i < X->n; i++ )
+        X->p[i] *= ( 1 - assign );
+
+cleanup:
+    return( ret );
+}
+#endif
+
+#if defined(MBEDTLS_HI_NO_CUT)
+/*
+ * Conditionally swap X and Y, without leaking information
+ * about whether the swap was made or not.
+ * Here it is not ok to simply swap the pointers, which whould lead to
+ * different memory access patterns when X and Y are used afterwards.
+ */
+int mbedtls_mpi_safe_cond_swap( mbedtls_mpi *X, mbedtls_mpi *Y, unsigned char swap )
+{
+    int ret, s;
+    size_t i;
+    mbedtls_mpi_uint tmp;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( Y != NULL );
+
+    if( X == Y )
+        return( 0 );
+
+    /* make sure swap is 0 or 1 in a time-constant manner */
+    swap = (swap | (unsigned char)-swap) >> 7;
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, Y->n ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( Y, X->n ) );
+
+    s = X->s;
+    X->s = X->s * ( 1 - swap ) + Y->s * swap;
+    Y->s = Y->s * ( 1 - swap ) +    s * swap;
+
+
+    for( i = 0; i < X->n; i++ )
+    {
+        tmp = X->p[i];
+        X->p[i] = X->p[i] * ( 1 - swap ) + Y->p[i] * swap;
+        Y->p[i] = Y->p[i] * ( 1 - swap ) +     tmp * swap;
+    }
+
+cleanup:
+    return( ret );
+}
+#endif
+
+/*
+ * Set value from integer
+ */
+int mbedtls_mpi_lset( mbedtls_mpi *X, mbedtls_mpi_sint z )
+{
+    int ret;
+    MPI_VALIDATE_RET( X != NULL );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, 1 ) );
+    memset( X->p, 0, X->n * ciL );
+
+    X->p[0] = ( z < 0 ) ? -z : z;
+    X->s    = ( z < 0 ) ? -1 : 1;
+
+cleanup:
+
+    return( ret );
+}
+
+/*
+ * Get a specific bit
+ */
+int mbedtls_mpi_get_bit( const mbedtls_mpi *X, size_t pos )
+{
+    MPI_VALIDATE_RET( X != NULL );
+
+    if( X->n * biL <= pos )
+        return( 0 );
+
+    return( ( X->p[pos / biL] >> ( pos % biL ) ) & 0x01 );
+}
+
+/* Get a specific byte, without range checks. */
+#define GET_BYTE( X, i )                                \
+    ( ( ( X )->p[( i ) / ciL] >> ( ( ( i ) % ciL ) * 8 ) ) & 0xff )
+
+/*
+ * Set a bit to a specific value of 0 or 1
+ */
+int mbedtls_mpi_set_bit( mbedtls_mpi *X, size_t pos, unsigned char val )
+{
+    int ret = 0;
+    size_t off = pos / biL;
+    size_t idx = pos % biL;
+    MPI_VALIDATE_RET( X != NULL );
+
+    if( val != 0 && val != 1 )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    if( X->n * biL <= pos )
+    {
+        if( val == 0 )
+            return( 0 );
+
+        MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, off + 1 ) );
+    }
+
+    X->p[off] &= ~( (mbedtls_mpi_uint) 0x01 << idx );
+    X->p[off] |= (mbedtls_mpi_uint) val << idx;
+
+cleanup:
+
+    return( ret );
+}
+
+/*
+ * Return the number of less significant zero-bits
+ */
+size_t mbedtls_mpi_lsb( const mbedtls_mpi *X )
+{
+    size_t i, j, count = 0;
+    MBEDTLS_INTERNAL_VALIDATE_RET( X != NULL, 0 );
+
+    for( i = 0; i < X->n; i++ )
+        for( j = 0; j < biL; j++, count++ )
+            if( ( ( X->p[i] >> j ) & 1 ) != 0 )
+                return( count );
+
+    return( 0 );
+}
+
+/*
+ * Count leading zero bits in a given integer
+ */
+static size_t mbedtls_clz( const mbedtls_mpi_uint x )
+{
+    size_t j;
+    mbedtls_mpi_uint mask = (mbedtls_mpi_uint) 1 << (biL - 1);
+
+    for( j = 0; j < biL; j++ )
+    {
+        if( x & mask ) break;
+
+        mask >>= 1;
+    }
+
+    return j;
+}
+
+/*
+ * Return the number of bits
+ */
+size_t mbedtls_mpi_bitlen( const mbedtls_mpi *X )
+{
+    size_t i, j;
+
+    if( X->n == 0 )
+        return( 0 );
+
+    for( i = X->n - 1; i > 0; i-- )
+        if( X->p[i] != 0 )
+            break;
+
+    j = biL - mbedtls_clz( X->p[i] );
+
+    return( ( i * biL ) + j );
+}
+
+/*
+ * Return the total size in bytes
+ */
+size_t mbedtls_mpi_size( const mbedtls_mpi *X )
+{
+    return( ( mbedtls_mpi_bitlen( X ) + 7 ) >> 3 );
+}
+
+/*
+ * Convert an ASCII character to digit value
+ */
+static int mpi_get_digit( mbedtls_mpi_uint *d, int radix, char c )
+{
+    *d = 255;
+
+    if( c >= 0x30 && c <= 0x39 ) *d = c - 0x30;
+    if( c >= 0x41 && c <= 0x46 ) *d = c - 0x37;
+    if( c >= 0x61 && c <= 0x66 ) *d = c - 0x57;
+
+    if( *d >= (mbedtls_mpi_uint) radix )
+        return( MBEDTLS_ERR_MPI_INVALID_CHARACTER );
+
+    return( 0 );
+}
+
+/*
+ * Import from an ASCII string
+ */
+int mbedtls_mpi_read_string( mbedtls_mpi *X, int radix, const char *s )
+{
+    int ret;
+    size_t i, j, slen, n;
+    mbedtls_mpi_uint d;
+    mbedtls_mpi T;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( s != NULL );
+
+    if( radix < 2 || radix > 16 )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    mbedtls_mpi_init( &T );
+
+    slen = strlen( s );
+
+    if( radix == 16 )
+    {
+        if( slen > MPI_SIZE_T_MAX >> 2 )
+            return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+        n = BITS_TO_LIMBS( slen << 2 );
+
+        MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, n ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_lset( X, 0 ) );
+
+        for( i = slen, j = 0; i > 0; i--, j++ )
+        {
+            if( i == 1 && s[i - 1] == '-' )
+            {
+                X->s = -1;
+                break;
+            }
+
+            MBEDTLS_MPI_CHK( mpi_get_digit( &d, radix, s[i - 1] ) );
+            X->p[j / ( 2 * ciL )] |= d << ( ( j % ( 2 * ciL ) ) << 2 );
+        }
+    }
+    else
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_lset( X, 0 ) );
+
+        for( i = 0; i < slen; i++ )
+        {
+            if( i == 0 && s[i] == '-' )
+            {
+                X->s = -1;
+                continue;
+            }
+
+            MBEDTLS_MPI_CHK( mpi_get_digit( &d, radix, s[i] ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_mul_int( &T, X, radix ) );
+
+            if( X->s == 1 )
+            {
+                MBEDTLS_MPI_CHK( mbedtls_mpi_add_int( X, &T, d ) );
+            }
+            else
+            {
+                MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( X, &T, d ) );
+            }
+        }
+    }
+
+cleanup:
+
+    mbedtls_mpi_free( &T );
+
+    return( ret );
+}
+
+#if defined(MBEDTLS_HI_NO_CUT)
+/*
+ * Helper to write the digits high-order first
+ */
+static int mpi_write_hlp( mbedtls_mpi *X, int radix, char **p )
+{
+    int ret;
+    mbedtls_mpi_uint r;
+
+    if( radix < 2 || radix > 16 )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mod_int( &r, X, radix ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_div_int( X, NULL, X, radix ) );
+
+    if( mbedtls_mpi_cmp_int( X, 0 ) != 0 )
+        MBEDTLS_MPI_CHK( mpi_write_hlp( X, radix, p ) );
+
+    if( r < 10 )
+        *(*p)++ = (char)( r + 0x30 );
+    else
+        *(*p)++ = (char)( r + 0x37 );
+
+cleanup:
+
+    return( ret );
+}
+
+/*
+ * Export into an ASCII string
+ */
+int mbedtls_mpi_write_string( const mbedtls_mpi *X, int radix,
+                              char *buf, size_t buflen, size_t *olen )
+{
+    int ret = 0;
+    size_t n;
+    char *p;
+    mbedtls_mpi T;
+    MPI_VALIDATE_RET( X    != NULL );
+    MPI_VALIDATE_RET( olen != NULL );
+    MPI_VALIDATE_RET( buflen == 0 || buf != NULL );
+
+    if( radix < 2 || radix > 16 )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    n = mbedtls_mpi_bitlen( X );
+    if( radix >=  4 ) n >>= 1;
+    if( radix >= 16 ) n >>= 1;
+    /*
+     * Round up the buffer length to an even value to ensure that there is
+     * enough room for hexadecimal values that can be represented in an odd
+     * number of digits.
+     */
+    n += 3 + ( ( n + 1 ) & 1 );
+
+    if( buflen < n )
+    {
+        *olen = n;
+        return( MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL );
+    }
+
+    p = buf;
+    mbedtls_mpi_init( &T );
+
+    if( X->s == -1 )
+        *p++ = '-';
+
+    if( radix == 16 )
+    {
+        int c;
+        size_t i, j, k;
+
+        for( i = X->n, k = 0; i > 0; i-- )
+        {
+            for( j = ciL; j > 0; j-- )
+            {
+                c = ( X->p[i - 1] >> ( ( j - 1 ) << 3) ) & 0xFF;
+
+                if( c == 0 && k == 0 && ( i + j ) != 2 )
+                    continue;
+
+                *(p++) = "0123456789ABCDEF" [c / 16];
+                *(p++) = "0123456789ABCDEF" [c % 16];
+                k = 1;
+            }
+        }
+    }
+    else
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &T, X ) );
+
+        if( T.s == -1 )
+            T.s = 1;
+
+        MBEDTLS_MPI_CHK( mpi_write_hlp( &T, radix, &p ) );
+    }
+
+    *p++ = '\0';
+    *olen = p - buf;
+
+cleanup:
+
+    mbedtls_mpi_free( &T );
+
+    return( ret );
+}
+#endif
+
+#if defined(MBEDTLS_FS_IO)
+/*
+ * Read X from an opened file
+ */
+int mbedtls_mpi_read_file( mbedtls_mpi *X, int radix, FILE *fin )
+{
+    mbedtls_mpi_uint d;
+    size_t slen;
+    char *p;
+    /*
+     * Buffer should have space for (short) label and decimal formatted MPI,
+     * newline characters and '\0'
+     */
+    char s[ MBEDTLS_MPI_RW_BUFFER_SIZE ];
+
+    MPI_VALIDATE_RET( X   != NULL );
+    MPI_VALIDATE_RET( fin != NULL );
+
+    if( radix < 2 || radix > 16 )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    memset( s, 0, sizeof( s ) );
+    if( fgets( s, sizeof( s ) - 1, fin ) == NULL )
+        return( MBEDTLS_ERR_MPI_FILE_IO_ERROR );
+
+    slen = strlen( s );
+    if( slen == sizeof( s ) - 2 )
+        return( MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL );
+
+    if( slen > 0 && s[slen - 1] == '\n' ) { slen--; s[slen] = '\0'; }
+    if( slen > 0 && s[slen - 1] == '\r' ) { slen--; s[slen] = '\0'; }
+
+    p = s + slen;
+    while( p-- > s )
+        if( mpi_get_digit( &d, radix, *p ) != 0 )
+            break;
+
+    return( mbedtls_mpi_read_string( X, radix, p + 1 ) );
+}
+
+/*
+ * Write X into an opened file (or stdout if fout == NULL)
+ */
+int mbedtls_mpi_write_file( const char *p, const mbedtls_mpi *X, int radix, FILE *fout )
+{
+    int ret;
+    size_t n, slen, plen;
+    /*
+     * Buffer should have space for (short) label and decimal formatted MPI,
+     * newline characters and '\0'
+     */
+    char s[ MBEDTLS_MPI_RW_BUFFER_SIZE ];
+    MPI_VALIDATE_RET( X != NULL );
+
+    if( radix < 2 || radix > 16 )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    memset( s, 0, sizeof( s ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_write_string( X, radix, s, sizeof( s ) - 2, &n ) );
+
+    if( p == NULL ) p = "";
+
+    plen = strlen( p );
+    slen = strlen( s );
+    s[slen++] = '\r';
+    s[slen++] = '\n';
+
+    if( fout != NULL )
+    {
+        if( fwrite( p, 1, plen, fout ) != plen ||
+            fwrite( s, 1, slen, fout ) != slen )
+            return( MBEDTLS_ERR_MPI_FILE_IO_ERROR );
+    }
+    else
+        mbedtls_printf( "%s%s", p, s );
+
+cleanup:
+
+    return( ret );
+}
+#endif /* MBEDTLS_FS_IO */
+
+/*
+ * Import X from unsigned binary data, big endian
+ */
+int mbedtls_mpi_read_binary( mbedtls_mpi *X, const unsigned char *buf, size_t buflen )
+{
+    int ret;
+    size_t i, j;
+    size_t const limbs = CHARS_TO_LIMBS( buflen );
+
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( buflen == 0 || buf != NULL );
+
+    /* Ensure that target MPI has exactly the necessary number of limbs */
+    if( X->n != limbs )
+    {
+        mbedtls_mpi_free( X );
+        mbedtls_mpi_init( X );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, limbs ) );
+    }
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_lset( X, 0 ) );
+
+    for( i = buflen, j = 0; i > 0; i--, j++ )
+        X->p[j / ciL] |= ((mbedtls_mpi_uint) buf[i - 1]) << ((j % ciL) << 3);
+
+cleanup:
+
+    return( ret );
+}
+
+/*
+ * Export X into unsigned binary data, big endian
+ */
+int mbedtls_mpi_write_binary( const mbedtls_mpi *X,
+                              unsigned char *buf, size_t buflen )
+{
+    size_t stored_bytes;
+    size_t bytes_to_copy;
+    unsigned char *p;
+    size_t i;
+
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( buflen == 0 || buf != NULL );
+
+    stored_bytes = X->n * ciL;
+
+    if( stored_bytes < buflen )
+    {
+        /* There is enough space in the output buffer. Write initial
+         * null bytes and record the position at which to start
+         * writing the significant bytes. In this case, the execution
+         * trace of this function does not depend on the value of the
+         * number. */
+        bytes_to_copy = stored_bytes;
+        p = buf + buflen - stored_bytes;
+        memset( buf, 0, buflen - stored_bytes );
+    }
+    else
+    {
+        /* The output buffer is smaller than the allocated size of X.
+         * However X may fit if its leading bytes are zero. */
+        bytes_to_copy = buflen;
+        p = buf;
+        for( i = bytes_to_copy; i < stored_bytes; i++ )
+        {
+            if( GET_BYTE( X, i ) != 0 )
+                return( MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL );
+        }
+    }
+
+    for( i = 0; i < bytes_to_copy; i++ )
+        p[bytes_to_copy - i - 1] = GET_BYTE( X, i );
+
+    return( 0 );
+}
+
+/*
+ * Left-shift: X <<= count
+ */
+int mbedtls_mpi_shift_l( mbedtls_mpi *X, size_t count )
+{
+    int ret;
+    size_t i, v0, t1;
+    mbedtls_mpi_uint r0 = 0, r1;
+    MPI_VALIDATE_RET( X != NULL );
+
+    v0 = count / (biL    );
+    t1 = count & (biL - 1);
+
+    i = mbedtls_mpi_bitlen( X ) + count;
+
+    if( X->n * biL < i )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, BITS_TO_LIMBS( i ) ) );
+
+    ret = 0;
+
+    /*
+     * shift by count / limb_size
+     */
+    if( v0 > 0 )
+    {
+        for( i = X->n; i > v0; i-- )
+            X->p[i - 1] = X->p[i - v0 - 1];
+
+        for( ; i > 0; i-- )
+            X->p[i - 1] = 0;
+    }
+
+    /*
+     * shift by count % limb_size
+     */
+    if( t1 > 0 )
+    {
+        for( i = v0; i < X->n; i++ )
+        {
+            r1 = X->p[i] >> (biL - t1);
+            X->p[i] <<= t1;
+            X->p[i] |= r0;
+            r0 = r1;
+        }
+    }
+
+cleanup:
+
+    return( ret );
+}
+
+/*
+ * Right-shift: X >>= count
+ */
+int mbedtls_mpi_shift_r( mbedtls_mpi *X, size_t count )
+{
+    size_t i, v0, v1;
+    mbedtls_mpi_uint r0 = 0, r1;
+    MPI_VALIDATE_RET( X != NULL );
+
+    v0 = count /  biL;
+    v1 = count & (biL - 1);
+
+    if( v0 > X->n || ( v0 == X->n && v1 > 0 ) )
+        return mbedtls_mpi_lset( X, 0 );
+
+    /*
+     * shift by count / limb_size
+     */
+    if( v0 > 0 )
+    {
+        for( i = 0; i < X->n - v0; i++ )
+            X->p[i] = X->p[i + v0];
+
+        for( ; i < X->n; i++ )
+            X->p[i] = 0;
+    }
+
+    /*
+     * shift by count % limb_size
+     */
+    if( v1 > 0 )
+    {
+        for( i = X->n; i > 0; i-- )
+        {
+            r1 = X->p[i - 1] << (biL - v1);
+            X->p[i - 1] >>= v1;
+            X->p[i - 1] |= r0;
+            r0 = r1;
+        }
+    }
+
+    return( 0 );
+}
+
+/*
+ * Compare unsigned values
+ */
+int mbedtls_mpi_cmp_abs( const mbedtls_mpi *X, const mbedtls_mpi *Y )
+{
+    size_t i, j;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( Y != NULL );
+
+    for( i = X->n; i > 0; i-- )
+        if( X->p[i - 1] != 0 )
+            break;
+
+    for( j = Y->n; j > 0; j-- )
+        if( Y->p[j - 1] != 0 )
+            break;
+
+    if( i == 0 && j == 0 )
+        return( 0 );
+
+    if( i > j ) return(  1 );
+    if( j > i ) return( -1 );
+
+    for( ; i > 0; i-- )
+    {
+        if( X->p[i - 1] > Y->p[i - 1] ) return(  1 );
+        if( X->p[i - 1] < Y->p[i - 1] ) return( -1 );
+    }
+
+    return( 0 );
+}
+
+/*
+ * Compare signed values
+ */
+int mbedtls_mpi_cmp_mpi( const mbedtls_mpi *X, const mbedtls_mpi *Y )
+{
+    size_t i, j;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( Y != NULL );
+
+    for( i = X->n; i > 0; i-- )
+        if( X->p[i - 1] != 0 )
+            break;
+
+    for( j = Y->n; j > 0; j-- )
+        if( Y->p[j - 1] != 0 )
+            break;
+
+    if( i == 0 && j == 0 )
+        return( 0 );
+
+    if( i > j ) return(  X->s );
+    if( j > i ) return( -Y->s );
+
+    if( X->s > 0 && Y->s < 0 ) return(  1 );
+    if( Y->s > 0 && X->s < 0 ) return( -1 );
+
+    for( ; i > 0; i-- )
+    {
+        if( X->p[i - 1] > Y->p[i - 1] ) return(  X->s );
+        if( X->p[i - 1] < Y->p[i - 1] ) return( -X->s );
+    }
+
+    return( 0 );
+}
+
+/*
+ * Compare signed values
+ */
+int mbedtls_mpi_cmp_int( const mbedtls_mpi *X, mbedtls_mpi_sint z )
+{
+    mbedtls_mpi Y;
+    mbedtls_mpi_uint p[1];
+    MPI_VALIDATE_RET( X != NULL );
+
+    *p  = ( z < 0 ) ? -z : z;
+    Y.s = ( z < 0 ) ? -1 : 1;
+    Y.n = 1;
+    Y.p = p;
+
+    return( mbedtls_mpi_cmp_mpi( X, &Y ) );
+}
+
+/*
+ * Unsigned addition: X = |A| + |B|  (HAC 14.7)
+ */
+int mbedtls_mpi_add_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
+{
+    int ret;
+    size_t i, j;
+    mbedtls_mpi_uint *o, *p, c, tmp;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+    MPI_VALIDATE_RET( B != NULL );
+
+    if( X == B )
+    {
+        const mbedtls_mpi *T = A; A = X; B = T;
+    }
+
+    if( X != A )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_copy( X, A ) );
+
+    /*
+     * X should always be positive as a result of unsigned additions.
+     */
+    X->s = 1;
+
+    for( j = B->n; j > 0; j-- )
+        if( B->p[j - 1] != 0 )
+            break;
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, j ) );
+
+    o = B->p; p = X->p; c = 0;
+
+    /*
+     * tmp is used because it might happen that p == o
+     */
+    for( i = 0; i < j; i++, o++, p++ )
+    {
+        tmp= *o;
+        *p +=  c; c  = ( *p <  c );
+        *p += tmp; c += ( *p < tmp );
+    }
+
+    while( c != 0 )
+    {
+        if( i >= X->n )
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, i + 1 ) );
+            p = X->p + i;
+        }
+
+        *p += c; c = ( *p < c ); i++; p++;
+    }
+
+cleanup:
+
+    return( ret );
+}
+
+/*
+ * Helper for mbedtls_mpi subtraction
+ */
+static void mpi_sub_hlp( size_t n, mbedtls_mpi_uint *s, mbedtls_mpi_uint *d )
+{
+    size_t i;
+    mbedtls_mpi_uint c, z;
+
+    for( i = c = 0; i < n; i++, s++, d++ )
+    {
+        z = ( *d <  c );     *d -=  c;
+        c = ( *d < *s ) + z; *d -= *s;
+    }
+
+    while( c != 0 )
+    {
+        z = ( *d < c ); *d -= c;
+        c = z; d++;
+    }
+}
+
+/*
+ * Unsigned subtraction: X = |A| - |B|  (HAC 14.9)
+ */
+int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
+{
+    mbedtls_mpi TB;
+    int ret;
+    size_t n;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+    MPI_VALIDATE_RET( B != NULL );
+
+    if( mbedtls_mpi_cmp_abs( A, B ) < 0 )
+        return( MBEDTLS_ERR_MPI_NEGATIVE_VALUE );
+
+    mbedtls_mpi_init( &TB );
+
+    if( X == B )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TB, B ) );
+        B = &TB;
+    }
+
+    if( X != A )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_copy( X, A ) );
+
+    /*
+     * X should always be positive as a result of unsigned subtractions.
+     */
+    X->s = 1;
+
+    ret = 0;
+
+    for( n = B->n; n > 0; n-- )
+        if( B->p[n - 1] != 0 )
+            break;
+
+    mpi_sub_hlp( n, B->p, X->p );
+
+cleanup:
+
+    mbedtls_mpi_free( &TB );
+
+    return( ret );
+}
+
+/*
+ * Signed addition: X = A + B
+ */
+int mbedtls_mpi_add_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
+{
+    int ret, s;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+    MPI_VALIDATE_RET( B != NULL );
+
+    s = A->s;
+    if( A->s * B->s < 0 )
+    {
+        if( mbedtls_mpi_cmp_abs( A, B ) >= 0 )
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( X, A, B ) );
+            X->s =  s;
+        }
+        else
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( X, B, A ) );
+            X->s = -s;
+        }
+    }
+    else
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_add_abs( X, A, B ) );
+        X->s = s;
+    }
+
+cleanup:
+
+    return( ret );
+}
+
+/*
+ * Signed subtraction: X = A - B
+ */
+int mbedtls_mpi_sub_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
+{
+    int ret, s;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+    MPI_VALIDATE_RET( B != NULL );
+
+    s = A->s;
+    if( A->s * B->s > 0 )
+    {
+        if( mbedtls_mpi_cmp_abs( A, B ) >= 0 )
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( X, A, B ) );
+            X->s =  s;
+        }
+        else
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( X, B, A ) );
+            X->s = -s;
+        }
+    }
+    else
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_add_abs( X, A, B ) );
+        X->s = s;
+    }
+
+cleanup:
+
+    return( ret );
+}
+
+/*
+ * Signed addition: X = A + b
+ */
+int mbedtls_mpi_add_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_sint b )
+{
+    mbedtls_mpi _B;
+    mbedtls_mpi_uint p[1];
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+
+    p[0] = ( b < 0 ) ? -b : b;
+    _B.s = ( b < 0 ) ? -1 : 1;
+    _B.n = 1;
+    _B.p = p;
+
+    return( mbedtls_mpi_add_mpi( X, A, &_B ) );
+}
+
+/*
+ * Signed subtraction: X = A - b
+ */
+int mbedtls_mpi_sub_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_sint b )
+{
+    mbedtls_mpi _B;
+    mbedtls_mpi_uint p[1];
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+
+    p[0] = ( b < 0 ) ? -b : b;
+    _B.s = ( b < 0 ) ? -1 : 1;
+    _B.n = 1;
+    _B.p = p;
+
+    return( mbedtls_mpi_sub_mpi( X, A, &_B ) );
+}
+
+/*
+ * Helper for mbedtls_mpi multiplication
+ */
+static
+#if defined(__APPLE__) && defined(__arm__)
+/*
+ * Apple LLVM version 4.2 (clang-425.0.24) (based on LLVM 3.2svn)
+ * appears to need this to prevent bad ARM code generation at -O3.
+ */
+__attribute__ ((noinline))
+#endif
+void mpi_mul_hlp( size_t i, mbedtls_mpi_uint *s, mbedtls_mpi_uint *d, mbedtls_mpi_uint b )
+{
+    mbedtls_mpi_uint c = 0, t = 0;
+
+#if defined(MULADDC_HUIT)
+    for( ; i >= 8; i -= 8 )
+    {
+        MULADDC_INIT
+        MULADDC_HUIT
+        MULADDC_STOP
+    }
+
+    for( ; i > 0; i-- )
+    {
+        MULADDC_INIT
+        MULADDC_CORE
+        MULADDC_STOP
+    }
+#else /* MULADDC_HUIT */
+    for( ; i >= 16; i -= 16 )
+    {
+        MULADDC_INIT
+        MULADDC_CORE   MULADDC_CORE
+        MULADDC_CORE   MULADDC_CORE
+        MULADDC_CORE   MULADDC_CORE
+        MULADDC_CORE   MULADDC_CORE
+
+        MULADDC_CORE   MULADDC_CORE
+        MULADDC_CORE   MULADDC_CORE
+        MULADDC_CORE   MULADDC_CORE
+        MULADDC_CORE   MULADDC_CORE
+        MULADDC_STOP
+    }
+
+    for( ; i >= 8; i -= 8 )
+    {
+        MULADDC_INIT
+        MULADDC_CORE   MULADDC_CORE
+        MULADDC_CORE   MULADDC_CORE
+
+        MULADDC_CORE   MULADDC_CORE
+        MULADDC_CORE   MULADDC_CORE
+        MULADDC_STOP
+    }
+
+    for( ; i > 0; i-- )
+    {
+        MULADDC_INIT
+        MULADDC_CORE
+        MULADDC_STOP
+    }
+#endif /* MULADDC_HUIT */
+
+    t++;
+
+    do {
+        *d += c; c = ( *d < c ); d++;
+    }
+    while( c != 0 );
+}
+
+/*
+ * Baseline multiplication: X = A * B  (HAC 14.12)
+ */
+int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
+{
+    int ret;
+    size_t i, j;
+    mbedtls_mpi TA, TB;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+    MPI_VALIDATE_RET( B != NULL );
+
+    mbedtls_mpi_init( &TA ); mbedtls_mpi_init( &TB );
+
+    if( X == A ) { MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TA, A ) ); A = &TA; }
+    if( X == B ) { MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TB, B ) ); B = &TB; }
+
+    for( i = A->n; i > 0; i-- )
+        if( A->p[i - 1] != 0 )
+            break;
+
+    for( j = B->n; j > 0; j-- )
+        if( B->p[j - 1] != 0 )
+            break;
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, i + j ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_lset( X, 0 ) );
+
+    for( ; j > 0; j-- )
+        mpi_mul_hlp( i, A->p, X->p + j - 1, B->p[j - 1] );
+
+    X->s = A->s * B->s;
+
+cleanup:
+
+    mbedtls_mpi_free( &TB ); mbedtls_mpi_free( &TA );
+
+    return( ret );
+}
+
+/*
+ * Baseline multiplication: X = A * b
+ */
+int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_uint b )
+{
+    mbedtls_mpi _B;
+    mbedtls_mpi_uint p[1];
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+
+    _B.s = 1;
+    _B.n = 1;
+    _B.p = p;
+    p[0] = b;
+
+    return( mbedtls_mpi_mul_mpi( X, A, &_B ) );
+}
+
+/*
+ * Unsigned integer divide - double mbedtls_mpi_uint dividend, u1/u0, and
+ * mbedtls_mpi_uint divisor, d
+ */
+static mbedtls_mpi_uint mbedtls_int_div_int( mbedtls_mpi_uint u1,
+            mbedtls_mpi_uint u0, mbedtls_mpi_uint d, mbedtls_mpi_uint *r )
+{
+#if defined(MBEDTLS_HAVE_UDBL)
+    mbedtls_t_udbl dividend, quotient;
+#else
+    const mbedtls_mpi_uint radix = (mbedtls_mpi_uint) 1 << biH;
+    const mbedtls_mpi_uint uint_halfword_mask = ( (mbedtls_mpi_uint) 1 << biH ) - 1;
+    mbedtls_mpi_uint d0, d1, q0, q1, rAX, r0, quotient;
+    mbedtls_mpi_uint u0_msw, u0_lsw;
+    size_t s;
+#endif
+
+    /*
+     * Check for overflow
+     */
+    if( 0 == d || u1 >= d )
+    {
+        if (r != NULL) *r = ~0;
+
+        return ( ~0 );
+    }
+
+#if defined(MBEDTLS_HAVE_UDBL)
+    dividend  = (mbedtls_t_udbl) u1 << biL;
+    dividend |= (mbedtls_t_udbl) u0;
+    quotient = dividend / d;
+    if( quotient > ( (mbedtls_t_udbl) 1 << biL ) - 1 )
+        quotient = ( (mbedtls_t_udbl) 1 << biL ) - 1;
+
+    if( r != NULL )
+        *r = (mbedtls_mpi_uint)( dividend - (quotient * d ) );
+
+    return (mbedtls_mpi_uint) quotient;
+#else
+
+    /*
+     * Algorithm D, Section 4.3.1 - The Art of Computer Programming
+     *   Vol. 2 - Seminumerical Algorithms, Knuth
+     */
+
+    /*
+     * Normalize the divisor, d, and dividend, u0, u1
+     */
+    s = mbedtls_clz( d );
+    d = d << s;
+
+    u1 = u1 << s;
+    u1 |= ( u0 >> ( biL - s ) ) & ( -(mbedtls_mpi_sint)s >> ( biL - 1 ) );
+    u0 =  u0 << s;
+
+    d1 = d >> biH;
+    d0 = d & uint_halfword_mask;
+
+    u0_msw = u0 >> biH;
+    u0_lsw = u0 & uint_halfword_mask;
+
+    /*
+     * Find the first quotient and remainder
+     */
+    q1 = u1 / d1;
+    r0 = u1 - d1 * q1;
+
+    while( q1 >= radix || ( q1 * d0 > radix * r0 + u0_msw ) )
+    {
+        q1 -= 1;
+        r0 += d1;
+
+        if ( r0 >= radix ) break;
+    }
+
+    rAX = ( u1 * radix ) + ( u0_msw - q1 * d );
+    q0 = rAX / d1;
+    r0 = rAX - q0 * d1;
+
+    while( q0 >= radix || ( q0 * d0 > radix * r0 + u0_lsw ) )
+    {
+        q0 -= 1;
+        r0 += d1;
+
+        if ( r0 >= radix ) break;
+    }
+
+    if (r != NULL)
+        *r = ( rAX * radix + u0_lsw - q0 * d ) >> s;
+
+    quotient = q1 * radix + q0;
+
+    return quotient;
+#endif
+}
+
+/*
+ * Division by mbedtls_mpi: A = Q * B + R  (HAC 14.20)
+ */
+int mbedtls_mpi_div_mpi( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
+                         const mbedtls_mpi *B )
+{
+    int ret;
+    size_t i, n, t, k;
+    mbedtls_mpi X, Y, Z, T1, T2;
+    MPI_VALIDATE_RET( A != NULL );
+    MPI_VALIDATE_RET( B != NULL );
+
+    if( mbedtls_mpi_cmp_int( B, 0 ) == 0 )
+        return( MBEDTLS_ERR_MPI_DIVISION_BY_ZERO );
+
+    mbedtls_mpi_init( &X ); mbedtls_mpi_init( &Y ); mbedtls_mpi_init( &Z );
+    mbedtls_mpi_init( &T1 ); mbedtls_mpi_init( &T2 );
+
+    if( mbedtls_mpi_cmp_abs( A, B ) < 0 )
+    {
+        if( Q != NULL ) MBEDTLS_MPI_CHK( mbedtls_mpi_lset( Q, 0 ) );
+        if( R != NULL ) MBEDTLS_MPI_CHK( mbedtls_mpi_copy( R, A ) );
+        return( 0 );
+    }
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &X, A ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &Y, B ) );
+    X.s = Y.s = 1;
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( &Z, A->n + 2 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &Z,  0 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( &T1, 2 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( &T2, 3 ) );
+
+    k = mbedtls_mpi_bitlen( &Y ) % biL;
+    if( k < biL - 1 )
+    {
+        k = biL - 1 - k;
+        MBEDTLS_MPI_CHK( mbedtls_mpi_shift_l( &X, k ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_shift_l( &Y, k ) );
+    }
+    else k = 0;
+
+    n = X.n - 1;
+    t = Y.n - 1;
+    MBEDTLS_MPI_CHK( mbedtls_mpi_shift_l( &Y, biL * ( n - t ) ) );
+
+    while( mbedtls_mpi_cmp_mpi( &X, &Y ) >= 0 )
+    {
+        Z.p[n - t]++;
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &X, &X, &Y ) );
+    }
+    MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &Y, biL * ( n - t ) ) );
+
+    for( i = n; i > t ; i-- )
+    {
+        if( X.p[i] >= Y.p[t] )
+            Z.p[i - t - 1] = ~0;
+        else
+        {
+            Z.p[i - t - 1] = mbedtls_int_div_int( X.p[i], X.p[i - 1],
+                                                            Y.p[t], NULL);
+        }
+
+        Z.p[i - t - 1]++;
+        do
+        {
+            Z.p[i - t - 1]--;
+
+            MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &T1, 0 ) );
+            T1.p[0] = ( t < 1 ) ? 0 : Y.p[t - 1];
+            T1.p[1] = Y.p[t];
+            MBEDTLS_MPI_CHK( mbedtls_mpi_mul_int( &T1, &T1, Z.p[i - t - 1] ) );
+
+            MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &T2, 0 ) );
+            T2.p[0] = ( i < 2 ) ? 0 : X.p[i - 2];
+            T2.p[1] = ( i < 1 ) ? 0 : X.p[i - 1];
+            T2.p[2] = X.p[i];
+        }
+        while( mbedtls_mpi_cmp_mpi( &T1, &T2 ) > 0 );
+
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_int( &T1, &Y, Z.p[i - t - 1] ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_shift_l( &T1,  biL * ( i - t - 1 ) ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &X, &X, &T1 ) );
+
+        if( mbedtls_mpi_cmp_int( &X, 0 ) < 0 )
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &T1, &Y ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_shift_l( &T1, biL * ( i - t - 1 ) ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &X, &X, &T1 ) );
+            Z.p[i - t - 1]--;
+        }
+    }
+
+    if( Q != NULL )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_copy( Q, &Z ) );
+        Q->s = A->s * B->s;
+    }
+
+    if( R != NULL )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &X, k ) );
+        X.s = A->s;
+        MBEDTLS_MPI_CHK( mbedtls_mpi_copy( R, &X ) );
+
+        if( mbedtls_mpi_cmp_int( R, 0 ) == 0 )
+            R->s = 1;
+    }
+
+cleanup:
+
+    mbedtls_mpi_free( &X ); mbedtls_mpi_free( &Y ); mbedtls_mpi_free( &Z );
+    mbedtls_mpi_free( &T1 ); mbedtls_mpi_free( &T2 );
+
+    return( ret );
+}
+
+#if defined(MBEDTLS_HI_NO_CUT)
+/*
+ * Division by int: A = Q * b + R
+ */
+int mbedtls_mpi_div_int( mbedtls_mpi *Q, mbedtls_mpi *R,
+                         const mbedtls_mpi *A,
+                         mbedtls_mpi_sint b )
+{
+    mbedtls_mpi _B;
+    mbedtls_mpi_uint p[1];
+    MPI_VALIDATE_RET( A != NULL );
+
+    p[0] = ( b < 0 ) ? -b : b;
+    _B.s = ( b < 0 ) ? -1 : 1;
+    _B.n = 1;
+    _B.p = p;
+
+    return( mbedtls_mpi_div_mpi( Q, R, A, &_B ) );
+}
+#endif
+
+/*
+ * Modulo: R = A mod B
+ */
+int mbedtls_mpi_mod_mpi( mbedtls_mpi *R, const mbedtls_mpi *A, const mbedtls_mpi *B )
+{
+    int ret;
+    MPI_VALIDATE_RET( R != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+    MPI_VALIDATE_RET( B != NULL );
+
+    if( mbedtls_mpi_cmp_int( B, 0 ) < 0 )
+        return( MBEDTLS_ERR_MPI_NEGATIVE_VALUE );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_div_mpi( NULL, R, A, B ) );
+
+    while( mbedtls_mpi_cmp_int( R, 0 ) < 0 )
+      MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( R, R, B ) );
+
+    while( mbedtls_mpi_cmp_mpi( R, B ) >= 0 )
+      MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( R, R, B ) );
+
+cleanup:
+
+    return( ret );
+}
+
+#if defined(MBEDTLS_GENPRIME)
+/*
+ * Modulo: r = A mod b
+ */
+int mbedtls_mpi_mod_int( mbedtls_mpi_uint *r, const mbedtls_mpi *A, mbedtls_mpi_sint b )
+{
+    size_t i;
+    mbedtls_mpi_uint x, y, z;
+    MPI_VALIDATE_RET( r != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+
+    if( b == 0 )
+        return( MBEDTLS_ERR_MPI_DIVISION_BY_ZERO );
+
+    if( b < 0 )
+        return( MBEDTLS_ERR_MPI_NEGATIVE_VALUE );
+
+    /*
+     * handle trivial cases
+     */
+    if( b == 1 )
+    {
+        *r = 0;
+        return( 0 );
+    }
+
+    if( b == 2 )
+    {
+        *r = A->p[0] & 1;
+        return( 0 );
+    }
+
+    /*
+     * general case
+     */
+    for( i = A->n, y = 0; i > 0; i-- )
+    {
+        x  = A->p[i - 1];
+        y  = ( y << biH ) | ( x >> biH );
+        z  = y / b;
+        y -= z * b;
+
+        x <<= biH;
+        y  = ( y << biH ) | ( x >> biH );
+        z  = y / b;
+        y -= z * b;
+    }
+
+    /*
+     * If A is negative, then the current y represents a negative value.
+     * Flipping it to the positive side.
+     */
+    if( A->s < 0 && y != 0 )
+        y = b - y;
+
+    *r = y;
+
+    return( 0 );
+}
+
+/*
+ * Fast Montgomery initialization (thanks to Tom St Denis)
+ */
+static void mpi_montg_init( mbedtls_mpi_uint *mm, const mbedtls_mpi *N )
+{
+    mbedtls_mpi_uint x, m0 = N->p[0];
+    unsigned int i;
+
+    x  = m0;
+    x += ( ( m0 + 2 ) & 4 ) << 1;
+
+    for( i = biL; i >= 8; i /= 2 )
+        x *= ( 2 - ( m0 * x ) );
+
+    *mm = ~x + 1;
+}
+
+/*
+ * Montgomery multiplication: A = A * B * R^-1 mod N  (HAC 14.36)
+ */
+static int mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi *N, mbedtls_mpi_uint mm,
+                         const mbedtls_mpi *T )
+{
+    size_t i, n, m;
+    mbedtls_mpi_uint u0, u1, *d;
+
+    if( T->n < N->n + 1 || T->p == NULL )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    memset( T->p, 0, T->n * ciL );
+
+    d = T->p;
+    n = N->n;
+    m = ( B->n < n ) ? B->n : n;
+
+    for( i = 0; i < n; i++ )
+    {
+        /*
+         * T = (T + u0*B + u1*N) / 2^biL
+         */
+        u0 = A->p[i];
+        u1 = ( d[0] + u0 * B->p[0] ) * mm;
+
+        mpi_mul_hlp( m, B->p, d, u0 );
+        mpi_mul_hlp( n, N->p, d, u1 );
+
+        *d++ = u0; d[n + 1] = 0;
+    }
+
+    memcpy( A->p, d, ( n + 1 ) * ciL );
+
+    if( mbedtls_mpi_cmp_abs( A, N ) >= 0 )
+        mpi_sub_hlp( n, N->p, A->p );
+    else
+        /* prevent timing attacks */
+        mpi_sub_hlp( n, A->p, T->p );
+
+    return( 0 );
+}
+
+/*
+ * Montgomery reduction: A = A * R^-1 mod N
+ */
+static int mpi_montred( mbedtls_mpi *A, const mbedtls_mpi *N,
+                        mbedtls_mpi_uint mm, const mbedtls_mpi *T )
+{
+    mbedtls_mpi_uint z = 1;
+    mbedtls_mpi U;
+
+    U.n = U.s = (int) z;
+    U.p = &z;
+
+    return( mpi_montmul( A, &U, N, mm, T ) );
+}
+
+/*
+ * Sliding-window exponentiation: X = A^E mod N  (HAC 14.85)
+ */
+int mbedtls_mpi_exp_mod_sw( mbedtls_mpi *X, const mbedtls_mpi *A,
+                         const mbedtls_mpi *E, const mbedtls_mpi *N,
+                         mbedtls_mpi *_RR )
+{
+    int ret;
+    size_t wbits, wsize, one = 1;
+    size_t i, j, nblimbs;
+    size_t bufsize, nbits;
+    mbedtls_mpi_uint ei, mm, state;
+    mbedtls_mpi RR, T, Apos;
+    mbedtls_mpi *W = NULL;
+    int neg;
+
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+    MPI_VALIDATE_RET( E != NULL );
+    MPI_VALIDATE_RET( N != NULL );
+
+    if( mbedtls_mpi_cmp_int( N, 0 ) <= 0 || ( N->p[0] & 1 ) == 0 )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    if( mbedtls_mpi_cmp_int( E, 0 ) < 0 )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    W = (mbedtls_mpi *)mbedtls_calloc(2 << MBEDTLS_MPI_WINDOW_SIZE, sizeof(mbedtls_mpi));
+    if (W == NULL)
+    {
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+    }
+    memset( W, 0, sizeof( mbedtls_mpi )*(2 << MBEDTLS_MPI_WINDOW_SIZE) );
+
+    /*
+     * Init temps and window size
+     */
+    mpi_montg_init( &mm, N );
+    mbedtls_mpi_init( &RR ); mbedtls_mpi_init( &T );
+    mbedtls_mpi_init( &Apos );
+
+    i = mbedtls_mpi_bitlen( E );
+
+    wsize = ( i > 671 ) ? 6 : ( i > 239 ) ? 5 :
+            ( i >  79 ) ? 4 : ( i >  23 ) ? 3 : 1;
+
+    if( wsize > MBEDTLS_MPI_WINDOW_SIZE )
+        wsize = MBEDTLS_MPI_WINDOW_SIZE;
+
+    j = N->n + 1;
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, j ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( &W[1],  j ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( &T, j * 2 ) );
+
+    /*
+     * Compensate for negative A (and correct at the end)
+     */
+    neg = ( A->s == -1 );
+    if( neg )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &Apos, A ) );
+        Apos.s = 1;
+        A = &Apos;
+    }
+
+    /*
+     * If 1st call, pre-compute R^2 mod N
+     */
+    if( _RR == NULL || _RR->p == NULL )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &RR, 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_shift_l( &RR, N->n * 2 * biL ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &RR, &RR, N ) );
+
+        if( _RR != NULL )
+            memcpy( _RR, &RR, sizeof( mbedtls_mpi ) );
+    }
+    else
+        memcpy( &RR, _RR, sizeof( mbedtls_mpi ) );
+
+    /*
+     * W[1] = A * R^2 * R^-1 mod N = A * R mod N
+     */
+    if( mbedtls_mpi_cmp_mpi( A, N ) >= 0 )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &W[1], A, N ) );
+    else
+        MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &W[1], A ) );
+
+    MBEDTLS_MPI_CHK( mpi_montmul( &W[1], &RR, N, mm, &T ) );
+
+    /*
+     * X = R^2 * R^-1 mod N = R mod N
+     */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( X, &RR ) );
+    MBEDTLS_MPI_CHK( mpi_montred( X, N, mm, &T ) );
+
+    if( wsize > 1 )
+    {
+        /*
+         * W[1 << (wsize - 1)] = W[1] ^ (wsize - 1)
+         */
+        j =  one << ( wsize - 1 );
+
+        MBEDTLS_MPI_CHK( mbedtls_mpi_grow( &W[j], N->n + 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &W[j], &W[1]    ) );
+
+        for( i = 0; i < wsize - 1; i++ )
+            MBEDTLS_MPI_CHK( mpi_montmul( &W[j], &W[j], N, mm, &T ) );
+
+        /*
+         * W[i] = W[i - 1] * W[1]
+         */
+        for( i = j + 1; i < ( one << wsize ); i++ )
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_grow( &W[i], N->n + 1 ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &W[i], &W[i - 1] ) );
+
+            MBEDTLS_MPI_CHK( mpi_montmul( &W[i], &W[1], N, mm, &T ) );
+        }
+    }
+
+    nblimbs = E->n;
+    bufsize = 0;
+    nbits   = 0;
+    wbits   = 0;
+    state   = 0;
+
+    while( 1 )
+    {
+        if( bufsize == 0 )
+        {
+            if( nblimbs == 0 )
+                break;
+
+            nblimbs--;
+
+            bufsize = sizeof( mbedtls_mpi_uint ) << 3;
+        }
+
+        bufsize--;
+
+        ei = (E->p[nblimbs] >> bufsize) & 1;
+
+        /*
+         * skip leading 0s
+         */
+        if( ei == 0 && state == 0 )
+            continue;
+
+        if( ei == 0 && state == 1 )
+        {
+            /*
+             * out of window, square X
+             */
+            MBEDTLS_MPI_CHK( mpi_montmul( X, X, N, mm, &T ) );
+            continue;
+        }
+
+        /*
+         * add ei to current window
+         */
+        state = 2;
+
+        nbits++;
+        wbits |= ( ei << ( wsize - nbits ) );
+
+        if( nbits == wsize )
+        {
+            /*
+             * X = X^wsize R^-1 mod N
+             */
+            for( i = 0; i < wsize; i++ )
+                MBEDTLS_MPI_CHK( mpi_montmul( X, X, N, mm, &T ) );
+
+            /*
+             * X = X * W[wbits] R^-1 mod N
+             */
+            MBEDTLS_MPI_CHK( mpi_montmul( X, &W[wbits], N, mm, &T ) );
+
+            state--;
+            nbits = 0;
+            wbits = 0;
+        }
+    }
+
+    /*
+     * process the remaining bits
+     */
+    for( i = 0; i < nbits; i++ )
+    {
+        MBEDTLS_MPI_CHK( mpi_montmul( X, X, N, mm, &T ) );
+
+        wbits <<= 1;
+
+        if( ( wbits & ( one << wsize ) ) != 0 )
+            MBEDTLS_MPI_CHK( mpi_montmul( X, &W[1], N, mm, &T ) );
+    }
+
+    /*
+     * X = A^E * R * R^-1 mod N = A^E mod N
+     */
+    MBEDTLS_MPI_CHK( mpi_montred( X, N, mm, &T ) );
+
+    if( neg && E->n != 0 && ( E->p[0] & 1 ) != 0 )
+    {
+        X->s = -1;
+        MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( X, N, X ) );
+    }
+
+cleanup:
+
+    for( i = ( one << ( wsize - 1 ) ); i < ( one << wsize ); i++ )
+        mbedtls_mpi_free( &W[i] );
+
+    mbedtls_mpi_free( &W[1] ); mbedtls_mpi_free( &T ); mbedtls_mpi_free( &Apos );
+
+    if( _RR == NULL || _RR->p == NULL )
+        mbedtls_mpi_free( &RR );
+
+    if (W != NULL)
+    {
+        mbedtls_free(W);
+        W = NULL;
+    }
+
+    return( ret );
+}
+
+/*
+ * Greatest common divisor: G = gcd(A, B)  (HAC 14.54)
+ */
+int mbedtls_mpi_gcd( mbedtls_mpi *G, const mbedtls_mpi *A, const mbedtls_mpi *B )
+{
+    int ret;
+    size_t lz, lzt;
+    mbedtls_mpi TG, TA, TB;
+
+    MPI_VALIDATE_RET( G != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+    MPI_VALIDATE_RET( B != NULL );
+
+    mbedtls_mpi_init( &TG ); mbedtls_mpi_init( &TA ); mbedtls_mpi_init( &TB );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TA, A ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TB, B ) );
+
+    lz = mbedtls_mpi_lsb( &TA );
+    lzt = mbedtls_mpi_lsb( &TB );
+
+    if( lzt < lz )
+        lz = lzt;
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &TA, lz ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &TB, lz ) );
+
+    TA.s = TB.s = 1;
+
+    while( mbedtls_mpi_cmp_int( &TA, 0 ) != 0 )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &TA, mbedtls_mpi_lsb( &TA ) ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &TB, mbedtls_mpi_lsb( &TB ) ) );
+
+        if( mbedtls_mpi_cmp_mpi( &TA, &TB ) >= 0 )
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( &TA, &TA, &TB ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &TA, 1 ) );
+        }
+        else
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( &TB, &TB, &TA ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &TB, 1 ) );
+        }
+    }
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_shift_l( &TB, lz ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( G, &TB ) );
+
+cleanup:
+
+    mbedtls_mpi_free( &TG ); mbedtls_mpi_free( &TA ); mbedtls_mpi_free( &TB );
+
+    return( ret );
+}
+
+/*
+ * Fill X with size bytes of random.
+ *
+ * Use a temporary bytes representation to make sure the result is the same
+ * regardless of the platform endianness (useful when f_rng is actually
+ * deterministic, eg for tests).
+ */
+int mbedtls_mpi_fill_random( mbedtls_mpi *X, size_t size,
+                     int (*f_rng)(void *, unsigned char *, size_t),
+                     void *p_rng )
+{
+    int ret;
+    unsigned char *buf = NULL;
+    MPI_VALIDATE_RET( X     != NULL );
+    MPI_VALIDATE_RET( f_rng != NULL );
+
+    if( size > MBEDTLS_MPI_MAX_SIZE )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    buf = (unsigned char *)mbedtls_calloc(MBEDTLS_MPI_MAX_SIZE,sizeof(unsigned char));
+    if (buf == NULL)
+    {
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+    }
+    memset( buf, 0, sizeof( unsigned char ) * MBEDTLS_MPI_MAX_SIZE );
+
+    MBEDTLS_MPI_CHK( f_rng( p_rng, buf, size ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_binary( X, buf, size ) );
+
+cleanup:
+    mbedtls_platform_zeroize( buf, sizeof( unsigned char ) * MBEDTLS_MPI_MAX_SIZE );
+
+    if (buf != NULL)
+    {
+        mbedtls_free(buf);
+        buf = NULL;
+    }
+
+    return( ret );
+}
+
+/*
+ * Modular inverse: X = A^-1 mod N  (HAC 14.61 / 14.64)
+ */
+int mbedtls_mpi_inv_mod( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *N )
+{
+    int ret;
+    mbedtls_mpi G, TA, TU, U1, U2, TB, TV, V1, V2;
+    MPI_VALIDATE_RET( X != NULL );
+    MPI_VALIDATE_RET( A != NULL );
+    MPI_VALIDATE_RET( N != NULL );
+
+    if( mbedtls_mpi_cmp_int( N, 1 ) <= 0 )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    mbedtls_mpi_init( &TA ); mbedtls_mpi_init( &TU ); mbedtls_mpi_init( &U1 ); mbedtls_mpi_init( &U2 );
+    mbedtls_mpi_init( &G ); mbedtls_mpi_init( &TB ); mbedtls_mpi_init( &TV );
+    mbedtls_mpi_init( &V1 ); mbedtls_mpi_init( &V2 );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_gcd( &G, A, N ) );
+
+    if( mbedtls_mpi_cmp_int( &G, 1 ) != 0 )
+    {
+        ret = MBEDTLS_ERR_MPI_NOT_ACCEPTABLE;
+        goto cleanup;
+    }
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &TA, A, N ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TU, &TA ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TB, N ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TV, N ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &U1, 1 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &U2, 0 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &V1, 0 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &V2, 1 ) );
+
+    do
+    {
+        while( ( TU.p[0] & 1 ) == 0 )
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &TU, 1 ) );
+
+            if( ( U1.p[0] & 1 ) != 0 || ( U2.p[0] & 1 ) != 0 )
+            {
+                MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &U1, &U1, &TB ) );
+                MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &U2, &U2, &TA ) );
+            }
+
+            MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &U1, 1 ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &U2, 1 ) );
+        }
+
+        while( ( TV.p[0] & 1 ) == 0 )
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &TV, 1 ) );
+
+            if( ( V1.p[0] & 1 ) != 0 || ( V2.p[0] & 1 ) != 0 )
+            {
+                MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &V1, &V1, &TB ) );
+                MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &V2, &V2, &TA ) );
+            }
+
+            MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &V1, 1 ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &V2, 1 ) );
+        }
+
+        if( mbedtls_mpi_cmp_mpi( &TU, &TV ) >= 0 )
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &TU, &TU, &TV ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &U1, &U1, &V1 ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &U2, &U2, &V2 ) );
+        }
+        else
+        {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &TV, &TV, &TU ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &V1, &V1, &U1 ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &V2, &V2, &U2 ) );
+        }
+    }
+    while( mbedtls_mpi_cmp_int( &TU, 0 ) != 0 );
+
+    while( mbedtls_mpi_cmp_int( &V1, 0 ) < 0 )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &V1, &V1, N ) );
+
+    while( mbedtls_mpi_cmp_mpi( &V1, N ) >= 0 )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &V1, &V1, N ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( X, &V1 ) );
+
+cleanup:
+
+    mbedtls_mpi_free( &TA ); mbedtls_mpi_free( &TU ); mbedtls_mpi_free( &U1 ); mbedtls_mpi_free( &U2 );
+    mbedtls_mpi_free( &G ); mbedtls_mpi_free( &TB ); mbedtls_mpi_free( &TV );
+    mbedtls_mpi_free( &V1 ); mbedtls_mpi_free( &V2 );
+
+    return( ret );
+}
+
+static const int small_prime[] =
+{
+        3,    5,    7,   11,   13,   17,   19,   23,
+       29,   31,   37,   41,   43,   47,   53,   59,
+       61,   67,   71,   73,   79,   83,   89,   97,
+      101,  103,  107,  109,  113,  127,  131,  137,
+      139,  149,  151,  157,  163,  167,  173,  179,
+      181,  191,  193,  197,  199,  211,  223,  227,
+      229,  233,  239,  241,  251,  257,  263,  269,
+      271,  277,  281,  283,  293,  307,  311,  313,
+      317,  331,  337,  347,  349,  353,  359,  367,
+      373,  379,  383,  389,  397,  401,  409,  419,
+      421,  431,  433,  439,  443,  449,  457,  461,
+      463,  467,  479,  487,  491,  499,  503,  509,
+      521,  523,  541,  547,  557,  563,  569,  571,
+      577,  587,  593,  599,  601,  607,  613,  617,
+      619,  631,  641,  643,  647,  653,  659,  661,
+      673,  677,  683,  691,  701,  709,  719,  727,
+      733,  739,  743,  751,  757,  761,  769,  773,
+      787,  797,  809,  811,  821,  823,  827,  829,
+      839,  853,  857,  859,  863,  877,  881,  883,
+      887,  907,  911,  919,  929,  937,  941,  947,
+      953,  967,  971,  977,  983,  991,  997, -103
+};
+
+/*
+ * Small divisors test (X must be positive)
+ *
+ * Return values:
+ * 0: no small factor (possible prime, more tests needed)
+ * 1: certain prime
+ * MBEDTLS_ERR_MPI_NOT_ACCEPTABLE: certain non-prime
+ * other negative: error
+ */
+static int mpi_check_small_factors( const mbedtls_mpi *X )
+{
+    int ret = 0;
+    size_t i;
+    mbedtls_mpi_uint r;
+
+    if( ( X->p[0] & 1 ) == 0 )
+        return( MBEDTLS_ERR_MPI_NOT_ACCEPTABLE );
+
+    for( i = 0; small_prime[i] > 0; i++ )
+    {
+        if( mbedtls_mpi_cmp_int( X, small_prime[i] ) <= 0 )
+            return( 1 );
+
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_int( &r, X, small_prime[i] ) );
+
+        if( r == 0 )
+            return( MBEDTLS_ERR_MPI_NOT_ACCEPTABLE );
+    }
+
+cleanup:
+    return( ret );
+}
+
+/*
+ * Miller-Rabin pseudo-primality test  (HAC 4.24)
+ */
+static int mpi_miller_rabin( const mbedtls_mpi *X, size_t rounds,
+                             int (*f_rng)(void *, unsigned char *, size_t),
+                             void *p_rng )
+{
+    int ret, count;
+    size_t i, j, k, s;
+    mbedtls_mpi W, R, T, A, RR;
+
+    MPI_VALIDATE_RET( X     != NULL );
+    MPI_VALIDATE_RET( f_rng != NULL );
+
+    mbedtls_mpi_init( &W ); mbedtls_mpi_init( &R );
+    mbedtls_mpi_init( &T ); mbedtls_mpi_init( &A );
+    mbedtls_mpi_init( &RR );
+
+    /*
+     * W = |X| - 1
+     * R = W >> lsb( W )
+     */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &W, X, 1 ) );
+    s = mbedtls_mpi_lsb( &W );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &R, &W ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &R, s ) );
+
+    i = mbedtls_mpi_bitlen( X );
+
+    for( i = 0; i < rounds; i++ )
+    {
+        /*
+         * pick a random A, 1 < A < |X| - 1
+         */
+        count = 0;
+        do {
+            MBEDTLS_MPI_CHK( mbedtls_mpi_fill_random( &A, X->n * ciL, f_rng, p_rng ) );
+
+            j = mbedtls_mpi_bitlen( &A );
+            k = mbedtls_mpi_bitlen( &W );
+            if (j > k) {
+                A.p[A.n - 1] &= ( (mbedtls_mpi_uint) 1 << ( k - ( A.n - 1 ) * biL - 1 ) ) - 1;
+            }
+
+            if (count++ > 30) {
+                return MBEDTLS_ERR_MPI_NOT_ACCEPTABLE;
+            }
+
+        } while ( mbedtls_mpi_cmp_mpi( &A, &W ) >= 0 ||
+                  mbedtls_mpi_cmp_int( &A, 1 )  <= 0    );
+
+        /*
+         * A = A^R mod |X|
+         */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &A, &A, &R, X, &RR ) );
+
+        if( mbedtls_mpi_cmp_mpi( &A, &W ) == 0 ||
+            mbedtls_mpi_cmp_int( &A,  1 ) == 0 )
+            continue;
+
+        j = 1;
+        while( j < s && mbedtls_mpi_cmp_mpi( &A, &W ) != 0 )
+        {
+            /*
+             * A = A * A mod |X|
+             */
+            MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &T, &A, &A ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &A, &T, X  ) );
+
+            if( mbedtls_mpi_cmp_int( &A, 1 ) == 0 )
+                break;
+
+            j++;
+        }
+
+        /*
+         * not prime if A != |X| - 1 or A == 1
+         */
+        if( mbedtls_mpi_cmp_mpi( &A, &W ) != 0 ||
+            mbedtls_mpi_cmp_int( &A,  1 ) == 0 )
+        {
+            ret = MBEDTLS_ERR_MPI_NOT_ACCEPTABLE;
+            break;
+        }
+    }
+
+cleanup:
+    mbedtls_mpi_free( &W ); mbedtls_mpi_free( &R );
+    mbedtls_mpi_free( &T ); mbedtls_mpi_free( &A );
+    mbedtls_mpi_free( &RR );
+
+    return( ret );
+}
+
+/*
+ * Pseudo-primality test: small factors, then Miller-Rabin
+ */
+int mbedtls_mpi_is_prime_ext( const mbedtls_mpi *X, int rounds,
+                              int (*f_rng)(void *, unsigned char *, size_t),
+                              void *p_rng )
+{
+    int ret;
+    mbedtls_mpi XX;
+    MPI_VALIDATE_RET( X     != NULL );
+    MPI_VALIDATE_RET( f_rng != NULL );
+
+    XX.s = 1;
+    XX.n = X->n;
+    XX.p = X->p;
+
+    if( mbedtls_mpi_cmp_int( &XX, 0 ) == 0 ||
+        mbedtls_mpi_cmp_int( &XX, 1 ) == 0 )
+        return( MBEDTLS_ERR_MPI_NOT_ACCEPTABLE );
+
+    if( mbedtls_mpi_cmp_int( &XX, 2 ) == 0 )
+        return( 0 );
+
+    if( ( ret = mpi_check_small_factors( &XX ) ) != 0 )
+    {
+        if( ret == 1 )
+            return( 0 );
+
+        return( ret );
+    }
+
+    return( mpi_miller_rabin( &XX, rounds, f_rng, p_rng ) );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+/*
+ * Pseudo-primality test, error probability 2^-80
+ */
+int mbedtls_mpi_is_prime( const mbedtls_mpi *X,
+                  int (*f_rng)(void *, unsigned char *, size_t),
+                  void *p_rng )
+{
+    MPI_VALIDATE_RET( X     != NULL );
+    MPI_VALIDATE_RET( f_rng != NULL );
+
+    /*
+     * In the past our key generation aimed for an error rate of at most
+     * 2^-80. Since this function is deprecated, aim for the same certainty
+     * here as well.
+     */
+    return( mbedtls_mpi_is_prime_ext( X, 40, f_rng, p_rng ) );
+}
+#endif
+
+/*
+ * Prime number generation
+ *
+ * To generate an RSA key in a way recommended by FIPS 186-4, both primes must
+ * be either 1024 bits or 1536 bits long, and flags must contain
+ * MBEDTLS_MPI_GEN_PRIME_FLAG_LOW_ERR.
+ */
+int mbedtls_mpi_gen_prime( mbedtls_mpi *X, size_t nbits, int flags,
+                   int (*f_rng)(void *, unsigned char *, size_t),
+                   void *p_rng )
+{
+#ifdef MBEDTLS_HAVE_INT64
+// ceil(2^63.5)
+#define CEIL_MAXUINT_DIV_SQRT2 0xb504f333f9de6485ULL
+#else
+// ceil(2^31.5)
+#define CEIL_MAXUINT_DIV_SQRT2 0xb504f334U
+#endif
+    int ret = MBEDTLS_ERR_MPI_NOT_ACCEPTABLE;
+    size_t k, n;
+    int rounds;
+    mbedtls_mpi_uint r;
+    mbedtls_mpi Y;
+
+    MPI_VALIDATE_RET( X     != NULL );
+    MPI_VALIDATE_RET( f_rng != NULL );
+
+    if( nbits < 3 || nbits > MBEDTLS_MPI_MAX_BITS )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    mbedtls_mpi_init( &Y );
+
+    n = BITS_TO_LIMBS( nbits );
+
+    if( ( flags & MBEDTLS_MPI_GEN_PRIME_FLAG_LOW_ERR ) == 0 )
+    {
+        /*
+         * 2^-80 error probability, number of rounds chosen per HAC, table 4.4
+         */
+        rounds = ( ( nbits >= 1300 ) ?  2 : ( nbits >=  850 ) ?  3 :
+                   ( nbits >=  650 ) ?  4 : ( nbits >=  350 ) ?  8 :
+                   ( nbits >=  250 ) ? 12 : ( nbits >=  150 ) ? 18 : 27 );
+    }
+    else
+    {
+        /*
+         * 2^-100 error probability, number of rounds computed based on HAC,
+         * fact 4.48
+         */
+        rounds = ( ( nbits >= 1450 ) ?  4 : ( nbits >=  1150 ) ?  5 :
+                   ( nbits >= 1000 ) ?  6 : ( nbits >=   850 ) ?  7 :
+                   ( nbits >=  750 ) ?  8 : ( nbits >=   500 ) ? 13 :
+                   ( nbits >=  250 ) ? 28 : ( nbits >=   150 ) ? 40 : 51 );
+    }
+
+    while( 1 )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_fill_random( X, n * ciL, f_rng, p_rng ) );
+        /* make sure generated number is at least (nbits-1)+0.5 bits (FIPS 186-4.3.3 steps 4.4, 5.5) */
+        if( X->p[n-1] < CEIL_MAXUINT_DIV_SQRT2 ) continue;
+
+        k = n * biL;
+        if( k > nbits ) MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( X, k - nbits ) );
+        X->p[0] |= 1;
+
+        if( ( flags & MBEDTLS_MPI_GEN_PRIME_FLAG_DH ) == 0 )
+        {
+            ret = mbedtls_mpi_is_prime_ext( X, rounds, f_rng, p_rng );
+
+            if( ret != MBEDTLS_ERR_MPI_NOT_ACCEPTABLE )
+                goto cleanup;
+        }
+        else
+        {
+            /*
+             * An necessary condition for Y and X = 2Y + 1 to be prime
+             * is X = 2 mod 3 (which is equivalent to Y = 2 mod 3).
+             * Make sure it is satisfied, while keeping X = 3 mod 4
+             */
+
+            X->p[0] |= 2;
+
+            MBEDTLS_MPI_CHK( mbedtls_mpi_mod_int( &r, X, 3 ) );
+            if( r == 0 )
+                MBEDTLS_MPI_CHK( mbedtls_mpi_add_int( X, X, 8 ) );
+            else if( r == 1 )
+                MBEDTLS_MPI_CHK( mbedtls_mpi_add_int( X, X, 4 ) );
+
+            /* Set Y = (X-1) / 2, which is X / 2 because X is odd */
+            MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &Y, X ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &Y, 1 ) );
+
+            while( 1 )
+            {
+                /*
+                 * First, check small factors for X and Y
+                 * before doing Miller-Rabin on any of them
+                 */
+                if( ( ret = mpi_check_small_factors(  X         ) ) == 0 &&
+                    ( ret = mpi_check_small_factors( &Y         ) ) == 0 &&
+                    ( ret = mpi_miller_rabin(  X, rounds, f_rng, p_rng  ) )
+                                                                    == 0 &&
+                    ( ret = mpi_miller_rabin( &Y, rounds, f_rng, p_rng  ) )
+                                                                    == 0 )
+                    goto cleanup;
+
+                if( ret != MBEDTLS_ERR_MPI_NOT_ACCEPTABLE )
+                    goto cleanup;
+
+                /*
+                 * Next candidates. We want to preserve Y = (X-1) / 2 and
+                 * Y = 1 mod 2 and Y = 2 mod 3 (eq X = 3 mod 4 and X = 2 mod 3)
+                 * so up Y by 6 and X by 12.
+                 */
+                MBEDTLS_MPI_CHK( mbedtls_mpi_add_int(  X,  X, 12 ) );
+                MBEDTLS_MPI_CHK( mbedtls_mpi_add_int( &Y, &Y, 6  ) );
+            }
+        }
+    }
+
+cleanup:
+
+    mbedtls_mpi_free( &Y );
+
+    return( ret );
+}
+
+#endif /* MBEDTLS_GENPRIME */
+
+#if defined(MBEDTLS_SELF_TEST)
+
+#define GCD_PAIR_COUNT  3
+
+static const int gcd_pairs[GCD_PAIR_COUNT][3] =
+{
+    { 693, 609, 21 },
+    { 1764, 868, 28 },
+    { 768454923, 542167814, 1 }
+};
+
+/*
+ * Checkup routine
+ */
+int mbedtls_mpi_self_test( int verbose )
+{
+    int ret, i;
+    mbedtls_mpi A, E, N, X, Y, U, V;
+
+    mbedtls_mpi_init( &A ); mbedtls_mpi_init( &E ); mbedtls_mpi_init( &N ); mbedtls_mpi_init( &X );
+    mbedtls_mpi_init( &Y ); mbedtls_mpi_init( &U ); mbedtls_mpi_init( &V );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &A, 16,
+        "EFE021C2645FD1DC586E69184AF4A31E" \
+        "D5F53E93B5F123FA41680867BA110131" \
+        "944FE7952E2517337780CB0DB80E61AA" \
+        "E7C8DDC6C5C6AADEB34EB38A2F40D5E6" ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &E, 16,
+        "B2E7EFD37075B9F03FF989C7C5051C20" \
+        "34D2A323810251127E7BF8625A4F49A5" \
+        "F3E27F4DA8BD59C47D6DAABA4C8127BD" \
+        "5B5C25763222FEFCCFC38B832366C29E" ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &N, 16,
+        "0066A198186C18C10B2F5ED9B522752A" \
+        "9830B69916E535C8F047518A889A43A5" \
+        "94B6BED27A168D31D4A52F88925AA8F5" ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &X, &A, &N ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &U, 16,
+        "602AB7ECA597A3D6B56FF9829A5E8B85" \
+        "9E857EA95A03512E2BAE7391688D264A" \
+        "A5663B0341DB9CCFD2C4C5F421FEC814" \
+        "8001B72E848A38CAE1C65F78E56ABDEF" \
+        "E12D3C039B8A02D6BE593F0BBBDA56F1" \
+        "ECF677152EF804370C1A305CAF3B5BF1" \
+        "30879B56C61DE584A0F53A2447A51E" ) );
+
+    if( verbose != 0 )
+        mbedtls_printf( "  MPI test #1 (mul_mpi): " );
+
+    if( mbedtls_mpi_cmp_mpi( &X, &U ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        ret = 1;
+        goto cleanup;
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "passed\n" );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_div_mpi( &X, &Y, &A, &N ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &U, 16,
+        "256567336059E52CAE22925474705F39A94" ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &V, 16,
+        "6613F26162223DF488E9CD48CC132C7A" \
+        "0AC93C701B001B092E4E5B9F73BCD27B" \
+        "9EE50D0657C77F374E903CDFA4C642" ) );
+
+    if( verbose != 0 )
+        mbedtls_printf( "  MPI test #2 (div_mpi): " );
+
+    if( mbedtls_mpi_cmp_mpi( &X, &U ) != 0 ||
+        mbedtls_mpi_cmp_mpi( &Y, &V ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        ret = 1;
+        goto cleanup;
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "passed\n" );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &X, &A, &E, &N, NULL ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &U, 16,
+        "36E139AEA55215609D2816998ED020BB" \
+        "BD96C37890F65171D948E9BC7CBAA4D9" \
+        "325D24D6A3C12710F10A09FA08AB87" ) );
+
+    if( verbose != 0 )
+        mbedtls_printf( "  MPI test #3 (exp_mod): " );
+
+    if( mbedtls_mpi_cmp_mpi( &X, &U ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        ret = 1;
+        goto cleanup;
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "passed\n" );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_inv_mod( &X, &A, &N ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &U, 16,
+        "003A0AAEDD7E784FC07D8F9EC6E3BFD5" \
+        "C3DBA76456363A10869622EAC2DD84EC" \
+        "C5B8A74DAC4D09E03B5E0BE779F2DF61" ) );
+
+    if( verbose != 0 )
+        mbedtls_printf( "  MPI test #4 (inv_mod): " );
+
+    if( mbedtls_mpi_cmp_mpi( &X, &U ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        ret = 1;
+        goto cleanup;
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "passed\n" );
+
+    if( verbose != 0 )
+        mbedtls_printf( "  MPI test #5 (simple gcd): " );
+
+    for( i = 0; i < GCD_PAIR_COUNT; i++ )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &X, gcd_pairs[i][0] ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &Y, gcd_pairs[i][1] ) );
+
+        MBEDTLS_MPI_CHK( mbedtls_mpi_gcd( &A, &X, &Y ) );
+
+        if( mbedtls_mpi_cmp_int( &A, gcd_pairs[i][2] ) != 0 )
+        {
+            if( verbose != 0 )
+                mbedtls_printf( "failed at %d\n", i );
+
+            ret = 1;
+            goto cleanup;
+        }
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "passed\n" );
+
+cleanup:
+
+    if( ret != 0 && verbose != 0 )
+        mbedtls_printf( "Unexpected error, return code = %08X\n", ret );
+
+    mbedtls_mpi_free( &A ); mbedtls_mpi_free( &E ); mbedtls_mpi_free( &N ); mbedtls_mpi_free( &X );
+    mbedtls_mpi_free( &Y ); mbedtls_mpi_free( &U ); mbedtls_mpi_free( &V );
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+
+    return( ret );
+}
+
+#endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_BIGNUM_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/ccm.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/ccm.c
@@ -1,0 +1,549 @@
+/*
+ *  NIST SP800-38C compliant CCM implementation
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+/*
+ * Definition of CCM:
+ * http://csrc.nist.gov/publications/nistpubs/800-38C/SP800-38C_updated-July20_2007.pdf
+ * RFC 3610 "Counter with CBC-MAC (CCM)"
+ *
+ * Related:
+ * RFC 5116 "An Interface and Algorithms for Authenticated Encryption"
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_CCM_C)
+
+#include "mbedtls/ccm.h"
+#include "mbedtls/platform_util.h"
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#define mbedtls_printf printf
+#endif /* MBEDTLS_PLATFORM_C */
+
+
+#if !defined(MBEDTLS_CCM_ALT)
+
+#define CCM_VALIDATE_RET( cond ) \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_CCM_BAD_INPUT )
+#define CCM_VALIDATE( cond ) \
+    MBEDTLS_INTERNAL_VALIDATE( cond )
+
+#define CCM_ENCRYPT 0
+#define CCM_DECRYPT 1
+
+/*
+ * Initialize context
+ */
+void mbedtls_ccm_init( mbedtls_ccm_context *ctx )
+{
+    CCM_VALIDATE( ctx != NULL );
+    memset( ctx, 0, sizeof( mbedtls_ccm_context ) );
+}
+
+int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
+                        mbedtls_cipher_id_t cipher,
+                        const unsigned char *key,
+                        unsigned int keybits )
+{
+    int ret;
+    const mbedtls_cipher_info_t *cipher_info;
+
+    CCM_VALIDATE_RET( ctx != NULL );
+    CCM_VALIDATE_RET( key != NULL );
+
+    cipher_info = mbedtls_cipher_info_from_values( cipher, keybits, MBEDTLS_MODE_ECB );
+    if( cipher_info == NULL )
+        return( MBEDTLS_ERR_CCM_BAD_INPUT );
+
+    if( cipher_info->block_size != 16 )
+        return( MBEDTLS_ERR_CCM_BAD_INPUT );
+
+    mbedtls_cipher_free( &ctx->cipher_ctx );
+
+    if( ( ret = mbedtls_cipher_setup( &ctx->cipher_ctx, cipher_info ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_cipher_setkey( &ctx->cipher_ctx, key, keybits,
+                               MBEDTLS_ENCRYPT ) ) != 0 )
+    {
+        return( ret );
+    }
+
+    return( 0 );
+}
+
+/*
+ * Free context
+ */
+void mbedtls_ccm_free( mbedtls_ccm_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+    mbedtls_cipher_free( &ctx->cipher_ctx );
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_ccm_context ) );
+}
+
+/*
+ * Macros for common operations.
+ * Results in smaller compiled code than static inline functions.
+ */
+
+/*
+ * Update the CBC-MAC state in y using a block in b
+ * (Always using b as the source helps the compiler optimise a bit better.)
+ */
+#define UPDATE_CBC_MAC                                                      \
+    for( i = 0; i < 16; i++ )                                               \
+        y[i] ^= b[i];                                                       \
+                                                                            \
+    if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, y, 16, y, &olen ) ) != 0 ) \
+        return( ret );
+
+/*
+ * Encrypt or decrypt a partial block with CTR
+ * Warning: using b for temporary storage! src and dst must not be b!
+ * This avoids allocating one more 16 bytes buffer while allowing src == dst.
+ */
+#define CTR_CRYPT( dst, src, len  )                                            \
+    if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, ctr, 16, b, &olen ) ) != 0 )  \
+        return( ret );                                                         \
+                                                                               \
+    for( i = 0; i < len; i++ )                                                 \
+        dst[i] = src[i] ^ b[i];
+
+/*
+ * Authenticated encryption or decryption
+ */
+static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
+                           const unsigned char *iv, size_t iv_len,
+                           const unsigned char *add, size_t add_len,
+                           const unsigned char *input, unsigned char *output,
+                           unsigned char *tag, size_t tag_len )
+{
+    int ret;
+    unsigned char i;
+    unsigned char q;
+    size_t len_left, olen;
+    unsigned char b[16];
+    unsigned char y[16];
+    unsigned char ctr[16];
+    const unsigned char *src;
+    unsigned char *dst;
+
+    /*
+     * Check length requirements: SP800-38C A.1
+     * Additional requirement: a < 2^16 - 2^8 to simplify the code.
+     * 'length' checked later (when writing it to the first block)
+     *
+     * Also, loosen the requirements to enable support for CCM* (IEEE 802.15.4).
+     */
+    if( tag_len == 2 || tag_len > 16 || tag_len % 2 != 0 )
+        return( MBEDTLS_ERR_CCM_BAD_INPUT );
+
+    /* Also implies q is within bounds */
+    if( iv_len < 7 || iv_len > 13 )
+        return( MBEDTLS_ERR_CCM_BAD_INPUT );
+
+    q = 16 - 1 - (unsigned char) iv_len;
+
+    /*
+     * First block B_0:
+     * 0        .. 0        flags
+     * 1        .. iv_len   nonce (aka iv)
+     * iv_len+1 .. 15       length
+     *
+     * With flags as (bits):
+     * 7        0
+     * 6        add present?
+     * 5 .. 3   (t - 2) / 2
+     * 2 .. 0   q - 1
+     */
+    b[0] = 0;
+    b[0] |= ( add_len > 0 ) << 6;
+    b[0] |= ( ( tag_len - 2 ) / 2 ) << 3;
+    b[0] |= q - 1;
+
+    memcpy( b + 1, iv, iv_len );
+
+    for( i = 0, len_left = length; i < q; i++, len_left >>= 8 )
+        b[15-i] = (unsigned char)( len_left & 0xFF );
+
+    if( len_left > 0 )
+        return( MBEDTLS_ERR_CCM_BAD_INPUT );
+
+
+    /* Start CBC-MAC with first block */
+    memset( y, 0, 16 );
+    UPDATE_CBC_MAC;
+
+    /*
+     * If there is additional data, update CBC-MAC with
+     * add_len, add, 0 (padding to a block boundary)
+     */
+    if( add_len > 0 )
+    {
+        size_t use_len;
+        len_left = add_len;
+        src = add;
+
+        memset( b, 0, 16 );
+
+        if (add_len <= 0xFF00)
+        {
+            b[0] = (unsigned char)( ( add_len >> 8 ) & 0xFF );
+            b[1] = (unsigned char)( ( add_len      ) & 0xFF );
+
+            use_len = len_left < 16 - 2 ? len_left : 16 - 2;
+            memcpy( b + 2, src, use_len );
+        }
+        else
+        {
+            b[0] = 0xFF;
+            b[1] = 0xFE;
+            b[2] = (unsigned char)( ( add_len >> 24 ) & 0xFF );
+            b[3] = (unsigned char)( ( add_len >> 16 ) & 0xFF );
+            b[4] = (unsigned char)( ( add_len >> 8  ) & 0xFF );
+            b[5] = (unsigned char)( ( add_len       ) & 0xFF );
+
+            use_len = len_left < 16 - 6 ? len_left : 16 - 6;
+            memcpy( b + 6, src, use_len );
+        }
+        len_left -= use_len;
+        src += use_len;
+
+        UPDATE_CBC_MAC;
+
+        while( len_left > 0 )
+        {
+            use_len = len_left > 16 ? 16 : len_left;
+
+            memset( b, 0, 16 );
+            memcpy( b, src, use_len );
+            UPDATE_CBC_MAC;
+
+            len_left -= use_len;
+            src += use_len;
+        }
+    }
+
+    /*
+     * Prepare counter block for encryption:
+     * 0        .. 0        flags
+     * 1        .. iv_len   nonce (aka iv)
+     * iv_len+1 .. 15       counter (initially 1)
+     *
+     * With flags as (bits):
+     * 7 .. 3   0
+     * 2 .. 0   q - 1
+     */
+    ctr[0] = q - 1;
+    memcpy( ctr + 1, iv, iv_len );
+    memset( ctr + 1 + iv_len, 0, q );
+    ctr[15] = 1;
+
+    /*
+     * Authenticate and {en,de}crypt the message.
+     *
+     * The only difference between encryption and decryption is
+     * the respective order of authentication and {en,de}cryption.
+     */
+    len_left = length;
+    src = input;
+    dst = output;
+
+    while( len_left > 0 )
+    {
+        size_t use_len = len_left > 16 ? 16 : len_left;
+
+        if( mode == CCM_ENCRYPT )
+        {
+            memset( b, 0, 16 );
+            memcpy( b, src, use_len );
+            UPDATE_CBC_MAC;
+        }
+
+        CTR_CRYPT( dst, src, use_len );
+
+        if( mode == CCM_DECRYPT )
+        {
+            memset( b, 0, 16 );
+            memcpy( b, dst, use_len );
+            UPDATE_CBC_MAC;
+        }
+
+        dst += use_len;
+        src += use_len;
+        len_left -= use_len;
+
+        /*
+         * Increment counter.
+         * No need to check for overflow thanks to the length check above.
+         */
+        for( i = 0; i < q; i++ )
+            if( ++ctr[15-i] != 0 )
+                break;
+    }
+
+    /*
+     * Authentication: reset counter and crypt/mask internal tag
+     */
+    for( i = 0; i < q; i++ )
+        ctr[15-i] = 0;
+
+    CTR_CRYPT( y, y, 16 );
+    memcpy( tag, y, tag_len );
+
+    return( 0 );
+}
+
+/*
+ * Authenticated encryption
+ */
+int mbedtls_ccm_star_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
+                         const unsigned char *iv, size_t iv_len,
+                         const unsigned char *add, size_t add_len,
+                         const unsigned char *input, unsigned char *output,
+                         unsigned char *tag, size_t tag_len )
+{
+    CCM_VALIDATE_RET( ctx != NULL );
+    CCM_VALIDATE_RET( iv != NULL );
+    CCM_VALIDATE_RET( add_len == 0 || add != NULL );
+    CCM_VALIDATE_RET( length == 0 || input != NULL );
+    CCM_VALIDATE_RET( length == 0 || output != NULL );
+    CCM_VALIDATE_RET( tag_len == 0 || tag != NULL );
+    return( ccm_auth_crypt( ctx, CCM_ENCRYPT, length, iv, iv_len,
+                            add, add_len, input, output, tag, tag_len ) );
+}
+
+int mbedtls_ccm_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
+                         const unsigned char *iv, size_t iv_len,
+                         const unsigned char *add, size_t add_len,
+                         const unsigned char *input, unsigned char *output,
+                         unsigned char *tag, size_t tag_len )
+{
+    CCM_VALIDATE_RET( ctx != NULL );
+    CCM_VALIDATE_RET( iv != NULL );
+    CCM_VALIDATE_RET( add_len == 0 || add != NULL );
+    CCM_VALIDATE_RET( length == 0 || input != NULL );
+    CCM_VALIDATE_RET( length == 0 || output != NULL );
+    CCM_VALIDATE_RET( tag_len == 0 || tag != NULL );
+    if( tag_len == 0 )
+        return( MBEDTLS_ERR_CCM_BAD_INPUT );
+
+    return( mbedtls_ccm_star_encrypt_and_tag( ctx, length, iv, iv_len, add,
+                add_len, input, output, tag, tag_len ) );
+}
+
+/*
+ * Authenticated decryption
+ */
+int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
+                      const unsigned char *iv, size_t iv_len,
+                      const unsigned char *add, size_t add_len,
+                      const unsigned char *input, unsigned char *output,
+                      const unsigned char *tag, size_t tag_len )
+{
+    int ret;
+    unsigned char check_tag[16];
+    unsigned char i;
+    int diff;
+
+    CCM_VALIDATE_RET( ctx != NULL );
+    CCM_VALIDATE_RET( iv != NULL );
+    CCM_VALIDATE_RET( add_len == 0 || add != NULL );
+    CCM_VALIDATE_RET( length == 0 || input != NULL );
+    CCM_VALIDATE_RET( length == 0 || output != NULL );
+    CCM_VALIDATE_RET( tag_len == 0 || tag != NULL );
+
+    if( ( ret = ccm_auth_crypt( ctx, CCM_DECRYPT, length,
+                                iv, iv_len, add, add_len,
+                                input, output, check_tag, tag_len ) ) != 0 )
+    {
+        return( ret );
+    }
+
+    /* Check tag in "constant-time" */
+    for( diff = 0, i = 0; i < tag_len; i++ )
+        diff |= tag[i] ^ check_tag[i];
+
+    if( diff != 0 )
+    {
+        mbedtls_platform_zeroize( output, length );
+        return( MBEDTLS_ERR_CCM_AUTH_FAILED );
+    }
+
+    return( 0 );
+}
+
+int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
+                      const unsigned char *iv, size_t iv_len,
+                      const unsigned char *add, size_t add_len,
+                      const unsigned char *input, unsigned char *output,
+                      const unsigned char *tag, size_t tag_len )
+{
+    CCM_VALIDATE_RET( ctx != NULL );
+    CCM_VALIDATE_RET( iv != NULL );
+    CCM_VALIDATE_RET( add_len == 0 || add != NULL );
+    CCM_VALIDATE_RET( length == 0 || input != NULL );
+    CCM_VALIDATE_RET( length == 0 || output != NULL );
+    CCM_VALIDATE_RET( tag_len == 0 || tag != NULL );
+
+    if( tag_len == 0 )
+        return( MBEDTLS_ERR_CCM_BAD_INPUT );
+
+    return( mbedtls_ccm_star_auth_decrypt( ctx, length, iv, iv_len, add,
+                add_len, input, output, tag, tag_len ) );
+}
+#endif /* !MBEDTLS_CCM_ALT */
+
+#if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
+/*
+ * Examples 1 to 3 from SP800-38C Appendix C
+ */
+
+#define NB_TESTS 3
+#define CCM_SELFTEST_PT_MAX_LEN 24
+#define CCM_SELFTEST_CT_MAX_LEN 32
+/*
+ * The data is the same for all tests, only the used length changes
+ */
+static const unsigned char key[] = {
+    0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
+    0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f
+};
+
+static const unsigned char iv[] = {
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+    0x18, 0x19, 0x1a, 0x1b
+};
+
+static const unsigned char ad[] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13
+};
+
+static const unsigned char msg[CCM_SELFTEST_PT_MAX_LEN] = {
+    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
+    0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
+    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+};
+
+static const size_t iv_len [NB_TESTS] = { 7, 8,  12 };
+static const size_t add_len[NB_TESTS] = { 8, 16, 20 };
+static const size_t msg_len[NB_TESTS] = { 4, 16, 24 };
+static const size_t tag_len[NB_TESTS] = { 4, 6,  8  };
+
+static const unsigned char res[NB_TESTS][CCM_SELFTEST_CT_MAX_LEN] = {
+    {   0x71, 0x62, 0x01, 0x5b, 0x4d, 0xac, 0x25, 0x5d },
+    {   0xd2, 0xa1, 0xf0, 0xe0, 0x51, 0xea, 0x5f, 0x62,
+        0x08, 0x1a, 0x77, 0x92, 0x07, 0x3d, 0x59, 0x3d,
+        0x1f, 0xc6, 0x4f, 0xbf, 0xac, 0xcd },
+    {   0xe3, 0xb2, 0x01, 0xa9, 0xf5, 0xb7, 0x1a, 0x7a,
+        0x9b, 0x1c, 0xea, 0xec, 0xcd, 0x97, 0xe7, 0x0b,
+        0x61, 0x76, 0xaa, 0xd9, 0xa4, 0x42, 0x8a, 0xa5,
+        0x48, 0x43, 0x92, 0xfb, 0xc1, 0xb0, 0x99, 0x51 }
+};
+
+int mbedtls_ccm_self_test( int verbose )
+{
+    mbedtls_ccm_context ctx;
+    /*
+     * Some hardware accelerators require the input and output buffers
+     * would be in RAM, because the flash is not accessible.
+     * Use buffers on the stack to hold the test vectors data.
+     */
+    unsigned char plaintext[CCM_SELFTEST_PT_MAX_LEN];
+    unsigned char ciphertext[CCM_SELFTEST_CT_MAX_LEN];
+    size_t i;
+    int ret;
+
+    mbedtls_ccm_init( &ctx );
+
+    if( mbedtls_ccm_setkey( &ctx, MBEDTLS_CIPHER_ID_AES, key, 8 * sizeof key ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "  CCM: setup failed" );
+
+        return( 1 );
+    }
+
+    for( i = 0; i < NB_TESTS; i++ )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "  CCM-AES #%u: ", (unsigned int) i + 1 );
+
+        memset( plaintext, 0, CCM_SELFTEST_PT_MAX_LEN );
+        memset( ciphertext, 0, CCM_SELFTEST_CT_MAX_LEN );
+        memcpy( plaintext, msg, msg_len[i] );
+
+        ret = mbedtls_ccm_encrypt_and_tag( &ctx, msg_len[i],
+                                           iv, iv_len[i], ad, add_len[i],
+                                           plaintext, ciphertext,
+                                           ciphertext + msg_len[i], tag_len[i] );
+
+        if( ret != 0 ||
+            memcmp( ciphertext, res[i], msg_len[i] + tag_len[i] ) != 0 )
+        {
+            if( verbose != 0 )
+                mbedtls_printf( "failed\n" );
+
+            return( 1 );
+        }
+        memset( plaintext, 0, CCM_SELFTEST_PT_MAX_LEN );
+
+        ret = mbedtls_ccm_auth_decrypt( &ctx, msg_len[i],
+                                        iv, iv_len[i], ad, add_len[i],
+                                        ciphertext, plaintext,
+                                        ciphertext + msg_len[i], tag_len[i] );
+
+        if( ret != 0 ||
+            memcmp( plaintext, msg, msg_len[i] ) != 0 )
+        {
+            if( verbose != 0 )
+                mbedtls_printf( "failed\n" );
+
+            return( 1 );
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+
+    mbedtls_ccm_free( &ctx );
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+
+    return( 0 );
+}
+
+#endif /* MBEDTLS_SELF_TEST && MBEDTLS_AES_C */
+
+#endif /* MBEDTLS_CCM_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/cipher.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/cipher.c
@@ -1,0 +1,1161 @@
+/**
+ * \file cipher.c
+ *
+ * \brief Generic cipher wrapper for mbed TLS
+ *
+ * \author Adriaan de Jong <dejong@fox-it.com>
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_CIPHER_C)
+
+#include "mbedtls/cipher.h"
+#include "mbedtls/cipher_internal.h"
+#include "mbedtls/platform_util.h"
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+#include "mbedtls/chachapoly.h"
+#endif
+
+#if defined(MBEDTLS_GCM_C)
+#include "mbedtls/gcm.h"
+#endif
+
+#if defined(MBEDTLS_CCM_C)
+#include "mbedtls/ccm.h"
+#endif
+
+#if defined(MBEDTLS_CHACHA20_C)
+#include "mbedtls/chacha20.h"
+#endif
+
+#if defined(MBEDTLS_CMAC_C)
+#include "mbedtls/cmac.h"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#define mbedtls_calloc calloc
+#define mbedtls_free   free
+#endif
+
+#define CIPHER_VALIDATE_RET( cond )    \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA )
+#define CIPHER_VALIDATE( cond )        \
+    MBEDTLS_INTERNAL_VALIDATE( cond )
+
+#if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
+/* Compare the contents of two buffers in constant time.
+ * Returns 0 if the contents are bitwise identical, otherwise returns
+ * a non-zero value.
+ * This is currently only used by GCM and ChaCha20+Poly1305.
+ */
+static int mbedtls_constant_time_memcmp( const void *v1, const void *v2, size_t len )
+{
+    const unsigned char *p1 = (const unsigned char*) v1;
+    const unsigned char *p2 = (const unsigned char*) v2;
+    size_t i;
+    unsigned char diff;
+
+    for( diff = 0, i = 0; i < len; i++ )
+        diff |= p1[i] ^ p2[i];
+
+    return( (int)diff );
+}
+#endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
+
+static int supported_init = 0;
+
+const int *mbedtls_cipher_list( void )
+{
+    const mbedtls_cipher_definition_t *def;
+    int *type;
+
+    if( ! supported_init )
+    {
+        def = mbedtls_cipher_definitions;
+        type = mbedtls_cipher_supported;
+
+        while( def->type != 0 )
+            *type++ = (*def++).type;
+
+        *type = 0;
+
+        supported_init = 1;
+    }
+
+    return( mbedtls_cipher_supported );
+}
+
+const mbedtls_cipher_info_t *mbedtls_cipher_info_from_type( const mbedtls_cipher_type_t cipher_type )
+{
+    const mbedtls_cipher_definition_t *def;
+
+    for( def = mbedtls_cipher_definitions; def->info != NULL; def++ )
+        if( def->type == cipher_type )
+            return( def->info );
+
+    return( NULL );
+}
+
+const mbedtls_cipher_info_t *mbedtls_cipher_info_from_string( const char *cipher_name )
+{
+    const mbedtls_cipher_definition_t *def;
+
+    if( NULL == cipher_name )
+        return( NULL );
+
+    for( def = mbedtls_cipher_definitions; def->info != NULL; def++ )
+        if( !  strcmp( def->info->name, cipher_name ) )
+            return( def->info );
+
+    return( NULL );
+}
+
+const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values( const mbedtls_cipher_id_t cipher_id,
+                                              int key_bitlen,
+                                              const mbedtls_cipher_mode_t mode )
+{
+    const mbedtls_cipher_definition_t *def;
+
+    for( def = mbedtls_cipher_definitions; def->info != NULL; def++ )
+        if( def->info->base->cipher == cipher_id &&
+            def->info->key_bitlen == (unsigned) key_bitlen &&
+            def->info->mode == mode )
+            return( def->info );
+
+    return( NULL );
+}
+
+void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx )
+{
+    CIPHER_VALIDATE( ctx != NULL );
+    memset( ctx, 0, sizeof( mbedtls_cipher_context_t ) );
+}
+
+void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+#if defined(MBEDTLS_CMAC_C)
+    if( ctx->cmac_ctx )
+    {
+       mbedtls_platform_zeroize( ctx->cmac_ctx,
+                                 sizeof( mbedtls_cmac_context_t ) );
+       mbedtls_free( ctx->cmac_ctx );
+    }
+#endif
+
+    if( ctx->cipher_ctx )
+        ctx->cipher_info->base->ctx_free_func( ctx->cipher_ctx );
+
+    mbedtls_platform_zeroize( ctx, sizeof(mbedtls_cipher_context_t) );
+}
+
+int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx, const mbedtls_cipher_info_t *cipher_info )
+{
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    if( cipher_info == NULL )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    memset( ctx, 0, sizeof( mbedtls_cipher_context_t ) );
+
+    if( NULL == ( ctx->cipher_ctx = cipher_info->base->ctx_alloc_func() ) )
+        return( MBEDTLS_ERR_CIPHER_ALLOC_FAILED );
+
+    ctx->cipher_info = cipher_info;
+
+#if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
+    /*
+     * Ignore possible errors caused by a cipher mode that doesn't use padding
+     */
+#if defined(MBEDTLS_CIPHER_PADDING_PKCS7)
+    (void) mbedtls_cipher_set_padding_mode( ctx, MBEDTLS_PADDING_PKCS7 );
+#else
+    (void) mbedtls_cipher_set_padding_mode( ctx, MBEDTLS_PADDING_NONE );
+#endif
+#endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
+
+    return( 0 );
+}
+
+int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
+                           const unsigned char *key,
+                           int key_bitlen,
+                           const mbedtls_operation_t operation )
+{
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    CIPHER_VALIDATE_RET( key != NULL );
+    CIPHER_VALIDATE_RET( operation == MBEDTLS_ENCRYPT ||
+                         operation == MBEDTLS_DECRYPT );
+    if( ctx->cipher_info == NULL )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    if( ( ctx->cipher_info->flags & MBEDTLS_CIPHER_VARIABLE_KEY_LEN ) == 0 &&
+        (int) ctx->cipher_info->key_bitlen != key_bitlen )
+    {
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    }
+
+    ctx->key_bitlen = key_bitlen;
+    ctx->operation = operation;
+
+    /*
+     * For OFB, CFB and CTR mode always use the encryption key schedule
+     */
+    if( MBEDTLS_ENCRYPT == operation ||
+        MBEDTLS_MODE_CFB == ctx->cipher_info->mode ||
+        MBEDTLS_MODE_OFB == ctx->cipher_info->mode ||
+        MBEDTLS_MODE_CTR == ctx->cipher_info->mode )
+    {
+        return( ctx->cipher_info->base->setkey_enc_func( ctx->cipher_ctx, key,
+                                                         ctx->key_bitlen ) );
+    }
+
+    if( MBEDTLS_DECRYPT == operation )
+        return( ctx->cipher_info->base->setkey_dec_func( ctx->cipher_ctx, key,
+                                                         ctx->key_bitlen ) );
+
+    return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+}
+
+int mbedtls_cipher_set_iv( mbedtls_cipher_context_t *ctx,
+                           const unsigned char *iv,
+                           size_t iv_len )
+{
+    size_t actual_iv_size;
+
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    CIPHER_VALIDATE_RET( iv_len == 0 || iv != NULL );
+    if( ctx->cipher_info == NULL )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    /* avoid buffer overflow in ctx->iv */
+    if( iv_len > MBEDTLS_MAX_IV_LENGTH )
+        return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
+
+    if( ( ctx->cipher_info->flags & MBEDTLS_CIPHER_VARIABLE_IV_LEN ) != 0 )
+        actual_iv_size = iv_len;
+    else
+    {
+        actual_iv_size = ctx->cipher_info->iv_size;
+
+        /* avoid reading past the end of input buffer */
+        if( actual_iv_size > iv_len )
+            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    }
+
+#if defined(MBEDTLS_CHACHA20_C)
+    if ( ctx->cipher_info->type == MBEDTLS_CIPHER_CHACHA20 )
+    {
+        if ( 0 != mbedtls_chacha20_starts( (mbedtls_chacha20_context*)ctx->cipher_ctx,
+                                           iv,
+                                           0U ) ) /* Initial counter value */
+        {
+            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+        }
+    }
+#endif
+
+    if ( actual_iv_size != 0 )
+    {
+        memcpy( ctx->iv, iv, actual_iv_size );
+        ctx->iv_size = actual_iv_size;
+    }
+
+    return( 0 );
+}
+
+int mbedtls_cipher_reset( mbedtls_cipher_context_t *ctx )
+{
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    if( ctx->cipher_info == NULL )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    ctx->unprocessed_len = 0;
+
+    return( 0 );
+}
+
+#if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
+int mbedtls_cipher_update_ad( mbedtls_cipher_context_t *ctx,
+                      const unsigned char *ad, size_t ad_len )
+{
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    CIPHER_VALIDATE_RET( ad_len == 0 || ad != NULL );
+    if( ctx->cipher_info == NULL )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+#if defined(MBEDTLS_GCM_C)
+    if( MBEDTLS_MODE_GCM == ctx->cipher_info->mode )
+    {
+        return( mbedtls_gcm_starts( (mbedtls_gcm_context *) ctx->cipher_ctx, ctx->operation,
+                                    ctx->iv, ctx->iv_size, ad, ad_len ) );
+    }
+#endif
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+    if (MBEDTLS_CIPHER_CHACHA20_POLY1305 == ctx->cipher_info->type )
+    {
+        int result;
+        mbedtls_chachapoly_mode_t mode;
+
+        mode = ( ctx->operation == MBEDTLS_ENCRYPT )
+                ? MBEDTLS_CHACHAPOLY_ENCRYPT
+                : MBEDTLS_CHACHAPOLY_DECRYPT;
+
+        result = mbedtls_chachapoly_starts( (mbedtls_chachapoly_context*) ctx->cipher_ctx,
+                                                        ctx->iv,
+                                                        mode );
+        if ( result != 0 )
+            return( result );
+
+        return( mbedtls_chachapoly_update_aad( (mbedtls_chachapoly_context*) ctx->cipher_ctx,
+                                               ad, ad_len ) );
+    }
+#endif
+
+    return( 0 );
+}
+#endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
+
+int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *input,
+                   size_t ilen, unsigned char *output, size_t *olen )
+{
+    int ret;
+    size_t block_size;
+
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    CIPHER_VALIDATE_RET( ilen == 0 || input != NULL );
+    CIPHER_VALIDATE_RET( output != NULL );
+    CIPHER_VALIDATE_RET( olen != NULL );
+    if( ctx->cipher_info == NULL )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    *olen = 0;
+    block_size = mbedtls_cipher_get_block_size( ctx );
+
+    if( ctx->cipher_info->mode == MBEDTLS_MODE_ECB )
+    {
+        if( ilen != block_size )
+            return( MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED );
+
+        *olen = ilen;
+
+        if( 0 != ( ret = ctx->cipher_info->base->ecb_func( ctx->cipher_ctx,
+                    ctx->operation, input, output ) ) )
+        {
+            return( ret );
+        }
+
+        return( 0 );
+    }
+
+#if defined(MBEDTLS_GCM_C)
+    if( ctx->cipher_info->mode == MBEDTLS_MODE_GCM )
+    {
+        *olen = ilen;
+        return( mbedtls_gcm_update( (mbedtls_gcm_context *) ctx->cipher_ctx, ilen, input,
+                                    output ) );
+    }
+#endif
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+    if ( ctx->cipher_info->type == MBEDTLS_CIPHER_CHACHA20_POLY1305 )
+    {
+        *olen = ilen;
+        return( mbedtls_chachapoly_update( (mbedtls_chachapoly_context*) ctx->cipher_ctx,
+                                           ilen, input, output ) );
+    }
+#endif
+
+    if ( 0 == block_size )
+    {
+        return( MBEDTLS_ERR_CIPHER_INVALID_CONTEXT );
+    }
+
+    if( input == output &&
+       ( ctx->unprocessed_len != 0 || ilen % block_size ) )
+    {
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    }
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    if( ctx->cipher_info->mode == MBEDTLS_MODE_CBC )
+    {
+        size_t copy_len = 0;
+
+        /*
+         * If there is not enough data for a full block, cache it.
+         */
+        if( ( ctx->operation == MBEDTLS_DECRYPT && NULL != ctx->add_padding &&
+                ilen <= block_size - ctx->unprocessed_len ) ||
+            ( ctx->operation == MBEDTLS_DECRYPT && NULL == ctx->add_padding &&
+                ilen < block_size - ctx->unprocessed_len ) ||
+             ( ctx->operation == MBEDTLS_ENCRYPT &&
+                ilen < block_size - ctx->unprocessed_len ) )
+        {
+            memcpy( &( ctx->unprocessed_data[ctx->unprocessed_len] ), input,
+                    ilen );
+
+            ctx->unprocessed_len += ilen;
+            return( 0 );
+        }
+
+        /*
+         * Process cached data first
+         */
+        if( 0 != ctx->unprocessed_len )
+        {
+            copy_len = block_size - ctx->unprocessed_len;
+
+            memcpy( &( ctx->unprocessed_data[ctx->unprocessed_len] ), input,
+                    copy_len );
+
+            if( 0 != ( ret = ctx->cipher_info->base->cbc_func( ctx->cipher_ctx,
+                    ctx->operation, block_size, ctx->iv,
+                    ctx->unprocessed_data, output ) ) )
+            {
+                return( ret );
+            }
+
+            *olen += block_size;
+            output += block_size;
+            ctx->unprocessed_len = 0;
+
+            input += copy_len;
+            ilen -= copy_len;
+        }
+
+        /*
+         * Cache final, incomplete block
+         */
+        if( 0 != ilen )
+        {
+            if( 0 == block_size )
+            {
+                return( MBEDTLS_ERR_CIPHER_INVALID_CONTEXT );
+            }
+
+            /* Encryption: only cache partial blocks
+             * Decryption w/ padding: always keep at least one whole block
+             * Decryption w/o padding: only cache partial blocks
+             */
+            copy_len = ilen % block_size;
+            if( copy_len == 0 &&
+                ctx->operation == MBEDTLS_DECRYPT &&
+                NULL != ctx->add_padding)
+            {
+                copy_len = block_size;
+            }
+
+            memcpy( ctx->unprocessed_data, &( input[ilen - copy_len] ),
+                    copy_len );
+
+            ctx->unprocessed_len += copy_len;
+            ilen -= copy_len;
+        }
+
+        /*
+         * Process remaining full blocks
+         */
+        if( ilen )
+        {
+            if( 0 != ( ret = ctx->cipher_info->base->cbc_func( ctx->cipher_ctx,
+                    ctx->operation, ilen, ctx->iv, input, output ) ) )
+            {
+                return( ret );
+            }
+
+            *olen += ilen;
+        }
+
+        return( 0 );
+    }
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    if( ctx->cipher_info->mode == MBEDTLS_MODE_CFB )
+    {
+        if( 0 != ( ret = ctx->cipher_info->base->cfb_func( ctx->cipher_ctx,
+                ctx->operation, ilen, &ctx->unprocessed_len, ctx->iv,
+                input, output ) ) )
+        {
+            return( ret );
+        }
+
+        *olen = ilen;
+
+        return( 0 );
+    }
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    if( ctx->cipher_info->mode == MBEDTLS_MODE_OFB )
+    {
+        if( 0 != ( ret = ctx->cipher_info->base->ofb_func( ctx->cipher_ctx,
+                ilen, &ctx->unprocessed_len, ctx->iv, input, output ) ) )
+        {
+            return( ret );
+        }
+
+        *olen = ilen;
+
+        return( 0 );
+    }
+#endif /* MBEDTLS_CIPHER_MODE_OFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    if( ctx->cipher_info->mode == MBEDTLS_MODE_CTR )
+    {
+        if( 0 != ( ret = ctx->cipher_info->base->ctr_func( ctx->cipher_ctx,
+                ilen, &ctx->unprocessed_len, ctx->iv,
+                ctx->unprocessed_data, input, output ) ) )
+        {
+            return( ret );
+        }
+
+        *olen = ilen;
+
+        return( 0 );
+    }
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    if( ctx->cipher_info->mode == MBEDTLS_MODE_XTS )
+    {
+        if( ctx->unprocessed_len > 0 ) {
+            /* We can only process an entire data unit at a time. */
+            return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
+        }
+
+        ret = ctx->cipher_info->base->xts_func( ctx->cipher_ctx,
+                ctx->operation, ilen, ctx->iv, input, output );
+        if( ret != 0 )
+        {
+            return( ret );
+        }
+
+        *olen = ilen;
+
+        return( 0 );
+    }
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    if( ctx->cipher_info->mode == MBEDTLS_MODE_STREAM )
+    {
+        if( 0 != ( ret = ctx->cipher_info->base->stream_func( ctx->cipher_ctx,
+                                                    ilen, input, output ) ) )
+        {
+            return( ret );
+        }
+
+        *olen = ilen;
+
+        return( 0 );
+    }
+#endif /* MBEDTLS_CIPHER_MODE_STREAM */
+
+    return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
+#if defined(MBEDTLS_CIPHER_PADDING_PKCS7)
+/*
+ * PKCS7 (and PKCS5) padding: fill with ll bytes, with ll = padding_len
+ */
+static void add_pkcs_padding( unsigned char *output, size_t output_len,
+        size_t data_len )
+{
+    size_t padding_len = output_len - data_len;
+    unsigned char i;
+
+    for( i = 0; i < padding_len; i++ )
+        output[data_len + i] = (unsigned char) padding_len;
+}
+
+static int get_pkcs_padding( unsigned char *input, size_t input_len,
+        size_t *data_len )
+{
+    size_t i, pad_idx;
+    unsigned char padding_len, bad = 0;
+
+    if( NULL == input || NULL == data_len )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    padding_len = input[input_len - 1];
+    *data_len = input_len - padding_len;
+
+    /* Avoid logical || since it results in a branch */
+    bad |= padding_len > input_len;
+    bad |= padding_len == 0;
+
+    /* The number of bytes checked must be independent of padding_len,
+     * so pick input_len, which is usually 8 or 16 (one block) */
+    pad_idx = input_len - padding_len;
+    for( i = 0; i < input_len; i++ )
+        bad |= ( input[i] ^ padding_len ) * ( i >= pad_idx );
+
+    return( MBEDTLS_ERR_CIPHER_INVALID_PADDING * ( bad != 0 ) );
+}
+#endif /* MBEDTLS_CIPHER_PADDING_PKCS7 */
+
+#if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS)
+/*
+ * One and zeros padding: fill with 80 00 ... 00
+ */
+static void add_one_and_zeros_padding( unsigned char *output,
+                                       size_t output_len, size_t data_len )
+{
+    size_t padding_len = output_len - data_len;
+    unsigned char i = 0;
+
+    output[data_len] = 0x80;
+    for( i = 1; i < padding_len; i++ )
+        output[data_len + i] = 0x00;
+}
+
+static int get_one_and_zeros_padding( unsigned char *input, size_t input_len,
+                                      size_t *data_len )
+{
+    size_t i;
+    unsigned char done = 0, prev_done, bad;
+
+    if( NULL == input || NULL == data_len )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    bad = 0x80;
+    *data_len = 0;
+    for( i = input_len; i > 0; i-- )
+    {
+        prev_done = done;
+        done |= ( input[i - 1] != 0 );
+        *data_len |= ( i - 1 ) * ( done != prev_done );
+        bad ^= input[i - 1] * ( done != prev_done );
+    }
+
+    return( MBEDTLS_ERR_CIPHER_INVALID_PADDING * ( bad != 0 ) );
+
+}
+#endif /* MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS */
+
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN)
+/*
+ * Zeros and len padding: fill with 00 ... 00 ll, where ll is padding length
+ */
+static void add_zeros_and_len_padding( unsigned char *output,
+                                       size_t output_len, size_t data_len )
+{
+    size_t padding_len = output_len - data_len;
+    unsigned char i = 0;
+
+    for( i = 1; i < padding_len; i++ )
+        output[data_len + i - 1] = 0x00;
+    output[output_len - 1] = (unsigned char) padding_len;
+}
+
+static int get_zeros_and_len_padding( unsigned char *input, size_t input_len,
+                                      size_t *data_len )
+{
+    size_t i, pad_idx;
+    unsigned char padding_len, bad = 0;
+
+    if( NULL == input || NULL == data_len )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    padding_len = input[input_len - 1];
+    *data_len = input_len - padding_len;
+
+    /* Avoid logical || since it results in a branch */
+    bad |= padding_len > input_len;
+    bad |= padding_len == 0;
+
+    /* The number of bytes checked must be independent of padding_len */
+    pad_idx = input_len - padding_len;
+    for( i = 0; i < input_len - 1; i++ )
+        bad |= input[i] * ( i >= pad_idx );
+
+    return( MBEDTLS_ERR_CIPHER_INVALID_PADDING * ( bad != 0 ) );
+}
+#endif /* MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN */
+
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS)
+/*
+ * Zero padding: fill with 00 ... 00
+ */
+static void add_zeros_padding( unsigned char *output,
+                               size_t output_len, size_t data_len )
+{
+    size_t i;
+
+    for( i = data_len; i < output_len; i++ )
+        output[i] = 0x00;
+}
+
+static int get_zeros_padding( unsigned char *input, size_t input_len,
+                              size_t *data_len )
+{
+    size_t i;
+    unsigned char done = 0, prev_done;
+
+    if( NULL == input || NULL == data_len )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    *data_len = 0;
+    for( i = input_len; i > 0; i-- )
+    {
+        prev_done = done;
+        done |= ( input[i-1] != 0 );
+        *data_len |= i * ( done != prev_done );
+    }
+
+    return( 0 );
+}
+#endif /* MBEDTLS_CIPHER_PADDING_ZEROS */
+
+/*
+ * No padding: don't pad :)
+ *
+ * There is no add_padding function (check for NULL in mbedtls_cipher_finish)
+ * but a trivial get_padding function
+ */
+static int get_no_padding( unsigned char *input, size_t input_len,
+                              size_t *data_len )
+{
+    if( NULL == input || NULL == data_len )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    *data_len = input_len;
+
+    return( 0 );
+}
+#endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
+
+int mbedtls_cipher_finish( mbedtls_cipher_context_t *ctx,
+                   unsigned char *output, size_t *olen )
+{
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    CIPHER_VALIDATE_RET( output != NULL );
+    CIPHER_VALIDATE_RET( olen != NULL );
+    if( ctx->cipher_info == NULL )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    *olen = 0;
+
+    if( MBEDTLS_MODE_CFB == ctx->cipher_info->mode ||
+        MBEDTLS_MODE_OFB == ctx->cipher_info->mode ||
+        MBEDTLS_MODE_CTR == ctx->cipher_info->mode ||
+        MBEDTLS_MODE_GCM == ctx->cipher_info->mode ||
+        MBEDTLS_MODE_XTS == ctx->cipher_info->mode ||
+        MBEDTLS_MODE_STREAM == ctx->cipher_info->mode )
+    {
+        return( 0 );
+    }
+
+    if ( ( MBEDTLS_CIPHER_CHACHA20          == ctx->cipher_info->type ) ||
+         ( MBEDTLS_CIPHER_CHACHA20_POLY1305 == ctx->cipher_info->type ) )
+    {
+        return( 0 );
+    }
+
+    if( MBEDTLS_MODE_ECB == ctx->cipher_info->mode )
+    {
+        if( ctx->unprocessed_len != 0 )
+            return( MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED );
+
+        return( 0 );
+    }
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    if( MBEDTLS_MODE_CBC == ctx->cipher_info->mode )
+    {
+        int ret = 0;
+
+        if( MBEDTLS_ENCRYPT == ctx->operation )
+        {
+            /* check for 'no padding' mode */
+            if( NULL == ctx->add_padding )
+            {
+                if( 0 != ctx->unprocessed_len )
+                    return( MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED );
+
+                return( 0 );
+            }
+
+            ctx->add_padding( ctx->unprocessed_data, mbedtls_cipher_get_iv_size( ctx ),
+                    ctx->unprocessed_len );
+        }
+        else if( mbedtls_cipher_get_block_size( ctx ) != ctx->unprocessed_len )
+        {
+            /*
+             * For decrypt operations, expect a full block,
+             * or an empty block if no padding
+             */
+            if( NULL == ctx->add_padding && 0 == ctx->unprocessed_len )
+                return( 0 );
+
+            return( MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED );
+        }
+
+        /* cipher block */
+        if( 0 != ( ret = ctx->cipher_info->base->cbc_func( ctx->cipher_ctx,
+                ctx->operation, mbedtls_cipher_get_block_size( ctx ), ctx->iv,
+                ctx->unprocessed_data, output ) ) )
+        {
+            return( ret );
+        }
+
+        /* Set output size for decryption */
+        if( MBEDTLS_DECRYPT == ctx->operation )
+            return( ctx->get_padding( output, mbedtls_cipher_get_block_size( ctx ),
+                                      olen ) );
+
+        /* Set output size for encryption */
+        *olen = mbedtls_cipher_get_block_size( ctx );
+        return( 0 );
+    }
+#else
+    ((void) output);
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+    return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
+int mbedtls_cipher_set_padding_mode( mbedtls_cipher_context_t *ctx,
+                                     mbedtls_cipher_padding_t mode )
+{
+    CIPHER_VALIDATE_RET( ctx != NULL );
+
+    if( NULL == ctx->cipher_info || MBEDTLS_MODE_CBC != ctx->cipher_info->mode )
+    {
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    }
+
+    switch( mode )
+    {
+#if defined(MBEDTLS_CIPHER_PADDING_PKCS7)
+    case MBEDTLS_PADDING_PKCS7:
+        ctx->add_padding = add_pkcs_padding;
+        ctx->get_padding = get_pkcs_padding;
+        break;
+#endif
+#if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS)
+    case MBEDTLS_PADDING_ONE_AND_ZEROS:
+        ctx->add_padding = add_one_and_zeros_padding;
+        ctx->get_padding = get_one_and_zeros_padding;
+        break;
+#endif
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN)
+    case MBEDTLS_PADDING_ZEROS_AND_LEN:
+        ctx->add_padding = add_zeros_and_len_padding;
+        ctx->get_padding = get_zeros_and_len_padding;
+        break;
+#endif
+#if defined(MBEDTLS_CIPHER_PADDING_ZEROS)
+    case MBEDTLS_PADDING_ZEROS:
+        ctx->add_padding = add_zeros_padding;
+        ctx->get_padding = get_zeros_padding;
+        break;
+#endif
+    case MBEDTLS_PADDING_NONE:
+        ctx->add_padding = NULL;
+        ctx->get_padding = get_no_padding;
+        break;
+
+    default:
+        return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
+    }
+
+    return( 0 );
+}
+#endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
+
+#if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
+int mbedtls_cipher_write_tag( mbedtls_cipher_context_t *ctx,
+                      unsigned char *tag, size_t tag_len )
+{
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    CIPHER_VALIDATE_RET( tag_len == 0 || tag != NULL );
+    if( ctx->cipher_info == NULL )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    if( MBEDTLS_ENCRYPT != ctx->operation )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+#if defined(MBEDTLS_GCM_C)
+    if( MBEDTLS_MODE_GCM == ctx->cipher_info->mode )
+        return( mbedtls_gcm_finish( (mbedtls_gcm_context *) ctx->cipher_ctx,
+                                    tag, tag_len ) );
+#endif
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+    if ( MBEDTLS_CIPHER_CHACHA20_POLY1305 == ctx->cipher_info->type )
+    {
+        /* Don't allow truncated MAC for Poly1305 */
+        if ( tag_len != 16U )
+            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+        return( mbedtls_chachapoly_finish( (mbedtls_chachapoly_context*) ctx->cipher_ctx,
+                                           tag ) );
+    }
+#endif
+
+    return( 0 );
+}
+
+int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
+                      const unsigned char *tag, size_t tag_len )
+{
+    unsigned char check_tag[16];
+    int ret;
+
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    CIPHER_VALIDATE_RET( tag_len == 0 || tag != NULL );
+    if( ctx->cipher_info == NULL )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    if( MBEDTLS_DECRYPT != ctx->operation )
+    {
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    }
+
+#if defined(MBEDTLS_GCM_C)
+    if( MBEDTLS_MODE_GCM == ctx->cipher_info->mode )
+    {
+        if( tag_len > sizeof( check_tag ) )
+            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+        if( 0 != ( ret = mbedtls_gcm_finish( (mbedtls_gcm_context *) ctx->cipher_ctx,
+                                     check_tag, tag_len ) ) )
+        {
+            return( ret );
+        }
+
+        /* Check the tag in "constant-time" */
+        if( mbedtls_constant_time_memcmp( tag, check_tag, tag_len ) != 0 )
+            return( MBEDTLS_ERR_CIPHER_AUTH_FAILED );
+
+        return( 0 );
+    }
+#endif /* MBEDTLS_GCM_C */
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+    if ( MBEDTLS_CIPHER_CHACHA20_POLY1305 == ctx->cipher_info->type )
+    {
+        /* Don't allow truncated MAC for Poly1305 */
+        if ( tag_len != sizeof( check_tag ) )
+            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+        ret = mbedtls_chachapoly_finish( (mbedtls_chachapoly_context*) ctx->cipher_ctx,
+                                                     check_tag );
+        if ( ret != 0 )
+        {
+            return( ret );
+        }
+
+        /* Check the tag in "constant-time" */
+        if( mbedtls_constant_time_memcmp( tag, check_tag, tag_len ) != 0 )
+            return( MBEDTLS_ERR_CIPHER_AUTH_FAILED );
+
+        return( 0 );
+    }
+#endif /* MBEDTLS_CHACHAPOLY_C */
+
+    return( 0 );
+}
+#endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
+
+/*
+ * Packet-oriented wrapper for non-AEAD modes
+ */
+int mbedtls_cipher_crypt( mbedtls_cipher_context_t *ctx,
+                  const unsigned char *iv, size_t iv_len,
+                  const unsigned char *input, size_t ilen,
+                  unsigned char *output, size_t *olen )
+{
+    int ret;
+    size_t finish_olen;
+
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    CIPHER_VALIDATE_RET( iv_len == 0 || iv != NULL );
+    CIPHER_VALIDATE_RET( ilen == 0 || input != NULL );
+    CIPHER_VALIDATE_RET( output != NULL );
+    CIPHER_VALIDATE_RET( olen != NULL );
+
+    if( ( ret = mbedtls_cipher_set_iv( ctx, iv, iv_len ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_cipher_reset( ctx ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_cipher_update( ctx, input, ilen, output, olen ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_cipher_finish( ctx, output + *olen, &finish_olen ) ) != 0 )
+        return( ret );
+
+    *olen += finish_olen;
+
+    return( 0 );
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_AEAD)
+/*
+ * Packet-oriented encryption for AEAD modes
+ */
+int mbedtls_cipher_auth_encrypt( mbedtls_cipher_context_t *ctx,
+                         const unsigned char *iv, size_t iv_len,
+                         const unsigned char *ad, size_t ad_len,
+                         const unsigned char *input, size_t ilen,
+                         unsigned char *output, size_t *olen,
+                         unsigned char *tag, size_t tag_len )
+{
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    CIPHER_VALIDATE_RET( iv != NULL );
+    CIPHER_VALIDATE_RET( ad_len == 0 || ad != NULL );
+    CIPHER_VALIDATE_RET( ilen == 0 || input != NULL );
+    CIPHER_VALIDATE_RET( output != NULL );
+    CIPHER_VALIDATE_RET( olen != NULL );
+    CIPHER_VALIDATE_RET( tag_len == 0 || tag != NULL );
+
+#if defined(MBEDTLS_GCM_C)
+    if( MBEDTLS_MODE_GCM == ctx->cipher_info->mode )
+    {
+        *olen = ilen;
+        return( mbedtls_gcm_crypt_and_tag( ctx->cipher_ctx, MBEDTLS_GCM_ENCRYPT, ilen,
+                                   iv, iv_len, ad, ad_len, input, output,
+                                   tag_len, tag ) );
+    }
+#endif /* MBEDTLS_GCM_C */
+#if defined(MBEDTLS_CCM_C)
+    if( MBEDTLS_MODE_CCM == ctx->cipher_info->mode )
+    {
+        *olen = ilen;
+        return( mbedtls_ccm_encrypt_and_tag( ctx->cipher_ctx, ilen,
+                                     iv, iv_len, ad, ad_len, input, output,
+                                     tag, tag_len ) );
+    }
+#endif /* MBEDTLS_CCM_C */
+#if defined(MBEDTLS_CHACHAPOLY_C)
+    if ( MBEDTLS_CIPHER_CHACHA20_POLY1305 == ctx->cipher_info->type )
+    {
+        /* ChachaPoly has fixed length nonce and MAC (tag) */
+        if ( ( iv_len != ctx->cipher_info->iv_size ) ||
+             ( tag_len != 16U ) )
+        {
+            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+        }
+
+        *olen = ilen;
+        return( mbedtls_chachapoly_encrypt_and_tag( ctx->cipher_ctx,
+                                ilen, iv, ad, ad_len, input, output, tag ) );
+    }
+#endif /* MBEDTLS_CHACHAPOLY_C */
+
+    return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
+}
+
+/*
+ * Packet-oriented decryption for AEAD modes
+ */
+int mbedtls_cipher_auth_decrypt( mbedtls_cipher_context_t *ctx,
+                         const unsigned char *iv, size_t iv_len,
+                         const unsigned char *ad, size_t ad_len,
+                         const unsigned char *input, size_t ilen,
+                         unsigned char *output, size_t *olen,
+                         const unsigned char *tag, size_t tag_len )
+{
+    CIPHER_VALIDATE_RET( ctx != NULL );
+    CIPHER_VALIDATE_RET( iv != NULL );
+    CIPHER_VALIDATE_RET( ad_len == 0 || ad != NULL );
+    CIPHER_VALIDATE_RET( ilen == 0 || input != NULL );
+    CIPHER_VALIDATE_RET( output != NULL );
+    CIPHER_VALIDATE_RET( olen != NULL );
+    CIPHER_VALIDATE_RET( tag_len == 0 || tag != NULL );
+
+#if defined(MBEDTLS_GCM_C)
+    if( MBEDTLS_MODE_GCM == ctx->cipher_info->mode )
+    {
+        int ret;
+
+        *olen = ilen;
+        ret = mbedtls_gcm_auth_decrypt( ctx->cipher_ctx, ilen,
+                                iv, iv_len, ad, ad_len,
+                                tag, tag_len, input, output );
+
+        if( ret == MBEDTLS_ERR_GCM_AUTH_FAILED )
+            ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
+
+        return( ret );
+    }
+#endif /* MBEDTLS_GCM_C */
+#if defined(MBEDTLS_CCM_C)
+    if( MBEDTLS_MODE_CCM == ctx->cipher_info->mode )
+    {
+        int ret;
+
+        *olen = ilen;
+        ret = mbedtls_ccm_auth_decrypt( ctx->cipher_ctx, ilen,
+                                iv, iv_len, ad, ad_len,
+                                input, output, tag, tag_len );
+
+        if( ret == MBEDTLS_ERR_CCM_AUTH_FAILED )
+            ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
+
+        return( ret );
+    }
+#endif /* MBEDTLS_CCM_C */
+#if defined(MBEDTLS_CHACHAPOLY_C)
+    if ( MBEDTLS_CIPHER_CHACHA20_POLY1305 == ctx->cipher_info->type )
+    {
+        int ret;
+
+        /* ChachaPoly has fixed length nonce and MAC (tag) */
+        if ( ( iv_len != ctx->cipher_info->iv_size ) ||
+             ( tag_len != 16U ) )
+        {
+            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+        }
+
+        *olen = ilen;
+        ret = mbedtls_chachapoly_auth_decrypt( ctx->cipher_ctx, ilen,
+                                iv, ad, ad_len, tag, input, output );
+
+        if( ret == MBEDTLS_ERR_CHACHAPOLY_AUTH_FAILED )
+            ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
+
+        return( ret );
+    }
+#endif /* MBEDTLS_CHACHAPOLY_C */
+
+    return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
+}
+#endif /* MBEDTLS_CIPHER_MODE_AEAD */
+
+#endif /* MBEDTLS_CIPHER_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/cipher_wrap.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/cipher_wrap.c
@@ -1,0 +1,2272 @@
+/**
+ * \file cipher_wrap.c
+ *
+ * \brief Generic cipher wrapper for mbed TLS
+ *
+ * \author Adriaan de Jong <dejong@fox-it.com>
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_CIPHER_C)
+
+#include "mbedtls/cipher_internal.h"
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+#include "mbedtls/chachapoly.h"
+#endif
+
+#if defined(MBEDTLS_AES_C)
+#include "mbedtls/aes.h"
+#endif
+
+#if defined(MBEDTLS_ARC4_C)
+#include "mbedtls/arc4.h"
+#endif
+
+#if defined(MBEDTLS_CAMELLIA_C)
+#include "mbedtls/camellia.h"
+#endif
+
+#if defined(MBEDTLS_ARIA_C)
+#include "mbedtls/aria.h"
+#endif
+
+#if defined(MBEDTLS_DES_C)
+#include "mbedtls/des.h"
+#endif
+
+#if defined(MBEDTLS_BLOWFISH_C)
+#include "mbedtls/blowfish.h"
+#endif
+
+#if defined(MBEDTLS_CHACHA20_C)
+#include "mbedtls/chacha20.h"
+#endif
+
+#if defined(MBEDTLS_GCM_C)
+#include "mbedtls/gcm.h"
+#endif
+
+#if defined(MBEDTLS_CCM_C)
+#include "mbedtls/ccm.h"
+#endif
+
+#if defined(MBEDTLS_CIPHER_NULL_CIPHER)
+#include <string.h>
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdlib.h>
+#define mbedtls_calloc    calloc
+#define mbedtls_free       free
+#endif
+
+#if defined(MBEDTLS_GCM_C)
+/* shared by all GCM ciphers */
+static void *gcm_ctx_alloc( void )
+{
+    void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_gcm_context ) );
+
+    if( ctx != NULL )
+        mbedtls_gcm_init( (mbedtls_gcm_context *) ctx );
+
+    return( ctx );
+}
+
+static void gcm_ctx_free( void *ctx )
+{
+    mbedtls_gcm_free( ctx );
+    mbedtls_free( ctx );
+}
+#endif /* MBEDTLS_GCM_C */
+
+#if defined(MBEDTLS_CCM_C)
+/* shared by all CCM ciphers */
+static void *ccm_ctx_alloc( void )
+{
+    void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_ccm_context ) );
+
+    if( ctx != NULL )
+        mbedtls_ccm_init( (mbedtls_ccm_context *) ctx );
+
+    return( ctx );
+}
+
+static void ccm_ctx_free( void *ctx )
+{
+    mbedtls_ccm_free( ctx );
+    mbedtls_free( ctx );
+}
+#endif /* MBEDTLS_CCM_C */
+
+#if defined(MBEDTLS_AES_C)
+
+static int aes_crypt_ecb_wrap( void *ctx, mbedtls_operation_t operation,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_aes_crypt_ecb( (mbedtls_aes_context *) ctx, operation, input, output );
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static int aes_crypt_cbc_wrap( void *ctx, mbedtls_operation_t operation, size_t length,
+        unsigned char *iv, const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_aes_crypt_cbc( (mbedtls_aes_context *) ctx, operation, length, iv, input,
+                          output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+static int aes_crypt_cfb128_wrap( void *ctx, mbedtls_operation_t operation,
+        size_t length, size_t *iv_off, unsigned char *iv,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_aes_crypt_cfb128( (mbedtls_aes_context *) ctx, operation, length, iv_off, iv,
+                             input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+static int aes_crypt_ofb_wrap( void *ctx, size_t length, size_t *iv_off,
+        unsigned char *iv, const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_aes_crypt_ofb( (mbedtls_aes_context *) ctx, length, iv_off,
+                                    iv, input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_OFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+static int aes_crypt_ctr_wrap( void *ctx, size_t length, size_t *nc_off,
+        unsigned char *nonce_counter, unsigned char *stream_block,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_aes_crypt_ctr( (mbedtls_aes_context *) ctx, length, nc_off, nonce_counter,
+                          stream_block, input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+static int aes_crypt_xts_wrap( void *ctx, mbedtls_operation_t operation,
+                               size_t length,
+                               const unsigned char data_unit[16],
+                               const unsigned char *input,
+                               unsigned char *output )
+{
+    mbedtls_aes_xts_context *xts_ctx = ctx;
+    int mode;
+
+    switch( operation )
+    {
+        case MBEDTLS_ENCRYPT:
+            mode = MBEDTLS_AES_ENCRYPT;
+            break;
+        case MBEDTLS_DECRYPT:
+            mode = MBEDTLS_AES_DECRYPT;
+            break;
+        default:
+            return MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA;
+    }
+
+    return mbedtls_aes_crypt_xts( xts_ctx, mode, length,
+                                  data_unit, input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+static int aes_setkey_dec_wrap( void *ctx, const unsigned char *key,
+                                unsigned int key_bitlen )
+{
+    return mbedtls_aes_setkey_dec( (mbedtls_aes_context *) ctx, key, key_bitlen );
+}
+
+static int aes_setkey_enc_wrap( void *ctx, const unsigned char *key,
+                                unsigned int key_bitlen )
+{
+    return mbedtls_aes_setkey_enc( (mbedtls_aes_context *) ctx, key, key_bitlen );
+}
+
+static void * aes_ctx_alloc( void )
+{
+    mbedtls_aes_context *aes = mbedtls_calloc( 1, sizeof( mbedtls_aes_context ) );
+
+    if( aes == NULL )
+        return( NULL );
+
+    mbedtls_aes_init( aes );
+
+    return( aes );
+}
+
+static void aes_ctx_free( void *ctx )
+{
+    mbedtls_aes_free( (mbedtls_aes_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static const mbedtls_cipher_base_t aes_info = {
+    MBEDTLS_CIPHER_ID_AES,
+    aes_crypt_ecb_wrap,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    aes_crypt_cbc_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    aes_crypt_cfb128_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    aes_crypt_ofb_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    aes_crypt_ctr_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    aes_setkey_enc_wrap,
+    aes_setkey_dec_wrap,
+    aes_ctx_alloc,
+    aes_ctx_free
+};
+
+static const mbedtls_cipher_info_t aes_128_ecb_info = {
+    MBEDTLS_CIPHER_AES_128_ECB,
+    MBEDTLS_MODE_ECB,
+    128,
+    "AES-128-ECB",
+    0,
+    0,
+    16,
+    &aes_info
+};
+
+static const mbedtls_cipher_info_t aes_192_ecb_info = {
+    MBEDTLS_CIPHER_AES_192_ECB,
+    MBEDTLS_MODE_ECB,
+    192,
+    "AES-192-ECB",
+    0,
+    0,
+    16,
+    &aes_info
+};
+
+static const mbedtls_cipher_info_t aes_256_ecb_info = {
+    MBEDTLS_CIPHER_AES_256_ECB,
+    MBEDTLS_MODE_ECB,
+    256,
+    "AES-256-ECB",
+    0,
+    0,
+    16,
+    &aes_info
+};
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static const mbedtls_cipher_info_t aes_128_cbc_info = {
+    MBEDTLS_CIPHER_AES_128_CBC,
+    MBEDTLS_MODE_CBC,
+    128,
+    "AES-128-CBC",
+    16,
+    0,
+    16,
+    &aes_info
+};
+
+static const mbedtls_cipher_info_t aes_192_cbc_info = {
+    MBEDTLS_CIPHER_AES_192_CBC,
+    MBEDTLS_MODE_CBC,
+    192,
+    "AES-192-CBC",
+    16,
+    0,
+    16,
+    &aes_info
+};
+
+static const mbedtls_cipher_info_t aes_256_cbc_info = {
+    MBEDTLS_CIPHER_AES_256_CBC,
+    MBEDTLS_MODE_CBC,
+    256,
+    "AES-256-CBC",
+    16,
+    0,
+    16,
+    &aes_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+static const mbedtls_cipher_info_t aes_128_cfb128_info = {
+    MBEDTLS_CIPHER_AES_128_CFB128,
+    MBEDTLS_MODE_CFB,
+    128,
+    "AES-128-CFB128",
+    16,
+    0,
+    16,
+    &aes_info
+};
+
+static const mbedtls_cipher_info_t aes_192_cfb128_info = {
+    MBEDTLS_CIPHER_AES_192_CFB128,
+    MBEDTLS_MODE_CFB,
+    192,
+    "AES-192-CFB128",
+    16,
+    0,
+    16,
+    &aes_info
+};
+
+static const mbedtls_cipher_info_t aes_256_cfb128_info = {
+    MBEDTLS_CIPHER_AES_256_CFB128,
+    MBEDTLS_MODE_CFB,
+    256,
+    "AES-256-CFB128",
+    16,
+    0,
+    16,
+    &aes_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+static const mbedtls_cipher_info_t aes_128_ofb_info = {
+    MBEDTLS_CIPHER_AES_128_OFB,
+    MBEDTLS_MODE_OFB,
+    128,
+    "AES-128-OFB",
+    16,
+    0,
+    16,
+    &aes_info
+};
+
+static const mbedtls_cipher_info_t aes_192_ofb_info = {
+    MBEDTLS_CIPHER_AES_192_OFB,
+    MBEDTLS_MODE_OFB,
+    192,
+    "AES-192-OFB",
+    16,
+    0,
+    16,
+    &aes_info
+};
+
+static const mbedtls_cipher_info_t aes_256_ofb_info = {
+    MBEDTLS_CIPHER_AES_256_OFB,
+    MBEDTLS_MODE_OFB,
+    256,
+    "AES-256-OFB",
+    16,
+    0,
+    16,
+    &aes_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_OFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+static const mbedtls_cipher_info_t aes_128_ctr_info = {
+    MBEDTLS_CIPHER_AES_128_CTR,
+    MBEDTLS_MODE_CTR,
+    128,
+    "AES-128-CTR",
+    16,
+    0,
+    16,
+    &aes_info
+};
+
+static const mbedtls_cipher_info_t aes_192_ctr_info = {
+    MBEDTLS_CIPHER_AES_192_CTR,
+    MBEDTLS_MODE_CTR,
+    192,
+    "AES-192-CTR",
+    16,
+    0,
+    16,
+    &aes_info
+};
+
+static const mbedtls_cipher_info_t aes_256_ctr_info = {
+    MBEDTLS_CIPHER_AES_256_CTR,
+    MBEDTLS_MODE_CTR,
+    256,
+    "AES-256-CTR",
+    16,
+    0,
+    16,
+    &aes_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+static int xts_aes_setkey_enc_wrap( void *ctx, const unsigned char *key,
+                                    unsigned int key_bitlen )
+{
+    mbedtls_aes_xts_context *xts_ctx = ctx;
+    return( mbedtls_aes_xts_setkey_enc( xts_ctx, key, key_bitlen ) );
+}
+
+static int xts_aes_setkey_dec_wrap( void *ctx, const unsigned char *key,
+                                    unsigned int key_bitlen )
+{
+    mbedtls_aes_xts_context *xts_ctx = ctx;
+    return( mbedtls_aes_xts_setkey_dec( xts_ctx, key, key_bitlen ) );
+}
+
+static void *xts_aes_ctx_alloc( void )
+{
+    mbedtls_aes_xts_context *xts_ctx = mbedtls_calloc( 1, sizeof( *xts_ctx ) );
+
+    if( xts_ctx != NULL )
+        mbedtls_aes_xts_init( xts_ctx );
+
+    return( xts_ctx );
+}
+
+static void xts_aes_ctx_free( void *ctx )
+{
+    mbedtls_aes_xts_context *xts_ctx = ctx;
+
+    if( xts_ctx == NULL )
+        return;
+
+    mbedtls_aes_xts_free( xts_ctx );
+    mbedtls_free( xts_ctx );
+}
+
+static const mbedtls_cipher_base_t xts_aes_info = {
+    MBEDTLS_CIPHER_ID_AES,
+    NULL,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    aes_crypt_xts_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    xts_aes_setkey_enc_wrap,
+    xts_aes_setkey_dec_wrap,
+    xts_aes_ctx_alloc,
+    xts_aes_ctx_free
+};
+
+static const mbedtls_cipher_info_t aes_128_xts_info = {
+    MBEDTLS_CIPHER_AES_128_XTS,
+    MBEDTLS_MODE_XTS,
+    256,
+    "AES-128-XTS",
+    16,
+    0,
+    16,
+    &xts_aes_info
+};
+
+static const mbedtls_cipher_info_t aes_256_xts_info = {
+    MBEDTLS_CIPHER_AES_256_XTS,
+    MBEDTLS_MODE_XTS,
+    512,
+    "AES-256-XTS",
+    16,
+    0,
+    16,
+    &xts_aes_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_XTS */
+
+#if defined(MBEDTLS_GCM_C)
+static int gcm_aes_setkey_wrap( void *ctx, const unsigned char *key,
+                                unsigned int key_bitlen )
+{
+    return mbedtls_gcm_setkey( (mbedtls_gcm_context *) ctx, MBEDTLS_CIPHER_ID_AES,
+                     key, key_bitlen );
+}
+
+static const mbedtls_cipher_base_t gcm_aes_info = {
+    MBEDTLS_CIPHER_ID_AES,
+    NULL,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    gcm_aes_setkey_wrap,
+    gcm_aes_setkey_wrap,
+    gcm_ctx_alloc,
+    gcm_ctx_free,
+};
+
+static const mbedtls_cipher_info_t aes_128_gcm_info = {
+    MBEDTLS_CIPHER_AES_128_GCM,
+    MBEDTLS_MODE_GCM,
+    128,
+    "AES-128-GCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &gcm_aes_info
+};
+
+static const mbedtls_cipher_info_t aes_192_gcm_info = {
+    MBEDTLS_CIPHER_AES_192_GCM,
+    MBEDTLS_MODE_GCM,
+    192,
+    "AES-192-GCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &gcm_aes_info
+};
+
+static const mbedtls_cipher_info_t aes_256_gcm_info = {
+    MBEDTLS_CIPHER_AES_256_GCM,
+    MBEDTLS_MODE_GCM,
+    256,
+    "AES-256-GCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &gcm_aes_info
+};
+#endif /* MBEDTLS_GCM_C */
+
+#if defined(MBEDTLS_CCM_C)
+static int ccm_aes_setkey_wrap( void *ctx, const unsigned char *key,
+                                unsigned int key_bitlen )
+{
+    return mbedtls_ccm_setkey( (mbedtls_ccm_context *) ctx, MBEDTLS_CIPHER_ID_AES,
+                     key, key_bitlen );
+}
+
+static const mbedtls_cipher_base_t ccm_aes_info = {
+    MBEDTLS_CIPHER_ID_AES,
+    NULL,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    ccm_aes_setkey_wrap,
+    ccm_aes_setkey_wrap,
+    ccm_ctx_alloc,
+    ccm_ctx_free,
+};
+
+static const mbedtls_cipher_info_t aes_128_ccm_info = {
+    MBEDTLS_CIPHER_AES_128_CCM,
+    MBEDTLS_MODE_CCM,
+    128,
+    "AES-128-CCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &ccm_aes_info
+};
+
+static const mbedtls_cipher_info_t aes_192_ccm_info = {
+    MBEDTLS_CIPHER_AES_192_CCM,
+    MBEDTLS_MODE_CCM,
+    192,
+    "AES-192-CCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &ccm_aes_info
+};
+
+static const mbedtls_cipher_info_t aes_256_ccm_info = {
+    MBEDTLS_CIPHER_AES_256_CCM,
+    MBEDTLS_MODE_CCM,
+    256,
+    "AES-256-CCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &ccm_aes_info
+};
+#endif /* MBEDTLS_CCM_C */
+
+#endif /* MBEDTLS_AES_C */
+
+#if defined(MBEDTLS_CAMELLIA_C)
+
+static int camellia_crypt_ecb_wrap( void *ctx, mbedtls_operation_t operation,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_camellia_crypt_ecb( (mbedtls_camellia_context *) ctx, operation, input,
+                               output );
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static int camellia_crypt_cbc_wrap( void *ctx, mbedtls_operation_t operation,
+        size_t length, unsigned char *iv,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_camellia_crypt_cbc( (mbedtls_camellia_context *) ctx, operation, length, iv,
+                               input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+static int camellia_crypt_cfb128_wrap( void *ctx, mbedtls_operation_t operation,
+        size_t length, size_t *iv_off, unsigned char *iv,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_camellia_crypt_cfb128( (mbedtls_camellia_context *) ctx, operation, length,
+                                  iv_off, iv, input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+static int camellia_crypt_ctr_wrap( void *ctx, size_t length, size_t *nc_off,
+        unsigned char *nonce_counter, unsigned char *stream_block,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_camellia_crypt_ctr( (mbedtls_camellia_context *) ctx, length, nc_off,
+                               nonce_counter, stream_block, input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+static int camellia_setkey_dec_wrap( void *ctx, const unsigned char *key,
+                                     unsigned int key_bitlen )
+{
+    return mbedtls_camellia_setkey_dec( (mbedtls_camellia_context *) ctx, key, key_bitlen );
+}
+
+static int camellia_setkey_enc_wrap( void *ctx, const unsigned char *key,
+                                     unsigned int key_bitlen )
+{
+    return mbedtls_camellia_setkey_enc( (mbedtls_camellia_context *) ctx, key, key_bitlen );
+}
+
+static void * camellia_ctx_alloc( void )
+{
+    mbedtls_camellia_context *ctx;
+    ctx = mbedtls_calloc( 1, sizeof( mbedtls_camellia_context ) );
+
+    if( ctx == NULL )
+        return( NULL );
+
+    mbedtls_camellia_init( ctx );
+
+    return( ctx );
+}
+
+static void camellia_ctx_free( void *ctx )
+{
+    mbedtls_camellia_free( (mbedtls_camellia_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static const mbedtls_cipher_base_t camellia_info = {
+    MBEDTLS_CIPHER_ID_CAMELLIA,
+    camellia_crypt_ecb_wrap,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    camellia_crypt_cbc_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    camellia_crypt_cfb128_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    camellia_crypt_ctr_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    camellia_setkey_enc_wrap,
+    camellia_setkey_dec_wrap,
+    camellia_ctx_alloc,
+    camellia_ctx_free
+};
+
+static const mbedtls_cipher_info_t camellia_128_ecb_info = {
+    MBEDTLS_CIPHER_CAMELLIA_128_ECB,
+    MBEDTLS_MODE_ECB,
+    128,
+    "CAMELLIA-128-ECB",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_192_ecb_info = {
+    MBEDTLS_CIPHER_CAMELLIA_192_ECB,
+    MBEDTLS_MODE_ECB,
+    192,
+    "CAMELLIA-192-ECB",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_256_ecb_info = {
+    MBEDTLS_CIPHER_CAMELLIA_256_ECB,
+    MBEDTLS_MODE_ECB,
+    256,
+    "CAMELLIA-256-ECB",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static const mbedtls_cipher_info_t camellia_128_cbc_info = {
+    MBEDTLS_CIPHER_CAMELLIA_128_CBC,
+    MBEDTLS_MODE_CBC,
+    128,
+    "CAMELLIA-128-CBC",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_192_cbc_info = {
+    MBEDTLS_CIPHER_CAMELLIA_192_CBC,
+    MBEDTLS_MODE_CBC,
+    192,
+    "CAMELLIA-192-CBC",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_256_cbc_info = {
+    MBEDTLS_CIPHER_CAMELLIA_256_CBC,
+    MBEDTLS_MODE_CBC,
+    256,
+    "CAMELLIA-256-CBC",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+static const mbedtls_cipher_info_t camellia_128_cfb128_info = {
+    MBEDTLS_CIPHER_CAMELLIA_128_CFB128,
+    MBEDTLS_MODE_CFB,
+    128,
+    "CAMELLIA-128-CFB128",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_192_cfb128_info = {
+    MBEDTLS_CIPHER_CAMELLIA_192_CFB128,
+    MBEDTLS_MODE_CFB,
+    192,
+    "CAMELLIA-192-CFB128",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_256_cfb128_info = {
+    MBEDTLS_CIPHER_CAMELLIA_256_CFB128,
+    MBEDTLS_MODE_CFB,
+    256,
+    "CAMELLIA-256-CFB128",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+static const mbedtls_cipher_info_t camellia_128_ctr_info = {
+    MBEDTLS_CIPHER_CAMELLIA_128_CTR,
+    MBEDTLS_MODE_CTR,
+    128,
+    "CAMELLIA-128-CTR",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_192_ctr_info = {
+    MBEDTLS_CIPHER_CAMELLIA_192_CTR,
+    MBEDTLS_MODE_CTR,
+    192,
+    "CAMELLIA-192-CTR",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_256_ctr_info = {
+    MBEDTLS_CIPHER_CAMELLIA_256_CTR,
+    MBEDTLS_MODE_CTR,
+    256,
+    "CAMELLIA-256-CTR",
+    16,
+    0,
+    16,
+    &camellia_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+#if defined(MBEDTLS_GCM_C)
+static int gcm_camellia_setkey_wrap( void *ctx, const unsigned char *key,
+                                     unsigned int key_bitlen )
+{
+    return mbedtls_gcm_setkey( (mbedtls_gcm_context *) ctx, MBEDTLS_CIPHER_ID_CAMELLIA,
+                     key, key_bitlen );
+}
+
+static const mbedtls_cipher_base_t gcm_camellia_info = {
+    MBEDTLS_CIPHER_ID_CAMELLIA,
+    NULL,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    gcm_camellia_setkey_wrap,
+    gcm_camellia_setkey_wrap,
+    gcm_ctx_alloc,
+    gcm_ctx_free,
+};
+
+static const mbedtls_cipher_info_t camellia_128_gcm_info = {
+    MBEDTLS_CIPHER_CAMELLIA_128_GCM,
+    MBEDTLS_MODE_GCM,
+    128,
+    "CAMELLIA-128-GCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &gcm_camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_192_gcm_info = {
+    MBEDTLS_CIPHER_CAMELLIA_192_GCM,
+    MBEDTLS_MODE_GCM,
+    192,
+    "CAMELLIA-192-GCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &gcm_camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_256_gcm_info = {
+    MBEDTLS_CIPHER_CAMELLIA_256_GCM,
+    MBEDTLS_MODE_GCM,
+    256,
+    "CAMELLIA-256-GCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &gcm_camellia_info
+};
+#endif /* MBEDTLS_GCM_C */
+
+#if defined(MBEDTLS_CCM_C)
+static int ccm_camellia_setkey_wrap( void *ctx, const unsigned char *key,
+                                     unsigned int key_bitlen )
+{
+    return mbedtls_ccm_setkey( (mbedtls_ccm_context *) ctx, MBEDTLS_CIPHER_ID_CAMELLIA,
+                     key, key_bitlen );
+}
+
+static const mbedtls_cipher_base_t ccm_camellia_info = {
+    MBEDTLS_CIPHER_ID_CAMELLIA,
+    NULL,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    ccm_camellia_setkey_wrap,
+    ccm_camellia_setkey_wrap,
+    ccm_ctx_alloc,
+    ccm_ctx_free,
+};
+
+static const mbedtls_cipher_info_t camellia_128_ccm_info = {
+    MBEDTLS_CIPHER_CAMELLIA_128_CCM,
+    MBEDTLS_MODE_CCM,
+    128,
+    "CAMELLIA-128-CCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &ccm_camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_192_ccm_info = {
+    MBEDTLS_CIPHER_CAMELLIA_192_CCM,
+    MBEDTLS_MODE_CCM,
+    192,
+    "CAMELLIA-192-CCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &ccm_camellia_info
+};
+
+static const mbedtls_cipher_info_t camellia_256_ccm_info = {
+    MBEDTLS_CIPHER_CAMELLIA_256_CCM,
+    MBEDTLS_MODE_CCM,
+    256,
+    "CAMELLIA-256-CCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &ccm_camellia_info
+};
+#endif /* MBEDTLS_CCM_C */
+
+#endif /* MBEDTLS_CAMELLIA_C */
+
+#if defined(MBEDTLS_ARIA_C)
+
+static int aria_crypt_ecb_wrap( void *ctx, mbedtls_operation_t operation,
+        const unsigned char *input, unsigned char *output )
+{
+    (void) operation;
+    return mbedtls_aria_crypt_ecb( (mbedtls_aria_context *) ctx, input,
+                               output );
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static int aria_crypt_cbc_wrap( void *ctx, mbedtls_operation_t operation,
+        size_t length, unsigned char *iv,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_aria_crypt_cbc( (mbedtls_aria_context *) ctx, operation, length, iv,
+                               input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+static int aria_crypt_cfb128_wrap( void *ctx, mbedtls_operation_t operation,
+        size_t length, size_t *iv_off, unsigned char *iv,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_aria_crypt_cfb128( (mbedtls_aria_context *) ctx, operation, length,
+                                  iv_off, iv, input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+static int aria_crypt_ctr_wrap( void *ctx, size_t length, size_t *nc_off,
+        unsigned char *nonce_counter, unsigned char *stream_block,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_aria_crypt_ctr( (mbedtls_aria_context *) ctx, length, nc_off,
+                               nonce_counter, stream_block, input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+static int aria_setkey_dec_wrap( void *ctx, const unsigned char *key,
+                                     unsigned int key_bitlen )
+{
+    return mbedtls_aria_setkey_dec( (mbedtls_aria_context *) ctx, key, key_bitlen );
+}
+
+static int aria_setkey_enc_wrap( void *ctx, const unsigned char *key,
+                                     unsigned int key_bitlen )
+{
+    return mbedtls_aria_setkey_enc( (mbedtls_aria_context *) ctx, key, key_bitlen );
+}
+
+static void * aria_ctx_alloc( void )
+{
+    mbedtls_aria_context *ctx;
+    ctx = mbedtls_calloc( 1, sizeof( mbedtls_aria_context ) );
+
+    if( ctx == NULL )
+        return( NULL );
+
+    mbedtls_aria_init( ctx );
+
+    return( ctx );
+}
+
+static void aria_ctx_free( void *ctx )
+{
+    mbedtls_aria_free( (mbedtls_aria_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static const mbedtls_cipher_base_t aria_info = {
+    MBEDTLS_CIPHER_ID_ARIA,
+    aria_crypt_ecb_wrap,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    aria_crypt_cbc_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    aria_crypt_cfb128_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    aria_crypt_ctr_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    aria_setkey_enc_wrap,
+    aria_setkey_dec_wrap,
+    aria_ctx_alloc,
+    aria_ctx_free
+};
+
+static const mbedtls_cipher_info_t aria_128_ecb_info = {
+    MBEDTLS_CIPHER_ARIA_128_ECB,
+    MBEDTLS_MODE_ECB,
+    128,
+    "ARIA-128-ECB",
+    16,
+    0,
+    16,
+    &aria_info
+};
+
+static const mbedtls_cipher_info_t aria_192_ecb_info = {
+    MBEDTLS_CIPHER_ARIA_192_ECB,
+    MBEDTLS_MODE_ECB,
+    192,
+    "ARIA-192-ECB",
+    16,
+    0,
+    16,
+    &aria_info
+};
+
+static const mbedtls_cipher_info_t aria_256_ecb_info = {
+    MBEDTLS_CIPHER_ARIA_256_ECB,
+    MBEDTLS_MODE_ECB,
+    256,
+    "ARIA-256-ECB",
+    16,
+    0,
+    16,
+    &aria_info
+};
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static const mbedtls_cipher_info_t aria_128_cbc_info = {
+    MBEDTLS_CIPHER_ARIA_128_CBC,
+    MBEDTLS_MODE_CBC,
+    128,
+    "ARIA-128-CBC",
+    16,
+    0,
+    16,
+    &aria_info
+};
+
+static const mbedtls_cipher_info_t aria_192_cbc_info = {
+    MBEDTLS_CIPHER_ARIA_192_CBC,
+    MBEDTLS_MODE_CBC,
+    192,
+    "ARIA-192-CBC",
+    16,
+    0,
+    16,
+    &aria_info
+};
+
+static const mbedtls_cipher_info_t aria_256_cbc_info = {
+    MBEDTLS_CIPHER_ARIA_256_CBC,
+    MBEDTLS_MODE_CBC,
+    256,
+    "ARIA-256-CBC",
+    16,
+    0,
+    16,
+    &aria_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+static const mbedtls_cipher_info_t aria_128_cfb128_info = {
+    MBEDTLS_CIPHER_ARIA_128_CFB128,
+    MBEDTLS_MODE_CFB,
+    128,
+    "ARIA-128-CFB128",
+    16,
+    0,
+    16,
+    &aria_info
+};
+
+static const mbedtls_cipher_info_t aria_192_cfb128_info = {
+    MBEDTLS_CIPHER_ARIA_192_CFB128,
+    MBEDTLS_MODE_CFB,
+    192,
+    "ARIA-192-CFB128",
+    16,
+    0,
+    16,
+    &aria_info
+};
+
+static const mbedtls_cipher_info_t aria_256_cfb128_info = {
+    MBEDTLS_CIPHER_ARIA_256_CFB128,
+    MBEDTLS_MODE_CFB,
+    256,
+    "ARIA-256-CFB128",
+    16,
+    0,
+    16,
+    &aria_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+static const mbedtls_cipher_info_t aria_128_ctr_info = {
+    MBEDTLS_CIPHER_ARIA_128_CTR,
+    MBEDTLS_MODE_CTR,
+    128,
+    "ARIA-128-CTR",
+    16,
+    0,
+    16,
+    &aria_info
+};
+
+static const mbedtls_cipher_info_t aria_192_ctr_info = {
+    MBEDTLS_CIPHER_ARIA_192_CTR,
+    MBEDTLS_MODE_CTR,
+    192,
+    "ARIA-192-CTR",
+    16,
+    0,
+    16,
+    &aria_info
+};
+
+static const mbedtls_cipher_info_t aria_256_ctr_info = {
+    MBEDTLS_CIPHER_ARIA_256_CTR,
+    MBEDTLS_MODE_CTR,
+    256,
+    "ARIA-256-CTR",
+    16,
+    0,
+    16,
+    &aria_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+#if defined(MBEDTLS_GCM_C)
+static int gcm_aria_setkey_wrap( void *ctx, const unsigned char *key,
+                                     unsigned int key_bitlen )
+{
+    return mbedtls_gcm_setkey( (mbedtls_gcm_context *) ctx, MBEDTLS_CIPHER_ID_ARIA,
+                     key, key_bitlen );
+}
+
+static const mbedtls_cipher_base_t gcm_aria_info = {
+    MBEDTLS_CIPHER_ID_ARIA,
+    NULL,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    gcm_aria_setkey_wrap,
+    gcm_aria_setkey_wrap,
+    gcm_ctx_alloc,
+    gcm_ctx_free,
+};
+
+static const mbedtls_cipher_info_t aria_128_gcm_info = {
+    MBEDTLS_CIPHER_ARIA_128_GCM,
+    MBEDTLS_MODE_GCM,
+    128,
+    "ARIA-128-GCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &gcm_aria_info
+};
+
+static const mbedtls_cipher_info_t aria_192_gcm_info = {
+    MBEDTLS_CIPHER_ARIA_192_GCM,
+    MBEDTLS_MODE_GCM,
+    192,
+    "ARIA-192-GCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &gcm_aria_info
+};
+
+static const mbedtls_cipher_info_t aria_256_gcm_info = {
+    MBEDTLS_CIPHER_ARIA_256_GCM,
+    MBEDTLS_MODE_GCM,
+    256,
+    "ARIA-256-GCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &gcm_aria_info
+};
+#endif /* MBEDTLS_GCM_C */
+
+#if defined(MBEDTLS_CCM_C)
+static int ccm_aria_setkey_wrap( void *ctx, const unsigned char *key,
+                                     unsigned int key_bitlen )
+{
+    return mbedtls_ccm_setkey( (mbedtls_ccm_context *) ctx, MBEDTLS_CIPHER_ID_ARIA,
+                     key, key_bitlen );
+}
+
+static const mbedtls_cipher_base_t ccm_aria_info = {
+    MBEDTLS_CIPHER_ID_ARIA,
+    NULL,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    ccm_aria_setkey_wrap,
+    ccm_aria_setkey_wrap,
+    ccm_ctx_alloc,
+    ccm_ctx_free,
+};
+
+static const mbedtls_cipher_info_t aria_128_ccm_info = {
+    MBEDTLS_CIPHER_ARIA_128_CCM,
+    MBEDTLS_MODE_CCM,
+    128,
+    "ARIA-128-CCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &ccm_aria_info
+};
+
+static const mbedtls_cipher_info_t aria_192_ccm_info = {
+    MBEDTLS_CIPHER_ARIA_192_CCM,
+    MBEDTLS_MODE_CCM,
+    192,
+    "ARIA-192-CCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &ccm_aria_info
+};
+
+static const mbedtls_cipher_info_t aria_256_ccm_info = {
+    MBEDTLS_CIPHER_ARIA_256_CCM,
+    MBEDTLS_MODE_CCM,
+    256,
+    "ARIA-256-CCM",
+    12,
+    MBEDTLS_CIPHER_VARIABLE_IV_LEN,
+    16,
+    &ccm_aria_info
+};
+#endif /* MBEDTLS_CCM_C */
+
+#endif /* MBEDTLS_ARIA_C */
+
+#if defined(MBEDTLS_DES_C)
+
+static int des_crypt_ecb_wrap( void *ctx, mbedtls_operation_t operation,
+        const unsigned char *input, unsigned char *output )
+{
+    ((void) operation);
+    return mbedtls_des_crypt_ecb( (mbedtls_des_context *) ctx, input, output );
+}
+
+static int des3_crypt_ecb_wrap( void *ctx, mbedtls_operation_t operation,
+        const unsigned char *input, unsigned char *output )
+{
+    ((void) operation);
+    return mbedtls_des3_crypt_ecb( (mbedtls_des3_context *) ctx, input, output );
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static int des_crypt_cbc_wrap( void *ctx, mbedtls_operation_t operation, size_t length,
+        unsigned char *iv, const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_des_crypt_cbc( (mbedtls_des_context *) ctx, operation, length, iv, input,
+                          output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static int des3_crypt_cbc_wrap( void *ctx, mbedtls_operation_t operation, size_t length,
+        unsigned char *iv, const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_des3_crypt_cbc( (mbedtls_des3_context *) ctx, operation, length, iv, input,
+                           output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+static int des_setkey_dec_wrap( void *ctx, const unsigned char *key,
+                                unsigned int key_bitlen )
+{
+    ((void) key_bitlen);
+
+    return mbedtls_des_setkey_dec( (mbedtls_des_context *) ctx, key );
+}
+
+static int des_setkey_enc_wrap( void *ctx, const unsigned char *key,
+                                unsigned int key_bitlen )
+{
+    ((void) key_bitlen);
+
+    return mbedtls_des_setkey_enc( (mbedtls_des_context *) ctx, key );
+}
+
+static int des3_set2key_dec_wrap( void *ctx, const unsigned char *key,
+                                  unsigned int key_bitlen )
+{
+    ((void) key_bitlen);
+
+    return mbedtls_des3_set2key_dec( (mbedtls_des3_context *) ctx, key );
+}
+
+static int des3_set2key_enc_wrap( void *ctx, const unsigned char *key,
+                                  unsigned int key_bitlen )
+{
+    ((void) key_bitlen);
+
+    return mbedtls_des3_set2key_enc( (mbedtls_des3_context *) ctx, key );
+}
+
+static int des3_set3key_dec_wrap( void *ctx, const unsigned char *key,
+                                  unsigned int key_bitlen )
+{
+    ((void) key_bitlen);
+
+    return mbedtls_des3_set3key_dec( (mbedtls_des3_context *) ctx, key );
+}
+
+static int des3_set3key_enc_wrap( void *ctx, const unsigned char *key,
+                                  unsigned int key_bitlen )
+{
+    ((void) key_bitlen);
+
+    return mbedtls_des3_set3key_enc( (mbedtls_des3_context *) ctx, key );
+}
+
+static void * des_ctx_alloc( void )
+{
+    mbedtls_des_context *des = mbedtls_calloc( 1, sizeof( mbedtls_des_context ) );
+
+    if( des == NULL )
+        return( NULL );
+
+    mbedtls_des_init( des );
+
+    return( des );
+}
+
+static void des_ctx_free( void *ctx )
+{
+    mbedtls_des_free( (mbedtls_des_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static void * des3_ctx_alloc( void )
+{
+    mbedtls_des3_context *des3;
+    des3 = mbedtls_calloc( 1, sizeof( mbedtls_des3_context ) );
+
+    if( des3 == NULL )
+        return( NULL );
+
+    mbedtls_des3_init( des3 );
+
+    return( des3 );
+}
+
+static void des3_ctx_free( void *ctx )
+{
+    mbedtls_des3_free( (mbedtls_des3_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static const mbedtls_cipher_base_t des_info = {
+    MBEDTLS_CIPHER_ID_DES,
+    des_crypt_ecb_wrap,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    des_crypt_cbc_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    des_setkey_enc_wrap,
+    des_setkey_dec_wrap,
+    des_ctx_alloc,
+    des_ctx_free
+};
+
+static const mbedtls_cipher_info_t des_ecb_info = {
+    MBEDTLS_CIPHER_DES_ECB,
+    MBEDTLS_MODE_ECB,
+    MBEDTLS_KEY_LENGTH_DES,
+    "DES-ECB",
+    8,
+    0,
+    8,
+    &des_info
+};
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static const mbedtls_cipher_info_t des_cbc_info = {
+    MBEDTLS_CIPHER_DES_CBC,
+    MBEDTLS_MODE_CBC,
+    MBEDTLS_KEY_LENGTH_DES,
+    "DES-CBC",
+    8,
+    0,
+    8,
+    &des_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+static const mbedtls_cipher_base_t des_ede_info = {
+    MBEDTLS_CIPHER_ID_DES,
+    des3_crypt_ecb_wrap,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    des3_crypt_cbc_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    des3_set2key_enc_wrap,
+    des3_set2key_dec_wrap,
+    des3_ctx_alloc,
+    des3_ctx_free
+};
+
+static const mbedtls_cipher_info_t des_ede_ecb_info = {
+    MBEDTLS_CIPHER_DES_EDE_ECB,
+    MBEDTLS_MODE_ECB,
+    MBEDTLS_KEY_LENGTH_DES_EDE,
+    "DES-EDE-ECB",
+    8,
+    0,
+    8,
+    &des_ede_info
+};
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static const mbedtls_cipher_info_t des_ede_cbc_info = {
+    MBEDTLS_CIPHER_DES_EDE_CBC,
+    MBEDTLS_MODE_CBC,
+    MBEDTLS_KEY_LENGTH_DES_EDE,
+    "DES-EDE-CBC",
+    8,
+    0,
+    8,
+    &des_ede_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+static const mbedtls_cipher_base_t des_ede3_info = {
+    MBEDTLS_CIPHER_ID_3DES,
+    des3_crypt_ecb_wrap,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    des3_crypt_cbc_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    des3_set3key_enc_wrap,
+    des3_set3key_dec_wrap,
+    des3_ctx_alloc,
+    des3_ctx_free
+};
+
+static const mbedtls_cipher_info_t des_ede3_ecb_info = {
+    MBEDTLS_CIPHER_DES_EDE3_ECB,
+    MBEDTLS_MODE_ECB,
+    MBEDTLS_KEY_LENGTH_DES_EDE3,
+    "DES-EDE3-ECB",
+    8,
+    0,
+    8,
+    &des_ede3_info
+};
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static const mbedtls_cipher_info_t des_ede3_cbc_info = {
+    MBEDTLS_CIPHER_DES_EDE3_CBC,
+    MBEDTLS_MODE_CBC,
+    MBEDTLS_KEY_LENGTH_DES_EDE3,
+    "DES-EDE3-CBC",
+    8,
+    0,
+    8,
+    &des_ede3_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+#endif /* MBEDTLS_DES_C */
+
+#if defined(MBEDTLS_BLOWFISH_C)
+
+static int blowfish_crypt_ecb_wrap( void *ctx, mbedtls_operation_t operation,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_blowfish_crypt_ecb( (mbedtls_blowfish_context *) ctx, operation, input,
+                               output );
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static int blowfish_crypt_cbc_wrap( void *ctx, mbedtls_operation_t operation,
+        size_t length, unsigned char *iv, const unsigned char *input,
+        unsigned char *output )
+{
+    return mbedtls_blowfish_crypt_cbc( (mbedtls_blowfish_context *) ctx, operation, length, iv,
+                               input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+static int blowfish_crypt_cfb64_wrap( void *ctx, mbedtls_operation_t operation,
+        size_t length, size_t *iv_off, unsigned char *iv,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_blowfish_crypt_cfb64( (mbedtls_blowfish_context *) ctx, operation, length,
+                                 iv_off, iv, input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+static int blowfish_crypt_ctr_wrap( void *ctx, size_t length, size_t *nc_off,
+        unsigned char *nonce_counter, unsigned char *stream_block,
+        const unsigned char *input, unsigned char *output )
+{
+    return mbedtls_blowfish_crypt_ctr( (mbedtls_blowfish_context *) ctx, length, nc_off,
+                               nonce_counter, stream_block, input, output );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+static int blowfish_setkey_wrap( void *ctx, const unsigned char *key,
+                                 unsigned int key_bitlen )
+{
+    return mbedtls_blowfish_setkey( (mbedtls_blowfish_context *) ctx, key, key_bitlen );
+}
+
+static void * blowfish_ctx_alloc( void )
+{
+    mbedtls_blowfish_context *ctx;
+    ctx = mbedtls_calloc( 1, sizeof( mbedtls_blowfish_context ) );
+
+    if( ctx == NULL )
+        return( NULL );
+
+    mbedtls_blowfish_init( ctx );
+
+    return( ctx );
+}
+
+static void blowfish_ctx_free( void *ctx )
+{
+    mbedtls_blowfish_free( (mbedtls_blowfish_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static const mbedtls_cipher_base_t blowfish_info = {
+    MBEDTLS_CIPHER_ID_BLOWFISH,
+    blowfish_crypt_ecb_wrap,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    blowfish_crypt_cbc_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    blowfish_crypt_cfb64_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    blowfish_crypt_ctr_wrap,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    blowfish_setkey_wrap,
+    blowfish_setkey_wrap,
+    blowfish_ctx_alloc,
+    blowfish_ctx_free
+};
+
+static const mbedtls_cipher_info_t blowfish_ecb_info = {
+    MBEDTLS_CIPHER_BLOWFISH_ECB,
+    MBEDTLS_MODE_ECB,
+    128,
+    "BLOWFISH-ECB",
+    8,
+    MBEDTLS_CIPHER_VARIABLE_KEY_LEN,
+    8,
+    &blowfish_info
+};
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static const mbedtls_cipher_info_t blowfish_cbc_info = {
+    MBEDTLS_CIPHER_BLOWFISH_CBC,
+    MBEDTLS_MODE_CBC,
+    128,
+    "BLOWFISH-CBC",
+    8,
+    MBEDTLS_CIPHER_VARIABLE_KEY_LEN,
+    8,
+    &blowfish_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+static const mbedtls_cipher_info_t blowfish_cfb64_info = {
+    MBEDTLS_CIPHER_BLOWFISH_CFB64,
+    MBEDTLS_MODE_CFB,
+    128,
+    "BLOWFISH-CFB64",
+    8,
+    MBEDTLS_CIPHER_VARIABLE_KEY_LEN,
+    8,
+    &blowfish_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+static const mbedtls_cipher_info_t blowfish_ctr_info = {
+    MBEDTLS_CIPHER_BLOWFISH_CTR,
+    MBEDTLS_MODE_CTR,
+    128,
+    "BLOWFISH-CTR",
+    8,
+    MBEDTLS_CIPHER_VARIABLE_KEY_LEN,
+    8,
+    &blowfish_info
+};
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+#endif /* MBEDTLS_BLOWFISH_C */
+
+#if defined(MBEDTLS_ARC4_C)
+static int arc4_crypt_stream_wrap( void *ctx, size_t length,
+                                   const unsigned char *input,
+                                   unsigned char *output )
+{
+    return( mbedtls_arc4_crypt( (mbedtls_arc4_context *) ctx, length, input, output ) );
+}
+
+static int arc4_setkey_wrap( void *ctx, const unsigned char *key,
+                             unsigned int key_bitlen )
+{
+    /* we get key_bitlen in bits, arc4 expects it in bytes */
+    if( key_bitlen % 8 != 0 )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    mbedtls_arc4_setup( (mbedtls_arc4_context *) ctx, key, key_bitlen / 8 );
+    return( 0 );
+}
+
+static void * arc4_ctx_alloc( void )
+{
+    mbedtls_arc4_context *ctx;
+    ctx = mbedtls_calloc( 1, sizeof( mbedtls_arc4_context ) );
+
+    if( ctx == NULL )
+        return( NULL );
+
+    mbedtls_arc4_init( ctx );
+
+    return( ctx );
+}
+
+static void arc4_ctx_free( void *ctx )
+{
+    mbedtls_arc4_free( (mbedtls_arc4_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static const mbedtls_cipher_base_t arc4_base_info = {
+    MBEDTLS_CIPHER_ID_ARC4,
+    NULL,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    arc4_crypt_stream_wrap,
+#endif
+    arc4_setkey_wrap,
+    arc4_setkey_wrap,
+    arc4_ctx_alloc,
+    arc4_ctx_free
+};
+
+static const mbedtls_cipher_info_t arc4_128_info = {
+    MBEDTLS_CIPHER_ARC4_128,
+    MBEDTLS_MODE_STREAM,
+    128,
+    "ARC4-128",
+    0,
+    0,
+    1,
+    &arc4_base_info
+};
+#endif /* MBEDTLS_ARC4_C */
+
+#if defined(MBEDTLS_CHACHA20_C)
+
+static int chacha20_setkey_wrap( void *ctx, const unsigned char *key,
+                                 unsigned int key_bitlen )
+{
+    if( key_bitlen != 256U )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    if ( 0 != mbedtls_chacha20_setkey( (mbedtls_chacha20_context*)ctx, key ) )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    return( 0 );
+}
+
+static int chacha20_stream_wrap( void *ctx,  size_t length,
+                                 const unsigned char *input,
+                                 unsigned char *output )
+{
+    int ret;
+
+    ret = mbedtls_chacha20_update( ctx, length, input, output );
+    if( ret == MBEDTLS_ERR_CHACHA20_BAD_INPUT_DATA )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    return( ret );
+}
+
+static void * chacha20_ctx_alloc( void )
+{
+    mbedtls_chacha20_context *ctx;
+    ctx = mbedtls_calloc( 1, sizeof( mbedtls_chacha20_context ) );
+
+    if( ctx == NULL )
+        return( NULL );
+
+    mbedtls_chacha20_init( ctx );
+
+    return( ctx );
+}
+
+static void chacha20_ctx_free( void *ctx )
+{
+    mbedtls_chacha20_free( (mbedtls_chacha20_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static const mbedtls_cipher_base_t chacha20_base_info = {
+    MBEDTLS_CIPHER_ID_CHACHA20,
+    NULL,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    chacha20_stream_wrap,
+#endif
+    chacha20_setkey_wrap,
+    chacha20_setkey_wrap,
+    chacha20_ctx_alloc,
+    chacha20_ctx_free
+};
+static const mbedtls_cipher_info_t chacha20_info = {
+    MBEDTLS_CIPHER_CHACHA20,
+    MBEDTLS_MODE_STREAM,
+    256,
+    "CHACHA20",
+    12,
+    0,
+    1,
+    &chacha20_base_info
+};
+#endif /* MBEDTLS_CHACHA20_C */
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+
+static int chachapoly_setkey_wrap( void *ctx,
+                                   const unsigned char *key,
+                                   unsigned int key_bitlen )
+{
+    if( key_bitlen != 256U )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    if ( 0 != mbedtls_chachapoly_setkey( (mbedtls_chachapoly_context*)ctx, key ) )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    return( 0 );
+}
+
+static void * chachapoly_ctx_alloc( void )
+{
+    mbedtls_chachapoly_context *ctx;
+    ctx = mbedtls_calloc( 1, sizeof( mbedtls_chachapoly_context ) );
+
+    if( ctx == NULL )
+        return( NULL );
+
+    mbedtls_chachapoly_init( ctx );
+
+    return( ctx );
+}
+
+static void chachapoly_ctx_free( void *ctx )
+{
+    mbedtls_chachapoly_free( (mbedtls_chachapoly_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static const mbedtls_cipher_base_t chachapoly_base_info = {
+    MBEDTLS_CIPHER_ID_CHACHA20,
+    NULL,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    NULL,
+#endif
+    chachapoly_setkey_wrap,
+    chachapoly_setkey_wrap,
+    chachapoly_ctx_alloc,
+    chachapoly_ctx_free
+};
+static const mbedtls_cipher_info_t chachapoly_info = {
+    MBEDTLS_CIPHER_CHACHA20_POLY1305,
+    MBEDTLS_MODE_CHACHAPOLY,
+    256,
+    "CHACHA20-POLY1305",
+    12,
+    0,
+    1,
+    &chachapoly_base_info
+};
+#endif /* MBEDTLS_CHACHAPOLY_C */
+
+#if defined(MBEDTLS_CIPHER_NULL_CIPHER)
+static int null_crypt_stream( void *ctx, size_t length,
+                              const unsigned char *input,
+                              unsigned char *output )
+{
+    ((void) ctx);
+    memmove( output, input, length );
+    return( 0 );
+}
+
+static int null_setkey( void *ctx, const unsigned char *key,
+                        unsigned int key_bitlen )
+{
+    ((void) ctx);
+    ((void) key);
+    ((void) key_bitlen);
+
+    return( 0 );
+}
+
+static void * null_ctx_alloc( void )
+{
+    return( (void *) 1 );
+}
+
+static void null_ctx_free( void *ctx )
+{
+    ((void) ctx);
+}
+
+static const mbedtls_cipher_base_t null_base_info = {
+    MBEDTLS_CIPHER_ID_NULL,
+    NULL,
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    NULL,
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_STREAM)
+    null_crypt_stream,
+#endif
+    null_setkey,
+    null_setkey,
+    null_ctx_alloc,
+    null_ctx_free
+};
+
+static const mbedtls_cipher_info_t null_cipher_info = {
+    MBEDTLS_CIPHER_NULL,
+    MBEDTLS_MODE_STREAM,
+    0,
+    "NULL",
+    0,
+    0,
+    1,
+    &null_base_info
+};
+#endif /* defined(MBEDTLS_CIPHER_NULL_CIPHER) */
+
+const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
+{
+#if defined(MBEDTLS_AES_C)
+    { MBEDTLS_CIPHER_AES_128_ECB,          &aes_128_ecb_info },
+    { MBEDTLS_CIPHER_AES_192_ECB,          &aes_192_ecb_info },
+    { MBEDTLS_CIPHER_AES_256_ECB,          &aes_256_ecb_info },
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    { MBEDTLS_CIPHER_AES_128_CBC,          &aes_128_cbc_info },
+    { MBEDTLS_CIPHER_AES_192_CBC,          &aes_192_cbc_info },
+    { MBEDTLS_CIPHER_AES_256_CBC,          &aes_256_cbc_info },
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    { MBEDTLS_CIPHER_AES_128_CFB128,       &aes_128_cfb128_info },
+    { MBEDTLS_CIPHER_AES_192_CFB128,       &aes_192_cfb128_info },
+    { MBEDTLS_CIPHER_AES_256_CFB128,       &aes_256_cfb128_info },
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+    { MBEDTLS_CIPHER_AES_128_OFB,          &aes_128_ofb_info },
+    { MBEDTLS_CIPHER_AES_192_OFB,          &aes_192_ofb_info },
+    { MBEDTLS_CIPHER_AES_256_OFB,          &aes_256_ofb_info },
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    { MBEDTLS_CIPHER_AES_128_CTR,          &aes_128_ctr_info },
+    { MBEDTLS_CIPHER_AES_192_CTR,          &aes_192_ctr_info },
+    { MBEDTLS_CIPHER_AES_256_CTR,          &aes_256_ctr_info },
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+    { MBEDTLS_CIPHER_AES_128_XTS,          &aes_128_xts_info },
+    { MBEDTLS_CIPHER_AES_256_XTS,          &aes_256_xts_info },
+#endif
+#if defined(MBEDTLS_GCM_C)
+    { MBEDTLS_CIPHER_AES_128_GCM,          &aes_128_gcm_info },
+    { MBEDTLS_CIPHER_AES_192_GCM,          &aes_192_gcm_info },
+    { MBEDTLS_CIPHER_AES_256_GCM,          &aes_256_gcm_info },
+#endif
+#if defined(MBEDTLS_CCM_C)
+    { MBEDTLS_CIPHER_AES_128_CCM,          &aes_128_ccm_info },
+    { MBEDTLS_CIPHER_AES_192_CCM,          &aes_192_ccm_info },
+    { MBEDTLS_CIPHER_AES_256_CCM,          &aes_256_ccm_info },
+#endif
+#endif /* MBEDTLS_AES_C */
+
+#if defined(MBEDTLS_ARC4_C)
+    { MBEDTLS_CIPHER_ARC4_128,             &arc4_128_info },
+#endif
+
+#if defined(MBEDTLS_BLOWFISH_C)
+    { MBEDTLS_CIPHER_BLOWFISH_ECB,         &blowfish_ecb_info },
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    { MBEDTLS_CIPHER_BLOWFISH_CBC,         &blowfish_cbc_info },
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    { MBEDTLS_CIPHER_BLOWFISH_CFB64,       &blowfish_cfb64_info },
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    { MBEDTLS_CIPHER_BLOWFISH_CTR,         &blowfish_ctr_info },
+#endif
+#endif /* MBEDTLS_BLOWFISH_C */
+
+#if defined(MBEDTLS_CAMELLIA_C)
+    { MBEDTLS_CIPHER_CAMELLIA_128_ECB,     &camellia_128_ecb_info },
+    { MBEDTLS_CIPHER_CAMELLIA_192_ECB,     &camellia_192_ecb_info },
+    { MBEDTLS_CIPHER_CAMELLIA_256_ECB,     &camellia_256_ecb_info },
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    { MBEDTLS_CIPHER_CAMELLIA_128_CBC,     &camellia_128_cbc_info },
+    { MBEDTLS_CIPHER_CAMELLIA_192_CBC,     &camellia_192_cbc_info },
+    { MBEDTLS_CIPHER_CAMELLIA_256_CBC,     &camellia_256_cbc_info },
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    { MBEDTLS_CIPHER_CAMELLIA_128_CFB128,  &camellia_128_cfb128_info },
+    { MBEDTLS_CIPHER_CAMELLIA_192_CFB128,  &camellia_192_cfb128_info },
+    { MBEDTLS_CIPHER_CAMELLIA_256_CFB128,  &camellia_256_cfb128_info },
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    { MBEDTLS_CIPHER_CAMELLIA_128_CTR,     &camellia_128_ctr_info },
+    { MBEDTLS_CIPHER_CAMELLIA_192_CTR,     &camellia_192_ctr_info },
+    { MBEDTLS_CIPHER_CAMELLIA_256_CTR,     &camellia_256_ctr_info },
+#endif
+#if defined(MBEDTLS_GCM_C)
+    { MBEDTLS_CIPHER_CAMELLIA_128_GCM,     &camellia_128_gcm_info },
+    { MBEDTLS_CIPHER_CAMELLIA_192_GCM,     &camellia_192_gcm_info },
+    { MBEDTLS_CIPHER_CAMELLIA_256_GCM,     &camellia_256_gcm_info },
+#endif
+#if defined(MBEDTLS_CCM_C)
+    { MBEDTLS_CIPHER_CAMELLIA_128_CCM,     &camellia_128_ccm_info },
+    { MBEDTLS_CIPHER_CAMELLIA_192_CCM,     &camellia_192_ccm_info },
+    { MBEDTLS_CIPHER_CAMELLIA_256_CCM,     &camellia_256_ccm_info },
+#endif
+#endif /* MBEDTLS_CAMELLIA_C */
+
+#if defined(MBEDTLS_ARIA_C)
+    { MBEDTLS_CIPHER_ARIA_128_ECB,     &aria_128_ecb_info },
+    { MBEDTLS_CIPHER_ARIA_192_ECB,     &aria_192_ecb_info },
+    { MBEDTLS_CIPHER_ARIA_256_ECB,     &aria_256_ecb_info },
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    { MBEDTLS_CIPHER_ARIA_128_CBC,     &aria_128_cbc_info },
+    { MBEDTLS_CIPHER_ARIA_192_CBC,     &aria_192_cbc_info },
+    { MBEDTLS_CIPHER_ARIA_256_CBC,     &aria_256_cbc_info },
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    { MBEDTLS_CIPHER_ARIA_128_CFB128,  &aria_128_cfb128_info },
+    { MBEDTLS_CIPHER_ARIA_192_CFB128,  &aria_192_cfb128_info },
+    { MBEDTLS_CIPHER_ARIA_256_CFB128,  &aria_256_cfb128_info },
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    { MBEDTLS_CIPHER_ARIA_128_CTR,     &aria_128_ctr_info },
+    { MBEDTLS_CIPHER_ARIA_192_CTR,     &aria_192_ctr_info },
+    { MBEDTLS_CIPHER_ARIA_256_CTR,     &aria_256_ctr_info },
+#endif
+#if defined(MBEDTLS_GCM_C)
+    { MBEDTLS_CIPHER_ARIA_128_GCM,     &aria_128_gcm_info },
+    { MBEDTLS_CIPHER_ARIA_192_GCM,     &aria_192_gcm_info },
+    { MBEDTLS_CIPHER_ARIA_256_GCM,     &aria_256_gcm_info },
+#endif
+#if defined(MBEDTLS_CCM_C)
+    { MBEDTLS_CIPHER_ARIA_128_CCM,     &aria_128_ccm_info },
+    { MBEDTLS_CIPHER_ARIA_192_CCM,     &aria_192_ccm_info },
+    { MBEDTLS_CIPHER_ARIA_256_CCM,     &aria_256_ccm_info },
+#endif
+#endif /* MBEDTLS_ARIA_C */
+
+#if defined(MBEDTLS_DES_C)
+    { MBEDTLS_CIPHER_DES_ECB,              &des_ecb_info },
+    { MBEDTLS_CIPHER_DES_EDE_ECB,          &des_ede_ecb_info },
+    { MBEDTLS_CIPHER_DES_EDE3_ECB,         &des_ede3_ecb_info },
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    { MBEDTLS_CIPHER_DES_CBC,              &des_cbc_info },
+    { MBEDTLS_CIPHER_DES_EDE_CBC,          &des_ede_cbc_info },
+    { MBEDTLS_CIPHER_DES_EDE3_CBC,         &des_ede3_cbc_info },
+#endif
+#endif /* MBEDTLS_DES_C */
+
+#if defined(MBEDTLS_CHACHA20_C)
+    { MBEDTLS_CIPHER_CHACHA20,             &chacha20_info },
+#endif
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+    { MBEDTLS_CIPHER_CHACHA20_POLY1305,    &chachapoly_info },
+#endif
+
+#if defined(MBEDTLS_CIPHER_NULL_CIPHER)
+    { MBEDTLS_CIPHER_NULL,                 &null_cipher_info },
+#endif /* MBEDTLS_CIPHER_NULL_CIPHER */
+
+    { MBEDTLS_CIPHER_NONE, NULL }
+};
+
+#define NUM_CIPHERS sizeof mbedtls_cipher_definitions / sizeof mbedtls_cipher_definitions[0]
+int mbedtls_cipher_supported[NUM_CIPHERS];
+
+#endif /* MBEDTLS_CIPHER_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/des.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/des.c
@@ -1,0 +1,1055 @@
+/*
+ *  FIPS-46-3 compliant Triple-DES implementation
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+/*
+ *  DES, on which TDES is based, was originally designed by Horst Feistel
+ *  at IBM in 1974, and was adopted as a standard by NIST (formerly NBS).
+ *
+ *  http://csrc.nist.gov/publications/fips/fips46-3/fips46-3.pdf
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_DES_C)
+
+#include "mbedtls/des.h"
+#include "mbedtls/platform_util.h"
+
+#if defined(MBEDTLS_SELF_TEST)
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#define mbedtls_printf printf
+#endif /* MBEDTLS_PLATFORM_C */
+#endif /* MBEDTLS_SELF_TEST */
+
+#if !defined(MBEDTLS_DES_ALT)
+
+/*
+ * 32-bit integer manipulation macros (big endian)
+ */
+#ifndef GET_UINT32_BE
+#define GET_UINT32_BE(n,b,i)                            \
+{                                                       \
+    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
+        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
+        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
+        | ( (uint32_t) (b)[(i) + 3]       );            \
+}
+#endif
+
+#ifndef PUT_UINT32_BE
+#define PUT_UINT32_BE(n,b,i)                            \
+{                                                       \
+    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
+    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
+    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
+    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
+}
+#endif
+
+/*
+ * Expanded DES S-boxes
+ */
+static const uint32_t SB1[64] =
+{
+    0x01010400, 0x00000000, 0x00010000, 0x01010404,
+    0x01010004, 0x00010404, 0x00000004, 0x00010000,
+    0x00000400, 0x01010400, 0x01010404, 0x00000400,
+    0x01000404, 0x01010004, 0x01000000, 0x00000004,
+    0x00000404, 0x01000400, 0x01000400, 0x00010400,
+    0x00010400, 0x01010000, 0x01010000, 0x01000404,
+    0x00010004, 0x01000004, 0x01000004, 0x00010004,
+    0x00000000, 0x00000404, 0x00010404, 0x01000000,
+    0x00010000, 0x01010404, 0x00000004, 0x01010000,
+    0x01010400, 0x01000000, 0x01000000, 0x00000400,
+    0x01010004, 0x00010000, 0x00010400, 0x01000004,
+    0x00000400, 0x00000004, 0x01000404, 0x00010404,
+    0x01010404, 0x00010004, 0x01010000, 0x01000404,
+    0x01000004, 0x00000404, 0x00010404, 0x01010400,
+    0x00000404, 0x01000400, 0x01000400, 0x00000000,
+    0x00010004, 0x00010400, 0x00000000, 0x01010004
+};
+
+static const uint32_t SB2[64] =
+{
+    0x80108020, 0x80008000, 0x00008000, 0x00108020,
+    0x00100000, 0x00000020, 0x80100020, 0x80008020,
+    0x80000020, 0x80108020, 0x80108000, 0x80000000,
+    0x80008000, 0x00100000, 0x00000020, 0x80100020,
+    0x00108000, 0x00100020, 0x80008020, 0x00000000,
+    0x80000000, 0x00008000, 0x00108020, 0x80100000,
+    0x00100020, 0x80000020, 0x00000000, 0x00108000,
+    0x00008020, 0x80108000, 0x80100000, 0x00008020,
+    0x00000000, 0x00108020, 0x80100020, 0x00100000,
+    0x80008020, 0x80100000, 0x80108000, 0x00008000,
+    0x80100000, 0x80008000, 0x00000020, 0x80108020,
+    0x00108020, 0x00000020, 0x00008000, 0x80000000,
+    0x00008020, 0x80108000, 0x00100000, 0x80000020,
+    0x00100020, 0x80008020, 0x80000020, 0x00100020,
+    0x00108000, 0x00000000, 0x80008000, 0x00008020,
+    0x80000000, 0x80100020, 0x80108020, 0x00108000
+};
+
+static const uint32_t SB3[64] =
+{
+    0x00000208, 0x08020200, 0x00000000, 0x08020008,
+    0x08000200, 0x00000000, 0x00020208, 0x08000200,
+    0x00020008, 0x08000008, 0x08000008, 0x00020000,
+    0x08020208, 0x00020008, 0x08020000, 0x00000208,
+    0x08000000, 0x00000008, 0x08020200, 0x00000200,
+    0x00020200, 0x08020000, 0x08020008, 0x00020208,
+    0x08000208, 0x00020200, 0x00020000, 0x08000208,
+    0x00000008, 0x08020208, 0x00000200, 0x08000000,
+    0x08020200, 0x08000000, 0x00020008, 0x00000208,
+    0x00020000, 0x08020200, 0x08000200, 0x00000000,
+    0x00000200, 0x00020008, 0x08020208, 0x08000200,
+    0x08000008, 0x00000200, 0x00000000, 0x08020008,
+    0x08000208, 0x00020000, 0x08000000, 0x08020208,
+    0x00000008, 0x00020208, 0x00020200, 0x08000008,
+    0x08020000, 0x08000208, 0x00000208, 0x08020000,
+    0x00020208, 0x00000008, 0x08020008, 0x00020200
+};
+
+static const uint32_t SB4[64] =
+{
+    0x00802001, 0x00002081, 0x00002081, 0x00000080,
+    0x00802080, 0x00800081, 0x00800001, 0x00002001,
+    0x00000000, 0x00802000, 0x00802000, 0x00802081,
+    0x00000081, 0x00000000, 0x00800080, 0x00800001,
+    0x00000001, 0x00002000, 0x00800000, 0x00802001,
+    0x00000080, 0x00800000, 0x00002001, 0x00002080,
+    0x00800081, 0x00000001, 0x00002080, 0x00800080,
+    0x00002000, 0x00802080, 0x00802081, 0x00000081,
+    0x00800080, 0x00800001, 0x00802000, 0x00802081,
+    0x00000081, 0x00000000, 0x00000000, 0x00802000,
+    0x00002080, 0x00800080, 0x00800081, 0x00000001,
+    0x00802001, 0x00002081, 0x00002081, 0x00000080,
+    0x00802081, 0x00000081, 0x00000001, 0x00002000,
+    0x00800001, 0x00002001, 0x00802080, 0x00800081,
+    0x00002001, 0x00002080, 0x00800000, 0x00802001,
+    0x00000080, 0x00800000, 0x00002000, 0x00802080
+};
+
+static const uint32_t SB5[64] =
+{
+    0x00000100, 0x02080100, 0x02080000, 0x42000100,
+    0x00080000, 0x00000100, 0x40000000, 0x02080000,
+    0x40080100, 0x00080000, 0x02000100, 0x40080100,
+    0x42000100, 0x42080000, 0x00080100, 0x40000000,
+    0x02000000, 0x40080000, 0x40080000, 0x00000000,
+    0x40000100, 0x42080100, 0x42080100, 0x02000100,
+    0x42080000, 0x40000100, 0x00000000, 0x42000000,
+    0x02080100, 0x02000000, 0x42000000, 0x00080100,
+    0x00080000, 0x42000100, 0x00000100, 0x02000000,
+    0x40000000, 0x02080000, 0x42000100, 0x40080100,
+    0x02000100, 0x40000000, 0x42080000, 0x02080100,
+    0x40080100, 0x00000100, 0x02000000, 0x42080000,
+    0x42080100, 0x00080100, 0x42000000, 0x42080100,
+    0x02080000, 0x00000000, 0x40080000, 0x42000000,
+    0x00080100, 0x02000100, 0x40000100, 0x00080000,
+    0x00000000, 0x40080000, 0x02080100, 0x40000100
+};
+
+static const uint32_t SB6[64] =
+{
+    0x20000010, 0x20400000, 0x00004000, 0x20404010,
+    0x20400000, 0x00000010, 0x20404010, 0x00400000,
+    0x20004000, 0x00404010, 0x00400000, 0x20000010,
+    0x00400010, 0x20004000, 0x20000000, 0x00004010,
+    0x00000000, 0x00400010, 0x20004010, 0x00004000,
+    0x00404000, 0x20004010, 0x00000010, 0x20400010,
+    0x20400010, 0x00000000, 0x00404010, 0x20404000,
+    0x00004010, 0x00404000, 0x20404000, 0x20000000,
+    0x20004000, 0x00000010, 0x20400010, 0x00404000,
+    0x20404010, 0x00400000, 0x00004010, 0x20000010,
+    0x00400000, 0x20004000, 0x20000000, 0x00004010,
+    0x20000010, 0x20404010, 0x00404000, 0x20400000,
+    0x00404010, 0x20404000, 0x00000000, 0x20400010,
+    0x00000010, 0x00004000, 0x20400000, 0x00404010,
+    0x00004000, 0x00400010, 0x20004010, 0x00000000,
+    0x20404000, 0x20000000, 0x00400010, 0x20004010
+};
+
+static const uint32_t SB7[64] =
+{
+    0x00200000, 0x04200002, 0x04000802, 0x00000000,
+    0x00000800, 0x04000802, 0x00200802, 0x04200800,
+    0x04200802, 0x00200000, 0x00000000, 0x04000002,
+    0x00000002, 0x04000000, 0x04200002, 0x00000802,
+    0x04000800, 0x00200802, 0x00200002, 0x04000800,
+    0x04000002, 0x04200000, 0x04200800, 0x00200002,
+    0x04200000, 0x00000800, 0x00000802, 0x04200802,
+    0x00200800, 0x00000002, 0x04000000, 0x00200800,
+    0x04000000, 0x00200800, 0x00200000, 0x04000802,
+    0x04000802, 0x04200002, 0x04200002, 0x00000002,
+    0x00200002, 0x04000000, 0x04000800, 0x00200000,
+    0x04200800, 0x00000802, 0x00200802, 0x04200800,
+    0x00000802, 0x04000002, 0x04200802, 0x04200000,
+    0x00200800, 0x00000000, 0x00000002, 0x04200802,
+    0x00000000, 0x00200802, 0x04200000, 0x00000800,
+    0x04000002, 0x04000800, 0x00000800, 0x00200002
+};
+
+static const uint32_t SB8[64] =
+{
+    0x10001040, 0x00001000, 0x00040000, 0x10041040,
+    0x10000000, 0x10001040, 0x00000040, 0x10000000,
+    0x00040040, 0x10040000, 0x10041040, 0x00041000,
+    0x10041000, 0x00041040, 0x00001000, 0x00000040,
+    0x10040000, 0x10000040, 0x10001000, 0x00001040,
+    0x00041000, 0x00040040, 0x10040040, 0x10041000,
+    0x00001040, 0x00000000, 0x00000000, 0x10040040,
+    0x10000040, 0x10001000, 0x00041040, 0x00040000,
+    0x00041040, 0x00040000, 0x10041000, 0x00001000,
+    0x00000040, 0x10040040, 0x00001000, 0x00041040,
+    0x10001000, 0x00000040, 0x10000040, 0x10040000,
+    0x10040040, 0x10000000, 0x00040000, 0x10001040,
+    0x00000000, 0x10041040, 0x00040040, 0x10000040,
+    0x10040000, 0x10001000, 0x10001040, 0x00000000,
+    0x10041040, 0x00041000, 0x00041000, 0x00001040,
+    0x00001040, 0x00040040, 0x10000000, 0x10041000
+};
+
+/*
+ * PC1: left and right halves bit-swap
+ */
+static const uint32_t LHs[16] =
+{
+    0x00000000, 0x00000001, 0x00000100, 0x00000101,
+    0x00010000, 0x00010001, 0x00010100, 0x00010101,
+    0x01000000, 0x01000001, 0x01000100, 0x01000101,
+    0x01010000, 0x01010001, 0x01010100, 0x01010101
+};
+
+static const uint32_t RHs[16] =
+{
+    0x00000000, 0x01000000, 0x00010000, 0x01010000,
+    0x00000100, 0x01000100, 0x00010100, 0x01010100,
+    0x00000001, 0x01000001, 0x00010001, 0x01010001,
+    0x00000101, 0x01000101, 0x00010101, 0x01010101,
+};
+
+/*
+ * Initial Permutation macro
+ */
+#define DES_IP(X,Y)                                             \
+{                                                               \
+    T = ((X >>  4) ^ Y) & 0x0F0F0F0F; Y ^= T; X ^= (T <<  4);   \
+    T = ((X >> 16) ^ Y) & 0x0000FFFF; Y ^= T; X ^= (T << 16);   \
+    T = ((Y >>  2) ^ X) & 0x33333333; X ^= T; Y ^= (T <<  2);   \
+    T = ((Y >>  8) ^ X) & 0x00FF00FF; X ^= T; Y ^= (T <<  8);   \
+    Y = ((Y << 1) | (Y >> 31)) & 0xFFFFFFFF;                    \
+    T = (X ^ Y) & 0xAAAAAAAA; Y ^= T; X ^= T;                   \
+    X = ((X << 1) | (X >> 31)) & 0xFFFFFFFF;                    \
+}
+
+/*
+ * Final Permutation macro
+ */
+#define DES_FP(X,Y)                                             \
+{                                                               \
+    X = ((X << 31) | (X >> 1)) & 0xFFFFFFFF;                    \
+    T = (X ^ Y) & 0xAAAAAAAA; X ^= T; Y ^= T;                   \
+    Y = ((Y << 31) | (Y >> 1)) & 0xFFFFFFFF;                    \
+    T = ((Y >>  8) ^ X) & 0x00FF00FF; X ^= T; Y ^= (T <<  8);   \
+    T = ((Y >>  2) ^ X) & 0x33333333; X ^= T; Y ^= (T <<  2);   \
+    T = ((X >> 16) ^ Y) & 0x0000FFFF; Y ^= T; X ^= (T << 16);   \
+    T = ((X >>  4) ^ Y) & 0x0F0F0F0F; Y ^= T; X ^= (T <<  4);   \
+}
+
+/*
+ * DES round macro
+ */
+#define DES_ROUND(X,Y)                          \
+{                                               \
+    T = *SK++ ^ X;                              \
+    Y ^= SB8[ (T      ) & 0x3F ] ^              \
+         SB6[ (T >>  8) & 0x3F ] ^              \
+         SB4[ (T >> 16) & 0x3F ] ^              \
+         SB2[ (T >> 24) & 0x3F ];               \
+                                                \
+    T = *SK++ ^ ((X << 28) | (X >> 4));         \
+    Y ^= SB7[ (T      ) & 0x3F ] ^              \
+         SB5[ (T >>  8) & 0x3F ] ^              \
+         SB3[ (T >> 16) & 0x3F ] ^              \
+         SB1[ (T >> 24) & 0x3F ];               \
+}
+
+#define SWAP(a,b) { uint32_t t = a; a = b; b = t; t = 0; }
+
+void mbedtls_des_init( mbedtls_des_context *ctx )
+{
+    memset( ctx, 0, sizeof( mbedtls_des_context ) );
+}
+
+void mbedtls_des_free( mbedtls_des_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_des_context ) );
+}
+
+void mbedtls_des3_init( mbedtls_des3_context *ctx )
+{
+    memset( ctx, 0, sizeof( mbedtls_des3_context ) );
+}
+
+void mbedtls_des3_free( mbedtls_des3_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_des3_context ) );
+}
+
+static const unsigned char odd_parity_table[128] = { 1,  2,  4,  7,  8,
+        11, 13, 14, 16, 19, 21, 22, 25, 26, 28, 31, 32, 35, 37, 38, 41, 42, 44,
+        47, 49, 50, 52, 55, 56, 59, 61, 62, 64, 67, 69, 70, 73, 74, 76, 79, 81,
+        82, 84, 87, 88, 91, 93, 94, 97, 98, 100, 103, 104, 107, 109, 110, 112,
+        115, 117, 118, 121, 122, 124, 127, 128, 131, 133, 134, 137, 138, 140,
+        143, 145, 146, 148, 151, 152, 155, 157, 158, 161, 162, 164, 167, 168,
+        171, 173, 174, 176, 179, 181, 182, 185, 186, 188, 191, 193, 194, 196,
+        199, 200, 203, 205, 206, 208, 211, 213, 214, 217, 218, 220, 223, 224,
+        227, 229, 230, 233, 234, 236, 239, 241, 242, 244, 247, 248, 251, 253,
+        254 };
+
+void mbedtls_des_key_set_parity( unsigned char key[MBEDTLS_DES_KEY_SIZE] )
+{
+    int i;
+
+    for( i = 0; i < MBEDTLS_DES_KEY_SIZE; i++ )
+        key[i] = odd_parity_table[key[i] / 2];
+}
+
+/*
+ * Check the given key's parity, returns 1 on failure, 0 on SUCCESS
+ */
+int mbedtls_des_key_check_key_parity( const unsigned char key[MBEDTLS_DES_KEY_SIZE] )
+{
+    int i;
+
+    for( i = 0; i < MBEDTLS_DES_KEY_SIZE; i++ )
+        if( key[i] != odd_parity_table[key[i] / 2] )
+            return( 1 );
+
+    return( 0 );
+}
+
+/*
+ * Table of weak and semi-weak keys
+ *
+ * Source: http://en.wikipedia.org/wiki/Weak_key
+ *
+ * Weak:
+ * Alternating ones + zeros (0x0101010101010101)
+ * Alternating 'F' + 'E' (0xFEFEFEFEFEFEFEFE)
+ * '0xE0E0E0E0F1F1F1F1'
+ * '0x1F1F1F1F0E0E0E0E'
+ *
+ * Semi-weak:
+ * 0x011F011F010E010E and 0x1F011F010E010E01
+ * 0x01E001E001F101F1 and 0xE001E001F101F101
+ * 0x01FE01FE01FE01FE and 0xFE01FE01FE01FE01
+ * 0x1FE01FE00EF10EF1 and 0xE01FE01FF10EF10E
+ * 0x1FFE1FFE0EFE0EFE and 0xFE1FFE1FFE0EFE0E
+ * 0xE0FEE0FEF1FEF1FE and 0xFEE0FEE0FEF1FEF1
+ *
+ */
+
+#define WEAK_KEY_COUNT 16
+
+static const unsigned char weak_key_table[WEAK_KEY_COUNT][MBEDTLS_DES_KEY_SIZE] =
+{
+    { 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 },
+    { 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE },
+    { 0x1F, 0x1F, 0x1F, 0x1F, 0x0E, 0x0E, 0x0E, 0x0E },
+    { 0xE0, 0xE0, 0xE0, 0xE0, 0xF1, 0xF1, 0xF1, 0xF1 },
+
+    { 0x01, 0x1F, 0x01, 0x1F, 0x01, 0x0E, 0x01, 0x0E },
+    { 0x1F, 0x01, 0x1F, 0x01, 0x0E, 0x01, 0x0E, 0x01 },
+    { 0x01, 0xE0, 0x01, 0xE0, 0x01, 0xF1, 0x01, 0xF1 },
+    { 0xE0, 0x01, 0xE0, 0x01, 0xF1, 0x01, 0xF1, 0x01 },
+    { 0x01, 0xFE, 0x01, 0xFE, 0x01, 0xFE, 0x01, 0xFE },
+    { 0xFE, 0x01, 0xFE, 0x01, 0xFE, 0x01, 0xFE, 0x01 },
+    { 0x1F, 0xE0, 0x1F, 0xE0, 0x0E, 0xF1, 0x0E, 0xF1 },
+    { 0xE0, 0x1F, 0xE0, 0x1F, 0xF1, 0x0E, 0xF1, 0x0E },
+    { 0x1F, 0xFE, 0x1F, 0xFE, 0x0E, 0xFE, 0x0E, 0xFE },
+    { 0xFE, 0x1F, 0xFE, 0x1F, 0xFE, 0x0E, 0xFE, 0x0E },
+    { 0xE0, 0xFE, 0xE0, 0xFE, 0xF1, 0xFE, 0xF1, 0xFE },
+    { 0xFE, 0xE0, 0xFE, 0xE0, 0xFE, 0xF1, 0xFE, 0xF1 }
+};
+
+int mbedtls_des_key_check_weak( const unsigned char key[MBEDTLS_DES_KEY_SIZE] )
+{
+    int i;
+
+    for( i = 0; i < WEAK_KEY_COUNT; i++ )
+        if( memcmp( weak_key_table[i], key, MBEDTLS_DES_KEY_SIZE) == 0 )
+            return( 1 );
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DES_SETKEY_ALT)
+void mbedtls_des_setkey( uint32_t SK[32], const unsigned char key[MBEDTLS_DES_KEY_SIZE] )
+{
+    int i;
+    uint32_t X, Y, T;
+
+    GET_UINT32_BE( X, key, 0 );
+    GET_UINT32_BE( Y, key, 4 );
+
+    /*
+     * Permuted Choice 1
+     */
+    T =  ((Y >>  4) ^ X) & 0x0F0F0F0F;  X ^= T; Y ^= (T <<  4);
+    T =  ((Y      ) ^ X) & 0x10101010;  X ^= T; Y ^= (T      );
+
+    X =   (LHs[ (X      ) & 0xF] << 3) | (LHs[ (X >>  8) & 0xF ] << 2)
+        | (LHs[ (X >> 16) & 0xF] << 1) | (LHs[ (X >> 24) & 0xF ]     )
+        | (LHs[ (X >>  5) & 0xF] << 7) | (LHs[ (X >> 13) & 0xF ] << 6)
+        | (LHs[ (X >> 21) & 0xF] << 5) | (LHs[ (X >> 29) & 0xF ] << 4);
+
+    Y =   (RHs[ (Y >>  1) & 0xF] << 3) | (RHs[ (Y >>  9) & 0xF ] << 2)
+        | (RHs[ (Y >> 17) & 0xF] << 1) | (RHs[ (Y >> 25) & 0xF ]     )
+        | (RHs[ (Y >>  4) & 0xF] << 7) | (RHs[ (Y >> 12) & 0xF ] << 6)
+        | (RHs[ (Y >> 20) & 0xF] << 5) | (RHs[ (Y >> 28) & 0xF ] << 4);
+
+    X &= 0x0FFFFFFF;
+    Y &= 0x0FFFFFFF;
+
+    /*
+     * calculate subkeys
+     */
+    for( i = 0; i < 16; i++ )
+    {
+        if( i < 2 || i == 8 || i == 15 )
+        {
+            X = ((X <<  1) | (X >> 27)) & 0x0FFFFFFF;
+            Y = ((Y <<  1) | (Y >> 27)) & 0x0FFFFFFF;
+        }
+        else
+        {
+            X = ((X <<  2) | (X >> 26)) & 0x0FFFFFFF;
+            Y = ((Y <<  2) | (Y >> 26)) & 0x0FFFFFFF;
+        }
+
+        *SK++ =   ((X <<  4) & 0x24000000) | ((X << 28) & 0x10000000)
+                | ((X << 14) & 0x08000000) | ((X << 18) & 0x02080000)
+                | ((X <<  6) & 0x01000000) | ((X <<  9) & 0x00200000)
+                | ((X >>  1) & 0x00100000) | ((X << 10) & 0x00040000)
+                | ((X <<  2) & 0x00020000) | ((X >> 10) & 0x00010000)
+                | ((Y >> 13) & 0x00002000) | ((Y >>  4) & 0x00001000)
+                | ((Y <<  6) & 0x00000800) | ((Y >>  1) & 0x00000400)
+                | ((Y >> 14) & 0x00000200) | ((Y      ) & 0x00000100)
+                | ((Y >>  5) & 0x00000020) | ((Y >> 10) & 0x00000010)
+                | ((Y >>  3) & 0x00000008) | ((Y >> 18) & 0x00000004)
+                | ((Y >> 26) & 0x00000002) | ((Y >> 24) & 0x00000001);
+
+        *SK++ =   ((X << 15) & 0x20000000) | ((X << 17) & 0x10000000)
+                | ((X << 10) & 0x08000000) | ((X << 22) & 0x04000000)
+                | ((X >>  2) & 0x02000000) | ((X <<  1) & 0x01000000)
+                | ((X << 16) & 0x00200000) | ((X << 11) & 0x00100000)
+                | ((X <<  3) & 0x00080000) | ((X >>  6) & 0x00040000)
+                | ((X << 15) & 0x00020000) | ((X >>  4) & 0x00010000)
+                | ((Y >>  2) & 0x00002000) | ((Y <<  8) & 0x00001000)
+                | ((Y >> 14) & 0x00000808) | ((Y >>  9) & 0x00000400)
+                | ((Y      ) & 0x00000200) | ((Y <<  7) & 0x00000100)
+                | ((Y >>  7) & 0x00000020) | ((Y >>  3) & 0x00000011)
+                | ((Y <<  2) & 0x00000004) | ((Y >> 21) & 0x00000002);
+    }
+}
+#endif /* !MBEDTLS_DES_SETKEY_ALT */
+
+/*
+ * DES key schedule (56-bit, encryption)
+ */
+int mbedtls_des_setkey_enc( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] )
+{
+    mbedtls_des_setkey( ctx->sk, key );
+
+    return( 0 );
+}
+
+/*
+ * DES key schedule (56-bit, decryption)
+ */
+int mbedtls_des_setkey_dec( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] )
+{
+    int i;
+
+    mbedtls_des_setkey( ctx->sk, key );
+
+    for( i = 0; i < 16; i += 2 )
+    {
+        SWAP( ctx->sk[i    ], ctx->sk[30 - i] );
+        SWAP( ctx->sk[i + 1], ctx->sk[31 - i] );
+    }
+
+    return( 0 );
+}
+
+static void des3_set2key( uint32_t esk[96],
+                          uint32_t dsk[96],
+                          const unsigned char key[MBEDTLS_DES_KEY_SIZE*2] )
+{
+    int i;
+
+    mbedtls_des_setkey( esk, key );
+    mbedtls_des_setkey( dsk + 32, key + 8 );
+
+    for( i = 0; i < 32; i += 2 )
+    {
+        dsk[i     ] = esk[30 - i];
+        dsk[i +  1] = esk[31 - i];
+
+        esk[i + 32] = dsk[62 - i];
+        esk[i + 33] = dsk[63 - i];
+
+        esk[i + 64] = esk[i    ];
+        esk[i + 65] = esk[i + 1];
+
+        dsk[i + 64] = dsk[i    ];
+        dsk[i + 65] = dsk[i + 1];
+    }
+}
+
+/*
+ * Triple-DES key schedule (112-bit, encryption)
+ */
+int mbedtls_des3_set2key_enc( mbedtls_des3_context *ctx,
+                      const unsigned char key[MBEDTLS_DES_KEY_SIZE * 2] )
+{
+    uint32_t sk[96];
+
+    des3_set2key( ctx->sk, sk, key );
+    mbedtls_platform_zeroize( sk,  sizeof( sk ) );
+
+    return( 0 );
+}
+
+/*
+ * Triple-DES key schedule (112-bit, decryption)
+ */
+int mbedtls_des3_set2key_dec( mbedtls_des3_context *ctx,
+                      const unsigned char key[MBEDTLS_DES_KEY_SIZE * 2] )
+{
+    uint32_t sk[96];
+
+    des3_set2key( sk, ctx->sk, key );
+    mbedtls_platform_zeroize( sk,  sizeof( sk ) );
+
+    return( 0 );
+}
+
+static void des3_set3key( uint32_t esk[96],
+                          uint32_t dsk[96],
+                          const unsigned char key[24] )
+{
+    int i;
+
+    mbedtls_des_setkey( esk, key );
+    mbedtls_des_setkey( dsk + 32, key +  8 );
+    mbedtls_des_setkey( esk + 64, key + 16 );
+
+    for( i = 0; i < 32; i += 2 )
+    {
+        dsk[i     ] = esk[94 - i];
+        dsk[i +  1] = esk[95 - i];
+
+        esk[i + 32] = dsk[62 - i];
+        esk[i + 33] = dsk[63 - i];
+
+        dsk[i + 64] = esk[30 - i];
+        dsk[i + 65] = esk[31 - i];
+    }
+}
+
+/*
+ * Triple-DES key schedule (168-bit, encryption)
+ */
+int mbedtls_des3_set3key_enc( mbedtls_des3_context *ctx,
+                      const unsigned char key[MBEDTLS_DES_KEY_SIZE * 3] )
+{
+    uint32_t sk[96];
+
+    des3_set3key( ctx->sk, sk, key );
+    mbedtls_platform_zeroize( sk,  sizeof( sk ) );
+
+    return( 0 );
+}
+
+/*
+ * Triple-DES key schedule (168-bit, decryption)
+ */
+int mbedtls_des3_set3key_dec( mbedtls_des3_context *ctx,
+                      const unsigned char key[MBEDTLS_DES_KEY_SIZE * 3] )
+{
+    uint32_t sk[96];
+
+    des3_set3key( sk, ctx->sk, key );
+    mbedtls_platform_zeroize( sk,  sizeof( sk ) );
+
+    return( 0 );
+}
+
+/*
+ * DES-ECB block encryption/decryption
+ */
+#if !defined(MBEDTLS_DES_CRYPT_ECB_ALT)
+int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
+                    const unsigned char input[8],
+                    unsigned char output[8] )
+{
+    int i;
+    uint32_t X, Y, T, *SK;
+
+    SK = ctx->sk;
+
+    GET_UINT32_BE( X, input, 0 );
+    GET_UINT32_BE( Y, input, 4 );
+
+    DES_IP( X, Y );
+
+    for( i = 0; i < 8; i++ )
+    {
+        DES_ROUND( Y, X );
+        DES_ROUND( X, Y );
+    }
+
+    DES_FP( Y, X );
+
+    PUT_UINT32_BE( Y, output, 0 );
+    PUT_UINT32_BE( X, output, 4 );
+
+    return( 0 );
+}
+#endif /* !MBEDTLS_DES_CRYPT_ECB_ALT */
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+/*
+ * DES-CBC buffer encryption/decryption
+ */
+int mbedtls_des_crypt_cbc( mbedtls_des_context *ctx,
+                    int mode,
+                    size_t length,
+                    unsigned char iv[8],
+                    const unsigned char *input,
+                    unsigned char *output )
+{
+    int i;
+    unsigned char temp[8];
+
+    if( length % 8 )
+        return( MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH );
+
+    if( mode == MBEDTLS_DES_ENCRYPT )
+    {
+        while( length > 0 )
+        {
+            for( i = 0; i < 8; i++ )
+                output[i] = (unsigned char)( input[i] ^ iv[i] );
+
+            mbedtls_des_crypt_ecb( ctx, output, output );
+            memcpy( iv, output, 8 );
+
+            input  += 8;
+            output += 8;
+            length -= 8;
+        }
+    }
+    else /* MBEDTLS_DES_DECRYPT */
+    {
+        while( length > 0 )
+        {
+            memcpy( temp, input, 8 );
+            mbedtls_des_crypt_ecb( ctx, input, output );
+
+            for( i = 0; i < 8; i++ )
+                output[i] = (unsigned char)( output[i] ^ iv[i] );
+
+            memcpy( iv, temp, 8 );
+
+            input  += 8;
+            output += 8;
+            length -= 8;
+        }
+    }
+
+    return( 0 );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+/*
+ * 3DES-ECB block encryption/decryption
+ */
+#if !defined(MBEDTLS_DES3_CRYPT_ECB_ALT)
+int mbedtls_des3_crypt_ecb( mbedtls_des3_context *ctx,
+                     const unsigned char input[8],
+                     unsigned char output[8] )
+{
+    int i;
+    uint32_t X, Y, T, *SK;
+
+    SK = ctx->sk;
+
+    GET_UINT32_BE( X, input, 0 );
+    GET_UINT32_BE( Y, input, 4 );
+
+    DES_IP( X, Y );
+
+    for( i = 0; i < 8; i++ )
+    {
+        DES_ROUND( Y, X );
+        DES_ROUND( X, Y );
+    }
+
+    for( i = 0; i < 8; i++ )
+    {
+        DES_ROUND( X, Y );
+        DES_ROUND( Y, X );
+    }
+
+    for( i = 0; i < 8; i++ )
+    {
+        DES_ROUND( Y, X );
+        DES_ROUND( X, Y );
+    }
+
+    DES_FP( Y, X );
+
+    PUT_UINT32_BE( Y, output, 0 );
+    PUT_UINT32_BE( X, output, 4 );
+
+    return( 0 );
+}
+#endif /* !MBEDTLS_DES3_CRYPT_ECB_ALT */
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+/*
+ * 3DES-CBC buffer encryption/decryption
+ */
+int mbedtls_des3_crypt_cbc( mbedtls_des3_context *ctx,
+                     int mode,
+                     size_t length,
+                     unsigned char iv[8],
+                     const unsigned char *input,
+                     unsigned char *output )
+{
+    int i;
+    unsigned char temp[8];
+
+    if( length % 8 )
+        return( MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH );
+
+    if( mode == MBEDTLS_DES_ENCRYPT )
+    {
+        while( length > 0 )
+        {
+            for( i = 0; i < 8; i++ )
+                output[i] = (unsigned char)( input[i] ^ iv[i] );
+
+            mbedtls_des3_crypt_ecb( ctx, output, output );
+            memcpy( iv, output, 8 );
+
+            input  += 8;
+            output += 8;
+            length -= 8;
+        }
+    }
+    else /* MBEDTLS_DES_DECRYPT */
+    {
+        while( length > 0 )
+        {
+            memcpy( temp, input, 8 );
+            mbedtls_des3_crypt_ecb( ctx, input, output );
+
+            for( i = 0; i < 8; i++ )
+                output[i] = (unsigned char)( output[i] ^ iv[i] );
+
+            memcpy( iv, temp, 8 );
+
+            input  += 8;
+            output += 8;
+            length -= 8;
+        }
+    }
+
+    return( 0 );
+}
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#endif /* !MBEDTLS_DES_ALT */
+
+#if defined(MBEDTLS_SELF_TEST)
+/*
+ * DES and 3DES test vectors from:
+ *
+ * http://csrc.nist.gov/groups/STM/cavp/documents/des/tripledes-vectors.zip
+ */
+static const unsigned char des3_test_keys[24] =
+{
+    0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+    0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01,
+    0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23
+};
+
+static const unsigned char des3_test_buf[8] =
+{
+    0x4E, 0x6F, 0x77, 0x20, 0x69, 0x73, 0x20, 0x74
+};
+
+static const unsigned char des3_test_ecb_dec[3][8] =
+{
+    { 0xCD, 0xD6, 0x4F, 0x2F, 0x94, 0x27, 0xC1, 0x5D },
+    { 0x69, 0x96, 0xC8, 0xFA, 0x47, 0xA2, 0xAB, 0xEB },
+    { 0x83, 0x25, 0x39, 0x76, 0x44, 0x09, 0x1A, 0x0A }
+};
+
+static const unsigned char des3_test_ecb_enc[3][8] =
+{
+    { 0x6A, 0x2A, 0x19, 0xF4, 0x1E, 0xCA, 0x85, 0x4B },
+    { 0x03, 0xE6, 0x9F, 0x5B, 0xFA, 0x58, 0xEB, 0x42 },
+    { 0xDD, 0x17, 0xE8, 0xB8, 0xB4, 0x37, 0xD2, 0x32 }
+};
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+static const unsigned char des3_test_iv[8] =
+{
+    0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF,
+};
+
+static const unsigned char des3_test_cbc_dec[3][8] =
+{
+    { 0x12, 0x9F, 0x40, 0xB9, 0xD2, 0x00, 0x56, 0xB3 },
+    { 0x47, 0x0E, 0xFC, 0x9A, 0x6B, 0x8E, 0xE3, 0x93 },
+    { 0xC5, 0xCE, 0xCF, 0x63, 0xEC, 0xEC, 0x51, 0x4C }
+};
+
+static const unsigned char des3_test_cbc_enc[3][8] =
+{
+    { 0x54, 0xF1, 0x5A, 0xF6, 0xEB, 0xE3, 0xA4, 0xB4 },
+    { 0x35, 0x76, 0x11, 0x56, 0x5F, 0xA1, 0x8E, 0x4D },
+    { 0xCB, 0x19, 0x1F, 0x85, 0xD1, 0xED, 0x84, 0x39 }
+};
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+/*
+ * Checkup routine
+ */
+int mbedtls_des_self_test( int verbose )
+{
+    int i, j, u, v, ret = 0;
+    mbedtls_des_context ctx;
+    mbedtls_des3_context ctx3;
+    unsigned char buf[8];
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    unsigned char prv[8];
+    unsigned char iv[8];
+#endif
+
+    mbedtls_des_init( &ctx );
+    mbedtls_des3_init( &ctx3 );
+    /*
+     * ECB mode
+     */
+    for( i = 0; i < 6; i++ )
+    {
+        u = i >> 1;
+        v = i  & 1;
+
+        if( verbose != 0 )
+            mbedtls_printf( "  DES%c-ECB-%3d (%s): ",
+                             ( u == 0 ) ? ' ' : '3', 56 + u * 56,
+                             ( v == MBEDTLS_DES_DECRYPT ) ? "dec" : "enc" );
+
+        memcpy( buf, des3_test_buf, 8 );
+
+        switch( i )
+        {
+        case 0:
+            mbedtls_des_setkey_dec( &ctx, des3_test_keys );
+            break;
+
+        case 1:
+            mbedtls_des_setkey_enc( &ctx, des3_test_keys );
+            break;
+
+        case 2:
+            mbedtls_des3_set2key_dec( &ctx3, des3_test_keys );
+            break;
+
+        case 3:
+            mbedtls_des3_set2key_enc( &ctx3, des3_test_keys );
+            break;
+
+        case 4:
+            mbedtls_des3_set3key_dec( &ctx3, des3_test_keys );
+            break;
+
+        case 5:
+            mbedtls_des3_set3key_enc( &ctx3, des3_test_keys );
+            break;
+
+        default:
+            return( 1 );
+        }
+
+        for( j = 0; j < 10000; j++ )
+        {
+            if( u == 0 )
+                mbedtls_des_crypt_ecb( &ctx, buf, buf );
+            else
+                mbedtls_des3_crypt_ecb( &ctx3, buf, buf );
+        }
+
+        if( ( v == MBEDTLS_DES_DECRYPT &&
+                memcmp( buf, des3_test_ecb_dec[u], 8 ) != 0 ) ||
+            ( v != MBEDTLS_DES_DECRYPT &&
+                memcmp( buf, des3_test_ecb_enc[u], 8 ) != 0 ) )
+        {
+            if( verbose != 0 )
+                mbedtls_printf( "failed\n" );
+
+            ret = 1;
+            goto exit;
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    /*
+     * CBC mode
+     */
+    for( i = 0; i < 6; i++ )
+    {
+        u = i >> 1;
+        v = i  & 1;
+
+        if( verbose != 0 )
+            mbedtls_printf( "  DES%c-CBC-%3d (%s): ",
+                             ( u == 0 ) ? ' ' : '3', 56 + u * 56,
+                             ( v == MBEDTLS_DES_DECRYPT ) ? "dec" : "enc" );
+
+        memcpy( iv,  des3_test_iv,  8 );
+        memcpy( prv, des3_test_iv,  8 );
+        memcpy( buf, des3_test_buf, 8 );
+
+        switch( i )
+        {
+        case 0:
+            mbedtls_des_setkey_dec( &ctx, des3_test_keys );
+            break;
+
+        case 1:
+            mbedtls_des_setkey_enc( &ctx, des3_test_keys );
+            break;
+
+        case 2:
+            mbedtls_des3_set2key_dec( &ctx3, des3_test_keys );
+            break;
+
+        case 3:
+            mbedtls_des3_set2key_enc( &ctx3, des3_test_keys );
+            break;
+
+        case 4:
+            mbedtls_des3_set3key_dec( &ctx3, des3_test_keys );
+            break;
+
+        case 5:
+            mbedtls_des3_set3key_enc( &ctx3, des3_test_keys );
+            break;
+
+        default:
+            return( 1 );
+        }
+
+        if( v == MBEDTLS_DES_DECRYPT )
+        {
+            for( j = 0; j < 10000; j++ )
+            {
+                if( u == 0 )
+                    mbedtls_des_crypt_cbc( &ctx, v, 8, iv, buf, buf );
+                else
+                    mbedtls_des3_crypt_cbc( &ctx3, v, 8, iv, buf, buf );
+            }
+        }
+        else
+        {
+            for( j = 0; j < 10000; j++ )
+            {
+                unsigned char tmp[8];
+
+                if( u == 0 )
+                    mbedtls_des_crypt_cbc( &ctx, v, 8, iv, buf, buf );
+                else
+                    mbedtls_des3_crypt_cbc( &ctx3, v, 8, iv, buf, buf );
+
+                memcpy( tmp, prv, 8 );
+                memcpy( prv, buf, 8 );
+                memcpy( buf, tmp, 8 );
+            }
+
+            memcpy( buf, prv, 8 );
+        }
+
+        if( ( v == MBEDTLS_DES_DECRYPT &&
+                memcmp( buf, des3_test_cbc_dec[u], 8 ) != 0 ) ||
+            ( v != MBEDTLS_DES_DECRYPT &&
+                memcmp( buf, des3_test_cbc_enc[u], 8 ) != 0 ) )
+        {
+            if( verbose != 0 )
+                mbedtls_printf( "failed\n" );
+
+            ret = 1;
+            goto exit;
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+
+exit:
+    mbedtls_des_free( &ctx );
+    mbedtls_des3_free( &ctx3 );
+
+    return( ret );
+}
+
+#endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DES_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/error.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/error.c
@@ -1,0 +1,916 @@
+/*
+ *  Error message information
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_ERROR_C) || defined(MBEDTLS_ERROR_STRERROR_DUMMY)
+#include "mbedtls/error.h"
+#include <string.h>
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#define mbedtls_snprintf snprintf
+#define mbedtls_time_t   time_t
+#endif
+
+#if defined(MBEDTLS_ERROR_C)
+
+#include <stdio.h>
+
+#if defined(MBEDTLS_AES_C)
+#include "mbedtls/aes.h"
+#endif
+
+#if defined(MBEDTLS_ARC4_C)
+#include "mbedtls/arc4.h"
+#endif
+
+#if defined(MBEDTLS_ARIA_C)
+#include "mbedtls/aria.h"
+#endif
+
+#if defined(MBEDTLS_BASE64_C)
+#include "mbedtls/base64.h"
+#endif
+
+#if defined(MBEDTLS_BIGNUM_C)
+#include "mbedtls/bignum.h"
+#endif
+
+#if defined(MBEDTLS_BLOWFISH_C)
+#include "mbedtls/blowfish.h"
+#endif
+
+#if defined(MBEDTLS_CAMELLIA_C)
+#include "mbedtls/camellia.h"
+#endif
+
+#if defined(MBEDTLS_CCM_C)
+#include "mbedtls/ccm.h"
+#endif
+
+#if defined(MBEDTLS_CHACHA20_C)
+#include "mbedtls/chacha20.h"
+#endif
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+#include "mbedtls/chachapoly.h"
+#endif
+
+#if defined(MBEDTLS_CIPHER_C)
+#include "mbedtls/cipher.h"
+#endif
+
+#if defined(MBEDTLS_CMAC_C)
+#include "mbedtls/cmac.h"
+#endif
+
+#if defined(MBEDTLS_CTR_DRBG_C)
+#include "mbedtls/ctr_drbg.h"
+#endif
+
+#if defined(MBEDTLS_DES_C)
+#include "mbedtls/des.h"
+#endif
+
+#if defined(MBEDTLS_DHM_C)
+#include "mbedtls/dhm.h"
+#endif
+
+#if defined(MBEDTLS_ECP_C)
+#include "mbedtls/ecp.h"
+#endif
+
+#if defined(MBEDTLS_ENTROPY_C)
+#include "mbedtls/entropy.h"
+#endif
+
+#if defined(MBEDTLS_GCM_C)
+#include "mbedtls/gcm.h"
+#endif
+
+#if defined(MBEDTLS_HKDF_C)
+#include "mbedtls/hkdf.h"
+#endif
+
+#if defined(MBEDTLS_HMAC_DRBG_C)
+#include "mbedtls/hmac_drbg.h"
+#endif
+
+#if defined(MBEDTLS_MD_C)
+#include "mbedtls/md.h"
+#endif
+
+#if defined(MBEDTLS_MD2_C)
+#include "mbedtls/md2.h"
+#endif
+
+#if defined(MBEDTLS_MD4_C)
+#include "mbedtls/md4.h"
+#endif
+
+#if defined(MBEDTLS_MD5_C)
+#include "mbedtls/md5.h"
+#endif
+
+#if defined(MBEDTLS_NET_C)
+#include "mbedtls/net_sockets.h"
+#endif
+
+#if defined(MBEDTLS_OID_C)
+#include "mbedtls/oid.h"
+#endif
+
+#if defined(MBEDTLS_PADLOCK_C)
+#include "mbedtls/padlock.h"
+#endif
+
+#if defined(MBEDTLS_PEM_PARSE_C) || defined(MBEDTLS_PEM_WRITE_C)
+#include "mbedtls/pem.h"
+#endif
+
+#if defined(MBEDTLS_PK_C)
+#include "mbedtls/pk.h"
+#endif
+
+#if defined(MBEDTLS_PKCS12_C)
+#include "mbedtls/pkcs12.h"
+#endif
+
+#if defined(MBEDTLS_PKCS5_C)
+#include "mbedtls/pkcs5.h"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#endif
+
+#if defined(MBEDTLS_POLY1305_C)
+#include "mbedtls/poly1305.h"
+#endif
+
+#if defined(MBEDTLS_RIPEMD160_C)
+#include "mbedtls/ripemd160.h"
+#endif
+
+#if defined(MBEDTLS_RSA_C)
+#include "mbedtls/rsa.h"
+#endif
+
+#if defined(MBEDTLS_SHA1_C)
+#include "mbedtls/sha1.h"
+#endif
+
+#if defined(MBEDTLS_SHA256_C)
+#include "mbedtls/sha256.h"
+#endif
+
+#if defined(MBEDTLS_SHA512_C)
+#include "mbedtls/sha512.h"
+#endif
+
+#if defined(MBEDTLS_SSL_TLS_C)
+#include "mbedtls/ssl.h"
+#endif
+
+#if defined(MBEDTLS_THREADING_C)
+#include "mbedtls/threading.h"
+#endif
+
+#if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)
+#include "mbedtls/x509.h"
+#endif
+
+#if defined(MBEDTLS_XTEA_C)
+#include "mbedtls/xtea.h"
+#endif
+
+
+void mbedtls_strerror( int ret, char *buf, size_t buflen )
+{
+    size_t len;
+    int use_ret;
+
+    if( buflen == 0 )
+        return;
+
+    memset( buf, 0x00, buflen );
+
+    if( ret < 0 )
+        ret = -ret;
+
+    if( ret & 0xFF80 )
+    {
+        use_ret = ret & 0xFF80;
+
+        // High level error codes
+        //
+        // BEGIN generated code
+#if defined(MBEDTLS_CIPHER_C)
+        if( use_ret == -(MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE) )
+            mbedtls_snprintf( buf, buflen, "CIPHER - The selected feature is not available" );
+        if( use_ret == -(MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "CIPHER - Bad input parameters" );
+        if( use_ret == -(MBEDTLS_ERR_CIPHER_ALLOC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "CIPHER - Failed to allocate memory" );
+        if( use_ret == -(MBEDTLS_ERR_CIPHER_INVALID_PADDING) )
+            mbedtls_snprintf( buf, buflen, "CIPHER - Input data contains invalid padding and is rejected" );
+        if( use_ret == -(MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED) )
+            mbedtls_snprintf( buf, buflen, "CIPHER - Decryption of block requires a full block" );
+        if( use_ret == -(MBEDTLS_ERR_CIPHER_AUTH_FAILED) )
+            mbedtls_snprintf( buf, buflen, "CIPHER - Authentication failed (for AEAD modes)" );
+        if( use_ret == -(MBEDTLS_ERR_CIPHER_INVALID_CONTEXT) )
+            mbedtls_snprintf( buf, buflen, "CIPHER - The context is invalid. For example, because it was freed" );
+        if( use_ret == -(MBEDTLS_ERR_CIPHER_HW_ACCEL_FAILED) )
+            mbedtls_snprintf( buf, buflen, "CIPHER - Cipher hardware accelerator failed" );
+#endif /* MBEDTLS_CIPHER_C */
+
+#if defined(MBEDTLS_DHM_C)
+        if( use_ret == -(MBEDTLS_ERR_DHM_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "DHM - Bad input parameters" );
+        if( use_ret == -(MBEDTLS_ERR_DHM_READ_PARAMS_FAILED) )
+            mbedtls_snprintf( buf, buflen, "DHM - Reading of the DHM parameters failed" );
+        if( use_ret == -(MBEDTLS_ERR_DHM_MAKE_PARAMS_FAILED) )
+            mbedtls_snprintf( buf, buflen, "DHM - Making of the DHM parameters failed" );
+        if( use_ret == -(MBEDTLS_ERR_DHM_READ_PUBLIC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "DHM - Reading of the public values failed" );
+        if( use_ret == -(MBEDTLS_ERR_DHM_MAKE_PUBLIC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "DHM - Making of the public value failed" );
+        if( use_ret == -(MBEDTLS_ERR_DHM_CALC_SECRET_FAILED) )
+            mbedtls_snprintf( buf, buflen, "DHM - Calculation of the DHM secret failed" );
+        if( use_ret == -(MBEDTLS_ERR_DHM_INVALID_FORMAT) )
+            mbedtls_snprintf( buf, buflen, "DHM - The ASN.1 data is not formatted correctly" );
+        if( use_ret == -(MBEDTLS_ERR_DHM_ALLOC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "DHM - Allocation of memory failed" );
+        if( use_ret == -(MBEDTLS_ERR_DHM_FILE_IO_ERROR) )
+            mbedtls_snprintf( buf, buflen, "DHM - Read or write of file failed" );
+        if( use_ret == -(MBEDTLS_ERR_DHM_HW_ACCEL_FAILED) )
+            mbedtls_snprintf( buf, buflen, "DHM - DHM hardware accelerator failed" );
+        if( use_ret == -(MBEDTLS_ERR_DHM_SET_GROUP_FAILED) )
+            mbedtls_snprintf( buf, buflen, "DHM - Setting the modulus and generator failed" );
+#endif /* MBEDTLS_DHM_C */
+
+#if defined(MBEDTLS_ECP_C)
+        if( use_ret == -(MBEDTLS_ERR_ECP_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "ECP - Bad input parameters to function" );
+        if( use_ret == -(MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL) )
+            mbedtls_snprintf( buf, buflen, "ECP - The buffer is too small to write to" );
+        if( use_ret == -(MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE) )
+            mbedtls_snprintf( buf, buflen, "ECP - The requested feature is not available, for example, the requested curve is not supported" );
+        if( use_ret == -(MBEDTLS_ERR_ECP_VERIFY_FAILED) )
+            mbedtls_snprintf( buf, buflen, "ECP - The signature is not valid" );
+        if( use_ret == -(MBEDTLS_ERR_ECP_ALLOC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "ECP - Memory allocation failed" );
+        if( use_ret == -(MBEDTLS_ERR_ECP_RANDOM_FAILED) )
+            mbedtls_snprintf( buf, buflen, "ECP - Generation of random value, such as ephemeral key, failed" );
+        if( use_ret == -(MBEDTLS_ERR_ECP_INVALID_KEY) )
+            mbedtls_snprintf( buf, buflen, "ECP - Invalid private or public key" );
+        if( use_ret == -(MBEDTLS_ERR_ECP_SIG_LEN_MISMATCH) )
+            mbedtls_snprintf( buf, buflen, "ECP - The buffer contains a valid signature followed by more data" );
+        if( use_ret == -(MBEDTLS_ERR_ECP_HW_ACCEL_FAILED) )
+            mbedtls_snprintf( buf, buflen, "ECP - The ECP hardware accelerator failed" );
+        if( use_ret == -(MBEDTLS_ERR_ECP_IN_PROGRESS) )
+            mbedtls_snprintf( buf, buflen, "ECP - Operation in progress, call again with the same parameters to continue" );
+#endif /* MBEDTLS_ECP_C */
+
+#if defined(MBEDTLS_MD_C)
+        if( use_ret == -(MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE) )
+            mbedtls_snprintf( buf, buflen, "MD - The selected feature is not available" );
+        if( use_ret == -(MBEDTLS_ERR_MD_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "MD - Bad input parameters to function" );
+        if( use_ret == -(MBEDTLS_ERR_MD_ALLOC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "MD - Failed to allocate memory" );
+        if( use_ret == -(MBEDTLS_ERR_MD_FILE_IO_ERROR) )
+            mbedtls_snprintf( buf, buflen, "MD - Opening or reading of file failed" );
+        if( use_ret == -(MBEDTLS_ERR_MD_HW_ACCEL_FAILED) )
+            mbedtls_snprintf( buf, buflen, "MD - MD hardware accelerator failed" );
+#endif /* MBEDTLS_MD_C */
+
+#if defined(MBEDTLS_PEM_PARSE_C) || defined(MBEDTLS_PEM_WRITE_C)
+        if( use_ret == -(MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT) )
+            mbedtls_snprintf( buf, buflen, "PEM - No PEM header or footer found" );
+        if( use_ret == -(MBEDTLS_ERR_PEM_INVALID_DATA) )
+            mbedtls_snprintf( buf, buflen, "PEM - PEM string is not as expected" );
+        if( use_ret == -(MBEDTLS_ERR_PEM_ALLOC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "PEM - Failed to allocate memory" );
+        if( use_ret == -(MBEDTLS_ERR_PEM_INVALID_ENC_IV) )
+            mbedtls_snprintf( buf, buflen, "PEM - RSA IV is not in hex-format" );
+        if( use_ret == -(MBEDTLS_ERR_PEM_UNKNOWN_ENC_ALG) )
+            mbedtls_snprintf( buf, buflen, "PEM - Unsupported key encryption algorithm" );
+        if( use_ret == -(MBEDTLS_ERR_PEM_PASSWORD_REQUIRED) )
+            mbedtls_snprintf( buf, buflen, "PEM - Private key password can't be empty" );
+        if( use_ret == -(MBEDTLS_ERR_PEM_PASSWORD_MISMATCH) )
+            mbedtls_snprintf( buf, buflen, "PEM - Given private key password does not allow for correct decryption" );
+        if( use_ret == -(MBEDTLS_ERR_PEM_FEATURE_UNAVAILABLE) )
+            mbedtls_snprintf( buf, buflen, "PEM - Unavailable feature, e.g. hashing/encryption combination" );
+        if( use_ret == -(MBEDTLS_ERR_PEM_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "PEM - Bad input parameters to function" );
+#endif /* MBEDTLS_PEM_PARSE_C || MBEDTLS_PEM_WRITE_C */
+
+#if defined(MBEDTLS_PK_C)
+        if( use_ret == -(MBEDTLS_ERR_PK_ALLOC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "PK - Memory allocation failed" );
+        if( use_ret == -(MBEDTLS_ERR_PK_TYPE_MISMATCH) )
+            mbedtls_snprintf( buf, buflen, "PK - Type mismatch, eg attempt to encrypt with an ECDSA key" );
+        if( use_ret == -(MBEDTLS_ERR_PK_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "PK - Bad input parameters to function" );
+        if( use_ret == -(MBEDTLS_ERR_PK_FILE_IO_ERROR) )
+            mbedtls_snprintf( buf, buflen, "PK - Read/write of file failed" );
+        if( use_ret == -(MBEDTLS_ERR_PK_KEY_INVALID_VERSION) )
+            mbedtls_snprintf( buf, buflen, "PK - Unsupported key version" );
+        if( use_ret == -(MBEDTLS_ERR_PK_KEY_INVALID_FORMAT) )
+            mbedtls_snprintf( buf, buflen, "PK - Invalid key tag or value" );
+        if( use_ret == -(MBEDTLS_ERR_PK_UNKNOWN_PK_ALG) )
+            mbedtls_snprintf( buf, buflen, "PK - Key algorithm is unsupported (only RSA and EC are supported)" );
+        if( use_ret == -(MBEDTLS_ERR_PK_PASSWORD_REQUIRED) )
+            mbedtls_snprintf( buf, buflen, "PK - Private key password can't be empty" );
+        if( use_ret == -(MBEDTLS_ERR_PK_PASSWORD_MISMATCH) )
+            mbedtls_snprintf( buf, buflen, "PK - Given private key password does not allow for correct decryption" );
+        if( use_ret == -(MBEDTLS_ERR_PK_INVALID_PUBKEY) )
+            mbedtls_snprintf( buf, buflen, "PK - The pubkey tag or value is invalid (only RSA and EC are supported)" );
+        if( use_ret == -(MBEDTLS_ERR_PK_INVALID_ALG) )
+            mbedtls_snprintf( buf, buflen, "PK - The algorithm tag or value is invalid" );
+        if( use_ret == -(MBEDTLS_ERR_PK_UNKNOWN_NAMED_CURVE) )
+            mbedtls_snprintf( buf, buflen, "PK - Elliptic curve is unsupported (only NIST curves are supported)" );
+        if( use_ret == -(MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE) )
+            mbedtls_snprintf( buf, buflen, "PK - Unavailable feature, e.g. RSA disabled for RSA key" );
+        if( use_ret == -(MBEDTLS_ERR_PK_SIG_LEN_MISMATCH) )
+            mbedtls_snprintf( buf, buflen, "PK - The buffer contains a valid signature followed by more data" );
+        if( use_ret == -(MBEDTLS_ERR_PK_HW_ACCEL_FAILED) )
+            mbedtls_snprintf( buf, buflen, "PK - PK hardware accelerator failed" );
+#endif /* MBEDTLS_PK_C */
+
+#if defined(MBEDTLS_PKCS12_C)
+        if( use_ret == -(MBEDTLS_ERR_PKCS12_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "PKCS12 - Bad input parameters to function" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS12_FEATURE_UNAVAILABLE) )
+            mbedtls_snprintf( buf, buflen, "PKCS12 - Feature not available, e.g. unsupported encryption scheme" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS12_PBE_INVALID_FORMAT) )
+            mbedtls_snprintf( buf, buflen, "PKCS12 - PBE ASN.1 data not as expected" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS12_PASSWORD_MISMATCH) )
+            mbedtls_snprintf( buf, buflen, "PKCS12 - Given private key password does not allow for correct decryption" );
+#endif /* MBEDTLS_PKCS12_C */
+
+#if defined(MBEDTLS_PKCS5_C)
+        if( use_ret == -(MBEDTLS_ERR_PKCS5_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "PKCS5 - Bad input parameters to function" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS5_INVALID_FORMAT) )
+            mbedtls_snprintf( buf, buflen, "PKCS5 - Unexpected ASN.1 data" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS5_FEATURE_UNAVAILABLE) )
+            mbedtls_snprintf( buf, buflen, "PKCS5 - Requested encryption or digest alg not available" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS5_PASSWORD_MISMATCH) )
+            mbedtls_snprintf( buf, buflen, "PKCS5 - Given private key password does not allow for correct decryption" );
+#endif /* MBEDTLS_PKCS5_C */
+
+#if defined(MBEDTLS_RSA_C)
+        if( use_ret == -(MBEDTLS_ERR_RSA_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "RSA - Bad input parameters to function" );
+        if( use_ret == -(MBEDTLS_ERR_RSA_INVALID_PADDING) )
+            mbedtls_snprintf( buf, buflen, "RSA - Input data contains invalid padding and is rejected" );
+        if( use_ret == -(MBEDTLS_ERR_RSA_KEY_GEN_FAILED) )
+            mbedtls_snprintf( buf, buflen, "RSA - Something failed during generation of a key" );
+        if( use_ret == -(MBEDTLS_ERR_RSA_KEY_CHECK_FAILED) )
+            mbedtls_snprintf( buf, buflen, "RSA - Key failed to pass the validity check of the library" );
+        if( use_ret == -(MBEDTLS_ERR_RSA_PUBLIC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "RSA - The public key operation failed" );
+        if( use_ret == -(MBEDTLS_ERR_RSA_PRIVATE_FAILED) )
+            mbedtls_snprintf( buf, buflen, "RSA - The private key operation failed" );
+        if( use_ret == -(MBEDTLS_ERR_RSA_VERIFY_FAILED) )
+            mbedtls_snprintf( buf, buflen, "RSA - The PKCS#1 verification failed" );
+        if( use_ret == -(MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE) )
+            mbedtls_snprintf( buf, buflen, "RSA - The output buffer for decryption is not large enough" );
+        if( use_ret == -(MBEDTLS_ERR_RSA_RNG_FAILED) )
+            mbedtls_snprintf( buf, buflen, "RSA - The random generator failed to generate non-zeros" );
+        if( use_ret == -(MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION) )
+            mbedtls_snprintf( buf, buflen, "RSA - The implementation does not offer the requested operation, for example, because of security violations or lack of functionality" );
+        if( use_ret == -(MBEDTLS_ERR_RSA_HW_ACCEL_FAILED) )
+            mbedtls_snprintf( buf, buflen, "RSA - RSA hardware accelerator failed" );
+#endif /* MBEDTLS_RSA_C */
+
+#if defined(MBEDTLS_SSL_TLS_C)
+        if( use_ret == -(MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE) )
+            mbedtls_snprintf( buf, buflen, "SSL - The requested feature is not available" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "SSL - Bad input parameters to function" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_INVALID_MAC) )
+            mbedtls_snprintf( buf, buflen, "SSL - Verification of the message MAC failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_INVALID_RECORD) )
+            mbedtls_snprintf( buf, buflen, "SSL - An invalid SSL record was received" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_CONN_EOF) )
+            mbedtls_snprintf( buf, buflen, "SSL - The connection indicated an EOF" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_UNKNOWN_CIPHER) )
+            mbedtls_snprintf( buf, buflen, "SSL - An unknown cipher was received" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_NO_CIPHER_CHOSEN) )
+            mbedtls_snprintf( buf, buflen, "SSL - The server has no ciphersuites in common with the client" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_NO_RNG) )
+            mbedtls_snprintf( buf, buflen, "SSL - No RNG was provided to the SSL module" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_NO_CLIENT_CERTIFICATE) )
+            mbedtls_snprintf( buf, buflen, "SSL - No client certification received from the client, but required by the authentication mode" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_CERTIFICATE_TOO_LARGE) )
+            mbedtls_snprintf( buf, buflen, "SSL - Our own certificate(s) is/are too large to send in an SSL message" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_CERTIFICATE_REQUIRED) )
+            mbedtls_snprintf( buf, buflen, "SSL - The own certificate is not set, but needed by the server" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED) )
+            mbedtls_snprintf( buf, buflen, "SSL - The own private key or pre-shared key is not set, but needed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_CA_CHAIN_REQUIRED) )
+            mbedtls_snprintf( buf, buflen, "SSL - No CA Chain is set, but required to operate" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE) )
+            mbedtls_snprintf( buf, buflen, "SSL - An unexpected message was received from our peer" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE) )
+        {
+            mbedtls_snprintf( buf, buflen, "SSL - A fatal alert message was received from our peer" );
+            return;
+        }
+        if( use_ret == -(MBEDTLS_ERR_SSL_PEER_VERIFY_FAILED) )
+            mbedtls_snprintf( buf, buflen, "SSL - Verification of our peer failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) )
+            mbedtls_snprintf( buf, buflen, "SSL - The peer notified us that the connection is going to be closed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ClientHello handshake message failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ServerHello handshake message failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the Certificate handshake message failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_REQUEST) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the CertificateRequest handshake message failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ServerKeyExchange handshake message failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO_DONE) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ServerHelloDone handshake message failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ClientKeyExchange handshake message failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE_RP) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ClientKeyExchange handshake message failed in DHM / ECDH Read Public" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE_CS) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ClientKeyExchange handshake message failed in DHM / ECDH Calculate Secret" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_VERIFY) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the CertificateVerify handshake message failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CHANGE_CIPHER_SPEC) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ChangeCipherSpec handshake message failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_FINISHED) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the Finished handshake message failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_ALLOC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "SSL - Memory allocation failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_HW_ACCEL_FAILED) )
+            mbedtls_snprintf( buf, buflen, "SSL - Hardware acceleration function returned with error" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_HW_ACCEL_FALLTHROUGH) )
+            mbedtls_snprintf( buf, buflen, "SSL - Hardware acceleration function skipped / left alone data" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_COMPRESSION_FAILED) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the compression / decompression failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_PROTOCOL_VERSION) )
+            mbedtls_snprintf( buf, buflen, "SSL - Handshake protocol not within min/max boundaries" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET) )
+            mbedtls_snprintf( buf, buflen, "SSL - Processing of the NewSessionTicket handshake message failed" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED) )
+            mbedtls_snprintf( buf, buflen, "SSL - Session ticket has expired" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH) )
+            mbedtls_snprintf( buf, buflen, "SSL - Public key type mismatch (eg, asked for RSA key exchange and presented EC key)" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY) )
+            mbedtls_snprintf( buf, buflen, "SSL - Unknown identity received (eg, PSK identity)" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_INTERNAL_ERROR) )
+            mbedtls_snprintf( buf, buflen, "SSL - Internal error (eg, unexpected failure in lower-level module)" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_COUNTER_WRAPPING) )
+            mbedtls_snprintf( buf, buflen, "SSL - A counter would wrap (eg, too many messages exchanged)" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_WAITING_SERVER_HELLO_RENEGO) )
+            mbedtls_snprintf( buf, buflen, "SSL - Unexpected message at ServerHello in renegotiation" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED) )
+            mbedtls_snprintf( buf, buflen, "SSL - DTLS client must retry for hello verification" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL) )
+            mbedtls_snprintf( buf, buflen, "SSL - A buffer is too small to receive or write a message" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_NO_USABLE_CIPHERSUITE) )
+            mbedtls_snprintf( buf, buflen, "SSL - None of the common ciphersuites is usable (eg, no suitable certificate, see debug messages)" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_WANT_READ) )
+            mbedtls_snprintf( buf, buflen, "SSL - No data of requested type currently available on underlying transport" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_WANT_WRITE) )
+            mbedtls_snprintf( buf, buflen, "SSL - Connection requires a write call" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_TIMEOUT) )
+            mbedtls_snprintf( buf, buflen, "SSL - The operation timed out" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_CLIENT_RECONNECT) )
+            mbedtls_snprintf( buf, buflen, "SSL - The client initiated a reconnect from the same port" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_UNEXPECTED_RECORD) )
+            mbedtls_snprintf( buf, buflen, "SSL - Record header looks valid but is not expected" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_NON_FATAL) )
+            mbedtls_snprintf( buf, buflen, "SSL - The alert message received indicates a non-fatal error" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH) )
+            mbedtls_snprintf( buf, buflen, "SSL - Couldn't set the hash for verifying CertificateVerify" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_CONTINUE_PROCESSING) )
+            mbedtls_snprintf( buf, buflen, "SSL - Internal-only message signaling that further message-processing should be done" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) )
+            mbedtls_snprintf( buf, buflen, "SSL - The asynchronous operation is not completed yet" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_EARLY_MESSAGE) )
+            mbedtls_snprintf( buf, buflen, "SSL - Internal-only message signaling that a message arrived early" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) )
+            mbedtls_snprintf( buf, buflen, "SSL - A cryptographic operation is in progress. Try again later" );
+#endif /* MBEDTLS_SSL_TLS_C */
+
+#if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)
+        if( use_ret == -(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE) )
+            mbedtls_snprintf( buf, buflen, "X509 - Unavailable feature, e.g. RSA hashing/encryption combination" );
+        if( use_ret == -(MBEDTLS_ERR_X509_UNKNOWN_OID) )
+            mbedtls_snprintf( buf, buflen, "X509 - Requested OID is unknown" );
+        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_FORMAT) )
+            mbedtls_snprintf( buf, buflen, "X509 - The CRT/CRL/CSR format is invalid, e.g. different type expected" );
+        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_VERSION) )
+            mbedtls_snprintf( buf, buflen, "X509 - The CRT/CRL/CSR version element is invalid" );
+        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_SERIAL) )
+            mbedtls_snprintf( buf, buflen, "X509 - The serial tag or value is invalid" );
+        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_ALG) )
+            mbedtls_snprintf( buf, buflen, "X509 - The algorithm tag or value is invalid" );
+        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_NAME) )
+            mbedtls_snprintf( buf, buflen, "X509 - The name tag or value is invalid" );
+        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_DATE) )
+            mbedtls_snprintf( buf, buflen, "X509 - The date tag or value is invalid" );
+        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_SIGNATURE) )
+            mbedtls_snprintf( buf, buflen, "X509 - The signature tag or value invalid" );
+        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_EXTENSIONS) )
+            mbedtls_snprintf( buf, buflen, "X509 - The extension tag or value is invalid" );
+        if( use_ret == -(MBEDTLS_ERR_X509_UNKNOWN_VERSION) )
+            mbedtls_snprintf( buf, buflen, "X509 - CRT/CRL/CSR has an unsupported version number" );
+        if( use_ret == -(MBEDTLS_ERR_X509_UNKNOWN_SIG_ALG) )
+            mbedtls_snprintf( buf, buflen, "X509 - Signature algorithm (oid) is unsupported" );
+        if( use_ret == -(MBEDTLS_ERR_X509_SIG_MISMATCH) )
+            mbedtls_snprintf( buf, buflen, "X509 - Signature algorithms do not match. (see \\c ::mbedtls_x509_crt sig_oid)" );
+        if( use_ret == -(MBEDTLS_ERR_X509_CERT_VERIFY_FAILED) )
+            mbedtls_snprintf( buf, buflen, "X509 - Certificate verification failed, e.g. CRL, CA or signature check failed" );
+        if( use_ret == -(MBEDTLS_ERR_X509_CERT_UNKNOWN_FORMAT) )
+            mbedtls_snprintf( buf, buflen, "X509 - Format not recognized as DER or PEM" );
+        if( use_ret == -(MBEDTLS_ERR_X509_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "X509 - Input invalid" );
+        if( use_ret == -(MBEDTLS_ERR_X509_ALLOC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "X509 - Allocation of memory failed" );
+        if( use_ret == -(MBEDTLS_ERR_X509_FILE_IO_ERROR) )
+            mbedtls_snprintf( buf, buflen, "X509 - Read/write of file failed" );
+        if( use_ret == -(MBEDTLS_ERR_X509_BUFFER_TOO_SMALL) )
+            mbedtls_snprintf( buf, buflen, "X509 - Destination buffer is too small" );
+        if( use_ret == -(MBEDTLS_ERR_X509_FATAL_ERROR) )
+            mbedtls_snprintf( buf, buflen, "X509 - A fatal error occured, eg the chain is too long or the vrfy callback failed" );
+#endif /* MBEDTLS_X509_USE_C || MBEDTLS_X509_CREATE_C */
+        // END generated code
+
+        if( strlen( buf ) == 0 )
+            mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
+    }
+
+    use_ret = ret & ~0xFF80;
+
+    if( use_ret == 0 )
+        return;
+
+    // If high level code is present, make a concatenation between both
+    // error strings.
+    //
+    len = strlen( buf );
+
+    if( len > 0 )
+    {
+        if( buflen - len < 5 )
+            return;
+
+        mbedtls_snprintf( buf + len, buflen - len, " : " );
+
+        buf += len + 3;
+        buflen -= len + 3;
+    }
+
+    // Low level error codes
+    //
+    // BEGIN generated code
+#if defined(MBEDTLS_AES_C)
+    if( use_ret == -(MBEDTLS_ERR_AES_INVALID_KEY_LENGTH) )
+        mbedtls_snprintf( buf, buflen, "AES - Invalid key length" );
+    if( use_ret == -(MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH) )
+        mbedtls_snprintf( buf, buflen, "AES - Invalid data input length" );
+    if( use_ret == -(MBEDTLS_ERR_AES_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "AES - Invalid input data" );
+    if( use_ret == -(MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE) )
+        mbedtls_snprintf( buf, buflen, "AES - Feature not available. For example, an unsupported AES key size" );
+    if( use_ret == -(MBEDTLS_ERR_AES_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "AES - AES hardware accelerator failed" );
+#endif /* MBEDTLS_AES_C */
+
+#if defined(MBEDTLS_ARC4_C)
+    if( use_ret == -(MBEDTLS_ERR_ARC4_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "ARC4 - ARC4 hardware accelerator failed" );
+#endif /* MBEDTLS_ARC4_C */
+
+#if defined(MBEDTLS_ARIA_C)
+    if( use_ret == -(MBEDTLS_ERR_ARIA_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "ARIA - Bad input data" );
+    if( use_ret == -(MBEDTLS_ERR_ARIA_INVALID_INPUT_LENGTH) )
+        mbedtls_snprintf( buf, buflen, "ARIA - Invalid data input length" );
+    if( use_ret == -(MBEDTLS_ERR_ARIA_FEATURE_UNAVAILABLE) )
+        mbedtls_snprintf( buf, buflen, "ARIA - Feature not available. For example, an unsupported ARIA key size" );
+    if( use_ret == -(MBEDTLS_ERR_ARIA_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "ARIA - ARIA hardware accelerator failed" );
+#endif /* MBEDTLS_ARIA_C */
+
+#if defined(MBEDTLS_ASN1_PARSE_C)
+    if( use_ret == -(MBEDTLS_ERR_ASN1_OUT_OF_DATA) )
+        mbedtls_snprintf( buf, buflen, "ASN1 - Out of data when parsing an ASN1 data structure" );
+    if( use_ret == -(MBEDTLS_ERR_ASN1_UNEXPECTED_TAG) )
+        mbedtls_snprintf( buf, buflen, "ASN1 - ASN1 tag was of an unexpected value" );
+    if( use_ret == -(MBEDTLS_ERR_ASN1_INVALID_LENGTH) )
+        mbedtls_snprintf( buf, buflen, "ASN1 - Error when trying to determine the length or invalid length" );
+    if( use_ret == -(MBEDTLS_ERR_ASN1_LENGTH_MISMATCH) )
+        mbedtls_snprintf( buf, buflen, "ASN1 - Actual length differs from expected length" );
+    if( use_ret == -(MBEDTLS_ERR_ASN1_INVALID_DATA) )
+        mbedtls_snprintf( buf, buflen, "ASN1 - Data is invalid. (not used)" );
+    if( use_ret == -(MBEDTLS_ERR_ASN1_ALLOC_FAILED) )
+        mbedtls_snprintf( buf, buflen, "ASN1 - Memory allocation failed" );
+    if( use_ret == -(MBEDTLS_ERR_ASN1_BUF_TOO_SMALL) )
+        mbedtls_snprintf( buf, buflen, "ASN1 - Buffer too small when writing ASN.1 data structure" );
+#endif /* MBEDTLS_ASN1_PARSE_C */
+
+#if defined(MBEDTLS_BASE64_C)
+    if( use_ret == -(MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) )
+        mbedtls_snprintf( buf, buflen, "BASE64 - Output buffer too small" );
+    if( use_ret == -(MBEDTLS_ERR_BASE64_INVALID_CHARACTER) )
+        mbedtls_snprintf( buf, buflen, "BASE64 - Invalid character in input" );
+#endif /* MBEDTLS_BASE64_C */
+
+#if defined(MBEDTLS_BIGNUM_C)
+    if( use_ret == -(MBEDTLS_ERR_MPI_FILE_IO_ERROR) )
+        mbedtls_snprintf( buf, buflen, "BIGNUM - An error occurred while reading from or writing to a file" );
+    if( use_ret == -(MBEDTLS_ERR_MPI_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "BIGNUM - Bad input parameters to function" );
+    if( use_ret == -(MBEDTLS_ERR_MPI_INVALID_CHARACTER) )
+        mbedtls_snprintf( buf, buflen, "BIGNUM - There is an invalid character in the digit string" );
+    if( use_ret == -(MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL) )
+        mbedtls_snprintf( buf, buflen, "BIGNUM - The buffer is too small to write to" );
+    if( use_ret == -(MBEDTLS_ERR_MPI_NEGATIVE_VALUE) )
+        mbedtls_snprintf( buf, buflen, "BIGNUM - The input arguments are negative or result in illegal output" );
+    if( use_ret == -(MBEDTLS_ERR_MPI_DIVISION_BY_ZERO) )
+        mbedtls_snprintf( buf, buflen, "BIGNUM - The input argument for division is zero, which is not allowed" );
+    if( use_ret == -(MBEDTLS_ERR_MPI_NOT_ACCEPTABLE) )
+        mbedtls_snprintf( buf, buflen, "BIGNUM - The input arguments are not acceptable" );
+    if( use_ret == -(MBEDTLS_ERR_MPI_ALLOC_FAILED) )
+        mbedtls_snprintf( buf, buflen, "BIGNUM - Memory allocation failed" );
+#endif /* MBEDTLS_BIGNUM_C */
+
+#if defined(MBEDTLS_BLOWFISH_C)
+    if( use_ret == -(MBEDTLS_ERR_BLOWFISH_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "BLOWFISH - Bad input data" );
+    if( use_ret == -(MBEDTLS_ERR_BLOWFISH_INVALID_INPUT_LENGTH) )
+        mbedtls_snprintf( buf, buflen, "BLOWFISH - Invalid data input length" );
+    if( use_ret == -(MBEDTLS_ERR_BLOWFISH_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "BLOWFISH - Blowfish hardware accelerator failed" );
+#endif /* MBEDTLS_BLOWFISH_C */
+
+#if defined(MBEDTLS_CAMELLIA_C)
+    if( use_ret == -(MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "CAMELLIA - Bad input data" );
+    if( use_ret == -(MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH) )
+        mbedtls_snprintf( buf, buflen, "CAMELLIA - Invalid data input length" );
+    if( use_ret == -(MBEDTLS_ERR_CAMELLIA_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "CAMELLIA - Camellia hardware accelerator failed" );
+#endif /* MBEDTLS_CAMELLIA_C */
+
+#if defined(MBEDTLS_CCM_C)
+    if( use_ret == -(MBEDTLS_ERR_CCM_BAD_INPUT) )
+        mbedtls_snprintf( buf, buflen, "CCM - Bad input parameters to the function" );
+    if( use_ret == -(MBEDTLS_ERR_CCM_AUTH_FAILED) )
+        mbedtls_snprintf( buf, buflen, "CCM - Authenticated decryption failed" );
+    if( use_ret == -(MBEDTLS_ERR_CCM_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "CCM - CCM hardware accelerator failed" );
+#endif /* MBEDTLS_CCM_C */
+
+#if defined(MBEDTLS_CHACHA20_C)
+    if( use_ret == -(MBEDTLS_ERR_CHACHA20_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "CHACHA20 - Invalid input parameter(s)" );
+    if( use_ret == -(MBEDTLS_ERR_CHACHA20_FEATURE_UNAVAILABLE) )
+        mbedtls_snprintf( buf, buflen, "CHACHA20 - Feature not available. For example, s part of the API is not implemented" );
+    if( use_ret == -(MBEDTLS_ERR_CHACHA20_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "CHACHA20 - Chacha20 hardware accelerator failed" );
+#endif /* MBEDTLS_CHACHA20_C */
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+    if( use_ret == -(MBEDTLS_ERR_CHACHAPOLY_BAD_STATE) )
+        mbedtls_snprintf( buf, buflen, "CHACHAPOLY - The requested operation is not permitted in the current state" );
+    if( use_ret == -(MBEDTLS_ERR_CHACHAPOLY_AUTH_FAILED) )
+        mbedtls_snprintf( buf, buflen, "CHACHAPOLY - Authenticated decryption failed: data was not authentic" );
+#endif /* MBEDTLS_CHACHAPOLY_C */
+
+#if defined(MBEDTLS_CMAC_C)
+    if( use_ret == -(MBEDTLS_ERR_CMAC_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "CMAC - CMAC hardware accelerator failed" );
+#endif /* MBEDTLS_CMAC_C */
+
+#if defined(MBEDTLS_CTR_DRBG_C)
+    if( use_ret == -(MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED) )
+        mbedtls_snprintf( buf, buflen, "CTR_DRBG - The entropy source failed" );
+    if( use_ret == -(MBEDTLS_ERR_CTR_DRBG_REQUEST_TOO_BIG) )
+        mbedtls_snprintf( buf, buflen, "CTR_DRBG - The requested random buffer length is too big" );
+    if( use_ret == -(MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG) )
+        mbedtls_snprintf( buf, buflen, "CTR_DRBG - The input (entropy + additional data) is too large" );
+    if( use_ret == -(MBEDTLS_ERR_CTR_DRBG_FILE_IO_ERROR) )
+        mbedtls_snprintf( buf, buflen, "CTR_DRBG - Read or write error in file" );
+#endif /* MBEDTLS_CTR_DRBG_C */
+
+#if defined(MBEDTLS_DES_C)
+    if( use_ret == -(MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH) )
+        mbedtls_snprintf( buf, buflen, "DES - The data input has an invalid length" );
+    if( use_ret == -(MBEDTLS_ERR_DES_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "DES - DES hardware accelerator failed" );
+#endif /* MBEDTLS_DES_C */
+
+#if defined(MBEDTLS_ENTROPY_C)
+    if( use_ret == -(MBEDTLS_ERR_ENTROPY_SOURCE_FAILED) )
+        mbedtls_snprintf( buf, buflen, "ENTROPY - Critical entropy source failure" );
+    if( use_ret == -(MBEDTLS_ERR_ENTROPY_MAX_SOURCES) )
+        mbedtls_snprintf( buf, buflen, "ENTROPY - No more sources can be added" );
+    if( use_ret == -(MBEDTLS_ERR_ENTROPY_NO_SOURCES_DEFINED) )
+        mbedtls_snprintf( buf, buflen, "ENTROPY - No sources have been added to poll" );
+    if( use_ret == -(MBEDTLS_ERR_ENTROPY_NO_STRONG_SOURCE) )
+        mbedtls_snprintf( buf, buflen, "ENTROPY - No strong sources have been added to poll" );
+    if( use_ret == -(MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR) )
+        mbedtls_snprintf( buf, buflen, "ENTROPY - Read/write error in file" );
+#endif /* MBEDTLS_ENTROPY_C */
+
+#if defined(MBEDTLS_GCM_C)
+    if( use_ret == -(MBEDTLS_ERR_GCM_AUTH_FAILED) )
+        mbedtls_snprintf( buf, buflen, "GCM - Authenticated decryption failed" );
+    if( use_ret == -(MBEDTLS_ERR_GCM_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "GCM - GCM hardware accelerator failed" );
+    if( use_ret == -(MBEDTLS_ERR_GCM_BAD_INPUT) )
+        mbedtls_snprintf( buf, buflen, "GCM - Bad input parameters to function" );
+#endif /* MBEDTLS_GCM_C */
+
+#if defined(MBEDTLS_HKDF_C)
+    if( use_ret == -(MBEDTLS_ERR_HKDF_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "HKDF - Bad input parameters to function" );
+#endif /* MBEDTLS_HKDF_C */
+
+#if defined(MBEDTLS_HMAC_DRBG_C)
+    if( use_ret == -(MBEDTLS_ERR_HMAC_DRBG_REQUEST_TOO_BIG) )
+        mbedtls_snprintf( buf, buflen, "HMAC_DRBG - Too many random requested in single call" );
+    if( use_ret == -(MBEDTLS_ERR_HMAC_DRBG_INPUT_TOO_BIG) )
+        mbedtls_snprintf( buf, buflen, "HMAC_DRBG - Input too large (Entropy + additional)" );
+    if( use_ret == -(MBEDTLS_ERR_HMAC_DRBG_FILE_IO_ERROR) )
+        mbedtls_snprintf( buf, buflen, "HMAC_DRBG - Read/write error in file" );
+    if( use_ret == -(MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED) )
+        mbedtls_snprintf( buf, buflen, "HMAC_DRBG - The entropy source failed" );
+#endif /* MBEDTLS_HMAC_DRBG_C */
+
+#if defined(MBEDTLS_MD2_C)
+    if( use_ret == -(MBEDTLS_ERR_MD2_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "MD2 - MD2 hardware accelerator failed" );
+#endif /* MBEDTLS_MD2_C */
+
+#if defined(MBEDTLS_MD4_C)
+    if( use_ret == -(MBEDTLS_ERR_MD4_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "MD4 - MD4 hardware accelerator failed" );
+#endif /* MBEDTLS_MD4_C */
+
+#if defined(MBEDTLS_MD5_C)
+    if( use_ret == -(MBEDTLS_ERR_MD5_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "MD5 - MD5 hardware accelerator failed" );
+#endif /* MBEDTLS_MD5_C */
+
+#if defined(MBEDTLS_NET_C)
+    if( use_ret == -(MBEDTLS_ERR_NET_SOCKET_FAILED) )
+        mbedtls_snprintf( buf, buflen, "NET - Failed to open a socket" );
+    if( use_ret == -(MBEDTLS_ERR_NET_CONNECT_FAILED) )
+        mbedtls_snprintf( buf, buflen, "NET - The connection to the given server / port failed" );
+    if( use_ret == -(MBEDTLS_ERR_NET_BIND_FAILED) )
+        mbedtls_snprintf( buf, buflen, "NET - Binding of the socket failed" );
+    if( use_ret == -(MBEDTLS_ERR_NET_LISTEN_FAILED) )
+        mbedtls_snprintf( buf, buflen, "NET - Could not listen on the socket" );
+    if( use_ret == -(MBEDTLS_ERR_NET_ACCEPT_FAILED) )
+        mbedtls_snprintf( buf, buflen, "NET - Could not accept the incoming connection" );
+    if( use_ret == -(MBEDTLS_ERR_NET_RECV_FAILED) )
+        mbedtls_snprintf( buf, buflen, "NET - Reading information from the socket failed" );
+    if( use_ret == -(MBEDTLS_ERR_NET_SEND_FAILED) )
+        mbedtls_snprintf( buf, buflen, "NET - Sending information through the socket failed" );
+    if( use_ret == -(MBEDTLS_ERR_NET_CONN_RESET) )
+        mbedtls_snprintf( buf, buflen, "NET - Connection was reset by peer" );
+    if( use_ret == -(MBEDTLS_ERR_NET_UNKNOWN_HOST) )
+        mbedtls_snprintf( buf, buflen, "NET - Failed to get an IP address for the given hostname" );
+    if( use_ret == -(MBEDTLS_ERR_NET_BUFFER_TOO_SMALL) )
+        mbedtls_snprintf( buf, buflen, "NET - Buffer is too small to hold the data" );
+    if( use_ret == -(MBEDTLS_ERR_NET_INVALID_CONTEXT) )
+        mbedtls_snprintf( buf, buflen, "NET - The context is invalid, eg because it was free()ed" );
+    if( use_ret == -(MBEDTLS_ERR_NET_POLL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "NET - Polling the net context failed" );
+    if( use_ret == -(MBEDTLS_ERR_NET_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "NET - Input invalid" );
+#endif /* MBEDTLS_NET_C */
+
+#if defined(MBEDTLS_OID_C)
+    if( use_ret == -(MBEDTLS_ERR_OID_NOT_FOUND) )
+        mbedtls_snprintf( buf, buflen, "OID - OID is not found" );
+    if( use_ret == -(MBEDTLS_ERR_OID_BUF_TOO_SMALL) )
+        mbedtls_snprintf( buf, buflen, "OID - output buffer is too small" );
+#endif /* MBEDTLS_OID_C */
+
+#if defined(MBEDTLS_PADLOCK_C)
+    if( use_ret == -(MBEDTLS_ERR_PADLOCK_DATA_MISALIGNED) )
+        mbedtls_snprintf( buf, buflen, "PADLOCK - Input data should be aligned" );
+#endif /* MBEDTLS_PADLOCK_C */
+
+#if defined(MBEDTLS_PLATFORM_C)
+    if( use_ret == -(MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "PLATFORM - Hardware accelerator failed" );
+    if( use_ret == -(MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) )
+        mbedtls_snprintf( buf, buflen, "PLATFORM - The requested feature is not supported by the platform" );
+#endif /* MBEDTLS_PLATFORM_C */
+
+#if defined(MBEDTLS_POLY1305_C)
+    if( use_ret == -(MBEDTLS_ERR_POLY1305_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "POLY1305 - Invalid input parameter(s)" );
+    if( use_ret == -(MBEDTLS_ERR_POLY1305_FEATURE_UNAVAILABLE) )
+        mbedtls_snprintf( buf, buflen, "POLY1305 - Feature not available. For example, s part of the API is not implemented" );
+    if( use_ret == -(MBEDTLS_ERR_POLY1305_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "POLY1305 - Poly1305 hardware accelerator failed" );
+#endif /* MBEDTLS_POLY1305_C */
+
+#if defined(MBEDTLS_RIPEMD160_C)
+    if( use_ret == -(MBEDTLS_ERR_RIPEMD160_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "RIPEMD160 - RIPEMD160 hardware accelerator failed" );
+#endif /* MBEDTLS_RIPEMD160_C */
+
+#if defined(MBEDTLS_SHA1_C)
+    if( use_ret == -(MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "SHA1 - SHA-1 hardware accelerator failed" );
+    if( use_ret == -(MBEDTLS_ERR_SHA1_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "SHA1 - SHA-1 input data was malformed" );
+#endif /* MBEDTLS_SHA1_C */
+
+#if defined(MBEDTLS_SHA256_C)
+    if( use_ret == -(MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "SHA256 - SHA-256 hardware accelerator failed" );
+    if( use_ret == -(MBEDTLS_ERR_SHA256_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "SHA256 - SHA-256 input data was malformed" );
+#endif /* MBEDTLS_SHA256_C */
+
+#if defined(MBEDTLS_SHA512_C)
+    if( use_ret == -(MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "SHA512 - SHA-512 hardware accelerator failed" );
+    if( use_ret == -(MBEDTLS_ERR_SHA512_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "SHA512 - SHA-512 input data was malformed" );
+#endif /* MBEDTLS_SHA512_C */
+
+#if defined(MBEDTLS_THREADING_C)
+    if( use_ret == -(MBEDTLS_ERR_THREADING_FEATURE_UNAVAILABLE) )
+        mbedtls_snprintf( buf, buflen, "THREADING - The selected feature is not available" );
+    if( use_ret == -(MBEDTLS_ERR_THREADING_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "THREADING - Bad input parameters to function" );
+    if( use_ret == -(MBEDTLS_ERR_THREADING_MUTEX_ERROR) )
+        mbedtls_snprintf( buf, buflen, "THREADING - Locking / unlocking / free failed with error code" );
+#endif /* MBEDTLS_THREADING_C */
+
+#if defined(MBEDTLS_XTEA_C)
+    if( use_ret == -(MBEDTLS_ERR_XTEA_INVALID_INPUT_LENGTH) )
+        mbedtls_snprintf( buf, buflen, "XTEA - The data input has an invalid length" );
+    if( use_ret == -(MBEDTLS_ERR_XTEA_HW_ACCEL_FAILED) )
+        mbedtls_snprintf( buf, buflen, "XTEA - XTEA hardware accelerator failed" );
+#endif /* MBEDTLS_XTEA_C */
+    // END generated code
+
+    if( strlen( buf ) != 0 )
+        return;
+
+    mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
+}
+
+#else /* MBEDTLS_ERROR_C */
+
+#if defined(MBEDTLS_ERROR_STRERROR_DUMMY)
+
+/*
+ * Provide an non-function in case MBEDTLS_ERROR_C is not defined
+ */
+void mbedtls_strerror( int ret, char *buf, size_t buflen )
+{
+    ((void) ret);
+
+    if( buflen > 0 )
+        buf[0] = '\0';
+}
+
+#endif /* MBEDTLS_ERROR_STRERROR_DUMMY */
+
+#endif /* MBEDTLS_ERROR_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/gcm.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/gcm.c
@@ -1,0 +1,992 @@
+/*
+ *  NIST SP800-38D compliant GCM implementation
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+/*
+ * http://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf
+ *
+ * See also:
+ * [MGV] http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-revised-spec.pdf
+ *
+ * We use the algorithm described as Shoup's method with 4-bit tables in
+ * [MGV] 4.1, pp. 12-13, to enhance speed without using too much memory.
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_GCM_C)
+
+#include "mbedtls/gcm.h"
+#include "mbedtls/platform_util.h"
+
+#if defined(MBEDTLS_AESNI_C)
+#include "mbedtls/aesni.h"
+#endif
+
+#if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
+#include "mbedtls/aes.h"
+#include "mbedtls/platform.h"
+#if !defined(MBEDTLS_PLATFORM_C)
+#include <stdio.h>
+#define mbedtls_printf printf
+#endif /* MBEDTLS_PLATFORM_C */
+#endif /* MBEDTLS_SELF_TEST && MBEDTLS_AES_C */
+
+#if !defined(MBEDTLS_GCM_ALT)
+
+/* Parameter validation macros */
+#define GCM_VALIDATE_RET( cond ) \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_GCM_BAD_INPUT )
+#define GCM_VALIDATE( cond ) \
+    MBEDTLS_INTERNAL_VALIDATE( cond )
+
+/*
+ * 32-bit integer manipulation macros (big endian)
+ */
+#ifndef GET_UINT32_BE
+#define GET_UINT32_BE(n,b,i)                            \
+{                                                       \
+    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
+        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
+        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
+        | ( (uint32_t) (b)[(i) + 3]       );            \
+}
+#endif
+
+#ifndef PUT_UINT32_BE
+#define PUT_UINT32_BE(n,b,i)                            \
+{                                                       \
+    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
+    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
+    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
+    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
+}
+#endif
+
+/*
+ * Initialize a context
+ */
+void mbedtls_gcm_init( mbedtls_gcm_context *ctx )
+{
+    GCM_VALIDATE( ctx != NULL );
+    memset( ctx, 0, sizeof( mbedtls_gcm_context ) );
+}
+
+/*
+ * Precompute small multiples of H, that is set
+ *      HH[i] || HL[i] = H times i,
+ * where i is seen as a field element as in [MGV], ie high-order bits
+ * correspond to low powers of P. The result is stored in the same way, that
+ * is the high-order bit of HH corresponds to P^0 and the low-order bit of HL
+ * corresponds to P^127.
+ */
+static int gcm_gen_table( mbedtls_gcm_context *ctx )
+{
+    int ret, i, j;
+    uint64_t hi, lo;
+    uint64_t vl, vh;
+    unsigned char h[16];
+    size_t olen = 0;
+
+    memset( h, 0, 16 );
+    if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, h, 16, h, &olen ) ) != 0 )
+        return( ret );
+
+    /* pack h as two 64-bits ints, big-endian */
+    GET_UINT32_BE( hi, h,  0  );
+    GET_UINT32_BE( lo, h,  4  );
+    vh = (uint64_t) hi << 32 | lo;
+
+    GET_UINT32_BE( hi, h,  8  );
+    GET_UINT32_BE( lo, h,  12 );
+    vl = (uint64_t) hi << 32 | lo;
+
+    /* 8 = 1000 corresponds to 1 in GF(2^128) */
+    ctx->HL[8] = vl;
+    ctx->HH[8] = vh;
+
+#if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
+    /* With CLMUL support, we need only h, not the rest of the table */
+    if( mbedtls_aesni_has_support( MBEDTLS_AESNI_CLMUL ) )
+        return( 0 );
+#endif
+
+    /* 0 corresponds to 0 in GF(2^128) */
+    ctx->HH[0] = 0;
+    ctx->HL[0] = 0;
+
+    for( i = 4; i > 0; i >>= 1 )
+    {
+        uint32_t T = ( vl & 1 ) * 0xe1000000U;
+        vl  = ( vh << 63 ) | ( vl >> 1 );
+        vh  = ( vh >> 1 ) ^ ( (uint64_t) T << 32);
+
+        ctx->HL[i] = vl;
+        ctx->HH[i] = vh;
+    }
+
+    for( i = 2; i <= 8; i *= 2 )
+    {
+        uint64_t *HiL = ctx->HL + i, *HiH = ctx->HH + i;
+        vh = *HiH;
+        vl = *HiL;
+        for( j = 1; j < i; j++ )
+        {
+            HiH[j] = vh ^ ctx->HH[j];
+            HiL[j] = vl ^ ctx->HL[j];
+        }
+    }
+
+    return( 0 );
+}
+
+int mbedtls_gcm_setkey( mbedtls_gcm_context *ctx,
+                        mbedtls_cipher_id_t cipher,
+                        const unsigned char *key,
+                        unsigned int keybits )
+{
+    int ret;
+    const mbedtls_cipher_info_t *cipher_info;
+
+    GCM_VALIDATE_RET( ctx != NULL );
+    GCM_VALIDATE_RET( key != NULL );
+    GCM_VALIDATE_RET( keybits == 128 || keybits == 192 || keybits == 256 );
+
+    cipher_info = mbedtls_cipher_info_from_values( cipher, keybits, MBEDTLS_MODE_ECB );
+    if( cipher_info == NULL )
+        return( MBEDTLS_ERR_GCM_BAD_INPUT );
+
+    if( cipher_info->block_size != 16 )
+        return( MBEDTLS_ERR_GCM_BAD_INPUT );
+
+    mbedtls_cipher_free( &ctx->cipher_ctx );
+
+    if( ( ret = mbedtls_cipher_setup( &ctx->cipher_ctx, cipher_info ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_cipher_setkey( &ctx->cipher_ctx, key, keybits,
+                               MBEDTLS_ENCRYPT ) ) != 0 )
+    {
+        return( ret );
+    }
+
+    if( ( ret = gcm_gen_table( ctx ) ) != 0 )
+        return( ret );
+
+    return( 0 );
+}
+
+/*
+ * Shoup's method for multiplication use this table with
+ *      last4[x] = x times P^128
+ * where x and last4[x] are seen as elements of GF(2^128) as in [MGV]
+ */
+static const uint64_t last4[16] =
+{
+    0x0000, 0x1c20, 0x3840, 0x2460,
+    0x7080, 0x6ca0, 0x48c0, 0x54e0,
+    0xe100, 0xfd20, 0xd940, 0xc560,
+    0x9180, 0x8da0, 0xa9c0, 0xb5e0
+};
+
+/*
+ * Sets output to x times H using the precomputed tables.
+ * x and output are seen as elements of GF(2^128) as in [MGV].
+ */
+static void gcm_mult( mbedtls_gcm_context *ctx, const unsigned char x[16],
+                      unsigned char output[16] )
+{
+    int i = 0;
+    unsigned char lo, hi, rem;
+    uint64_t zh, zl;
+
+#if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
+    if( mbedtls_aesni_has_support( MBEDTLS_AESNI_CLMUL ) ) {
+        unsigned char h[16];
+
+        PUT_UINT32_BE( ctx->HH[8] >> 32, h,  0 );
+        PUT_UINT32_BE( ctx->HH[8],       h,  4 );
+        PUT_UINT32_BE( ctx->HL[8] >> 32, h,  8 );
+        PUT_UINT32_BE( ctx->HL[8],       h, 12 );
+
+        mbedtls_aesni_gcm_mult( output, x, h );
+        return;
+    }
+#endif /* MBEDTLS_AESNI_C && MBEDTLS_HAVE_X86_64 */
+
+    lo = x[15] & 0xf;
+
+    zh = ctx->HH[lo];
+    zl = ctx->HL[lo];
+
+    for( i = 15; i >= 0; i-- )
+    {
+        lo = x[i] & 0xf;
+        hi = x[i] >> 4;
+
+        if( i != 15 )
+        {
+            rem = (unsigned char) zl & 0xf;
+            zl = ( zh << 60 ) | ( zl >> 4 );
+            zh = ( zh >> 4 );
+            zh ^= (uint64_t) last4[rem] << 48;
+            zh ^= ctx->HH[lo];
+            zl ^= ctx->HL[lo];
+
+        }
+
+        rem = (unsigned char) zl & 0xf;
+        zl = ( zh << 60 ) | ( zl >> 4 );
+        zh = ( zh >> 4 );
+        zh ^= (uint64_t) last4[rem] << 48;
+        zh ^= ctx->HH[hi];
+        zl ^= ctx->HL[hi];
+    }
+
+    PUT_UINT32_BE( zh >> 32, output, 0 );
+    PUT_UINT32_BE( zh, output, 4 );
+    PUT_UINT32_BE( zl >> 32, output, 8 );
+    PUT_UINT32_BE( zl, output, 12 );
+}
+
+int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
+                int mode,
+                const unsigned char *iv,
+                size_t iv_len,
+                const unsigned char *add,
+                size_t add_len )
+{
+    int ret;
+    unsigned char work_buf[16];
+    size_t i;
+    const unsigned char *p;
+    size_t use_len, olen = 0;
+
+    GCM_VALIDATE_RET( ctx != NULL );
+    GCM_VALIDATE_RET( iv != NULL );
+    GCM_VALIDATE_RET( add_len == 0 || add != NULL );
+
+    /* IV and AD are limited to 2^64 bits, so 2^61 bytes */
+    /* IV is not allowed to be zero length */
+    if( iv_len == 0 ||
+      ( (uint64_t) iv_len  ) >> 61 != 0 ||
+      ( (uint64_t) add_len ) >> 61 != 0 )
+    {
+        return( MBEDTLS_ERR_GCM_BAD_INPUT );
+    }
+
+    memset( ctx->y, 0x00, sizeof(ctx->y) );
+    memset( ctx->buf, 0x00, sizeof(ctx->buf) );
+
+    ctx->mode = mode;
+    ctx->len = 0;
+    ctx->add_len = 0;
+
+    if( iv_len == 12 )
+    {
+        memcpy( ctx->y, iv, iv_len );
+        ctx->y[15] = 1;
+    }
+    else
+    {
+        memset( work_buf, 0x00, 16 );
+        PUT_UINT32_BE( iv_len * 8, work_buf, 12 );
+
+        p = iv;
+        while( iv_len > 0 )
+        {
+            use_len = ( iv_len < 16 ) ? iv_len : 16;
+
+            for( i = 0; i < use_len; i++ )
+                ctx->y[i] ^= p[i];
+
+            gcm_mult( ctx, ctx->y, ctx->y );
+
+            iv_len -= use_len;
+            p += use_len;
+        }
+
+        for( i = 0; i < 16; i++ )
+            ctx->y[i] ^= work_buf[i];
+
+        gcm_mult( ctx, ctx->y, ctx->y );
+    }
+
+    if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, ctx->y, 16, ctx->base_ectr,
+                             &olen ) ) != 0 )
+    {
+        return( ret );
+    }
+
+    ctx->add_len = add_len;
+    p = add;
+    while( add_len > 0 )
+    {
+        use_len = ( add_len < 16 ) ? add_len : 16;
+
+        for( i = 0; i < use_len; i++ )
+            ctx->buf[i] ^= p[i];
+
+        gcm_mult( ctx, ctx->buf, ctx->buf );
+
+        add_len -= use_len;
+        p += use_len;
+    }
+
+    return( 0 );
+}
+
+int mbedtls_gcm_update( mbedtls_gcm_context *ctx,
+                size_t length,
+                const unsigned char *input,
+                unsigned char *output )
+{
+    int ret;
+    unsigned char ectr[16];
+    size_t i;
+    const unsigned char *p;
+    unsigned char *out_p = output;
+    size_t use_len, olen = 0;
+
+    GCM_VALIDATE_RET( ctx != NULL );
+    GCM_VALIDATE_RET( length == 0 || input != NULL );
+    GCM_VALIDATE_RET( length == 0 || output != NULL );
+
+    if( output > input && (size_t) ( output - input ) < length )
+        return( MBEDTLS_ERR_GCM_BAD_INPUT );
+
+    /* Total length is restricted to 2^39 - 256 bits, ie 2^36 - 2^5 bytes
+     * Also check for possible overflow */
+    if( ctx->len + length < ctx->len ||
+        (uint64_t) ctx->len + length > 0xFFFFFFFE0ull )
+    {
+        return( MBEDTLS_ERR_GCM_BAD_INPUT );
+    }
+
+    ctx->len += length;
+
+    p = input;
+    while( length > 0 )
+    {
+        use_len = ( length < 16 ) ? length : 16;
+
+        for( i = 16; i > 12; i-- )
+            if( ++ctx->y[i - 1] != 0 )
+                break;
+
+        if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, ctx->y, 16, ectr,
+                                   &olen ) ) != 0 )
+        {
+            return( ret );
+        }
+
+        for( i = 0; i < use_len; i++ )
+        {
+            if( ctx->mode == MBEDTLS_GCM_DECRYPT )
+                ctx->buf[i] ^= p[i];
+            out_p[i] = ectr[i] ^ p[i];
+            if( ctx->mode == MBEDTLS_GCM_ENCRYPT )
+                ctx->buf[i] ^= out_p[i];
+        }
+
+        gcm_mult( ctx, ctx->buf, ctx->buf );
+
+        length -= use_len;
+        p += use_len;
+        out_p += use_len;
+    }
+
+    return( 0 );
+}
+
+int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
+                unsigned char *tag,
+                size_t tag_len )
+{
+    unsigned char work_buf[16];
+    size_t i;
+    uint64_t orig_len;
+    uint64_t orig_add_len;
+
+    GCM_VALIDATE_RET( ctx != NULL );
+    GCM_VALIDATE_RET( tag != NULL );
+
+    orig_len = ctx->len * 8;
+    orig_add_len = ctx->add_len * 8;
+
+    if( tag_len > 16 || tag_len < 4 )
+        return( MBEDTLS_ERR_GCM_BAD_INPUT );
+
+    memcpy( tag, ctx->base_ectr, tag_len );
+
+    if( orig_len || orig_add_len )
+    {
+        memset( work_buf, 0x00, 16 );
+
+        PUT_UINT32_BE( ( orig_add_len >> 32 ), work_buf, 0  );
+        PUT_UINT32_BE( ( orig_add_len       ), work_buf, 4  );
+        PUT_UINT32_BE( ( orig_len     >> 32 ), work_buf, 8  );
+        PUT_UINT32_BE( ( orig_len           ), work_buf, 12 );
+
+        for( i = 0; i < 16; i++ )
+            ctx->buf[i] ^= work_buf[i];
+
+        gcm_mult( ctx, ctx->buf, ctx->buf );
+
+        for( i = 0; i < tag_len; i++ )
+            tag[i] ^= ctx->buf[i];
+    }
+
+    return( 0 );
+}
+
+int mbedtls_gcm_crypt_and_tag( mbedtls_gcm_context *ctx,
+                       int mode,
+                       size_t length,
+                       const unsigned char *iv,
+                       size_t iv_len,
+                       const unsigned char *add,
+                       size_t add_len,
+                       const unsigned char *input,
+                       unsigned char *output,
+                       size_t tag_len,
+                       unsigned char *tag )
+{
+    int ret;
+
+    GCM_VALIDATE_RET( ctx != NULL );
+    GCM_VALIDATE_RET( iv != NULL );
+    GCM_VALIDATE_RET( add_len == 0 || add != NULL );
+    GCM_VALIDATE_RET( length == 0 || input != NULL );
+    GCM_VALIDATE_RET( length == 0 || output != NULL );
+    GCM_VALIDATE_RET( tag != NULL );
+
+    if( ( ret = mbedtls_gcm_starts( ctx, mode, iv, iv_len, add, add_len ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_gcm_update( ctx, length, input, output ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_gcm_finish( ctx, tag, tag_len ) ) != 0 )
+        return( ret );
+
+    return( 0 );
+}
+
+int mbedtls_gcm_auth_decrypt( mbedtls_gcm_context *ctx,
+                      size_t length,
+                      const unsigned char *iv,
+                      size_t iv_len,
+                      const unsigned char *add,
+                      size_t add_len,
+                      const unsigned char *tag,
+                      size_t tag_len,
+                      const unsigned char *input,
+                      unsigned char *output )
+{
+    int ret;
+    unsigned char check_tag[16];
+    size_t i;
+    int diff;
+
+    GCM_VALIDATE_RET( ctx != NULL );
+    GCM_VALIDATE_RET( iv != NULL );
+    GCM_VALIDATE_RET( add_len == 0 || add != NULL );
+    GCM_VALIDATE_RET( tag != NULL );
+    GCM_VALIDATE_RET( length == 0 || input != NULL );
+    GCM_VALIDATE_RET( length == 0 || output != NULL );
+
+    if( ( ret = mbedtls_gcm_crypt_and_tag( ctx, MBEDTLS_GCM_DECRYPT, length,
+                                   iv, iv_len, add, add_len,
+                                   input, output, tag_len, check_tag ) ) != 0 )
+    {
+        return( ret );
+    }
+
+    /* Check tag in "constant-time" */
+    for( diff = 0, i = 0; i < tag_len; i++ )
+        diff |= tag[i] ^ check_tag[i];
+
+    if( diff != 0 )
+    {
+        mbedtls_platform_zeroize( output, length );
+        return( MBEDTLS_ERR_GCM_AUTH_FAILED );
+    }
+
+    return( 0 );
+}
+
+void mbedtls_gcm_free( mbedtls_gcm_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+    mbedtls_cipher_free( &ctx->cipher_ctx );
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_gcm_context ) );
+}
+
+#endif /* !MBEDTLS_GCM_ALT */
+
+#if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
+/*
+ * AES-GCM test vectors from:
+ *
+ * http://csrc.nist.gov/groups/STM/cavp/documents/mac/gcmtestvectors.zip
+ */
+#define MAX_TESTS   6
+
+static const int key_index[MAX_TESTS] =
+    { 0, 0, 1, 1, 1, 1 };
+
+static const unsigned char key[MAX_TESTS][32] =
+{
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    { 0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
+      0x6d, 0x6a, 0x8f, 0x94, 0x67, 0x30, 0x83, 0x08,
+      0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
+      0x6d, 0x6a, 0x8f, 0x94, 0x67, 0x30, 0x83, 0x08 },
+};
+
+static const size_t iv_len[MAX_TESTS] =
+    { 12, 12, 12, 12, 8, 60 };
+
+static const int iv_index[MAX_TESTS] =
+    { 0, 0, 1, 1, 1, 2 };
+
+static const unsigned char iv[MAX_TESTS][64] =
+{
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00 },
+    { 0xca, 0xfe, 0xba, 0xbe, 0xfa, 0xce, 0xdb, 0xad,
+      0xde, 0xca, 0xf8, 0x88 },
+    { 0x93, 0x13, 0x22, 0x5d, 0xf8, 0x84, 0x06, 0xe5,
+      0x55, 0x90, 0x9c, 0x5a, 0xff, 0x52, 0x69, 0xaa,
+      0x6a, 0x7a, 0x95, 0x38, 0x53, 0x4f, 0x7d, 0xa1,
+      0xe4, 0xc3, 0x03, 0xd2, 0xa3, 0x18, 0xa7, 0x28,
+      0xc3, 0xc0, 0xc9, 0x51, 0x56, 0x80, 0x95, 0x39,
+      0xfc, 0xf0, 0xe2, 0x42, 0x9a, 0x6b, 0x52, 0x54,
+      0x16, 0xae, 0xdb, 0xf5, 0xa0, 0xde, 0x6a, 0x57,
+      0xa6, 0x37, 0xb3, 0x9b },
+};
+
+static const size_t add_len[MAX_TESTS] =
+    { 0, 0, 0, 20, 20, 20 };
+
+static const int add_index[MAX_TESTS] =
+    { 0, 0, 0, 1, 1, 1 };
+
+static const unsigned char additional[MAX_TESTS][64] =
+{
+    { 0x00 },
+    { 0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+      0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+      0xab, 0xad, 0xda, 0xd2 },
+};
+
+static const size_t pt_len[MAX_TESTS] =
+    { 0, 16, 64, 60, 60, 60 };
+
+static const int pt_index[MAX_TESTS] =
+    { 0, 0, 1, 1, 1, 1 };
+
+static const unsigned char pt[MAX_TESTS][64] =
+{
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    { 0xd9, 0x31, 0x32, 0x25, 0xf8, 0x84, 0x06, 0xe5,
+      0xa5, 0x59, 0x09, 0xc5, 0xaf, 0xf5, 0x26, 0x9a,
+      0x86, 0xa7, 0xa9, 0x53, 0x15, 0x34, 0xf7, 0xda,
+      0x2e, 0x4c, 0x30, 0x3d, 0x8a, 0x31, 0x8a, 0x72,
+      0x1c, 0x3c, 0x0c, 0x95, 0x95, 0x68, 0x09, 0x53,
+      0x2f, 0xcf, 0x0e, 0x24, 0x49, 0xa6, 0xb5, 0x25,
+      0xb1, 0x6a, 0xed, 0xf5, 0xaa, 0x0d, 0xe6, 0x57,
+      0xba, 0x63, 0x7b, 0x39, 0x1a, 0xaf, 0xd2, 0x55 },
+};
+
+static const unsigned char ct[MAX_TESTS * 3][64] =
+{
+    { 0x00 },
+    { 0x03, 0x88, 0xda, 0xce, 0x60, 0xb6, 0xa3, 0x92,
+      0xf3, 0x28, 0xc2, 0xb9, 0x71, 0xb2, 0xfe, 0x78 },
+    { 0x42, 0x83, 0x1e, 0xc2, 0x21, 0x77, 0x74, 0x24,
+      0x4b, 0x72, 0x21, 0xb7, 0x84, 0xd0, 0xd4, 0x9c,
+      0xe3, 0xaa, 0x21, 0x2f, 0x2c, 0x02, 0xa4, 0xe0,
+      0x35, 0xc1, 0x7e, 0x23, 0x29, 0xac, 0xa1, 0x2e,
+      0x21, 0xd5, 0x14, 0xb2, 0x54, 0x66, 0x93, 0x1c,
+      0x7d, 0x8f, 0x6a, 0x5a, 0xac, 0x84, 0xaa, 0x05,
+      0x1b, 0xa3, 0x0b, 0x39, 0x6a, 0x0a, 0xac, 0x97,
+      0x3d, 0x58, 0xe0, 0x91, 0x47, 0x3f, 0x59, 0x85 },
+    { 0x42, 0x83, 0x1e, 0xc2, 0x21, 0x77, 0x74, 0x24,
+      0x4b, 0x72, 0x21, 0xb7, 0x84, 0xd0, 0xd4, 0x9c,
+      0xe3, 0xaa, 0x21, 0x2f, 0x2c, 0x02, 0xa4, 0xe0,
+      0x35, 0xc1, 0x7e, 0x23, 0x29, 0xac, 0xa1, 0x2e,
+      0x21, 0xd5, 0x14, 0xb2, 0x54, 0x66, 0x93, 0x1c,
+      0x7d, 0x8f, 0x6a, 0x5a, 0xac, 0x84, 0xaa, 0x05,
+      0x1b, 0xa3, 0x0b, 0x39, 0x6a, 0x0a, 0xac, 0x97,
+      0x3d, 0x58, 0xe0, 0x91 },
+    { 0x61, 0x35, 0x3b, 0x4c, 0x28, 0x06, 0x93, 0x4a,
+      0x77, 0x7f, 0xf5, 0x1f, 0xa2, 0x2a, 0x47, 0x55,
+      0x69, 0x9b, 0x2a, 0x71, 0x4f, 0xcd, 0xc6, 0xf8,
+      0x37, 0x66, 0xe5, 0xf9, 0x7b, 0x6c, 0x74, 0x23,
+      0x73, 0x80, 0x69, 0x00, 0xe4, 0x9f, 0x24, 0xb2,
+      0x2b, 0x09, 0x75, 0x44, 0xd4, 0x89, 0x6b, 0x42,
+      0x49, 0x89, 0xb5, 0xe1, 0xeb, 0xac, 0x0f, 0x07,
+      0xc2, 0x3f, 0x45, 0x98 },
+    { 0x8c, 0xe2, 0x49, 0x98, 0x62, 0x56, 0x15, 0xb6,
+      0x03, 0xa0, 0x33, 0xac, 0xa1, 0x3f, 0xb8, 0x94,
+      0xbe, 0x91, 0x12, 0xa5, 0xc3, 0xa2, 0x11, 0xa8,
+      0xba, 0x26, 0x2a, 0x3c, 0xca, 0x7e, 0x2c, 0xa7,
+      0x01, 0xe4, 0xa9, 0xa4, 0xfb, 0xa4, 0x3c, 0x90,
+      0xcc, 0xdc, 0xb2, 0x81, 0xd4, 0x8c, 0x7c, 0x6f,
+      0xd6, 0x28, 0x75, 0xd2, 0xac, 0xa4, 0x17, 0x03,
+      0x4c, 0x34, 0xae, 0xe5 },
+    { 0x00 },
+    { 0x98, 0xe7, 0x24, 0x7c, 0x07, 0xf0, 0xfe, 0x41,
+      0x1c, 0x26, 0x7e, 0x43, 0x84, 0xb0, 0xf6, 0x00 },
+    { 0x39, 0x80, 0xca, 0x0b, 0x3c, 0x00, 0xe8, 0x41,
+      0xeb, 0x06, 0xfa, 0xc4, 0x87, 0x2a, 0x27, 0x57,
+      0x85, 0x9e, 0x1c, 0xea, 0xa6, 0xef, 0xd9, 0x84,
+      0x62, 0x85, 0x93, 0xb4, 0x0c, 0xa1, 0xe1, 0x9c,
+      0x7d, 0x77, 0x3d, 0x00, 0xc1, 0x44, 0xc5, 0x25,
+      0xac, 0x61, 0x9d, 0x18, 0xc8, 0x4a, 0x3f, 0x47,
+      0x18, 0xe2, 0x44, 0x8b, 0x2f, 0xe3, 0x24, 0xd9,
+      0xcc, 0xda, 0x27, 0x10, 0xac, 0xad, 0xe2, 0x56 },
+    { 0x39, 0x80, 0xca, 0x0b, 0x3c, 0x00, 0xe8, 0x41,
+      0xeb, 0x06, 0xfa, 0xc4, 0x87, 0x2a, 0x27, 0x57,
+      0x85, 0x9e, 0x1c, 0xea, 0xa6, 0xef, 0xd9, 0x84,
+      0x62, 0x85, 0x93, 0xb4, 0x0c, 0xa1, 0xe1, 0x9c,
+      0x7d, 0x77, 0x3d, 0x00, 0xc1, 0x44, 0xc5, 0x25,
+      0xac, 0x61, 0x9d, 0x18, 0xc8, 0x4a, 0x3f, 0x47,
+      0x18, 0xe2, 0x44, 0x8b, 0x2f, 0xe3, 0x24, 0xd9,
+      0xcc, 0xda, 0x27, 0x10 },
+    { 0x0f, 0x10, 0xf5, 0x99, 0xae, 0x14, 0xa1, 0x54,
+      0xed, 0x24, 0xb3, 0x6e, 0x25, 0x32, 0x4d, 0xb8,
+      0xc5, 0x66, 0x63, 0x2e, 0xf2, 0xbb, 0xb3, 0x4f,
+      0x83, 0x47, 0x28, 0x0f, 0xc4, 0x50, 0x70, 0x57,
+      0xfd, 0xdc, 0x29, 0xdf, 0x9a, 0x47, 0x1f, 0x75,
+      0xc6, 0x65, 0x41, 0xd4, 0xd4, 0xda, 0xd1, 0xc9,
+      0xe9, 0x3a, 0x19, 0xa5, 0x8e, 0x8b, 0x47, 0x3f,
+      0xa0, 0xf0, 0x62, 0xf7 },
+    { 0xd2, 0x7e, 0x88, 0x68, 0x1c, 0xe3, 0x24, 0x3c,
+      0x48, 0x30, 0x16, 0x5a, 0x8f, 0xdc, 0xf9, 0xff,
+      0x1d, 0xe9, 0xa1, 0xd8, 0xe6, 0xb4, 0x47, 0xef,
+      0x6e, 0xf7, 0xb7, 0x98, 0x28, 0x66, 0x6e, 0x45,
+      0x81, 0xe7, 0x90, 0x12, 0xaf, 0x34, 0xdd, 0xd9,
+      0xe2, 0xf0, 0x37, 0x58, 0x9b, 0x29, 0x2d, 0xb3,
+      0xe6, 0x7c, 0x03, 0x67, 0x45, 0xfa, 0x22, 0xe7,
+      0xe9, 0xb7, 0x37, 0x3b },
+    { 0x00 },
+    { 0xce, 0xa7, 0x40, 0x3d, 0x4d, 0x60, 0x6b, 0x6e,
+      0x07, 0x4e, 0xc5, 0xd3, 0xba, 0xf3, 0x9d, 0x18 },
+    { 0x52, 0x2d, 0xc1, 0xf0, 0x99, 0x56, 0x7d, 0x07,
+      0xf4, 0x7f, 0x37, 0xa3, 0x2a, 0x84, 0x42, 0x7d,
+      0x64, 0x3a, 0x8c, 0xdc, 0xbf, 0xe5, 0xc0, 0xc9,
+      0x75, 0x98, 0xa2, 0xbd, 0x25, 0x55, 0xd1, 0xaa,
+      0x8c, 0xb0, 0x8e, 0x48, 0x59, 0x0d, 0xbb, 0x3d,
+      0xa7, 0xb0, 0x8b, 0x10, 0x56, 0x82, 0x88, 0x38,
+      0xc5, 0xf6, 0x1e, 0x63, 0x93, 0xba, 0x7a, 0x0a,
+      0xbc, 0xc9, 0xf6, 0x62, 0x89, 0x80, 0x15, 0xad },
+    { 0x52, 0x2d, 0xc1, 0xf0, 0x99, 0x56, 0x7d, 0x07,
+      0xf4, 0x7f, 0x37, 0xa3, 0x2a, 0x84, 0x42, 0x7d,
+      0x64, 0x3a, 0x8c, 0xdc, 0xbf, 0xe5, 0xc0, 0xc9,
+      0x75, 0x98, 0xa2, 0xbd, 0x25, 0x55, 0xd1, 0xaa,
+      0x8c, 0xb0, 0x8e, 0x48, 0x59, 0x0d, 0xbb, 0x3d,
+      0xa7, 0xb0, 0x8b, 0x10, 0x56, 0x82, 0x88, 0x38,
+      0xc5, 0xf6, 0x1e, 0x63, 0x93, 0xba, 0x7a, 0x0a,
+      0xbc, 0xc9, 0xf6, 0x62 },
+    { 0xc3, 0x76, 0x2d, 0xf1, 0xca, 0x78, 0x7d, 0x32,
+      0xae, 0x47, 0xc1, 0x3b, 0xf1, 0x98, 0x44, 0xcb,
+      0xaf, 0x1a, 0xe1, 0x4d, 0x0b, 0x97, 0x6a, 0xfa,
+      0xc5, 0x2f, 0xf7, 0xd7, 0x9b, 0xba, 0x9d, 0xe0,
+      0xfe, 0xb5, 0x82, 0xd3, 0x39, 0x34, 0xa4, 0xf0,
+      0x95, 0x4c, 0xc2, 0x36, 0x3b, 0xc7, 0x3f, 0x78,
+      0x62, 0xac, 0x43, 0x0e, 0x64, 0xab, 0xe4, 0x99,
+      0xf4, 0x7c, 0x9b, 0x1f },
+    { 0x5a, 0x8d, 0xef, 0x2f, 0x0c, 0x9e, 0x53, 0xf1,
+      0xf7, 0x5d, 0x78, 0x53, 0x65, 0x9e, 0x2a, 0x20,
+      0xee, 0xb2, 0xb2, 0x2a, 0xaf, 0xde, 0x64, 0x19,
+      0xa0, 0x58, 0xab, 0x4f, 0x6f, 0x74, 0x6b, 0xf4,
+      0x0f, 0xc0, 0xc3, 0xb7, 0x80, 0xf2, 0x44, 0x45,
+      0x2d, 0xa3, 0xeb, 0xf1, 0xc5, 0xd8, 0x2c, 0xde,
+      0xa2, 0x41, 0x89, 0x97, 0x20, 0x0e, 0xf8, 0x2e,
+      0x44, 0xae, 0x7e, 0x3f },
+};
+
+static const unsigned char tag[MAX_TESTS * 3][16] =
+{
+    { 0x58, 0xe2, 0xfc, 0xce, 0xfa, 0x7e, 0x30, 0x61,
+      0x36, 0x7f, 0x1d, 0x57, 0xa4, 0xe7, 0x45, 0x5a },
+    { 0xab, 0x6e, 0x47, 0xd4, 0x2c, 0xec, 0x13, 0xbd,
+      0xf5, 0x3a, 0x67, 0xb2, 0x12, 0x57, 0xbd, 0xdf },
+    { 0x4d, 0x5c, 0x2a, 0xf3, 0x27, 0xcd, 0x64, 0xa6,
+      0x2c, 0xf3, 0x5a, 0xbd, 0x2b, 0xa6, 0xfa, 0xb4 },
+    { 0x5b, 0xc9, 0x4f, 0xbc, 0x32, 0x21, 0xa5, 0xdb,
+      0x94, 0xfa, 0xe9, 0x5a, 0xe7, 0x12, 0x1a, 0x47 },
+    { 0x36, 0x12, 0xd2, 0xe7, 0x9e, 0x3b, 0x07, 0x85,
+      0x56, 0x1b, 0xe1, 0x4a, 0xac, 0xa2, 0xfc, 0xcb },
+    { 0x61, 0x9c, 0xc5, 0xae, 0xff, 0xfe, 0x0b, 0xfa,
+      0x46, 0x2a, 0xf4, 0x3c, 0x16, 0x99, 0xd0, 0x50 },
+    { 0xcd, 0x33, 0xb2, 0x8a, 0xc7, 0x73, 0xf7, 0x4b,
+      0xa0, 0x0e, 0xd1, 0xf3, 0x12, 0x57, 0x24, 0x35 },
+    { 0x2f, 0xf5, 0x8d, 0x80, 0x03, 0x39, 0x27, 0xab,
+      0x8e, 0xf4, 0xd4, 0x58, 0x75, 0x14, 0xf0, 0xfb },
+    { 0x99, 0x24, 0xa7, 0xc8, 0x58, 0x73, 0x36, 0xbf,
+      0xb1, 0x18, 0x02, 0x4d, 0xb8, 0x67, 0x4a, 0x14 },
+    { 0x25, 0x19, 0x49, 0x8e, 0x80, 0xf1, 0x47, 0x8f,
+      0x37, 0xba, 0x55, 0xbd, 0x6d, 0x27, 0x61, 0x8c },
+    { 0x65, 0xdc, 0xc5, 0x7f, 0xcf, 0x62, 0x3a, 0x24,
+      0x09, 0x4f, 0xcc, 0xa4, 0x0d, 0x35, 0x33, 0xf8 },
+    { 0xdc, 0xf5, 0x66, 0xff, 0x29, 0x1c, 0x25, 0xbb,
+      0xb8, 0x56, 0x8f, 0xc3, 0xd3, 0x76, 0xa6, 0xd9 },
+    { 0x53, 0x0f, 0x8a, 0xfb, 0xc7, 0x45, 0x36, 0xb9,
+      0xa9, 0x63, 0xb4, 0xf1, 0xc4, 0xcb, 0x73, 0x8b },
+    { 0xd0, 0xd1, 0xc8, 0xa7, 0x99, 0x99, 0x6b, 0xf0,
+      0x26, 0x5b, 0x98, 0xb5, 0xd4, 0x8a, 0xb9, 0x19 },
+    { 0xb0, 0x94, 0xda, 0xc5, 0xd9, 0x34, 0x71, 0xbd,
+      0xec, 0x1a, 0x50, 0x22, 0x70, 0xe3, 0xcc, 0x6c },
+    { 0x76, 0xfc, 0x6e, 0xce, 0x0f, 0x4e, 0x17, 0x68,
+      0xcd, 0xdf, 0x88, 0x53, 0xbb, 0x2d, 0x55, 0x1b },
+    { 0x3a, 0x33, 0x7d, 0xbf, 0x46, 0xa7, 0x92, 0xc4,
+      0x5e, 0x45, 0x49, 0x13, 0xfe, 0x2e, 0xa8, 0xf2 },
+    { 0xa4, 0x4a, 0x82, 0x66, 0xee, 0x1c, 0x8e, 0xb0,
+      0xc8, 0xb5, 0xd4, 0xcf, 0x5a, 0xe9, 0xf1, 0x9a },
+};
+
+int mbedtls_gcm_self_test( int verbose )
+{
+    mbedtls_gcm_context ctx;
+    unsigned char buf[64];
+    unsigned char tag_buf[16];
+    int i, j, ret;
+    mbedtls_cipher_id_t cipher = MBEDTLS_CIPHER_ID_AES;
+
+    for( j = 0; j < 3; j++ )
+    {
+        int key_len = 128 + 64 * j;
+
+        for( i = 0; i < MAX_TESTS; i++ )
+        {
+            mbedtls_gcm_init( &ctx );
+
+            if( verbose != 0 )
+                mbedtls_printf( "  AES-GCM-%3d #%d (%s): ",
+                                key_len, i, "enc" );
+
+            ret = mbedtls_gcm_setkey( &ctx, cipher, key[key_index[i]],
+                                      key_len );
+            /*
+             * AES-192 is an optional feature that may be unavailable when
+             * there is an alternative underlying implementation i.e. when
+             * MBEDTLS_AES_ALT is defined.
+             */
+            if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED && key_len == 192 )
+            {
+                mbedtls_printf( "skipped\n" );
+                break;
+            }
+            else if( ret != 0 )
+            {
+                goto exit;
+            }
+
+            ret = mbedtls_gcm_crypt_and_tag( &ctx, MBEDTLS_GCM_ENCRYPT,
+                                        pt_len[i],
+                                        iv[iv_index[i]], iv_len[i],
+                                        additional[add_index[i]], add_len[i],
+                                        pt[pt_index[i]], buf, 16, tag_buf );
+            if( ret != 0 )
+                goto exit;
+
+            if ( memcmp( buf, ct[j * 6 + i], pt_len[i] ) != 0 ||
+                 memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
+            {
+                ret = 1;
+                goto exit;
+            }
+
+            mbedtls_gcm_free( &ctx );
+
+            if( verbose != 0 )
+                mbedtls_printf( "passed\n" );
+
+            mbedtls_gcm_init( &ctx );
+
+            if( verbose != 0 )
+                mbedtls_printf( "  AES-GCM-%3d #%d (%s): ",
+                                key_len, i, "dec" );
+
+            ret = mbedtls_gcm_setkey( &ctx, cipher, key[key_index[i]],
+                                      key_len );
+            if( ret != 0 )
+                goto exit;
+
+            ret = mbedtls_gcm_crypt_and_tag( &ctx, MBEDTLS_GCM_DECRYPT,
+                                        pt_len[i],
+                                        iv[iv_index[i]], iv_len[i],
+                                        additional[add_index[i]], add_len[i],
+                                        ct[j * 6 + i], buf, 16, tag_buf );
+
+            if( ret != 0 )
+                goto exit;
+
+            if( memcmp( buf, pt[pt_index[i]], pt_len[i] ) != 0 ||
+                memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
+            {
+                ret = 1;
+                goto exit;
+            }
+
+            mbedtls_gcm_free( &ctx );
+
+            if( verbose != 0 )
+                mbedtls_printf( "passed\n" );
+
+            mbedtls_gcm_init( &ctx );
+
+            if( verbose != 0 )
+                mbedtls_printf( "  AES-GCM-%3d #%d split (%s): ",
+                                key_len, i, "enc" );
+
+            ret = mbedtls_gcm_setkey( &ctx, cipher, key[key_index[i]],
+                                      key_len );
+            if( ret != 0 )
+                goto exit;
+
+            ret = mbedtls_gcm_starts( &ctx, MBEDTLS_GCM_ENCRYPT,
+                                      iv[iv_index[i]], iv_len[i],
+                                      additional[add_index[i]], add_len[i] );
+            if( ret != 0 )
+                goto exit;
+
+            if( pt_len[i] > 32 )
+            {
+                size_t rest_len = pt_len[i] - 32;
+                ret = mbedtls_gcm_update( &ctx, 32, pt[pt_index[i]], buf );
+                if( ret != 0 )
+                    goto exit;
+
+                ret = mbedtls_gcm_update( &ctx, rest_len, pt[pt_index[i]] + 32,
+                                  buf + 32 );
+                if( ret != 0 )
+                    goto exit;
+            }
+            else
+            {
+                ret = mbedtls_gcm_update( &ctx, pt_len[i], pt[pt_index[i]], buf );
+                if( ret != 0 )
+                    goto exit;
+            }
+
+            ret = mbedtls_gcm_finish( &ctx, tag_buf, 16 );
+            if( ret != 0 )
+                goto exit;
+
+            if( memcmp( buf, ct[j * 6 + i], pt_len[i] ) != 0 ||
+                memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
+            {
+                ret = 1;
+                goto exit;
+            }
+
+            mbedtls_gcm_free( &ctx );
+
+            if( verbose != 0 )
+                mbedtls_printf( "passed\n" );
+
+            mbedtls_gcm_init( &ctx );
+
+            if( verbose != 0 )
+                mbedtls_printf( "  AES-GCM-%3d #%d split (%s): ",
+                                key_len, i, "dec" );
+
+            ret = mbedtls_gcm_setkey( &ctx, cipher, key[key_index[i]],
+                                      key_len );
+            if( ret != 0 )
+                goto exit;
+
+            ret = mbedtls_gcm_starts( &ctx, MBEDTLS_GCM_DECRYPT,
+                              iv[iv_index[i]], iv_len[i],
+                              additional[add_index[i]], add_len[i] );
+            if( ret != 0 )
+                goto exit;
+
+            if( pt_len[i] > 32 )
+            {
+                size_t rest_len = pt_len[i] - 32;
+                ret = mbedtls_gcm_update( &ctx, 32, ct[j * 6 + i], buf );
+                if( ret != 0 )
+                    goto exit;
+
+                ret = mbedtls_gcm_update( &ctx, rest_len, ct[j * 6 + i] + 32,
+                                          buf + 32 );
+                if( ret != 0 )
+                    goto exit;
+            }
+            else
+            {
+                ret = mbedtls_gcm_update( &ctx, pt_len[i], ct[j * 6 + i],
+                                          buf );
+                if( ret != 0 )
+                    goto exit;
+            }
+
+            ret = mbedtls_gcm_finish( &ctx, tag_buf, 16 );
+            if( ret != 0 )
+                goto exit;
+
+            if( memcmp( buf, pt[pt_index[i]], pt_len[i] ) != 0 ||
+                memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
+            {
+                ret = 1;
+                goto exit;
+            }
+
+            mbedtls_gcm_free( &ctx );
+
+            if( verbose != 0 )
+                mbedtls_printf( "passed\n" );
+        }
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+
+    ret = 0;
+
+exit:
+    if( ret != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+        mbedtls_gcm_free( &ctx );
+    }
+
+    return( ret );
+}
+
+#endif /* MBEDTLS_SELF_TEST && MBEDTLS_AES_C */
+
+#endif /* MBEDTLS_GCM_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/md.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/md.c
@@ -1,0 +1,476 @@
+/**
+ * \file mbedtls_md.c
+ *
+ * \brief Generic message digest wrapper for mbed TLS
+ *
+ * \author Adriaan de Jong <dejong@fox-it.com>
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_MD_C)
+
+#include "mbedtls/md.h"
+#include "mbedtls/md_internal.h"
+#include "mbedtls/platform_util.h"
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdlib.h>
+#define mbedtls_calloc    calloc
+#define mbedtls_free       free
+#endif
+
+#if defined(MBEDTLS_FS_IO)
+#include <stdio.h>
+#endif
+
+#if defined(SOFT_SHA256_SUPPORT) || defined(SOFT_SHA512_SUPPORT)
+
+/*
+ * Reminder: update profiles in x509_crt.c when adding a new hash!
+ */
+static const int supported_digests[] = {
+
+#if defined(MBEDTLS_SHA512_C)
+        MBEDTLS_MD_SHA512,
+        MBEDTLS_MD_SHA384,
+#endif
+
+#if defined(MBEDTLS_SHA256_C)
+        MBEDTLS_MD_SHA256,
+        MBEDTLS_MD_SHA224,
+#endif
+
+#if defined(MBEDTLS_SHA1_C)
+        MBEDTLS_MD_SHA1,
+#endif
+
+#if defined(MBEDTLS_RIPEMD160_C)
+        MBEDTLS_MD_RIPEMD160,
+#endif
+
+#if defined(MBEDTLS_MD5_C)
+        MBEDTLS_MD_MD5,
+#endif
+
+#if defined(MBEDTLS_MD4_C)
+        MBEDTLS_MD_MD4,
+#endif
+
+#if defined(MBEDTLS_MD2_C)
+        MBEDTLS_MD_MD2,
+#endif
+
+        MBEDTLS_MD_NONE
+};
+
+const int *mbedtls_md_list( void )
+{
+    return( supported_digests );
+}
+
+const mbedtls_md_info_t *mbedtls_md_info_from_string( const char *md_name )
+{
+    if( NULL == md_name )
+        return( NULL );
+
+    /* Get the appropriate digest information */
+#if defined(MBEDTLS_MD2_C)
+    if( !strcmp( "MD2", md_name ) )
+        return mbedtls_md_info_from_type( MBEDTLS_MD_MD2 );
+#endif
+#if defined(MBEDTLS_MD4_C)
+    if( !strcmp( "MD4", md_name ) )
+        return mbedtls_md_info_from_type( MBEDTLS_MD_MD4 );
+#endif
+#if defined(MBEDTLS_MD5_C)
+    if( !strcmp( "MD5", md_name ) )
+        return mbedtls_md_info_from_type( MBEDTLS_MD_MD5 );
+#endif
+#if defined(MBEDTLS_RIPEMD160_C)
+    if( !strcmp( "RIPEMD160", md_name ) )
+        return mbedtls_md_info_from_type( MBEDTLS_MD_RIPEMD160 );
+#endif
+#if defined(MBEDTLS_SHA1_C)
+    if( !strcmp( "SHA1", md_name ) || !strcmp( "SHA", md_name ) )
+        return mbedtls_md_info_from_type( MBEDTLS_MD_SHA1 );
+#endif
+#if defined(MBEDTLS_SHA256_C)
+    if( !strcmp( "SHA224", md_name ) )
+        return mbedtls_md_info_from_type( MBEDTLS_MD_SHA224 );
+    if( !strcmp( "SHA256", md_name ) )
+        return mbedtls_md_info_from_type( MBEDTLS_MD_SHA256 );
+#endif
+#if defined(MBEDTLS_SHA512_C)
+    if( !strcmp( "SHA384", md_name ) )
+        return mbedtls_md_info_from_type( MBEDTLS_MD_SHA384 );
+    if( !strcmp( "SHA512", md_name ) )
+        return mbedtls_md_info_from_type( MBEDTLS_MD_SHA512 );
+#endif
+    return( NULL );
+}
+
+const mbedtls_md_info_t *mbedtls_md_info_from_type( mbedtls_md_type_t md_type )
+{
+    switch( md_type )
+    {
+#if defined(MBEDTLS_MD2_C)
+        case MBEDTLS_MD_MD2:
+            return( &mbedtls_md2_info );
+#endif
+#if defined(MBEDTLS_MD4_C)
+        case MBEDTLS_MD_MD4:
+            return( &mbedtls_md4_info );
+#endif
+#if defined(MBEDTLS_MD5_C)
+        case MBEDTLS_MD_MD5:
+            return( &mbedtls_md5_info );
+#endif
+#if defined(MBEDTLS_RIPEMD160_C)
+        case MBEDTLS_MD_RIPEMD160:
+            return( &mbedtls_ripemd160_info );
+#endif
+#if defined(MBEDTLS_SHA1_C)
+        case MBEDTLS_MD_SHA1:
+            return( &mbedtls_sha1_info );
+#endif
+#if defined(MBEDTLS_SHA256_C)
+        case MBEDTLS_MD_SHA224:
+            return( &mbedtls_sha224_info );
+        case MBEDTLS_MD_SHA256:
+            return( &mbedtls_sha256_info );
+#endif
+#if defined(MBEDTLS_SHA512_C)
+        case MBEDTLS_MD_SHA384:
+            return( &mbedtls_sha384_info );
+        case MBEDTLS_MD_SHA512:
+            return( &mbedtls_sha512_info );
+#endif
+        default:
+            return( NULL );
+    }
+}
+
+void mbedtls_md_init( mbedtls_md_context_t *ctx )
+{
+    memset( ctx, 0, sizeof( mbedtls_md_context_t ) );
+}
+
+void mbedtls_md_free( mbedtls_md_context_t *ctx )
+{
+    if( ctx == NULL || ctx->md_info == NULL )
+        return;
+
+    if( ctx->md_ctx != NULL )
+        ctx->md_info->ctx_free_func( ctx->md_ctx );
+
+    if( ctx->hmac_ctx != NULL )
+    {
+        mbedtls_platform_zeroize( ctx->hmac_ctx,
+                                  2 * ctx->md_info->block_size );
+        mbedtls_free( ctx->hmac_ctx );
+    }
+
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_md_context_t ) );
+}
+
+int mbedtls_md_clone( mbedtls_md_context_t *dst,
+                      const mbedtls_md_context_t *src )
+{
+    if( dst == NULL || dst->md_info == NULL ||
+        src == NULL || src->md_info == NULL ||
+        dst->md_info != src->md_info )
+    {
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+    }
+
+    dst->md_info->clone_func( dst->md_ctx, src->md_ctx );
+
+    return( 0 );
+}
+
+#if ! defined(MBEDTLS_DEPRECATED_REMOVED)
+int mbedtls_md_init_ctx( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info )
+{
+    return mbedtls_md_setup( ctx, md_info, 1 );
+}
+#endif
+
+int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info, int hmac )
+{
+    if( md_info == NULL || ctx == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    if( ( ctx->md_ctx = md_info->ctx_alloc_func() ) == NULL )
+        return( MBEDTLS_ERR_MD_ALLOC_FAILED );
+
+    if( hmac != 0 )
+    {
+        ctx->hmac_ctx = mbedtls_calloc( 2, md_info->block_size );
+        if( ctx->hmac_ctx == NULL )
+        {
+            md_info->ctx_free_func( ctx->md_ctx );
+            return( MBEDTLS_ERR_MD_ALLOC_FAILED );
+        }
+    }
+
+    ctx->md_info = md_info;
+
+    return( 0 );
+}
+
+int mbedtls_md_starts( mbedtls_md_context_t *ctx )
+{
+    if( ctx == NULL || ctx->md_info == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    return( ctx->md_info->starts_func( ctx->md_ctx ) );
+}
+
+int mbedtls_md_update( mbedtls_md_context_t *ctx, const unsigned char *input, size_t ilen )
+{
+    if( ctx == NULL || ctx->md_info == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    return( ctx->md_info->update_func( ctx->md_ctx, input, ilen ) );
+}
+
+int mbedtls_md_finish( mbedtls_md_context_t *ctx, unsigned char *output )
+{
+    if( ctx == NULL || ctx->md_info == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    return( ctx->md_info->finish_func( ctx->md_ctx, output ) );
+}
+
+int mbedtls_md( const mbedtls_md_info_t *md_info, const unsigned char *input, size_t ilen,
+            unsigned char *output )
+{
+    if( md_info == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    return( md_info->digest_func( input, ilen, output ) );
+}
+
+#if defined(MBEDTLS_FS_IO)
+int mbedtls_md_file( const mbedtls_md_info_t *md_info, const char *path, unsigned char *output )
+{
+    int ret;
+    FILE *f;
+    size_t n;
+    mbedtls_md_context_t ctx;
+    unsigned char buf[1024];
+
+    if( md_info == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    if( ( f = fopen( path, "rb" ) ) == NULL )
+        return( MBEDTLS_ERR_MD_FILE_IO_ERROR );
+
+    mbedtls_md_init( &ctx );
+
+    if( ( ret = mbedtls_md_setup( &ctx, md_info, 0 ) ) != 0 )
+        goto cleanup;
+
+    if( ( ret = md_info->starts_func( ctx.md_ctx ) ) != 0 )
+        goto cleanup;
+
+    while( ( n = fread( buf, 1, sizeof( buf ), f ) ) > 0 )
+        if( ( ret = md_info->update_func( ctx.md_ctx, buf, n ) ) != 0 )
+            goto cleanup;
+
+    if( ferror( f ) != 0 )
+        ret = MBEDTLS_ERR_MD_FILE_IO_ERROR;
+    else
+        ret = md_info->finish_func( ctx.md_ctx, output );
+
+cleanup:
+    mbedtls_platform_zeroize( buf, sizeof( buf ) );
+    fclose( f );
+    mbedtls_md_free( &ctx );
+
+    return( ret );
+}
+#endif /* MBEDTLS_FS_IO */
+
+int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key, size_t keylen )
+{
+    int ret;
+    unsigned char sum[MBEDTLS_MD_MAX_SIZE];
+    unsigned char *ipad, *opad;
+    size_t i;
+
+    if( ctx == NULL || ctx->md_info == NULL || ctx->hmac_ctx == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    if( keylen > (size_t) ctx->md_info->block_size )
+    {
+        if( ( ret = ctx->md_info->starts_func( ctx->md_ctx ) ) != 0 )
+            goto cleanup;
+        if( ( ret = ctx->md_info->update_func( ctx->md_ctx, key, keylen ) ) != 0 )
+            goto cleanup;
+        if( ( ret = ctx->md_info->finish_func( ctx->md_ctx, sum ) ) != 0 )
+            goto cleanup;
+
+        keylen = ctx->md_info->size;
+        key = sum;
+    }
+
+    ipad = (unsigned char *) ctx->hmac_ctx;
+    opad = (unsigned char *) ctx->hmac_ctx + ctx->md_info->block_size;
+
+    memset( ipad, 0x36, ctx->md_info->block_size );
+    memset( opad, 0x5C, ctx->md_info->block_size );
+
+    for( i = 0; i < keylen; i++ )
+    {
+        ipad[i] = (unsigned char)( ipad[i] ^ key[i] );
+        opad[i] = (unsigned char)( opad[i] ^ key[i] );
+    }
+
+    if( ( ret = ctx->md_info->starts_func( ctx->md_ctx ) ) != 0 )
+        goto cleanup;
+    if( ( ret = ctx->md_info->update_func( ctx->md_ctx, ipad,
+                                           ctx->md_info->block_size ) ) != 0 )
+        goto cleanup;
+
+cleanup:
+    mbedtls_platform_zeroize( sum, sizeof( sum ) );
+
+    return( ret );
+}
+
+int mbedtls_md_hmac_update( mbedtls_md_context_t *ctx, const unsigned char *input, size_t ilen )
+{
+    if( ctx == NULL || ctx->md_info == NULL || ctx->hmac_ctx == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    return( ctx->md_info->update_func( ctx->md_ctx, input, ilen ) );
+}
+
+int mbedtls_md_hmac_finish( mbedtls_md_context_t *ctx, unsigned char *output )
+{
+    int ret;
+    unsigned char tmp[MBEDTLS_MD_MAX_SIZE];
+    unsigned char *opad;
+
+    if( ctx == NULL || ctx->md_info == NULL || ctx->hmac_ctx == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    opad = (unsigned char *) ctx->hmac_ctx + ctx->md_info->block_size;
+
+    if( ( ret = ctx->md_info->finish_func( ctx->md_ctx, tmp ) ) != 0 )
+        return( ret );
+    if( ( ret = ctx->md_info->starts_func( ctx->md_ctx ) ) != 0 )
+        return( ret );
+    if( ( ret = ctx->md_info->update_func( ctx->md_ctx, opad,
+                                           ctx->md_info->block_size ) ) != 0 )
+        return( ret );
+    if( ( ret = ctx->md_info->update_func( ctx->md_ctx, tmp,
+                                           ctx->md_info->size ) ) != 0 )
+        return( ret );
+    return( ctx->md_info->finish_func( ctx->md_ctx, output ) );
+}
+
+int mbedtls_md_hmac_reset( mbedtls_md_context_t *ctx )
+{
+    int ret;
+    unsigned char *ipad;
+
+    if( ctx == NULL || ctx->md_info == NULL || ctx->hmac_ctx == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    ipad = (unsigned char *) ctx->hmac_ctx;
+
+    if( ( ret = ctx->md_info->starts_func( ctx->md_ctx ) ) != 0 )
+        return( ret );
+    return( ctx->md_info->update_func( ctx->md_ctx, ipad,
+                                       ctx->md_info->block_size ) );
+}
+
+int mbedtls_md_hmac( const mbedtls_md_info_t *md_info,
+                     const unsigned char *key, size_t keylen,
+                     const unsigned char *input, size_t ilen,
+                     unsigned char *output )
+{
+    mbedtls_md_context_t ctx;
+    int ret;
+
+    if( md_info == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    mbedtls_md_init( &ctx );
+
+    if( ( ret = mbedtls_md_setup( &ctx, md_info, 1 ) ) != 0 )
+        goto cleanup;
+
+    if( ( ret = mbedtls_md_hmac_starts( &ctx, key, keylen ) ) != 0 )
+        goto cleanup;
+    if( ( ret = mbedtls_md_hmac_update( &ctx, input, ilen ) ) != 0 )
+        goto cleanup;
+    if( ( ret = mbedtls_md_hmac_finish( &ctx, output ) ) != 0 )
+        goto cleanup;
+
+cleanup:
+    mbedtls_md_free( &ctx );
+
+    return( ret );
+}
+
+int mbedtls_md_process( mbedtls_md_context_t *ctx, const unsigned char *data )
+{
+    if( ctx == NULL || ctx->md_info == NULL )
+        return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
+
+    return( ctx->md_info->process_func( ctx->md_ctx, data ) );
+}
+
+unsigned char mbedtls_md_get_size( const mbedtls_md_info_t *md_info )
+{
+    if( md_info == NULL )
+        return( 0 );
+
+    return md_info->size;
+}
+
+mbedtls_md_type_t mbedtls_md_get_type( const mbedtls_md_info_t *md_info )
+{
+    if( md_info == NULL )
+        return( MBEDTLS_MD_NONE );
+
+    return md_info->type;
+}
+
+const char *mbedtls_md_get_name( const mbedtls_md_info_t *md_info )
+{
+    if( md_info == NULL )
+        return( NULL );
+
+    return md_info->name;
+}
+#endif
+
+#endif /* MBEDTLS_MD_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/md_wrap.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/md_wrap.c
@@ -1,0 +1,586 @@
+/**
+ * \file md_wrap.c
+ *
+ * \brief Generic message digest wrapper for mbed TLS
+ *
+ * \author Adriaan de Jong <dejong@fox-it.com>
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_MD_C)
+
+#include "mbedtls/md_internal.h"
+
+#if defined(MBEDTLS_MD2_C)
+#include "mbedtls/md2.h"
+#endif
+
+#if defined(MBEDTLS_MD4_C)
+#include "mbedtls/md4.h"
+#endif
+
+#if defined(MBEDTLS_MD5_C)
+#include "mbedtls/md5.h"
+#endif
+
+#if defined(MBEDTLS_RIPEMD160_C)
+#include "mbedtls/ripemd160.h"
+#endif
+
+#if defined(MBEDTLS_SHA1_C)
+#include "mbedtls/sha1.h"
+#endif
+
+#if defined(MBEDTLS_SHA256_C)
+#include "mbedtls/sha256.h"
+#endif
+
+#if defined(MBEDTLS_SHA512_C)
+#include "mbedtls/sha512.h"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdlib.h>
+#define mbedtls_calloc    calloc
+#define mbedtls_free       free
+#endif
+
+#if defined(MBEDTLS_MD2_C)
+
+static int md2_starts_wrap( void *ctx )
+{
+    return( mbedtls_md2_starts_ret( (mbedtls_md2_context *) ctx ) );
+}
+
+static int md2_update_wrap( void *ctx, const unsigned char *input,
+                             size_t ilen )
+{
+    return( mbedtls_md2_update_ret( (mbedtls_md2_context *) ctx, input, ilen ) );
+}
+
+static int md2_finish_wrap( void *ctx, unsigned char *output )
+{
+    return( mbedtls_md2_finish_ret( (mbedtls_md2_context *) ctx, output ) );
+}
+
+static void *md2_ctx_alloc( void )
+{
+    void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_md2_context ) );
+
+    if( ctx != NULL )
+        mbedtls_md2_init( (mbedtls_md2_context *) ctx );
+
+    return( ctx );
+}
+
+static void md2_ctx_free( void *ctx )
+{
+    mbedtls_md2_free( (mbedtls_md2_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static void md2_clone_wrap( void *dst, const void *src )
+{
+    mbedtls_md2_clone( (mbedtls_md2_context *) dst,
+                 (const mbedtls_md2_context *) src );
+}
+
+static int md2_process_wrap( void *ctx, const unsigned char *data )
+{
+    ((void) data);
+
+    return( mbedtls_internal_md2_process( (mbedtls_md2_context *) ctx ) );
+}
+
+const mbedtls_md_info_t mbedtls_md2_info = {
+    MBEDTLS_MD_MD2,
+    "MD2",
+    16,
+    16,
+    md2_starts_wrap,
+    md2_update_wrap,
+    md2_finish_wrap,
+    mbedtls_md2_ret,
+    md2_ctx_alloc,
+    md2_ctx_free,
+    md2_clone_wrap,
+    md2_process_wrap,
+};
+
+#endif /* MBEDTLS_MD2_C */
+
+#if defined(MBEDTLS_MD4_C)
+
+static int md4_starts_wrap( void *ctx )
+{
+    return( mbedtls_md4_starts_ret( (mbedtls_md4_context *) ctx ) );
+}
+
+static int md4_update_wrap( void *ctx, const unsigned char *input,
+                             size_t ilen )
+{
+    return( mbedtls_md4_update_ret( (mbedtls_md4_context *) ctx, input, ilen ) );
+}
+
+static int md4_finish_wrap( void *ctx, unsigned char *output )
+{
+    return( mbedtls_md4_finish_ret( (mbedtls_md4_context *) ctx, output ) );
+}
+
+static void *md4_ctx_alloc( void )
+{
+    void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_md4_context ) );
+
+    if( ctx != NULL )
+        mbedtls_md4_init( (mbedtls_md4_context *) ctx );
+
+    return( ctx );
+}
+
+static void md4_ctx_free( void *ctx )
+{
+    mbedtls_md4_free( (mbedtls_md4_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static void md4_clone_wrap( void *dst, const void *src )
+{
+    mbedtls_md4_clone( (mbedtls_md4_context *) dst,
+                       (const mbedtls_md4_context *) src );
+}
+
+static int md4_process_wrap( void *ctx, const unsigned char *data )
+{
+    return( mbedtls_internal_md4_process( (mbedtls_md4_context *) ctx, data ) );
+}
+
+const mbedtls_md_info_t mbedtls_md4_info = {
+    MBEDTLS_MD_MD4,
+    "MD4",
+    16,
+    64,
+    md4_starts_wrap,
+    md4_update_wrap,
+    md4_finish_wrap,
+    mbedtls_md4_ret,
+    md4_ctx_alloc,
+    md4_ctx_free,
+    md4_clone_wrap,
+    md4_process_wrap,
+};
+
+#endif /* MBEDTLS_MD4_C */
+
+#if defined(MBEDTLS_MD5_C)
+
+static int md5_starts_wrap( void *ctx )
+{
+    return( mbedtls_md5_starts_ret( (mbedtls_md5_context *) ctx ) );
+}
+
+static int md5_update_wrap( void *ctx, const unsigned char *input,
+                             size_t ilen )
+{
+    return( mbedtls_md5_update_ret( (mbedtls_md5_context *) ctx, input, ilen ) );
+}
+
+static int md5_finish_wrap( void *ctx, unsigned char *output )
+{
+    return( mbedtls_md5_finish_ret( (mbedtls_md5_context *) ctx, output ) );
+}
+
+static void *md5_ctx_alloc( void )
+{
+    void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_md5_context ) );
+
+    if( ctx != NULL )
+        mbedtls_md5_init( (mbedtls_md5_context *) ctx );
+
+    return( ctx );
+}
+
+static void md5_ctx_free( void *ctx )
+{
+    mbedtls_md5_free( (mbedtls_md5_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static void md5_clone_wrap( void *dst, const void *src )
+{
+    mbedtls_md5_clone( (mbedtls_md5_context *) dst,
+                       (const mbedtls_md5_context *) src );
+}
+
+static int md5_process_wrap( void *ctx, const unsigned char *data )
+{
+    return( mbedtls_internal_md5_process( (mbedtls_md5_context *) ctx, data ) );
+}
+
+const mbedtls_md_info_t mbedtls_md5_info = {
+    MBEDTLS_MD_MD5,
+    "MD5",
+    16,
+    64,
+    md5_starts_wrap,
+    md5_update_wrap,
+    md5_finish_wrap,
+    mbedtls_md5_ret,
+    md5_ctx_alloc,
+    md5_ctx_free,
+    md5_clone_wrap,
+    md5_process_wrap,
+};
+
+#endif /* MBEDTLS_MD5_C */
+
+#if defined(MBEDTLS_RIPEMD160_C)
+
+static int ripemd160_starts_wrap( void *ctx )
+{
+    return( mbedtls_ripemd160_starts_ret( (mbedtls_ripemd160_context *) ctx ) );
+}
+
+static int ripemd160_update_wrap( void *ctx, const unsigned char *input,
+                                   size_t ilen )
+{
+    return( mbedtls_ripemd160_update_ret( (mbedtls_ripemd160_context *) ctx,
+                                          input, ilen ) );
+}
+
+static int ripemd160_finish_wrap( void *ctx, unsigned char *output )
+{
+    return( mbedtls_ripemd160_finish_ret( (mbedtls_ripemd160_context *) ctx,
+                                          output ) );
+}
+
+static void *ripemd160_ctx_alloc( void )
+{
+    void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_ripemd160_context ) );
+
+    if( ctx != NULL )
+        mbedtls_ripemd160_init( (mbedtls_ripemd160_context *) ctx );
+
+    return( ctx );
+}
+
+static void ripemd160_ctx_free( void *ctx )
+{
+    mbedtls_ripemd160_free( (mbedtls_ripemd160_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static void ripemd160_clone_wrap( void *dst, const void *src )
+{
+    mbedtls_ripemd160_clone( (mbedtls_ripemd160_context *) dst,
+                       (const mbedtls_ripemd160_context *) src );
+}
+
+static int ripemd160_process_wrap( void *ctx, const unsigned char *data )
+{
+    return( mbedtls_internal_ripemd160_process(
+                                (mbedtls_ripemd160_context *) ctx, data ) );
+}
+
+const mbedtls_md_info_t mbedtls_ripemd160_info = {
+    MBEDTLS_MD_RIPEMD160,
+    "RIPEMD160",
+    20,
+    64,
+    ripemd160_starts_wrap,
+    ripemd160_update_wrap,
+    ripemd160_finish_wrap,
+    mbedtls_ripemd160_ret,
+    ripemd160_ctx_alloc,
+    ripemd160_ctx_free,
+    ripemd160_clone_wrap,
+    ripemd160_process_wrap,
+};
+
+#endif /* MBEDTLS_RIPEMD160_C */
+
+#if defined(MBEDTLS_SHA1_C)
+
+static int sha1_starts_wrap( void *ctx )
+{
+    return( mbedtls_sha1_starts_ret( (mbedtls_sha1_context *) ctx ) );
+}
+
+static int sha1_update_wrap( void *ctx, const unsigned char *input,
+                              size_t ilen )
+{
+    return( mbedtls_sha1_update_ret( (mbedtls_sha1_context *) ctx,
+                                     input, ilen ) );
+}
+
+static int sha1_finish_wrap( void *ctx, unsigned char *output )
+{
+    return( mbedtls_sha1_finish_ret( (mbedtls_sha1_context *) ctx, output ) );
+}
+
+static void *sha1_ctx_alloc( void )
+{
+    void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_sha1_context ) );
+
+    if( ctx != NULL )
+        mbedtls_sha1_init( (mbedtls_sha1_context *) ctx );
+
+    return( ctx );
+}
+
+static void sha1_clone_wrap( void *dst, const void *src )
+{
+    mbedtls_sha1_clone( (mbedtls_sha1_context *) dst,
+                  (const mbedtls_sha1_context *) src );
+}
+
+static void sha1_ctx_free( void *ctx )
+{
+    mbedtls_sha1_free( (mbedtls_sha1_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static int sha1_process_wrap( void *ctx, const unsigned char *data )
+{
+    return( mbedtls_internal_sha1_process( (mbedtls_sha1_context *) ctx,
+                                           data ) );
+}
+
+const mbedtls_md_info_t mbedtls_sha1_info = {
+    MBEDTLS_MD_SHA1,
+    "SHA1",
+    20,
+    64,
+    sha1_starts_wrap,
+    sha1_update_wrap,
+    sha1_finish_wrap,
+    mbedtls_sha1_ret,
+    sha1_ctx_alloc,
+    sha1_ctx_free,
+    sha1_clone_wrap,
+    sha1_process_wrap,
+};
+
+#endif /* MBEDTLS_SHA1_C */
+
+/*
+ * Wrappers for generic message digests
+ */
+#if defined(MBEDTLS_SHA256_C)
+
+static int sha224_starts_wrap( void *ctx )
+{
+    return( mbedtls_sha256_starts_ret( (mbedtls_sha256_context *) ctx, 1 ) );
+}
+
+static int sha224_update_wrap( void *ctx, const unsigned char *input,
+                                size_t ilen )
+{
+    return( mbedtls_sha256_update_ret( (mbedtls_sha256_context *) ctx,
+                                       input, ilen ) );
+}
+
+static int sha224_finish_wrap( void *ctx, unsigned char *output )
+{
+    return( mbedtls_sha256_finish_ret( (mbedtls_sha256_context *) ctx,
+                                       output ) );
+}
+
+static int sha224_wrap( const unsigned char *input, size_t ilen,
+                        unsigned char *output )
+{
+    return( mbedtls_sha256_ret( input, ilen, output, 1 ) );
+}
+
+static void *sha224_ctx_alloc( void )
+{
+    void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_sha256_context ) );
+
+    if( ctx != NULL )
+        mbedtls_sha256_init( (mbedtls_sha256_context *) ctx );
+
+    return( ctx );
+}
+
+static void sha224_ctx_free( void *ctx )
+{
+    mbedtls_sha256_free( (mbedtls_sha256_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static void sha224_clone_wrap( void *dst, const void *src )
+{
+    mbedtls_sha256_clone( (mbedtls_sha256_context *) dst,
+                    (const mbedtls_sha256_context *) src );
+}
+
+static int sha224_process_wrap( void *ctx, const unsigned char *data )
+{
+    return( mbedtls_internal_sha256_process( (mbedtls_sha256_context *) ctx,
+                                             data ) );
+}
+
+const mbedtls_md_info_t mbedtls_sha224_info = {
+    MBEDTLS_MD_SHA224,
+    "SHA224",
+    28,
+    64,
+    sha224_starts_wrap,
+    sha224_update_wrap,
+    sha224_finish_wrap,
+    sha224_wrap,
+    sha224_ctx_alloc,
+    sha224_ctx_free,
+    sha224_clone_wrap,
+    sha224_process_wrap,
+};
+
+static int sha256_starts_wrap( void *ctx )
+{
+    return( mbedtls_sha256_starts_ret( (mbedtls_sha256_context *) ctx, 0 ) );
+}
+
+static int sha256_wrap( const unsigned char *input, size_t ilen,
+                        unsigned char *output )
+{
+    return( mbedtls_sha256_ret( input, ilen, output, 0 ) );
+}
+
+const mbedtls_md_info_t mbedtls_sha256_info = {
+    MBEDTLS_MD_SHA256,
+    "SHA256",
+    32,
+    64,
+    sha256_starts_wrap,
+    sha224_update_wrap,
+    sha224_finish_wrap,
+    sha256_wrap,
+    sha224_ctx_alloc,
+    sha224_ctx_free,
+    sha224_clone_wrap,
+    sha224_process_wrap,
+};
+
+#endif /* MBEDTLS_SHA256_C */
+
+#if defined(MBEDTLS_SHA512_C)
+
+static int sha384_starts_wrap( void *ctx )
+{
+    return( mbedtls_sha512_starts_ret( (mbedtls_sha512_context *) ctx, 1 ) );
+}
+
+static int sha384_update_wrap( void *ctx, const unsigned char *input,
+                               size_t ilen )
+{
+    return( mbedtls_sha512_update_ret( (mbedtls_sha512_context *) ctx,
+                                       input, ilen ) );
+}
+
+static int sha384_finish_wrap( void *ctx, unsigned char *output )
+{
+    return( mbedtls_sha512_finish_ret( (mbedtls_sha512_context *) ctx,
+                                       output ) );
+}
+
+static int sha384_wrap( const unsigned char *input, size_t ilen,
+                        unsigned char *output )
+{
+    return( mbedtls_sha512_ret( input, ilen, output, 1 ) );
+}
+
+static void *sha384_ctx_alloc( void )
+{
+    void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_sha512_context ) );
+
+    if( ctx != NULL )
+        mbedtls_sha512_init( (mbedtls_sha512_context *) ctx );
+
+    return( ctx );
+}
+
+static void sha384_ctx_free( void *ctx )
+{
+    mbedtls_sha512_free( (mbedtls_sha512_context *) ctx );
+    mbedtls_free( ctx );
+}
+
+static void sha384_clone_wrap( void *dst, const void *src )
+{
+    mbedtls_sha512_clone( (mbedtls_sha512_context *) dst,
+                    (const mbedtls_sha512_context *) src );
+}
+
+static int sha384_process_wrap( void *ctx, const unsigned char *data )
+{
+    return( mbedtls_internal_sha512_process( (mbedtls_sha512_context *) ctx,
+                                             data ) );
+}
+
+const mbedtls_md_info_t mbedtls_sha384_info = {
+    MBEDTLS_MD_SHA384,
+    "SHA384",
+    48,
+    128,
+    sha384_starts_wrap,
+    sha384_update_wrap,
+    sha384_finish_wrap,
+    sha384_wrap,
+    sha384_ctx_alloc,
+    sha384_ctx_free,
+    sha384_clone_wrap,
+    sha384_process_wrap,
+};
+
+static int sha512_starts_wrap( void *ctx )
+{
+    return( mbedtls_sha512_starts_ret( (mbedtls_sha512_context *) ctx, 0 ) );
+}
+
+static int sha512_wrap( const unsigned char *input, size_t ilen,
+                        unsigned char *output )
+{
+    return( mbedtls_sha512_ret( input, ilen, output, 0 ) );
+}
+
+const mbedtls_md_info_t mbedtls_sha512_info = {
+    MBEDTLS_MD_SHA512,
+    "SHA512",
+    64,
+    128,
+    sha512_starts_wrap,
+    sha384_update_wrap,
+    sha384_finish_wrap,
+    sha512_wrap,
+    sha384_ctx_alloc,
+    sha384_ctx_free,
+    sha384_clone_wrap,
+    sha384_process_wrap,
+};
+
+#endif /* MBEDTLS_SHA512_C */
+
+#endif /* MBEDTLS_MD_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/oid.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/oid.c
@@ -1,0 +1,750 @@
+/**
+ * \file oid.c
+ *
+ * \brief Object Identifier (OID) database
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_OID_C)
+
+#include "mbedtls/oid.h"
+#include "mbedtls/rsa.h"
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#define mbedtls_snprintf snprintf
+#endif
+
+#if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)
+#include "mbedtls/x509.h"
+#endif
+
+/*
+ * Macro to automatically add the size of #define'd OIDs
+ */
+#define ADD_LEN(s)      s, MBEDTLS_OID_SIZE(s)
+
+/*
+ * Macro to generate an internal function for oid_XXX_from_asn1() (used by
+ * the other functions)
+ */
+#define FN_OID_TYPED_FROM_ASN1( TYPE_T, NAME, LIST )                        \
+static const TYPE_T * oid_ ## NAME ## _from_asn1( const mbedtls_asn1_buf *oid )     \
+{                                                                           \
+    const TYPE_T *p = LIST;                                                 \
+    const mbedtls_oid_descriptor_t *cur = (const mbedtls_oid_descriptor_t *) p;             \
+    if( p == NULL || oid == NULL ) return( NULL );                          \
+    while( cur->asn1 != NULL ) {                                            \
+        if( cur->asn1_len == oid->len &&                                    \
+            memcmp( cur->asn1, oid->p, oid->len ) == 0 ) {                  \
+            return( p );                                                    \
+        }                                                                   \
+        p++;                                                                \
+        cur = (const mbedtls_oid_descriptor_t *) p;                                 \
+    }                                                                       \
+    return( NULL );                                                         \
+}
+
+/*
+ * Macro to generate a function for retrieving a single attribute from the
+ * descriptor of an mbedtls_oid_descriptor_t wrapper.
+ */
+#define FN_OID_GET_DESCRIPTOR_ATTR1(FN_NAME, TYPE_T, TYPE_NAME, ATTR1_TYPE, ATTR1) \
+int FN_NAME( const mbedtls_asn1_buf *oid, ATTR1_TYPE * ATTR1 )                  \
+{                                                                       \
+    const TYPE_T *data = oid_ ## TYPE_NAME ## _from_asn1( oid );        \
+    if( data == NULL ) return( MBEDTLS_ERR_OID_NOT_FOUND );            \
+    *ATTR1 = data->descriptor.ATTR1;                                    \
+    return( 0 );                                                        \
+}
+
+/*
+ * Macro to generate a function for retrieving a single attribute from an
+ * mbedtls_oid_descriptor_t wrapper.
+ */
+#define FN_OID_GET_ATTR1(FN_NAME, TYPE_T, TYPE_NAME, ATTR1_TYPE, ATTR1) \
+int FN_NAME( const mbedtls_asn1_buf *oid, ATTR1_TYPE * ATTR1 )                  \
+{                                                                       \
+    const TYPE_T *data = oid_ ## TYPE_NAME ## _from_asn1( oid );        \
+    if( data == NULL ) return( MBEDTLS_ERR_OID_NOT_FOUND );            \
+    *ATTR1 = data->ATTR1;                                               \
+    return( 0 );                                                        \
+}
+
+/*
+ * Macro to generate a function for retrieving two attributes from an
+ * mbedtls_oid_descriptor_t wrapper.
+ */
+#define FN_OID_GET_ATTR2(FN_NAME, TYPE_T, TYPE_NAME, ATTR1_TYPE, ATTR1,     \
+                         ATTR2_TYPE, ATTR2)                                 \
+int FN_NAME( const mbedtls_asn1_buf *oid, ATTR1_TYPE * ATTR1, ATTR2_TYPE * ATTR2 )  \
+{                                                                           \
+    const TYPE_T *data = oid_ ## TYPE_NAME ## _from_asn1( oid );            \
+    if( data == NULL ) return( MBEDTLS_ERR_OID_NOT_FOUND );                \
+    *ATTR1 = data->ATTR1;                                                   \
+    *ATTR2 = data->ATTR2;                                                   \
+    return( 0 );                                                            \
+}
+
+/*
+ * Macro to generate a function for retrieving the OID based on a single
+ * attribute from a mbedtls_oid_descriptor_t wrapper.
+ */
+#define FN_OID_GET_OID_BY_ATTR1(FN_NAME, TYPE_T, LIST, ATTR1_TYPE, ATTR1)   \
+int FN_NAME( ATTR1_TYPE ATTR1, const char **oid, size_t *olen )             \
+{                                                                           \
+    const TYPE_T *cur = LIST;                                               \
+    while( cur->descriptor.asn1 != NULL ) {                                 \
+        if( cur->ATTR1 == ATTR1 ) {                                         \
+            *oid = cur->descriptor.asn1;                                    \
+            *olen = cur->descriptor.asn1_len;                               \
+            return( 0 );                                                    \
+        }                                                                   \
+        cur++;                                                              \
+    }                                                                       \
+    return( MBEDTLS_ERR_OID_NOT_FOUND );                                   \
+}
+
+/*
+ * Macro to generate a function for retrieving the OID based on two
+ * attributes from a mbedtls_oid_descriptor_t wrapper.
+ */
+#define FN_OID_GET_OID_BY_ATTR2(FN_NAME, TYPE_T, LIST, ATTR1_TYPE, ATTR1,   \
+                                ATTR2_TYPE, ATTR2)                          \
+int FN_NAME( ATTR1_TYPE ATTR1, ATTR2_TYPE ATTR2, const char **oid ,         \
+             size_t *olen )                                                 \
+{                                                                           \
+    const TYPE_T *cur = LIST;                                               \
+    while( cur->descriptor.asn1 != NULL ) {                                 \
+        if( cur->ATTR1 == ATTR1 && cur->ATTR2 == ATTR2 ) {                  \
+            *oid = cur->descriptor.asn1;                                    \
+            *olen = cur->descriptor.asn1_len;                               \
+            return( 0 );                                                    \
+        }                                                                   \
+        cur++;                                                              \
+    }                                                                       \
+    return( MBEDTLS_ERR_OID_NOT_FOUND );                                   \
+}
+
+#if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)
+/*
+ * For X520 attribute types
+ */
+typedef struct {
+    mbedtls_oid_descriptor_t    descriptor;
+    const char          *short_name;
+} oid_x520_attr_t;
+
+static const oid_x520_attr_t oid_x520_attr_type[] =
+{
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_CN ),          "id-at-commonName",               "Common Name" },
+        "CN",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_COUNTRY ),     "id-at-countryName",              "Country" },
+        "C",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_LOCALITY ),    "id-at-locality",                 "Locality" },
+        "L",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_STATE ),       "id-at-state",                    "State" },
+        "ST",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_ORGANIZATION ),"id-at-organizationName",         "Organization" },
+        "O",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_ORG_UNIT ),    "id-at-organizationalUnitName",   "Org Unit" },
+        "OU",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS9_EMAIL ),    "emailAddress",                   "E-mail address" },
+        "emailAddress",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_SERIAL_NUMBER ),"id-at-serialNumber",            "Serial number" },
+        "serialNumber",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_POSTAL_ADDRESS ),"id-at-postalAddress",          "Postal address" },
+        "postalAddress",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_POSTAL_CODE ), "id-at-postalCode",               "Postal code" },
+        "postalCode",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_SUR_NAME ),    "id-at-surName",                  "Surname" },
+        "SN",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_GIVEN_NAME ),  "id-at-givenName",                "Given name" },
+        "GN",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_INITIALS ),    "id-at-initials",                 "Initials" },
+        "initials",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_GENERATION_QUALIFIER ), "id-at-generationQualifier", "Generation qualifier" },
+        "generationQualifier",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_TITLE ),       "id-at-title",                    "Title" },
+        "title",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_DN_QUALIFIER ),"id-at-dnQualifier",              "Distinguished Name qualifier" },
+        "dnQualifier",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_PSEUDONYM ),   "id-at-pseudonym",                "Pseudonym" },
+        "pseudonym",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_DOMAIN_COMPONENT ), "id-domainComponent",           "Domain component" },
+        "DC",
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_AT_UNIQUE_IDENTIFIER ), "id-at-uniqueIdentifier",    "Unique Identifier" },
+        "uniqueIdentifier",
+    },
+    {
+        { NULL, 0, NULL, NULL },
+        NULL,
+    }
+};
+
+FN_OID_TYPED_FROM_ASN1(oid_x520_attr_t, x520_attr, oid_x520_attr_type)
+FN_OID_GET_ATTR1(mbedtls_oid_get_attr_short_name, oid_x520_attr_t, x520_attr, const char *, short_name)
+
+/*
+ * For X509 extensions
+ */
+typedef struct {
+    mbedtls_oid_descriptor_t    descriptor;
+    int                 ext_type;
+} oid_x509_ext_t;
+
+static const oid_x509_ext_t oid_x509_ext[] =
+{
+    {
+        { ADD_LEN( MBEDTLS_OID_BASIC_CONSTRAINTS ),    "id-ce-basicConstraints",   "Basic Constraints" },
+        MBEDTLS_X509_EXT_BASIC_CONSTRAINTS,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_KEY_USAGE ),            "id-ce-keyUsage",           "Key Usage" },
+        MBEDTLS_X509_EXT_KEY_USAGE,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_EXTENDED_KEY_USAGE ),   "id-ce-extKeyUsage",        "Extended Key Usage" },
+        MBEDTLS_X509_EXT_EXTENDED_KEY_USAGE,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_SUBJECT_ALT_NAME ),     "id-ce-subjectAltName",     "Subject Alt Name" },
+        MBEDTLS_X509_EXT_SUBJECT_ALT_NAME,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_NS_CERT_TYPE ),         "id-netscape-certtype",     "Netscape Certificate Type" },
+        MBEDTLS_X509_EXT_NS_CERT_TYPE,
+    },
+    {
+        { NULL, 0, NULL, NULL },
+        0,
+    },
+};
+
+FN_OID_TYPED_FROM_ASN1(oid_x509_ext_t, x509_ext, oid_x509_ext)
+FN_OID_GET_ATTR1(mbedtls_oid_get_x509_ext_type, oid_x509_ext_t, x509_ext, int, ext_type)
+
+static const mbedtls_oid_descriptor_t oid_ext_key_usage[] =
+{
+    { ADD_LEN( MBEDTLS_OID_SERVER_AUTH ),      "id-kp-serverAuth",      "TLS Web Server Authentication" },
+    { ADD_LEN( MBEDTLS_OID_CLIENT_AUTH ),      "id-kp-clientAuth",      "TLS Web Client Authentication" },
+    { ADD_LEN( MBEDTLS_OID_CODE_SIGNING ),     "id-kp-codeSigning",     "Code Signing" },
+    { ADD_LEN( MBEDTLS_OID_EMAIL_PROTECTION ), "id-kp-emailProtection", "E-mail Protection" },
+    { ADD_LEN( MBEDTLS_OID_TIME_STAMPING ),    "id-kp-timeStamping",    "Time Stamping" },
+    { ADD_LEN( MBEDTLS_OID_OCSP_SIGNING ),     "id-kp-OCSPSigning",     "OCSP Signing" },
+    { NULL, 0, NULL, NULL },
+};
+
+FN_OID_TYPED_FROM_ASN1(mbedtls_oid_descriptor_t, ext_key_usage, oid_ext_key_usage)
+FN_OID_GET_ATTR1(mbedtls_oid_get_extended_key_usage, mbedtls_oid_descriptor_t, ext_key_usage, const char *, description)
+#endif /* MBEDTLS_X509_USE_C || MBEDTLS_X509_CREATE_C */
+
+#if defined(MBEDTLS_HI_NO_CUT)//defined(MBEDTLS_MD_C)
+/*
+ * For SignatureAlgorithmIdentifier
+ */
+typedef struct {
+    mbedtls_oid_descriptor_t    descriptor;
+    mbedtls_md_type_t           md_alg;
+    mbedtls_pk_type_t           pk_alg;
+} oid_sig_alg_t;
+
+static const oid_sig_alg_t oid_sig_alg[] =
+{
+#if defined(MBEDTLS_RSA_C)
+#if defined(MBEDTLS_MD2_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS1_MD2 ),        "md2WithRSAEncryption",     "RSA with MD2" },
+        MBEDTLS_MD_MD2,      MBEDTLS_PK_RSA,
+    },
+#endif /* MBEDTLS_MD2_C */
+#if defined(MBEDTLS_MD4_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS1_MD4 ),        "md4WithRSAEncryption",     "RSA with MD4" },
+        MBEDTLS_MD_MD4,      MBEDTLS_PK_RSA,
+    },
+#endif /* MBEDTLS_MD4_C */
+#if defined(MBEDTLS_MD5_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS1_MD5 ),        "md5WithRSAEncryption",     "RSA with MD5" },
+        MBEDTLS_MD_MD5,      MBEDTLS_PK_RSA,
+    },
+#endif /* MBEDTLS_MD5_C */
+#if defined(MBEDTLS_SHA1_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS1_SHA1 ),       "sha-1WithRSAEncryption",   "RSA with SHA1" },
+        MBEDTLS_MD_SHA1,     MBEDTLS_PK_RSA,
+    },
+#endif /* MBEDTLS_SHA1_C */
+#if defined(MBEDTLS_SHA256_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS1_SHA224 ),     "sha224WithRSAEncryption",  "RSA with SHA-224" },
+        MBEDTLS_MD_SHA224,   MBEDTLS_PK_RSA,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS1_SHA256 ),     "sha256WithRSAEncryption",  "RSA with SHA-256" },
+        MBEDTLS_MD_SHA256,   MBEDTLS_PK_RSA,
+    },
+#endif /* MBEDTLS_SHA256_C */
+#if defined(MBEDTLS_SHA512_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS1_SHA384 ),     "sha384WithRSAEncryption",  "RSA with SHA-384" },
+        MBEDTLS_MD_SHA384,   MBEDTLS_PK_RSA,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS1_SHA512 ),     "sha512WithRSAEncryption",  "RSA with SHA-512" },
+        MBEDTLS_MD_SHA512,   MBEDTLS_PK_RSA,
+    },
+#endif /* MBEDTLS_SHA512_C */
+#if defined(MBEDTLS_SHA1_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_RSA_SHA_OBS ),      "sha-1WithRSAEncryption",   "RSA with SHA1" },
+        MBEDTLS_MD_SHA1,     MBEDTLS_PK_RSA,
+    },
+#endif /* MBEDTLS_SHA1_C */
+#endif /* MBEDTLS_RSA_C */
+#if defined(MBEDTLS_ECDSA_C)
+#if defined(MBEDTLS_SHA1_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_ECDSA_SHA1 ),       "ecdsa-with-SHA1",      "ECDSA with SHA1" },
+        MBEDTLS_MD_SHA1,     MBEDTLS_PK_ECDSA,
+    },
+#endif /* MBEDTLS_SHA1_C */
+#if defined(MBEDTLS_SHA256_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_ECDSA_SHA224 ),     "ecdsa-with-SHA224",    "ECDSA with SHA224" },
+        MBEDTLS_MD_SHA224,   MBEDTLS_PK_ECDSA,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_ECDSA_SHA256 ),     "ecdsa-with-SHA256",    "ECDSA with SHA256" },
+        MBEDTLS_MD_SHA256,   MBEDTLS_PK_ECDSA,
+    },
+#endif /* MBEDTLS_SHA256_C */
+#if defined(MBEDTLS_SHA512_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_ECDSA_SHA384 ),     "ecdsa-with-SHA384",    "ECDSA with SHA384" },
+        MBEDTLS_MD_SHA384,   MBEDTLS_PK_ECDSA,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_ECDSA_SHA512 ),     "ecdsa-with-SHA512",    "ECDSA with SHA512" },
+        MBEDTLS_MD_SHA512,   MBEDTLS_PK_ECDSA,
+    },
+#endif /* MBEDTLS_SHA512_C */
+#endif /* MBEDTLS_ECDSA_C */
+#if defined(MBEDTLS_RSA_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_RSASSA_PSS ),        "RSASSA-PSS",           "RSASSA-PSS" },
+        MBEDTLS_MD_NONE,     MBEDTLS_PK_RSASSA_PSS,
+    },
+#endif /* MBEDTLS_RSA_C */
+    {
+        { NULL, 0, NULL, NULL },
+        MBEDTLS_MD_NONE, MBEDTLS_PK_NONE,
+    },
+};
+
+FN_OID_TYPED_FROM_ASN1(oid_sig_alg_t, sig_alg, oid_sig_alg)
+FN_OID_GET_DESCRIPTOR_ATTR1(mbedtls_oid_get_sig_alg_desc, oid_sig_alg_t, sig_alg, const char *, description)
+FN_OID_GET_ATTR2(mbedtls_oid_get_sig_alg, oid_sig_alg_t, sig_alg, mbedtls_md_type_t, md_alg, mbedtls_pk_type_t, pk_alg)
+FN_OID_GET_OID_BY_ATTR2(mbedtls_oid_get_oid_by_sig_alg, oid_sig_alg_t, oid_sig_alg, mbedtls_pk_type_t, pk_alg, mbedtls_md_type_t, md_alg)
+#endif /* MBEDTLS_MD_C */
+
+#if defined(MBEDTLS_HI_NO_CUT)
+/*
+ * For PublicKeyInfo (PKCS1, RFC 5480)
+ */
+typedef struct {
+    mbedtls_oid_descriptor_t    descriptor;
+    mbedtls_pk_type_t           pk_alg;
+} oid_pk_alg_t;
+
+static const oid_pk_alg_t oid_pk_alg[] =
+{
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS1_RSA ),      "rsaEncryption",   "RSA" },
+        MBEDTLS_PK_RSA,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_ALG_UNRESTRICTED ),  "id-ecPublicKey",   "Generic EC key" },
+        MBEDTLS_PK_ECKEY,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_ALG_ECDH ),          "id-ecDH",          "EC key for ECDH" },
+        MBEDTLS_PK_ECKEY_DH,
+    },
+    {
+        { NULL, 0, NULL, NULL },
+        MBEDTLS_PK_NONE,
+    },
+};
+
+FN_OID_TYPED_FROM_ASN1(oid_pk_alg_t, pk_alg, oid_pk_alg)
+FN_OID_GET_ATTR1(mbedtls_oid_get_pk_alg, oid_pk_alg_t, pk_alg, mbedtls_pk_type_t, pk_alg)
+FN_OID_GET_OID_BY_ATTR1(mbedtls_oid_get_oid_by_pk_alg, oid_pk_alg_t, oid_pk_alg, mbedtls_pk_type_t, pk_alg)
+#endif
+
+#if defined(MBEDTLS_HI_NO_CUT) //defined(MBEDTLS_ECP_C)
+/*
+ * For namedCurve (RFC 5480)
+ */
+typedef struct {
+    mbedtls_oid_descriptor_t    descriptor;
+    mbedtls_ecp_group_id        grp_id;
+} oid_ecp_grp_t;
+
+static const oid_ecp_grp_t oid_ecp_grp[] =
+{
+#if defined(MBEDTLS_ECP_DP_SECP192R1_ENABLED)
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_GRP_SECP192R1 ), "secp192r1",    "secp192r1" },
+        MBEDTLS_ECP_DP_SECP192R1,
+    },
+#endif /* MBEDTLS_ECP_DP_SECP192R1_ENABLED */
+#if defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED)
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_GRP_SECP224R1 ), "secp224r1",    "secp224r1" },
+        MBEDTLS_ECP_DP_SECP224R1,
+    },
+#endif /* MBEDTLS_ECP_DP_SECP224R1_ENABLED */
+#if defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_GRP_SECP256R1 ), "secp256r1",    "secp256r1" },
+        MBEDTLS_ECP_DP_SECP256R1,
+    },
+#endif /* MBEDTLS_ECP_DP_SECP256R1_ENABLED */
+#if defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED)
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_GRP_SECP384R1 ), "secp384r1",    "secp384r1" },
+        MBEDTLS_ECP_DP_SECP384R1,
+    },
+#endif /* MBEDTLS_ECP_DP_SECP384R1_ENABLED */
+#if defined(MBEDTLS_ECP_DP_SECP521R1_ENABLED)
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_GRP_SECP521R1 ), "secp521r1",    "secp521r1" },
+        MBEDTLS_ECP_DP_SECP521R1,
+    },
+#endif /* MBEDTLS_ECP_DP_SECP521R1_ENABLED */
+#if defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED)
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_GRP_SECP192K1 ), "secp192k1",    "secp192k1" },
+        MBEDTLS_ECP_DP_SECP192K1,
+    },
+#endif /* MBEDTLS_ECP_DP_SECP192K1_ENABLED */
+#if defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_GRP_SECP224K1 ), "secp224k1",    "secp224k1" },
+        MBEDTLS_ECP_DP_SECP224K1,
+    },
+#endif /* MBEDTLS_ECP_DP_SECP224K1_ENABLED */
+#if defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_GRP_SECP256K1 ), "secp256k1",    "secp256k1" },
+        MBEDTLS_ECP_DP_SECP256K1,
+    },
+#endif /* MBEDTLS_ECP_DP_SECP256K1_ENABLED */
+#if defined(MBEDTLS_ECP_DP_BP256R1_ENABLED)
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_GRP_BP256R1 ),   "brainpoolP256r1","brainpool256r1" },
+        MBEDTLS_ECP_DP_BP256R1,
+    },
+#endif /* MBEDTLS_ECP_DP_BP256R1_ENABLED */
+#if defined(MBEDTLS_ECP_DP_BP384R1_ENABLED)
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_GRP_BP384R1 ),   "brainpoolP384r1","brainpool384r1" },
+        MBEDTLS_ECP_DP_BP384R1,
+    },
+#endif /* MBEDTLS_ECP_DP_BP384R1_ENABLED */
+#if defined(MBEDTLS_ECP_DP_BP512R1_ENABLED)
+    {
+        { ADD_LEN( MBEDTLS_OID_EC_GRP_BP512R1 ),   "brainpoolP512r1","brainpool512r1" },
+        MBEDTLS_ECP_DP_BP512R1,
+    },
+#endif /* MBEDTLS_ECP_DP_BP512R1_ENABLED */
+    {
+        { NULL, 0, NULL, NULL },
+        MBEDTLS_ECP_DP_NONE,
+    },
+};
+
+FN_OID_TYPED_FROM_ASN1(oid_ecp_grp_t, grp_id, oid_ecp_grp)
+FN_OID_GET_ATTR1(mbedtls_oid_get_ec_grp, oid_ecp_grp_t, grp_id, mbedtls_ecp_group_id, grp_id)
+FN_OID_GET_OID_BY_ATTR1(mbedtls_oid_get_oid_by_ec_grp, oid_ecp_grp_t, oid_ecp_grp, mbedtls_ecp_group_id, grp_id)
+#endif /* MBEDTLS_ECP_C */
+
+#if defined(MBEDTLS_HI_NO_CUT) //defined(MBEDTLS_CIPHER_C)
+/*
+ * For PKCS#5 PBES2 encryption algorithm
+ */
+typedef struct {
+    mbedtls_oid_descriptor_t    descriptor;
+    mbedtls_cipher_type_t       cipher_alg;
+} oid_cipher_alg_t;
+
+static const oid_cipher_alg_t oid_cipher_alg[] =
+{
+    {
+        { ADD_LEN( MBEDTLS_OID_DES_CBC ),              "desCBC",       "DES-CBC" },
+        MBEDTLS_CIPHER_DES_CBC,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_DES_EDE3_CBC ),         "des-ede3-cbc", "DES-EDE3-CBC" },
+        MBEDTLS_CIPHER_DES_EDE3_CBC,
+    },
+    {
+        { NULL, 0, NULL, NULL },
+        MBEDTLS_CIPHER_NONE,
+    },
+};
+
+FN_OID_TYPED_FROM_ASN1(oid_cipher_alg_t, cipher_alg, oid_cipher_alg)
+FN_OID_GET_ATTR1(mbedtls_oid_get_cipher_alg, oid_cipher_alg_t, cipher_alg, mbedtls_cipher_type_t, cipher_alg)
+#endif /* MBEDTLS_CIPHER_C */
+
+#if defined(MBEDTLS_MD_C)
+/*
+ * For digestAlgorithm
+ */
+typedef struct {
+    mbedtls_oid_descriptor_t    descriptor;
+    mbedtls_md_type_t           md_alg;
+} oid_md_alg_t;
+
+static const oid_md_alg_t oid_md_alg[] =
+{
+#if defined(MBEDTLS_MD2_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_DIGEST_ALG_MD2 ),       "id-md2",       "MD2" },
+        MBEDTLS_MD_MD2,
+    },
+#endif /* MBEDTLS_MD2_C */
+#if defined(MBEDTLS_MD4_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_DIGEST_ALG_MD4 ),       "id-md4",       "MD4" },
+        MBEDTLS_MD_MD4,
+    },
+#endif /* MBEDTLS_MD4_C */
+#if defined(MBEDTLS_MD5_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_DIGEST_ALG_MD5 ),       "id-md5",       "MD5" },
+        MBEDTLS_MD_MD5,
+    },
+#endif /* MBEDTLS_MD5_C */
+    {
+        { ADD_LEN( MBEDTLS_OID_DIGEST_ALG_SHA1 ),      "id-sha1",      "SHA-1" },
+        MBEDTLS_MD_SHA1,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_DIGEST_ALG_SHA224 ),    "id-sha224",    "SHA-224" },
+        MBEDTLS_MD_SHA224,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_DIGEST_ALG_SHA256 ),    "id-sha256",    "SHA-256" },
+        MBEDTLS_MD_SHA256,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_DIGEST_ALG_SHA384 ),    "id-sha384",    "SHA-384" },
+        MBEDTLS_MD_SHA384,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_DIGEST_ALG_SHA512 ),    "id-sha512",    "SHA-512" },
+        MBEDTLS_MD_SHA512,
+    },
+    {
+        { NULL, 0, NULL, NULL },
+        MBEDTLS_MD_NONE,
+    },
+};
+
+FN_OID_TYPED_FROM_ASN1(oid_md_alg_t, md_alg, oid_md_alg)
+FN_OID_GET_ATTR1(mbedtls_oid_get_md_alg, oid_md_alg_t, md_alg, mbedtls_md_type_t, md_alg)
+FN_OID_GET_OID_BY_ATTR1(mbedtls_oid_get_oid_by_md, oid_md_alg_t, oid_md_alg, mbedtls_md_type_t, md_alg)
+
+/*
+ * For HMAC digestAlgorithm
+ */
+typedef struct {
+    mbedtls_oid_descriptor_t    descriptor;
+    mbedtls_md_type_t           md_hmac;
+} oid_md_hmac_t;
+
+static const oid_md_hmac_t oid_md_hmac[] =
+{
+#if defined(MBEDTLS_SHA1_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_HMAC_SHA1 ),      "hmacSHA1",      "HMAC-SHA-1" },
+        MBEDTLS_MD_SHA1,
+    },
+#endif /* MBEDTLS_SHA1_C */
+#if defined(MBEDTLS_SHA256_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_HMAC_SHA224 ),    "hmacSHA224",    "HMAC-SHA-224" },
+        MBEDTLS_MD_SHA224,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_HMAC_SHA256 ),    "hmacSHA256",    "HMAC-SHA-256" },
+        MBEDTLS_MD_SHA256,
+    },
+#endif /* MBEDTLS_SHA256_C */
+#if defined(MBEDTLS_SHA512_C)
+    {
+        { ADD_LEN( MBEDTLS_OID_HMAC_SHA384 ),    "hmacSHA384",    "HMAC-SHA-384" },
+        MBEDTLS_MD_SHA384,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_HMAC_SHA512 ),    "hmacSHA512",    "HMAC-SHA-512" },
+        MBEDTLS_MD_SHA512,
+    },
+#endif /* MBEDTLS_SHA512_C */
+    {
+        { NULL, 0, NULL, NULL },
+        MBEDTLS_MD_NONE,
+    },
+};
+
+FN_OID_TYPED_FROM_ASN1(oid_md_hmac_t, md_hmac, oid_md_hmac)
+FN_OID_GET_ATTR1(mbedtls_oid_get_md_hmac, oid_md_hmac_t, md_hmac, mbedtls_md_type_t, md_hmac)
+#endif /* MBEDTLS_MD_C */
+
+#if defined(MBEDTLS_PKCS12_C)
+/*
+ * For PKCS#12 PBEs
+ */
+typedef struct {
+    mbedtls_oid_descriptor_t    descriptor;
+    mbedtls_md_type_t           md_alg;
+    mbedtls_cipher_type_t       cipher_alg;
+} oid_pkcs12_pbe_alg_t;
+
+static const oid_pkcs12_pbe_alg_t oid_pkcs12_pbe_alg[] =
+{
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS12_PBE_SHA1_DES3_EDE_CBC ), "pbeWithSHAAnd3-KeyTripleDES-CBC", "PBE with SHA1 and 3-Key 3DES" },
+        MBEDTLS_MD_SHA1,      MBEDTLS_CIPHER_DES_EDE3_CBC,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_PKCS12_PBE_SHA1_DES2_EDE_CBC ), "pbeWithSHAAnd2-KeyTripleDES-CBC", "PBE with SHA1 and 2-Key 3DES" },
+        MBEDTLS_MD_SHA1,      MBEDTLS_CIPHER_DES_EDE_CBC,
+    },
+    {
+        { NULL, 0, NULL, NULL },
+        MBEDTLS_MD_NONE, MBEDTLS_CIPHER_NONE,
+    },
+};
+
+FN_OID_TYPED_FROM_ASN1(oid_pkcs12_pbe_alg_t, pkcs12_pbe_alg, oid_pkcs12_pbe_alg)
+FN_OID_GET_ATTR2(mbedtls_oid_get_pkcs12_pbe_alg, oid_pkcs12_pbe_alg_t, pkcs12_pbe_alg, mbedtls_md_type_t, md_alg, mbedtls_cipher_type_t, cipher_alg)
+#endif /* MBEDTLS_PKCS12_C */
+
+#if defined(MBEDTLS_HI_NO_CUT)
+#define OID_SAFE_SNPRINTF                               \
+    do {                                                \
+        if( ret < 0 || (size_t) ret >= n )              \
+            return( MBEDTLS_ERR_OID_BUF_TOO_SMALL );    \
+                                                        \
+        n -= (size_t) ret;                              \
+        p += (size_t) ret;                              \
+    } while( 0 )
+
+/* Return the x.y.z.... style numeric string for the given OID */
+int mbedtls_oid_get_numeric_string( char *buf, size_t size,
+                            const mbedtls_asn1_buf *oid )
+{
+    int ret;
+    size_t i, n;
+    unsigned int value;
+    char *p;
+
+    p = buf;
+    n = size;
+
+    /* First byte contains first two dots */
+    if( oid->len > 0 )
+    {
+        ret = mbedtls_snprintf( p, n, "%d.%d", oid->p[0] / 40, oid->p[0] % 40 );
+        OID_SAFE_SNPRINTF;
+    }
+
+    value = 0;
+    for( i = 1; i < oid->len; i++ )
+    {
+        /* Prevent overflow in value. */
+        if( ( ( value << 7 ) >> 7 ) != value )
+            return( MBEDTLS_ERR_OID_BUF_TOO_SMALL );
+
+        value <<= 7;
+        value += oid->p[i] & 0x7F;
+
+        if( !( oid->p[i] & 0x80 ) )
+        {
+            /* Last byte */
+            ret = mbedtls_snprintf( p, n, ".%d", value );
+            OID_SAFE_SNPRINTF;
+            value = 0;
+        }
+    }
+
+    return( (int) ( size - n ) );
+}
+#endif
+
+#endif /* MBEDTLS_OID_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/platform_util.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/platform_util.c
@@ -1,0 +1,138 @@
+/*
+ * Common and shared functions used by multiple modules in the Mbed TLS
+ * library.
+ *
+ *  Copyright (C) 2018, Arm Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+
+/*
+ * Ensure gmtime_r is available even with -std=c99; must be defined before
+ * config.h, which pulls in glibc's features.h. Harmless on other platforms.
+ */
+#if !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 200112L
+#endif
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include "mbedtls/platform_util.h"
+#include "mbedtls/platform.h"
+
+#if defined(MBEDTLS_THREADING_C)
+#include "mbedtls/threading.h"
+#endif
+
+#include <linux/string.h>
+
+#if !defined(MBEDTLS_PLATFORM_ZEROIZE_ALT)
+/*
+ * This implementation should never be optimized out by the compiler
+ *
+ * This implementation for mbedtls_platform_zeroize() was inspired from Colin
+ * Percival's blog article at:
+ *
+ * http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
+ *
+ * It uses a volatile function pointer to the standard memset(). Because the
+ * pointer is volatile the compiler expects it to change at
+ * any time and will not optimize out the call that could potentially perform
+ * other operations on the input buffer instead of just setting it to 0.
+ * Nevertheless, as pointed out by davidtgoldblatt on Hacker News
+ * (refer to http://www.daemonology.net/blog/2014-09-05-erratum.html for
+ * details), optimizations of the following form are still possible:
+ *
+ * if( memset_func != memset )
+ *     memset_func( buf, 0, len );
+ *
+ * Note that it is extremely difficult to guarantee that
+ * mbedtls_platform_zeroize() will not be optimized out by aggressive compilers
+ * in a portable way. For this reason, Mbed TLS also provides the configuration
+ * option MBEDTLS_PLATFORM_ZEROIZE_ALT, which allows users to configure
+ * mbedtls_platform_zeroize() to use a suitable implementation for their
+ * platform and needs.
+ */
+static void * (* const volatile memset_func)( void *, int, size_t ) = memset;
+
+void mbedtls_platform_zeroize( void *buf, size_t len )
+{
+    memset_func( buf, 0, len );
+}
+#endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
+
+#if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
+#include <time.h>
+#if !defined(_WIN32) && (defined(unix) || \
+    defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
+    defined(__MACH__)))
+#include <unistd.h>
+#endif /* !_WIN32 && (unix || __unix || __unix__ ||
+        * (__APPLE__ && __MACH__)) */
+
+#if !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
+       ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
+         _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) )
+/*
+ * This is a convenience shorthand macro to avoid checking the long
+ * preprocessor conditions above. Ideally, we could expose this macro in
+ * platform_util.h and simply use it in platform_util.c, threading.c and
+ * threading.h. However, this macro is not part of the Mbed TLS public API, so
+ * we keep it private by only defining it in this file
+ */
+#if ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) )
+#define PLATFORM_UTIL_USE_GMTIME
+#endif /* ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) ) */
+
+#endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
+             ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
+                _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */
+
+struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
+                                      struct tm *tm_buf )
+{
+#if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
+    return( ( gmtime_s( tm_buf, tt ) == 0 ) ? tm_buf : NULL );
+#elif !defined(PLATFORM_UTIL_USE_GMTIME)
+    return( gmtime_r( tt, tm_buf ) );
+#else
+    struct tm *lt;
+
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_mutex_lock( &mbedtls_threading_gmtime_mutex ) != 0 )
+        return( NULL );
+#endif /* MBEDTLS_THREADING_C */
+
+    lt = gmtime( tt );
+
+    if( lt != NULL )
+    {
+        memcpy( tm_buf, lt, sizeof( struct tm ) );
+    }
+
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_mutex_unlock( &mbedtls_threading_gmtime_mutex ) != 0 )
+        return( NULL );
+#endif /* MBEDTLS_THREADING_C */
+
+    return( ( lt == NULL ) ? NULL : tm_buf );
+#endif /* _WIN32 && !EFIX64 && !EFI32 */
+}
+#endif /* MBEDTLS_HAVE_TIME_DATE && MBEDTLS_PLATFORM_GMTIME_R_ALT */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/rsa.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/rsa.c
@@ -1,0 +1,2879 @@
+/*
+ *  The RSA public-key cryptosystem
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+/*
+ *  The following sources were referenced in the design of this implementation
+ *  of the RSA algorithm:
+ *
+ *  [1] A method for obtaining digital signatures and public-key cryptosystems
+ *      R Rivest, A Shamir, and L Adleman
+ *      http://people.csail.mit.edu/rivest/pubs.html#RSA78
+ *
+ *  [2] Handbook of Applied Cryptography - 1997, Chapter 8
+ *      Menezes, van Oorschot and Vanstone
+ *
+ *  [3] Malware Guard Extension: Using SGX to Conceal Cache Attacks
+ *      Michael Schwarz, Samuel Weiser, Daniel Gruss, Clentine Maurice and
+ *      Stefan Mangard
+ *      https://arxiv.org/abs/1702.08719v2
+ *
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_RSA_C)
+
+#include "mbedtls/rsa.h"
+#include "mbedtls/rsa_internal.h"
+#include "mbedtls/oid.h"
+#include "mbedtls/platform_util.h"
+
+#if defined(MBEDTLS_PKCS1_V21)
+#include "mbedtls/md.h"
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#define mbedtls_printf printf
+#define mbedtls_calloc calloc
+#define mbedtls_free   free
+#endif
+
+#if !defined(MBEDTLS_RSA_ALT)
+
+/* Parameter validation macros */
+#define RSA_VALIDATE_RET( cond )                                       \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_RSA_BAD_INPUT_DATA )
+#define RSA_VALIDATE( cond )                                           \
+    MBEDTLS_INTERNAL_VALIDATE( cond )
+
+#if defined(MBEDTLS_PKCS1_V15)
+/* constant-time buffer comparison */
+static inline int mbedtls_safer_memcmp( const void *a, const void *b, size_t n )
+{
+    size_t i;
+    const unsigned char *A = (const unsigned char *) a;
+    const unsigned char *B = (const unsigned char *) b;
+    unsigned char diff = 0;
+
+    for( i = 0; i < n; i++ )
+        diff |= A[i] ^ B[i];
+
+    return( diff );
+}
+#endif /* MBEDTLS_PKCS1_V15 */
+
+#if defined(MBEDTLS_HI_NO_CUT)
+int mbedtls_rsa_import( mbedtls_rsa_context *ctx,
+                        const mbedtls_mpi *N,
+                        const mbedtls_mpi *P, const mbedtls_mpi *Q,
+                        const mbedtls_mpi *D, const mbedtls_mpi *E )
+{
+    int ret;
+    RSA_VALIDATE_RET( ctx != NULL );
+
+    if( ( N != NULL && ( ret = mbedtls_mpi_copy( &ctx->N, N ) ) != 0 ) ||
+        ( P != NULL && ( ret = mbedtls_mpi_copy( &ctx->P, P ) ) != 0 ) ||
+        ( Q != NULL && ( ret = mbedtls_mpi_copy( &ctx->Q, Q ) ) != 0 ) ||
+        ( D != NULL && ( ret = mbedtls_mpi_copy( &ctx->D, D ) ) != 0 ) ||
+        ( E != NULL && ( ret = mbedtls_mpi_copy( &ctx->E, E ) ) != 0 ) )
+    {
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+    }
+
+    if( N != NULL )
+        ctx->len = mbedtls_mpi_size( &ctx->N );
+
+    return( 0 );
+}
+
+int mbedtls_rsa_import_raw( mbedtls_rsa_context *ctx,
+                            unsigned char const *N, size_t N_len,
+                            unsigned char const *P, size_t P_len,
+                            unsigned char const *Q, size_t Q_len,
+                            unsigned char const *D, size_t D_len,
+                            unsigned char const *E, size_t E_len )
+{
+    int ret = 0;
+    RSA_VALIDATE_RET( ctx != NULL );
+
+    if( N != NULL )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_read_binary( &ctx->N, N, N_len ) );
+        ctx->len = mbedtls_mpi_size( &ctx->N );
+    }
+
+    if( P != NULL )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_read_binary( &ctx->P, P, P_len ) );
+
+    if( Q != NULL )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_read_binary( &ctx->Q, Q, Q_len ) );
+
+    if( D != NULL )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_read_binary( &ctx->D, D, D_len ) );
+
+    if( E != NULL )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_read_binary( &ctx->E, E, E_len ) );
+
+cleanup:
+
+    if( ret != 0 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+
+    return( 0 );
+}
+#endif
+
+/*
+ * Checks whether the context fields are set in such a way
+ * that the RSA primitives will be able to execute without error.
+ * It does *not* make guarantees for consistency of the parameters.
+ */
+static int rsa_check_context( mbedtls_rsa_context const *ctx, int is_priv,
+                              int blinding_needed )
+{
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    /* blinding_needed is only used for NO_CRT to decide whether
+     * P,Q need to be present or not. */
+    ((void) blinding_needed);
+#endif
+
+    if( ctx->len != mbedtls_mpi_size( &ctx->N ) ||
+        ctx->len > MBEDTLS_MPI_MAX_SIZE )
+    {
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+    }
+
+    /*
+     * 1. Modular exponentiation needs positive, odd moduli.
+     */
+
+    /* Modular exponentiation wrt. N is always used for
+     * RSA public key operations. */
+    if( mbedtls_mpi_cmp_int( &ctx->N, 0 ) <= 0 ||
+        mbedtls_mpi_get_bit( &ctx->N, 0 ) == 0  )
+    {
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+    }
+
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    /* Modular exponentiation for P and Q is only
+     * used for private key operations and if CRT
+     * is used. */
+    if( is_priv &&
+        ( mbedtls_mpi_cmp_int( &ctx->P, 0 ) <= 0 ||
+          mbedtls_mpi_get_bit( &ctx->P, 0 ) == 0 ||
+          mbedtls_mpi_cmp_int( &ctx->Q, 0 ) <= 0 ||
+          mbedtls_mpi_get_bit( &ctx->Q, 0 ) == 0  ) )
+    {
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+    }
+#endif /* !MBEDTLS_RSA_NO_CRT */
+
+    /*
+     * 2. Exponents must be positive
+     */
+
+    /* Always need E for public key operations */
+    if( mbedtls_mpi_cmp_int( &ctx->E, 0 ) <= 0 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+#if defined(MBEDTLS_RSA_NO_CRT)
+    /* For private key operations, use D or DP & DQ
+     * as (unblinded) exponents. */
+    if( is_priv && mbedtls_mpi_cmp_int( &ctx->D, 0 ) <= 0 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+#else
+    if( is_priv &&
+        ( mbedtls_mpi_cmp_int( &ctx->DP, 0 ) <= 0 ||
+          mbedtls_mpi_cmp_int( &ctx->DQ, 0 ) <= 0  ) )
+    {
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+    }
+#endif /* MBEDTLS_RSA_NO_CRT */
+
+    /* Blinding shouldn't make exponents negative either,
+     * so check that P, Q >= 1 if that hasn't yet been
+     * done as part of 1. */
+#if defined(MBEDTLS_RSA_NO_CRT)
+    if( is_priv && blinding_needed &&
+        ( mbedtls_mpi_cmp_int( &ctx->P, 0 ) <= 0 ||
+          mbedtls_mpi_cmp_int( &ctx->Q, 0 ) <= 0 ) )
+    {
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+    }
+#endif
+
+    /* It wouldn't lead to an error if it wasn't satisfied,
+     * but check for QP >= 1 nonetheless. */
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    if( is_priv &&
+        mbedtls_mpi_cmp_int( &ctx->QP, 0 ) <= 0 )
+    {
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+    }
+#endif
+
+    return( 0 );
+}
+
+#ifdef CIPHER_LITEOS_TEST_SUPPORT
+int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
+{
+    int ret = 0;
+    int have_N, have_P, have_Q, have_D, have_E;
+    int n_missing, pq_missing, d_missing, is_pub, is_priv;
+
+    RSA_VALIDATE_RET( ctx != NULL );
+
+    have_N = ( mbedtls_mpi_cmp_int( &ctx->N, 0 ) != 0 );
+    have_P = ( mbedtls_mpi_cmp_int( &ctx->P, 0 ) != 0 );
+    have_Q = ( mbedtls_mpi_cmp_int( &ctx->Q, 0 ) != 0 );
+    have_D = ( mbedtls_mpi_cmp_int( &ctx->D, 0 ) != 0 );
+    have_E = ( mbedtls_mpi_cmp_int( &ctx->E, 0 ) != 0 );
+
+    /*
+     * Check whether provided parameters are enough
+     * to deduce all others. The following incomplete
+     * parameter sets for private keys are supported:
+     *
+     * (1) P, Q missing.
+     * (2) D and potentially N missing.
+     *
+     */
+
+    n_missing  =              have_P &&  have_Q &&  have_D && have_E;
+    pq_missing =   have_N && !have_P && !have_Q &&  have_D && have_E;
+    d_missing  =              have_P &&  have_Q && !have_D && have_E;
+    is_pub     =   have_N && !have_P && !have_Q && !have_D && have_E;
+
+    /* These three alternatives are mutually exclusive */
+    is_priv = n_missing || pq_missing || d_missing;
+
+    if( !is_priv && !is_pub )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    /*
+     * Step 1: Deduce N if P, Q are provided.
+     */
+
+    if( !have_N && have_P && have_Q )
+    {
+        if( ( ret = mbedtls_mpi_mul_mpi( &ctx->N, &ctx->P,
+                                         &ctx->Q ) ) != 0 )
+        {
+            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+        }
+
+        ctx->len = mbedtls_mpi_size( &ctx->N );
+    }
+
+    /*
+     * Step 2: Deduce and verify all remaining core parameters.
+     */
+
+    if( pq_missing )
+    {
+        ret = mbedtls_rsa_deduce_primes( &ctx->N, &ctx->E, &ctx->D,
+                                         &ctx->P, &ctx->Q );
+        if( ret != 0 )
+            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+
+    }
+    else if( d_missing )
+    {
+        if( ( ret = mbedtls_rsa_deduce_private_exponent( &ctx->P,
+                                                         &ctx->Q,
+                                                         &ctx->E,
+                                                         &ctx->D ) ) != 0 )
+        {
+            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+        }
+    }
+
+    /*
+     * Step 3: Deduce all additional parameters specific
+     *         to our current RSA implementation.
+     */
+
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    if( is_priv )
+    {
+        ret = mbedtls_rsa_deduce_crt( &ctx->P,  &ctx->Q,  &ctx->D,
+                                      &ctx->DP, &ctx->DQ, &ctx->QP );
+        if( ret != 0 )
+            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+    }
+#endif /* MBEDTLS_RSA_NO_CRT */
+
+    /*
+     * Step 3: Basic sanity checks
+     */
+
+    return( rsa_check_context( ctx, is_priv, 1 ) );
+}
+#endif
+
+#if defined(MBEDTLS_HI_NO_CUT)
+int mbedtls_rsa_export_raw( const mbedtls_rsa_context *ctx,
+                            unsigned char *N, size_t N_len,
+                            unsigned char *P, size_t P_len,
+                            unsigned char *Q, size_t Q_len,
+                            unsigned char *D, size_t D_len,
+                            unsigned char *E, size_t E_len )
+{
+    int ret = 0;
+    int is_priv;
+    RSA_VALIDATE_RET( ctx != NULL );
+
+    /* Check if key is private or public */
+    is_priv =
+        mbedtls_mpi_cmp_int( &ctx->N, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->P, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->Q, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->D, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->E, 0 ) != 0;
+
+    if( !is_priv )
+    {
+        /* If we're trying to export private parameters for a public key,
+         * something must be wrong. */
+        if( P != NULL || Q != NULL || D != NULL )
+            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    }
+
+    if( N != NULL )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &ctx->N, N, N_len ) );
+
+    if( P != NULL )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &ctx->P, P, P_len ) );
+
+    if( Q != NULL )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &ctx->Q, Q, Q_len ) );
+
+    if( D != NULL )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &ctx->D, D, D_len ) );
+
+    if( E != NULL )
+        MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &ctx->E, E, E_len ) );
+
+cleanup:
+
+    return( ret );
+}
+
+int mbedtls_rsa_export( const mbedtls_rsa_context *ctx,
+                        mbedtls_mpi *N, mbedtls_mpi *P, mbedtls_mpi *Q,
+                        mbedtls_mpi *D, mbedtls_mpi *E )
+{
+    int ret;
+    int is_priv;
+    RSA_VALIDATE_RET( ctx != NULL );
+
+    /* Check if key is private or public */
+    is_priv =
+        mbedtls_mpi_cmp_int( &ctx->N, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->P, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->Q, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->D, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->E, 0 ) != 0;
+
+    if( !is_priv )
+    {
+        /* If we're trying to export private parameters for a public key,
+         * something must be wrong. */
+        if( P != NULL || Q != NULL || D != NULL )
+            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    }
+
+    /* Export all requested core parameters. */
+
+    if( ( N != NULL && ( ret = mbedtls_mpi_copy( N, &ctx->N ) ) != 0 ) ||
+        ( P != NULL && ( ret = mbedtls_mpi_copy( P, &ctx->P ) ) != 0 ) ||
+        ( Q != NULL && ( ret = mbedtls_mpi_copy( Q, &ctx->Q ) ) != 0 ) ||
+        ( D != NULL && ( ret = mbedtls_mpi_copy( D, &ctx->D ) ) != 0 ) ||
+        ( E != NULL && ( ret = mbedtls_mpi_copy( E, &ctx->E ) ) != 0 ) )
+    {
+        return( ret );
+    }
+
+    return( 0 );
+}
+
+/*
+ * Export CRT parameters
+ * This must also be implemented if CRT is not used, for being able to
+ * write DER encoded RSA keys. The helper function mbedtls_rsa_deduce_crt
+ * can be used in this case.
+ */
+int mbedtls_rsa_export_crt( const mbedtls_rsa_context *ctx,
+                            mbedtls_mpi *DP, mbedtls_mpi *DQ, mbedtls_mpi *QP )
+{
+    int ret;
+    int is_priv;
+    RSA_VALIDATE_RET( ctx != NULL );
+
+    /* Check if key is private or public */
+    is_priv =
+        mbedtls_mpi_cmp_int( &ctx->N, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->P, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->Q, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->D, 0 ) != 0 &&
+        mbedtls_mpi_cmp_int( &ctx->E, 0 ) != 0;
+
+    if( !is_priv )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    /* Export all requested blinding parameters. */
+    if( ( DP != NULL && ( ret = mbedtls_mpi_copy( DP, &ctx->DP ) ) != 0 ) ||
+        ( DQ != NULL && ( ret = mbedtls_mpi_copy( DQ, &ctx->DQ ) ) != 0 ) ||
+        ( QP != NULL && ( ret = mbedtls_mpi_copy( QP, &ctx->QP ) ) != 0 ) )
+    {
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+    }
+#else
+    if( ( ret = mbedtls_rsa_deduce_crt( &ctx->P, &ctx->Q, &ctx->D,
+                                        DP, DQ, QP ) ) != 0 )
+    {
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+    }
+#endif
+
+    return( 0 );
+}
+#endif
+
+/*
+ * Initialize an RSA context
+ */
+void mbedtls_rsa_init( mbedtls_rsa_context *ctx,
+               int padding,
+               int hash_id )
+{
+    RSA_VALIDATE( ctx != NULL );
+    RSA_VALIDATE( padding == MBEDTLS_RSA_PKCS_V15 ||
+                  padding == MBEDTLS_RSA_PKCS_V21 );
+
+    memset( ctx, 0, sizeof( mbedtls_rsa_context ) );
+
+    mbedtls_rsa_set_padding( ctx, padding, hash_id );
+
+#if defined(MBEDTLS_THREADING_C)
+    mbedtls_mutex_init( &ctx->mutex );
+#endif
+}
+
+/*
+ * Set padding for an existing RSA context
+ */
+void mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
+                              int hash_id )
+{
+    RSA_VALIDATE( ctx != NULL );
+    RSA_VALIDATE( padding == MBEDTLS_RSA_PKCS_V15 ||
+                  padding == MBEDTLS_RSA_PKCS_V21 );
+
+    ctx->padding = padding;
+    ctx->hash_id = hash_id;
+}
+
+/*
+ * Get length in bytes of RSA modulus
+ */
+
+size_t mbedtls_rsa_get_len( const mbedtls_rsa_context *ctx )
+{
+    return( ctx->len );
+}
+
+
+#if defined(MBEDTLS_GENPRIME)
+
+/*
+ * Generate an RSA keypair
+ *
+ * This generation method follows the RSA key pair generation procedure of
+ * FIPS 186-4 if 2^16 < exponent < 2^256 and nbits = 2048 or nbits = 3072.
+ */
+int mbedtls_rsa_gen_key( mbedtls_rsa_context *ctx,
+                 int (*f_rng)(void *, unsigned char *, size_t),
+                 void *p_rng,
+                 unsigned int nbits, int exponent )
+{
+    int ret;
+    mbedtls_mpi H, G, L;
+    int prime_quality = 0;
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( f_rng != NULL );
+
+    if( nbits < 128 || exponent < 3 || nbits % 2 != 0 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    /*
+     * If the modulus is 1024 bit long or shorter, then the security strength of
+     * the RSA algorithm is less than or equal to 80 bits and therefore an error
+     * rate of 2^-80 is sufficient.
+     */
+    if( nbits > 1024 )
+        prime_quality = MBEDTLS_MPI_GEN_PRIME_FLAG_LOW_ERR;
+
+    mbedtls_mpi_init( &H );
+    mbedtls_mpi_init( &G );
+    mbedtls_mpi_init( &L );
+
+    /*
+     * find primes P and Q with Q < P so that:
+     * 1.  |P-Q| > 2^( nbits / 2 - 100 )
+     * 2.  GCD( E, (P-1)*(Q-1) ) == 1
+     * 3.  E^-1 mod LCM(P-1, Q-1) > 2^( nbits / 2 )
+     */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &ctx->E, exponent ) );
+
+    do
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_gen_prime( &ctx->P, nbits >> 1,
+                                                prime_quality, f_rng, p_rng ) );
+
+        MBEDTLS_MPI_CHK( mbedtls_mpi_gen_prime( &ctx->Q, nbits >> 1,
+                                                prime_quality, f_rng, p_rng ) );
+
+        /* make sure the difference between p and q is not too small (FIPS 186-4.3.3 step 5.4) */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &H, &ctx->P, &ctx->Q ) );
+        if( mbedtls_mpi_bitlen( &H ) <= ( ( nbits >= 200 ) ? ( ( nbits >> 1 ) - 99 ) : 0 ) )
+        {
+            crypto_msleep(1);
+            continue;
+        }
+
+        /* not required by any standards, but some users rely on the fact that P > Q */
+        if( H.s < 0 )
+            mbedtls_mpi_swap( &ctx->P, &ctx->Q );
+
+        /* Temporarily replace P,Q by P-1, Q-1 */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &ctx->P, &ctx->P, 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &ctx->Q, &ctx->Q, 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &H, &ctx->P, &ctx->Q ) );
+
+        /* check GCD( E, (P-1)*(Q-1) ) == 1 (FIPS 186-4.3.1 criterion 2(a)) */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_gcd( &G, &ctx->E, &H  ) );
+        if( mbedtls_mpi_cmp_int( &G, 1 ) != 0 )
+        {
+            crypto_msleep(1);
+            continue;
+        }
+
+        /* compute smallest possible D = E^-1 mod LCM(P-1, Q-1) (FIPS 186-4.3.1 criterion 3(b)) */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_gcd( &G, &ctx->P, &ctx->Q ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_div_mpi( &L, NULL, &H, &G ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_inv_mod( &ctx->D, &ctx->E, &L ) );
+
+        if( mbedtls_mpi_bitlen( &ctx->D ) <= ( ( nbits + 1 ) / 2 ) ) // (FIPS 186-4.3.1 criterion 3(a))
+        {
+            crypto_msleep(1);
+            continue;
+        }
+
+        break;
+    }
+    while( 1 );
+
+    /* Restore P,Q */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_add_int( &ctx->P,  &ctx->P, 1 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_add_int( &ctx->Q,  &ctx->Q, 1 ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &ctx->N, &ctx->P, &ctx->Q ) );
+
+    ctx->len = mbedtls_mpi_size( &ctx->N );
+
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    /*
+     * DP = D mod (P - 1)
+     * DQ = D mod (Q - 1)
+     * QP = Q^-1 mod P
+     */
+    MBEDTLS_MPI_CHK( mbedtls_rsa_deduce_crt( &ctx->P, &ctx->Q, &ctx->D,
+                                             &ctx->DP, &ctx->DQ, &ctx->QP ) );
+#endif /* MBEDTLS_RSA_NO_CRT */
+
+    /* Double-check */
+    MBEDTLS_MPI_CHK( mbedtls_rsa_check_privkey( ctx ) );
+
+cleanup:
+
+    mbedtls_mpi_free( &H );
+    mbedtls_mpi_free( &G );
+    mbedtls_mpi_free( &L );
+
+    if( ret != 0 )
+    {
+        mbedtls_rsa_free( ctx );
+        return( MBEDTLS_ERR_RSA_KEY_GEN_FAILED + ret );
+    }
+
+    return( 0 );
+}
+
+#endif /* MBEDTLS_GENPRIME */
+
+/*
+ * Check a public RSA key
+ */
+int mbedtls_rsa_check_pubkey( const mbedtls_rsa_context *ctx )
+{
+    RSA_VALIDATE_RET( ctx != NULL );
+
+    if( rsa_check_context( ctx, 0 /* public */, 0 /* no blinding */ ) != 0 )
+        return( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
+
+    if( mbedtls_mpi_bitlen( &ctx->N ) < 128 )
+    {
+        return( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
+    }
+
+    if( mbedtls_mpi_get_bit( &ctx->E, 0 ) == 0 ||
+        mbedtls_mpi_bitlen( &ctx->E )     < 2  ||
+        mbedtls_mpi_cmp_mpi( &ctx->E, &ctx->N ) >= 0 )
+    {
+        return( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
+    }
+
+    return( 0 );
+}
+
+/*
+ * Check for the consistency of all fields in an RSA private key context
+ */
+int mbedtls_rsa_check_privkey( const mbedtls_rsa_context *ctx )
+{
+    RSA_VALIDATE_RET( ctx != NULL );
+
+    if( mbedtls_rsa_check_pubkey( ctx ) != 0 ||
+        rsa_check_context( ctx, 1 /* private */, 1 /* blinding */ ) != 0 )
+    {
+        return( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
+    }
+
+    if( mbedtls_rsa_validate_params( &ctx->N, &ctx->P, &ctx->Q,
+                                     &ctx->D, &ctx->E, NULL, NULL ) != 0 )
+    {
+        return( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
+    }
+
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    else if( mbedtls_rsa_validate_crt( &ctx->P, &ctx->Q, &ctx->D,
+                                       &ctx->DP, &ctx->DQ, &ctx->QP ) != 0 )
+    {
+        return( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
+    }
+#endif
+
+    return( 0 );
+}
+
+/*
+ * Check if contexts holding a public and private key match
+ */
+int mbedtls_rsa_check_pub_priv( const mbedtls_rsa_context *pub,
+                                const mbedtls_rsa_context *prv )
+{
+    RSA_VALIDATE_RET( pub != NULL );
+    RSA_VALIDATE_RET( prv != NULL );
+
+    if( mbedtls_rsa_check_pubkey( pub )  != 0 ||
+        mbedtls_rsa_check_privkey( prv ) != 0 )
+    {
+        return( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
+    }
+
+    if( mbedtls_mpi_cmp_mpi( &pub->N, &prv->N ) != 0 ||
+        mbedtls_mpi_cmp_mpi( &pub->E, &prv->E ) != 0 )
+    {
+        return( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
+    }
+
+    return( 0 );
+}
+
+/*
+ * Do an RSA public key operation
+ */
+int mbedtls_rsa_public( mbedtls_rsa_context *ctx,
+                const unsigned char *input,
+                unsigned char *output )
+{
+    int ret;
+    size_t olen;
+    mbedtls_mpi T;
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( input != NULL );
+    RSA_VALIDATE_RET( output != NULL );
+
+    if( rsa_check_context( ctx, 0 /* public */, 0 /* no blinding */ ) )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    mbedtls_mpi_init( &T );
+
+#if defined(MBEDTLS_THREADING_C)
+    if( ( ret = mbedtls_mutex_lock( &ctx->mutex ) ) != 0 )
+        return( ret );
+#endif
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_binary( &T, input, ctx->len ) );
+
+    if( mbedtls_mpi_cmp_mpi( &T, &ctx->N ) >= 0 )
+    {
+        ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
+        goto cleanup;
+    }
+
+    olen = ctx->len;
+    MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &T, &T, &ctx->E, &ctx->N, &ctx->RN ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &T, output, olen ) );
+
+cleanup:
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_mutex_unlock( &ctx->mutex ) != 0 )
+        return( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
+#endif
+
+    mbedtls_mpi_free( &T );
+
+    if( ret != 0 )
+        return( MBEDTLS_ERR_RSA_PUBLIC_FAILED + ret );
+
+    return( 0 );
+}
+
+#if defined(MBEDTLS_HI_NO_CUT)
+/*
+ * Generate or update blinding values, see section 10 of:
+ *  KOCHER, Paul C. Timing attacks on implementations of Diffie-Hellman, RSA,
+ *  DSS, and other systems. In : Advances in Cryptology-CRYPTO'96. Springer
+ *  Berlin Heidelberg, 1996. p. 104-113.
+ */
+static int rsa_prepare_blinding( mbedtls_rsa_context *ctx,
+                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
+{
+    int ret, count = 0;
+
+    if( ctx->Vf.p != NULL )
+    {
+        /* We already have blinding values, just update them by squaring */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &ctx->Vi, &ctx->Vi, &ctx->Vi ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &ctx->Vi, &ctx->Vi, &ctx->N ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &ctx->Vf, &ctx->Vf, &ctx->Vf ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &ctx->Vf, &ctx->Vf, &ctx->N ) );
+
+        goto cleanup;
+    }
+
+    /* Unblinding value: Vf = random number, invertible mod N */
+    do {
+        if( count++ > 10 )
+            return( MBEDTLS_ERR_RSA_RNG_FAILED );
+
+        MBEDTLS_MPI_CHK( mbedtls_mpi_fill_random( &ctx->Vf, ctx->len - 1, f_rng, p_rng ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_gcd( &ctx->Vi, &ctx->Vf, &ctx->N ) );
+    } while( mbedtls_mpi_cmp_int( &ctx->Vi, 1 ) != 0 );
+
+    /* Blinding value: Vi =  Vf^(-e) mod N */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_inv_mod( &ctx->Vi, &ctx->Vf, &ctx->N ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &ctx->Vi, &ctx->Vi, &ctx->E, &ctx->N, &ctx->RN ) );
+
+
+cleanup:
+    return( ret );
+}
+
+/*
+ * Exponent blinding supposed to prevent side-channel attacks using multiple
+ * traces of measurements to recover the RSA key. The more collisions are there,
+ * the more bits of the key can be recovered. See [3].
+ *
+ * Collecting n collisions with m bit long blinding value requires 2^(m-m/n)
+ * observations on avarage.
+ *
+ * For example with 28 byte blinding to achieve 2 collisions the adversary has
+ * to make 2^112 observations on avarage.
+ *
+ * (With the currently (as of 2017 April) known best algorithms breaking 2048
+ * bit RSA requires approximately as much time as trying out 2^112 random keys.
+ * Thus in this sense with 28 byte blinding the security is not reduced by
+ * side-channel attacks like the one in [3])
+ *
+ * This countermeasure does not help if the key recovery is possible with a
+ * single trace.
+ */
+#define RSA_EXPONENT_BLINDING 28
+
+/*
+ * Do an RSA private key operation
+ */
+int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
+                 int (*f_rng)(void *, unsigned char *, size_t),
+                 void *p_rng,
+                 const unsigned char *input,
+                 unsigned char *output )
+{
+    int ret;
+    size_t olen;
+
+    /* Temporary holding the result */
+    mbedtls_mpi T;
+
+    /* Temporaries holding P-1, Q-1 and the
+     * exponent blinding factor, respectively. */
+    mbedtls_mpi P1, Q1, R;
+
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    /* Temporaries holding the results mod p resp. mod q. */
+    mbedtls_mpi TP, TQ;
+
+    /* Temporaries holding the blinded exponents for
+     * the mod p resp. mod q computation (if used). */
+    mbedtls_mpi DP_blind, DQ_blind;
+
+    /* Pointers to actual exponents to be used - either the unblinded
+     * or the blinded ones, depending on the presence of a PRNG. */
+    mbedtls_mpi *DP = &ctx->DP;
+    mbedtls_mpi *DQ = &ctx->DQ;
+#else
+    /* Temporary holding the blinded exponent (if used). */
+    mbedtls_mpi D_blind;
+
+    /* Pointer to actual exponent to be used - either the unblinded
+     * or the blinded one, depending on the presence of a PRNG. */
+    mbedtls_mpi *D = &ctx->D;
+#endif /* MBEDTLS_RSA_NO_CRT */
+
+    /* Temporaries holding the initial input and the double
+     * checked result; should be the same in the end. */
+    mbedtls_mpi I, C;
+
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( input  != NULL );
+    RSA_VALIDATE_RET( output != NULL );
+
+    if( rsa_check_context( ctx, 1             /* private key checks */,
+                                f_rng != NULL /* blinding y/n       */ ) != 0 )
+    {
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+    }
+
+#if defined(MBEDTLS_THREADING_C)
+    if( ( ret = mbedtls_mutex_lock( &ctx->mutex ) ) != 0 )
+        return( ret );
+#endif
+
+    /* MPI Initialization */
+    mbedtls_mpi_init( &T );
+
+    mbedtls_mpi_init( &P1 );
+    mbedtls_mpi_init( &Q1 );
+    mbedtls_mpi_init( &R );
+
+    if( f_rng != NULL )
+    {
+#if defined(MBEDTLS_RSA_NO_CRT)
+        mbedtls_mpi_init( &D_blind );
+#else
+        mbedtls_mpi_init( &DP_blind );
+        mbedtls_mpi_init( &DQ_blind );
+#endif
+    }
+
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    mbedtls_mpi_init( &TP ); mbedtls_mpi_init( &TQ );
+#endif
+
+    mbedtls_mpi_init( &I );
+    mbedtls_mpi_init( &C );
+
+    /* End of MPI initialization */
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_binary( &T, input, ctx->len ) );
+    if( mbedtls_mpi_cmp_mpi( &T, &ctx->N ) >= 0 )
+    {
+        ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
+        goto cleanup;
+    }
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &I, &T ) );
+
+    if( f_rng != NULL )
+    {
+        /*
+         * Blinding
+         * T = T * Vi mod N
+         */
+        MBEDTLS_MPI_CHK( rsa_prepare_blinding( ctx, f_rng, p_rng ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &T, &T, &ctx->Vi ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &T, &T, &ctx->N ) );
+
+        /*
+         * Exponent blinding
+         */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &P1, &ctx->P, 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &Q1, &ctx->Q, 1 ) );
+
+#if defined(MBEDTLS_RSA_NO_CRT)
+        /*
+         * D_blind = ( P - 1 ) * ( Q - 1 ) * R + D
+         */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_fill_random( &R, RSA_EXPONENT_BLINDING,
+                         f_rng, p_rng ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &D_blind, &P1, &Q1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &D_blind, &D_blind, &R ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &D_blind, &D_blind, &ctx->D ) );
+
+        D = &D_blind;
+#else
+        /*
+         * DP_blind = ( P - 1 ) * R + DP
+         */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_fill_random( &R, RSA_EXPONENT_BLINDING,
+                         f_rng, p_rng ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &DP_blind, &P1, &R ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &DP_blind, &DP_blind,
+                    &ctx->DP ) );
+
+        DP = &DP_blind;
+
+        /*
+         * DQ_blind = ( Q - 1 ) * R + DQ
+         */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_fill_random( &R, RSA_EXPONENT_BLINDING,
+                         f_rng, p_rng ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &DQ_blind, &Q1, &R ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &DQ_blind, &DQ_blind,
+                    &ctx->DQ ) );
+
+        DQ = &DQ_blind;
+#endif /* MBEDTLS_RSA_NO_CRT */
+    }
+
+#if defined(MBEDTLS_RSA_NO_CRT)
+    MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &T, &T, D, &ctx->N, &ctx->RN ) );
+#else
+    /*
+     * Faster decryption using the CRT
+     *
+     * TP = input ^ dP mod P
+     * TQ = input ^ dQ mod Q
+     */
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &TP, &T, DP, &ctx->P, &ctx->RP ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &TQ, &T, DQ, &ctx->Q, &ctx->RQ ) );
+
+    /*
+     * T = (TP - TQ) * (Q^-1 mod P) mod P
+     */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &T, &TP, &TQ ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &TP, &T, &ctx->QP ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &T, &TP, &ctx->P ) );
+
+    /*
+     * T = TQ + T * Q
+     */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &TP, &T, &ctx->Q ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &T, &TQ, &TP ) );
+#endif /* MBEDTLS_RSA_NO_CRT */
+
+    if( f_rng != NULL )
+    {
+        /*
+         * Unblind
+         * T = T * Vf mod N
+         */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &T, &T, &ctx->Vf ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &T, &T, &ctx->N ) );
+    }
+
+    /* Verify the result to prevent glitching attacks. */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &C, &T, &ctx->E,
+                                          &ctx->N, &ctx->RN ) );
+    if( mbedtls_mpi_cmp_mpi( &C, &I ) != 0 )
+    {
+        ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
+        goto cleanup;
+    }
+
+    olen = ctx->len;
+    MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &T, output, olen ) );
+
+cleanup:
+#if defined(MBEDTLS_THREADING_C)
+    if( mbedtls_mutex_unlock( &ctx->mutex ) != 0 )
+        return( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
+#endif
+
+    mbedtls_mpi_free( &P1 );
+    mbedtls_mpi_free( &Q1 );
+    mbedtls_mpi_free( &R );
+
+    if( f_rng != NULL )
+    {
+#if defined(MBEDTLS_RSA_NO_CRT)
+        mbedtls_mpi_free( &D_blind );
+#else
+        mbedtls_mpi_free( &DP_blind );
+        mbedtls_mpi_free( &DQ_blind );
+#endif
+    }
+
+    mbedtls_mpi_free( &T );
+
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    mbedtls_mpi_free( &TP ); mbedtls_mpi_free( &TQ );
+#endif
+
+    mbedtls_mpi_free( &C );
+    mbedtls_mpi_free( &I );
+
+    if( ret != 0 )
+        return( MBEDTLS_ERR_RSA_PRIVATE_FAILED + ret );
+
+    return( 0 );
+}
+#else
+int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
+                 int (*f_rng)(void *, unsigned char *, size_t),
+                 void *p_rng,
+                 const unsigned char *input,
+                 unsigned char *output )
+{
+    int ret;
+    size_t olen;
+    mbedtls_mpi T, T1, T2;
+    mbedtls_mpi P1, Q1, R;
+    int crt = 0;
+    mbedtls_mpi *D = &ctx->D;
+    mbedtls_mpi *DP = &ctx->DP;
+    mbedtls_mpi *DQ = &ctx->DQ;
+
+    /* Make sure we have private key info, prevent possible misuse */
+    if( ctx->D.p != NULL )
+    {
+        crt = 0;
+    }
+    else if( ctx->P.p != NULL
+        && ctx->Q.p != NULL
+        && ctx->DP.p != NULL
+        && ctx->DQ.p != NULL
+        && ctx->QP.p != NULL )
+    {
+        crt = 1;
+    }
+    else
+    {
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+    }
+
+    mbedtls_mpi_init( &T ); mbedtls_mpi_init( &T1 ); mbedtls_mpi_init( &T2 );
+    mbedtls_mpi_init( &P1 ); mbedtls_mpi_init( &Q1 ); mbedtls_mpi_init( &R );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_binary( &T, input, ctx->len ) );
+   /* Remove the check of input >= N
+    * For DH, G(input) > P(N) is allowed,
+    * For RSA, the check of input >= N is do by cryp_check_data
+    * in cryp_rsa.c.
+    */
+
+    if ( crt == 0)
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &T, &T, D, &ctx->N, &ctx->RN ) );
+    }
+    else
+    {
+        /*
+         * faster decryption using the CRT
+         *
+         * T1 = input ^ dP mod P
+         * T2 = input ^ dQ mod Q
+         */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &T1, &T, DP, &ctx->P, &ctx->RP ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &T2, &T, DQ, &ctx->Q, &ctx->RQ ) );
+
+        /*
+         * T = (T1 - T2) * (Q^-1 mod P) mod P
+         */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &T, &T1, &T2 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &T1, &T, &ctx->QP ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &T, &T1, &ctx->P ) );
+
+        /*
+         * T = T2 + T * Q
+         */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &T1, &T, &ctx->Q ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &T, &T2, &T1 ) );
+    }
+
+    olen = ctx->len;
+    MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &T, output, olen ) );
+
+cleanup:
+
+    mbedtls_mpi_free( &T ); mbedtls_mpi_free( &T1 ); mbedtls_mpi_free( &T2 );
+    mbedtls_mpi_free( &P1 ); mbedtls_mpi_free( &Q1 ); mbedtls_mpi_free( &R );
+
+    if( ret != 0 )
+        return( MBEDTLS_ERR_RSA_PRIVATE_FAILED + ret );
+
+    return( 0 );
+}
+#endif
+
+#if defined(MBEDTLS_PKCS1_V21)
+static void mbedtls_get_hash_info(mbedtls_md_type_t type,
+                                  unsigned int *hlen,
+                                  hi_cipher_hash_type *hisi_type)
+{
+    hi_cipher_hash_type shatype = HI_CIPHER_HASH_TYPE_SHA1;
+
+    switch(type)
+    {
+        case MBEDTLS_MD_SHA1:
+            *hlen = 20;
+            shatype = HI_CIPHER_HASH_TYPE_SHA1;
+            break;
+        case MBEDTLS_MD_SHA224:
+            *hlen = 28;
+            shatype = HI_CIPHER_HASH_TYPE_SHA224;
+            break;
+        case MBEDTLS_MD_SHA256:
+            *hlen = 32;
+            shatype = HI_CIPHER_HASH_TYPE_SHA256;
+            break;
+        case MBEDTLS_MD_SHA384:
+            *hlen = 48;
+            shatype = HI_CIPHER_HASH_TYPE_SHA384;
+            break;
+        case MBEDTLS_MD_SHA512:
+            *hlen = 64;
+            shatype = HI_CIPHER_HASH_TYPE_SHA512;
+            break;
+        default:
+            *hlen = 0;
+            shatype = 0;
+            break;
+    }
+
+    if (HI_NULL != hisi_type)
+    {
+        *hisi_type = shatype;
+    }
+}
+
+/**
+ * Generate and apply the MGF1 operation (from PKCS#1 v2.1) to a buffer.
+ *
+ * \param dst       buffer to mask
+ * \param dlen      length of destination buffer
+ * \param src       source of the mask generation
+ * \param slen      length of the source buffer
+ * \param md_ctx    message digest context to use
+ */
+static int mgf_mask( unsigned char *dst, size_t dlen, unsigned char *src,
+                      size_t slen, mbedtls_md_type_t type )
+{
+    unsigned char mask[MBEDTLS_MD_MAX_SIZE];
+    unsigned char counter[4];
+    unsigned char *p;
+    unsigned int hlen, hisi_hlen;
+    size_t i, use_len;
+    hi_cipher_hash_type hisi_type = 0;
+    hi_u32 hashid = 0;
+    int ret = 0;
+
+    memset( mask, 0, MBEDTLS_MD_MAX_SIZE );
+    memset( counter, 0, 4 );
+
+    mbedtls_get_hash_info( type, &hlen, &hisi_type);
+
+    /* Generate and apply dbMask */
+    p = dst;
+
+    while( dlen > 0 )
+    {
+        use_len = hlen;
+        if( dlen < hlen )
+            use_len = dlen;
+
+        MBEDTLS_MPI_CHK(kapi_hash_start( &hashid, hisi_type, NULL, 0 ));
+        MBEDTLS_MPI_CHK(kapi_hash_update( hashid, src, slen, HASH_CHUNCK_SRC_LOCAL ));
+        MBEDTLS_MPI_CHK(kapi_hash_update( hashid, counter, 4, HASH_CHUNCK_SRC_LOCAL ));
+        MBEDTLS_MPI_CHK(kapi_hash_finish( hashid, mask, &hisi_hlen ));
+
+        for( i = 0; i < use_len; ++i )
+            *p++ ^= mask[i];
+
+        counter[3]++;
+
+        dlen -= use_len;
+    }
+
+cleanup:
+    mbedtls_platform_zeroize( mask, sizeof( mask ) );
+
+    return( ret );
+}
+#endif /* MBEDTLS_PKCS1_V21 */
+
+#if defined(MBEDTLS_PKCS1_V21)
+/*
+ * Implementation of the PKCS#1 v2.1 RSAES-OAEP-ENCRYPT function
+ */
+int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
+                            int (*f_rng)(void *, unsigned char *, size_t),
+                            void *p_rng,
+                            int mode,
+                            const unsigned char *label, size_t label_len,
+                            size_t ilen,
+                            const unsigned char *input,
+                            unsigned char *output )
+{
+    size_t olen;
+    int ret;
+    unsigned char *p = output;
+    unsigned int hlen, hisi_hlen;
+    hi_cipher_hash_type hisi_type = 0;
+    hi_u32 hashid = 0;
+
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( output != NULL );
+    RSA_VALIDATE_RET( input != NULL );
+    RSA_VALIDATE_RET( label_len == 0 || label != NULL );
+
+    if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V21 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    if( f_rng == NULL )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    olen = ctx->len;
+    mbedtls_get_hash_info(ctx->hash_id, &hlen, &hisi_type);
+
+    /* first comparison checks for overflow */
+    if( ilen + 2 * hlen + 2 < ilen || olen < ilen + 2 * hlen + 2 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    memset( output, 0, olen );
+
+    *p++ = 0;
+
+    /* Generate a random octet string seed */
+    if( ( ret = f_rng( p_rng, p, hlen ) ) != 0 )
+        return( MBEDTLS_ERR_RSA_RNG_FAILED + ret );
+
+    p += hlen;
+
+    /* Construct DB */
+    MBEDTLS_MPI_CHK(kapi_hash_start( &hashid, hisi_type, NULL, 0 ));
+    MBEDTLS_MPI_CHK(kapi_hash_update( hashid, (hi_u8 *)label, label_len, HASH_CHUNCK_SRC_LOCAL));
+    MBEDTLS_MPI_CHK(kapi_hash_finish( hashid, p, &hisi_hlen));
+
+    p += hlen;
+    p += olen - 2 * hlen - 2 - ilen;
+    *p++ = 1;
+    memcpy( p, input, ilen );
+
+    /* maskedDB: Apply dbMask to DB */
+    if( ( ret = mgf_mask( output + hlen + 1, olen - hlen - 1, output + 1, hlen,
+               ctx->hash_id )) != 0 )
+        goto exit;
+
+    /* maskedSeed: Apply seedMask to seed */
+    if( ( ret = mgf_mask( output + 1, hlen, output + hlen + 1, olen - hlen - 1,
+               ctx->hash_id ) ) != 0 )
+        goto exit;
+
+exit:
+    if( ret != 0 )
+        return( ret );
+
+    return( ( mode == MBEDTLS_RSA_PUBLIC )
+            ? mbedtls_rsa_public(  ctx, output, output )
+            : mbedtls_rsa_private( ctx, f_rng, p_rng, output, output ) );
+cleanup:
+    return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
+}
+#endif /* MBEDTLS_PKCS1_V21 */
+
+#if defined(MBEDTLS_PKCS1_V15)
+/*
+ * Implementation of the PKCS#1 v2.1 RSAES-PKCS1-V1_5-ENCRYPT function
+ */
+int mbedtls_rsa_rsaes_pkcs1_v15_encrypt( mbedtls_rsa_context *ctx,
+                                 int (*f_rng)(void *, unsigned char *, size_t),
+                                 void *p_rng,
+                                 int mode, size_t ilen,
+                                 const unsigned char *input,
+                                 unsigned char *output )
+{
+    size_t nb_pad, olen;
+    int ret;
+    unsigned char *p = output;
+
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( output != NULL );
+    RSA_VALIDATE_RET( input != NULL );
+
+    if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V15 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    olen = ctx->len;
+
+    /* first comparison checks for overflow */
+    if( ilen + 11 < ilen || olen < ilen + 11 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    nb_pad = olen - 3 - ilen;
+
+    *p++ = 0;
+    if( mode == MBEDTLS_RSA_PUBLIC )
+    {
+        if( f_rng == NULL )
+            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+        *p++ = MBEDTLS_RSA_CRYPT;
+
+        while( nb_pad-- > 0 )
+        {
+            int rng_dl = 100;
+
+            do {
+                ret = f_rng( p_rng, p, 1 );
+            } while( *p == 0 && --rng_dl && ret == 0 );
+
+            /* Check if RNG failed to generate data */
+            if( rng_dl == 0 || ret != 0 )
+                return( MBEDTLS_ERR_RSA_RNG_FAILED + ret );
+
+            p++;
+        }
+    }
+    else
+    {
+        *p++ = MBEDTLS_RSA_SIGN;
+
+        while( nb_pad-- > 0 )
+            *p++ = 0xFF;
+    }
+
+    *p++ = 0;
+    memcpy( p, input, ilen );
+
+    return( ( mode == MBEDTLS_RSA_PUBLIC )
+            ? mbedtls_rsa_public(  ctx, output, output )
+            : mbedtls_rsa_private( ctx, f_rng, p_rng, output, output ) );
+}
+#endif /* MBEDTLS_PKCS1_V15 */
+
+/*
+ * Add the message padding, then do an RSA operation
+ */
+int mbedtls_rsa_pkcs1_encrypt( mbedtls_rsa_context *ctx,
+                       int (*f_rng)(void *, unsigned char *, size_t),
+                       void *p_rng,
+                       int mode, size_t ilen,
+                       const unsigned char *input,
+                       unsigned char *output )
+{
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( output != NULL );
+    RSA_VALIDATE_RET( input != NULL );
+
+    switch( ctx->padding )
+    {
+#if defined(MBEDTLS_PKCS1_V15)
+        case MBEDTLS_RSA_PKCS_V15:
+            return mbedtls_rsa_rsaes_pkcs1_v15_encrypt( ctx, f_rng, p_rng, mode, ilen,
+                                                input, output );
+#endif
+
+#if defined(MBEDTLS_PKCS1_V21)
+        case MBEDTLS_RSA_PKCS_V21:
+            return mbedtls_rsa_rsaes_oaep_encrypt( ctx, f_rng, p_rng, mode, NULL, 0,
+                                           ilen, input, output );
+#endif
+
+        default:
+            return( MBEDTLS_ERR_RSA_INVALID_PADDING );
+    }
+}
+
+#if defined(MBEDTLS_PKCS1_V21)
+/*
+ * Implementation of the PKCS#1 v2.1 RSAES-OAEP-DECRYPT function
+ */
+int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
+                            int (*f_rng)(void *, unsigned char *, size_t),
+                            void *p_rng,
+                            int mode,
+                            const unsigned char *label, size_t label_len,
+                            size_t *olen,
+                            const unsigned char *input,
+                            unsigned char *output,
+                            size_t output_max_len )
+{
+    int ret;
+    size_t ilen, i, pad_len;
+    unsigned char *p, bad, pad_done;
+    unsigned char *buf = NULL;
+    unsigned char *lhash = NULL;
+    unsigned int hlen, hisi_hlen;
+    hi_cipher_hash_type hisi_type = 0;
+    hi_u32 hashid = 0;
+
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( output_max_len == 0 || output != NULL );
+    RSA_VALIDATE_RET( label_len == 0 || label != NULL );
+    RSA_VALIDATE_RET( input != NULL );
+    RSA_VALIDATE_RET( olen != NULL );
+
+    /* Parameters sanity checks */
+    if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V21 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    ilen = ctx->len;
+
+    if( ilen < 16 || ilen > MBEDTLS_MPI_MAX_SIZE )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    buf = (unsigned char *)mbedtls_calloc(MBEDTLS_MPI_MAX_SIZE,sizeof(unsigned char));
+    if (buf == NULL)
+    {
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+    }
+    memset( buf, 0, sizeof( unsigned char )* MBEDTLS_MPI_MAX_SIZE );
+
+    lhash = (unsigned char *)mbedtls_calloc(MBEDTLS_MD_MAX_SIZE,sizeof(unsigned char));
+    if (lhash == NULL)
+    {
+        if (buf != NULL)
+        {
+            mbedtls_free(buf);
+            buf = NULL;
+        }
+
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+    }
+    memset( lhash, 0, sizeof( unsigned char )* MBEDTLS_MD_MAX_SIZE );
+
+    /* RSA operation */
+    ret = ( mode == MBEDTLS_RSA_PUBLIC )
+          ? mbedtls_rsa_public(  ctx, input, buf )
+          : mbedtls_rsa_private( ctx, f_rng, p_rng, input, buf );
+
+    if( ret != 0 )
+        goto cleanup;
+
+    mbedtls_get_hash_info(ctx->hash_id, &hlen, &hisi_type);
+
+    // checking for integer underflow
+    if( 2 * hlen + 2 > ilen )
+    {
+        ret =  MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
+        goto cleanup;
+    }
+
+    /*
+     * RSA operation
+     */
+    ret = ( mode == MBEDTLS_RSA_PUBLIC )
+          ? mbedtls_rsa_public(  ctx, input, buf )
+          : mbedtls_rsa_private( ctx, f_rng, p_rng, input, buf );
+
+    if( ret != 0 )
+        goto cleanup;
+
+    /* seed: Apply seedMask to maskedSeed */
+    if( ( ret = mgf_mask( buf + 1, hlen, buf + hlen + 1, ilen - hlen - 1,
+               ctx->hash_id )) != 0 ||
+
+    /* DB: Apply dbMask to maskedDB */
+        ( ret = mgf_mask( buf + hlen + 1, ilen - hlen - 1, buf + 1, hlen,
+               ctx->hash_id ) ) != 0 )
+    {
+        goto cleanup;
+    }
+
+    /* Generate lHash */
+    MBEDTLS_MPI_CHK(kapi_hash_start( &hashid, hisi_type, NULL, 0 ));
+    MBEDTLS_MPI_CHK(kapi_hash_update( hashid, (hi_u8 *)label, label_len, HASH_CHUNCK_SRC_LOCAL ));
+    MBEDTLS_MPI_CHK(kapi_hash_finish( hashid, lhash, &hisi_hlen ));
+
+    /*
+     * Check contents, in "constant-time"
+     */
+    p = buf;
+    bad = 0;
+
+    bad |= *p++; /* First byte must be 0 */
+
+    p += hlen; /* Skip seed */
+
+    /* Check lHash */
+    for( i = 0; i < hlen; i++ )
+        bad |= lhash[i] ^ *p++;
+
+    /* Get zero-padding len, but always read till end of buffer
+     * (minus one, for the 01 byte) */
+    pad_len = 0;
+    pad_done = 0;
+    for( i = 0; i < ilen - 2 * hlen - 2; i++ )
+    {
+        pad_done |= p[i];
+        pad_len += ((pad_done | (unsigned char)-pad_done) >> 7) ^ 1;
+    }
+
+    p += pad_len;
+    bad |= *p++ ^ 0x01;
+
+    /*
+     * The only information "leaked" is whether the padding was correct or not
+     * (eg, no data is copied if it was not correct). This meets the
+     * recommendations in PKCS#1 v2.2: an opponent cannot distinguish between
+     * the different error conditions.
+     */
+    if( bad != 0 )
+    {
+        ret = MBEDTLS_ERR_RSA_INVALID_PADDING;
+        goto cleanup;
+    }
+
+    if( ilen - ( p - buf ) > output_max_len )
+    {
+        ret = MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE;
+        goto cleanup;
+    }
+
+    *olen = ilen - (p - buf);
+    memcpy( output, p, *olen );
+    ret = 0;
+
+cleanup:
+    mbedtls_platform_zeroize( buf, sizeof( unsigned char ) * MBEDTLS_MPI_MAX_SIZE );
+    mbedtls_platform_zeroize( lhash, sizeof( unsigned char ) * MBEDTLS_MD_MAX_SIZE );
+
+    if (buf != NULL)
+    {
+        mbedtls_free(buf);
+        buf = NULL;
+    }
+    if (lhash != NULL)
+    {
+        mbedtls_free(lhash);
+        lhash = NULL;
+    }
+
+    return( ret );
+}
+#endif /* MBEDTLS_PKCS1_V21 */
+
+#if defined(MBEDTLS_PKCS1_V15)
+/** Turn zero-or-nonzero into zero-or-all-bits-one, without branches.
+ *
+ * \param value     The value to analyze.
+ * \return          Zero if \p value is zero, otherwise all-bits-one.
+ */
+static unsigned all_or_nothing_int( unsigned value )
+{
+    /* MSVC has a warning about unary minus on unsigned, but this is
+     * well-defined and precisely what we want to do here */
+#if defined(_MSC_VER)
+#pragma warning( push )
+#pragma warning( disable : 4146 )
+#endif
+    return( - ( ( value | - value ) >> ( sizeof( value ) * 8 - 1 ) ) );
+#if defined(_MSC_VER)
+#pragma warning( pop )
+#endif
+}
+
+/** Check whether a size is out of bounds, without branches.
+ *
+ * This is equivalent to `size > max`, but is likely to be compiled to
+ * to code using bitwise operation rather than a branch.
+ *
+ * \param size      Size to check.
+ * \param max       Maximum desired value for \p size.
+ * \return          \c 0 if `size <= max`.
+ * \return          \c 1 if `size > max`.
+ */
+static unsigned size_greater_than( size_t size, size_t max )
+{
+    /* Return the sign bit (1 for negative) of (max - size). */
+    return( ( max - size ) >> ( sizeof( size_t ) * 8 - 1 ) );
+}
+
+/** Choose between two integer values, without branches.
+ *
+ * This is equivalent to `cond ? if1 : if0`, but is likely to be compiled
+ * to code using bitwise operation rather than a branch.
+ *
+ * \param cond      Condition to test.
+ * \param if1       Value to use if \p cond is nonzero.
+ * \param if0       Value to use if \p cond is zero.
+ * \return          \c if1 if \p cond is nonzero, otherwise \c if0.
+ */
+static unsigned if_int( unsigned cond, unsigned if1, unsigned if0 )
+{
+    unsigned mask = all_or_nothing_int( cond );
+    return( ( mask & if1 ) | (~mask & if0 ) );
+}
+
+/** Shift some data towards the left inside a buffer without leaking
+ * the length of the data through side channels.
+ *
+ * `mem_move_to_left(start, total, offset)` is functionally equivalent to
+ * ```
+ * memmove(start, start + offset, total - offset);
+ * memset(start + offset, 0, total - offset);
+ * ```
+ * but it strives to use a memory access pattern (and thus total timing)
+ * that does not depend on \p offset. This timing independence comes at
+ * the expense of performance.
+ *
+ * \param start     Pointer to the start of the buffer.
+ * \param total     Total size of the buffer.
+ * \param offset    Offset from which to copy \p total - \p offset bytes.
+ */
+static void mem_move_to_left( void *start,
+                              size_t total,
+                              size_t offset )
+{
+    volatile unsigned char *buf = start;
+    size_t i, n;
+    if( total == 0 )
+        return;
+    for( i = 0; i < total; i++ )
+    {
+        unsigned no_op = size_greater_than( total - offset, i );
+        /* The first `total - offset` passes are a no-op. The last
+         * `offset` passes shift the data one byte to the left and
+         * zero out the last byte. */
+        for( n = 0; n < total - 1; n++ )
+        {
+            unsigned char current_char = buf[n];
+            unsigned char next = buf[n+1];
+            buf[n] = if_int( no_op, current_char, next );
+        }
+        buf[total-1] = if_int( no_op, buf[total-1], 0 );
+    }
+}
+
+/*
+ * Implementation of the PKCS#1 v2.1 RSAES-PKCS1-V1_5-DECRYPT function
+ */
+int mbedtls_rsa_rsaes_pkcs1_v15_decrypt( mbedtls_rsa_context *ctx,
+                                 int (*f_rng)(void *, unsigned char *, size_t),
+                                 void *p_rng,
+                                 int mode, size_t *olen,
+                                 const unsigned char *input,
+                                 unsigned char *output,
+                                 size_t output_max_len )
+{
+    int ret;
+    size_t ilen, i, plaintext_max_size;
+    unsigned char *buf = NULL;
+    /* The following variables take sensitive values: their value must
+     * not leak into the observable behavior of the function other than
+     * the designated outputs (output, olen, return value). Otherwise
+     * this would open the execution of the function to
+     * side-channel-based variants of the Bleichenbacher padding oracle
+     * attack. Potential side channels include overall timing, memory
+     * access patterns (especially visible to an adversary who has access
+     * to a shared memory cache), and branches (especially visible to
+     * an adversary who has access to a shared code cache or to a shared
+     * branch predictor). */
+    size_t pad_count = 0;
+    unsigned bad = 0;
+    unsigned char pad_done = 0;
+    size_t plaintext_size = 0;
+    unsigned output_too_large;
+
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( output_max_len == 0 || output != NULL );
+    RSA_VALIDATE_RET( input != NULL );
+    RSA_VALIDATE_RET( olen != NULL );
+
+    ilen = ctx->len;
+    plaintext_max_size = ( output_max_len > ilen - 11 ?
+                           ilen - 11 :
+                           output_max_len );
+
+    if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V15 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    if( ilen < 16 || ilen > MBEDTLS_MPI_MAX_SIZE )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    buf = (unsigned char *)mbedtls_calloc(MBEDTLS_MPI_MAX_SIZE,sizeof(unsigned char));
+    if (buf == NULL)
+    {
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+    }
+    memset( buf, 0, sizeof( unsigned char )* MBEDTLS_MPI_MAX_SIZE );
+
+    ret = ( mode == MBEDTLS_RSA_PUBLIC )
+          ? mbedtls_rsa_public(  ctx, input, buf )
+          : mbedtls_rsa_private( ctx, f_rng, p_rng, input, buf );
+
+    if( ret != 0 )
+        goto cleanup;
+
+    /* Check and get padding length in constant time and constant
+     * memory trace. The first byte must be 0. */
+    bad |= buf[0];
+
+    if( mode == MBEDTLS_RSA_PRIVATE )
+    {
+        /* Decode EME-PKCS1-v1_5 padding: 0x00 || 0x02 || PS || 0x00
+         * where PS must be at least 8 nonzero bytes. */
+        bad |= buf[1] ^ MBEDTLS_RSA_CRYPT;
+
+        /* Read the whole buffer. Set pad_done to nonzero if we find
+         * the 0x00 byte and remember the padding length in pad_count. */
+        for( i = 2; i < ilen; i++ )
+        {
+            pad_done  |= ((buf[i] | (unsigned char)-buf[i]) >> 7) ^ 1;
+            pad_count += ((pad_done | (unsigned char)-pad_done) >> 7) ^ 1;
+        }
+    }
+    else
+    {
+        /* Decode EMSA-PKCS1-v1_5 padding: 0x00 || 0x01 || PS || 0x00
+         * where PS must be at least 8 bytes with the value 0xFF. */
+        bad |= buf[1] ^ MBEDTLS_RSA_SIGN;
+
+        /* Read the whole buffer. Set pad_done to nonzero if we find
+         * the 0x00 byte and remember the padding length in pad_count.
+         * If there's a non-0xff byte in the padding, the padding is bad. */
+        for( i = 2; i < ilen; i++ )
+        {
+            pad_done |= if_int( buf[i], 0, 1 );
+            pad_count += if_int( pad_done, 0, 1 );
+            bad |= if_int( pad_done, 0, buf[i] ^ 0xFF );
+        }
+    }
+
+    /* If pad_done is still zero, there's no data, only unfinished padding. */
+    bad |= if_int( pad_done, 0, 1 );
+
+    /* There must be at least 8 bytes of padding. */
+    bad |= size_greater_than( 8, pad_count );
+
+    /* If the padding is valid, set plaintext_size to the number of
+     * remaining bytes after stripping the padding. If the padding
+     * is invalid, avoid leaking this fact through the size of the
+     * output: use the maximum message size that fits in the output
+     * buffer. Do it without branches to avoid leaking the padding
+     * validity through timing. RSA keys are small enough that all the
+     * size_t values involved fit in unsigned int. */
+    plaintext_size = if_int( bad,
+                             (unsigned) plaintext_max_size,
+                             (unsigned) ( ilen - pad_count - 3 ) );
+
+    /* Set output_too_large to 0 if the plaintext fits in the output
+     * buffer and to 1 otherwise. */
+    output_too_large = size_greater_than( plaintext_size,
+                                          plaintext_max_size );
+
+    /* Set ret without branches to avoid timing attacks. Return:
+     * - INVALID_PADDING if the padding is bad (bad != 0).
+     * - OUTPUT_TOO_LARGE if the padding is good but the decrypted
+     *   plaintext does not fit in the output buffer.
+     * - 0 if the padding is correct. */
+    ret = - (int) if_int( bad, - MBEDTLS_ERR_RSA_INVALID_PADDING,
+                  if_int( output_too_large, - MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE,
+                          0 ) );
+
+    /* If the padding is bad or the plaintext is too large, zero the
+     * data that we're about to copy to the output buffer.
+     * We need to copy the same amount of data
+     * from the same buffer whether the padding is good or not to
+     * avoid leaking the padding validity through overall timing or
+     * through memory or cache access patterns. */
+    bad = all_or_nothing_int( bad | output_too_large );
+    for( i = 11; i < ilen; i++ )
+        buf[i] &= ~bad;
+
+    /* If the plaintext is too large, truncate it to the buffer size.
+     * Copy anyway to avoid revealing the length through timing, because
+     * revealing the length is as bad as revealing the padding validity
+     * for a Bleichenbacher attack. */
+    plaintext_size = if_int( output_too_large,
+                             (unsigned) plaintext_max_size,
+                             (unsigned) plaintext_size );
+
+    /* Move the plaintext to the leftmost position where it can start in
+     * the working buffer, i.e. make it start plaintext_max_size from
+     * the end of the buffer. Do this with a memory access trace that
+     * does not depend on the plaintext size. After this move, the
+     * starting location of the plaintext is no longer sensitive
+     * information. */
+    mem_move_to_left( buf + ilen - plaintext_max_size,
+                      plaintext_max_size,
+                      plaintext_max_size - plaintext_size );
+
+    /* Finally copy the decrypted plaintext plus trailing zeros
+     * into the output buffer. */
+    memcpy( output, buf + ilen - plaintext_max_size, plaintext_max_size );
+
+    /* Report the amount of data we copied to the output buffer. In case
+     * of errors (bad padding or output too large), the value of *olen
+     * when this function returns is not specified. Making it equivalent
+     * to the good case limits the risks of leaking the padding validity. */
+    *olen = plaintext_size;
+
+cleanup:
+    mbedtls_platform_zeroize( buf, sizeof( unsigned char ) * MBEDTLS_MPI_MAX_SIZE  );
+
+    if (buf != NULL)
+    {
+        mbedtls_free(buf);
+        buf = NULL;
+    }
+
+    return( ret );
+}
+#endif /* MBEDTLS_PKCS1_V15 */
+
+/*
+ * Do an RSA operation, then remove the message padding
+ */
+int mbedtls_rsa_pkcs1_decrypt( mbedtls_rsa_context *ctx,
+                       int (*f_rng)(void *, unsigned char *, size_t),
+                       void *p_rng,
+                       int mode, size_t *olen,
+                       const unsigned char *input,
+                       unsigned char *output,
+                       size_t output_max_len)
+{
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( output_max_len == 0 || output != NULL );
+    RSA_VALIDATE_RET( input != NULL );
+    RSA_VALIDATE_RET( olen != NULL );
+
+    switch( ctx->padding )
+    {
+#if defined(MBEDTLS_PKCS1_V15)
+        case MBEDTLS_RSA_PKCS_V15:
+            return mbedtls_rsa_rsaes_pkcs1_v15_decrypt( ctx, f_rng, p_rng, mode, olen,
+                                                input, output, output_max_len );
+#endif
+
+#if defined(MBEDTLS_PKCS1_V21)
+        case MBEDTLS_RSA_PKCS_V21:
+            return mbedtls_rsa_rsaes_oaep_decrypt( ctx, f_rng, p_rng, mode, NULL, 0,
+                                           olen, input, output,
+                                           output_max_len );
+#endif
+
+        default:
+            return( MBEDTLS_ERR_RSA_INVALID_PADDING );
+    }
+}
+
+#if defined(MBEDTLS_PKCS1_V21)
+/*
+ * Implementation of the PKCS#1 v2.1 RSASSA-PSS-SIGN function
+ */
+int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
+                         int (*f_rng)(void *, unsigned char *, size_t),
+                         void *p_rng,
+                         int mode,
+                         mbedtls_md_type_t md_alg,
+                         unsigned int hashlen,
+                         const unsigned char *hash,
+                         unsigned char *sig )
+{
+    size_t olen;
+    unsigned char *p = sig;
+    unsigned char salt[MBEDTLS_MD_MAX_SIZE] = {0};
+    size_t slen, min_slen, hlen, offset = 0;
+    int ret = HI_FAILURE;
+    size_t msb;
+    unsigned int hisi_hlen = 0, hashid = 0;
+    hi_cipher_hash_type hisi_type = 0;
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
+                        hashlen == 0 ) ||
+                      hash != NULL );
+    RSA_VALIDATE_RET( sig != NULL );
+
+    if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V21 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    if( f_rng == NULL )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    memset(&hisi_type, 0, sizeof(hisi_type));
+
+    olen = ctx->len;
+
+    if( md_alg != MBEDTLS_MD_NONE )
+    {
+        /* Gather length of hash to sign */
+        mbedtls_get_hash_info( ctx->hash_id, &hashlen, &hisi_type);
+    }
+
+    hlen = hashlen;
+
+    /* Calculate the largest possible salt length. Normally this is the hash
+     * length, which is the maximum length the salt can have. If there is not
+     * enough room, use the maximum salt length that fits. The constraint is
+     * that the hash length plus the salt length plus 2 bytes must be at most
+     * the key length. This complies with FIPS 186-4.5.5 (e) and RFC 8017
+     * (PKCS#1 v2.2) 9.1.1 step 3. */
+    min_slen = hlen - 2;
+    if( olen < hlen + min_slen + 2 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+    else if( olen >= hlen + hlen + 2 )
+        slen = hlen;
+    else
+        slen = olen - hlen - 2;
+
+    memset( sig, 0, olen );
+
+    /* Generate salt of length slen */
+    if( ( ret = f_rng( p_rng, salt, slen ) ) != 0 )
+        return( MBEDTLS_ERR_RSA_RNG_FAILED + ret );
+
+    /* Note: EMSA-PSS encoding is over the length of N - 1 bits */
+    if (1 > mbedtls_mpi_bitlen( &ctx->N ))
+        return ( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
+
+    msb = mbedtls_mpi_bitlen( &ctx->N ) - 1;
+    p += olen - hlen - slen - 2;
+    *p++ = 0x01;
+    memcpy( p, salt, slen );
+    p += slen;
+
+    /* Generate H = Hash( M' ) */
+    MBEDTLS_MPI_CHK(kapi_hash_start( &hashid, hisi_type, NULL, 0 ));
+    MBEDTLS_MPI_CHK(kapi_hash_update( hashid, p, 8, HASH_CHUNCK_SRC_LOCAL ));
+    MBEDTLS_MPI_CHK(kapi_hash_update( hashid, (hi_u8 *)hash, hashlen, HASH_CHUNCK_SRC_LOCAL ));
+    MBEDTLS_MPI_CHK(kapi_hash_update( hashid, salt, slen, HASH_CHUNCK_SRC_LOCAL ));
+    MBEDTLS_MPI_CHK(kapi_hash_finish( hashid, p, &hisi_hlen ));
+    mbedtls_platform_zeroize( salt, sizeof( salt ) );
+
+    /* Compensate for boundary condition when applying mask */
+    if( msb % 8 == 0 )
+        offset = 1;
+
+    /* maskedDB: Apply dbMask to DB */
+    if( ( ret = mgf_mask( sig + offset, olen - hlen - 1 - offset, p, hlen,
+            ctx->hash_id ) ) != 0 )
+        goto exit;
+
+    if (1 > mbedtls_mpi_bitlen( &ctx->N ))
+        return ( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
+
+    msb = mbedtls_mpi_bitlen( &ctx->N ) - 1;
+    sig[0] &= 0xFF >> ( olen * 8 - msb );
+
+    p += hlen;
+    *p++ = 0xBC;
+
+    mbedtls_platform_zeroize( salt, sizeof( salt ) );
+
+exit:
+    if( ret != 0 )
+        return( ret );
+
+    return( ( mode == MBEDTLS_RSA_PUBLIC )
+            ? mbedtls_rsa_public(  ctx, sig, sig )
+            : mbedtls_rsa_private( ctx, f_rng, p_rng, sig, sig ) );
+cleanup:
+    return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
+}
+#endif /* MBEDTLS_PKCS1_V21 */
+
+#if defined(MBEDTLS_PKCS1_V15)
+/*
+ * Implementation of the PKCS#1 v2.1 RSASSA-PKCS1-V1_5-SIGN function
+ */
+
+/* Construct a PKCS v1.5 encoding of a hashed message
+ *
+ * This is used both for signature generation and verification.
+ *
+ * Parameters:
+ * - md_alg:  Identifies the hash algorithm used to generate the given hash;
+ *            MBEDTLS_MD_NONE if raw data is signed.
+ * - hashlen: Length of hash in case hashlen is MBEDTLS_MD_NONE.
+ * - hash:    Buffer containing the hashed message or the raw data.
+ * - dst_len: Length of the encoded message.
+ * - dst:     Buffer to hold the encoded message.
+ *
+ * Assumptions:
+ * - hash has size hashlen if md_alg == MBEDTLS_MD_NONE.
+ * - hash has size corresponding to md_alg if md_alg != MBEDTLS_MD_NONE.
+ * - dst points to a buffer of size at least dst_len.
+ *
+ */
+static int rsa_rsassa_pkcs1_v15_encode( mbedtls_md_type_t md_alg,
+                                        unsigned int hashlen,
+                                        const unsigned char *hash,
+                                        size_t dst_len,
+                                        unsigned char *dst )
+{
+    size_t oid_size  = 0;
+    size_t nb_pad    = dst_len;
+    unsigned char *p = dst;
+    const char *oid  = NULL;
+    hi_cipher_hash_type hisi_type;
+
+    /* Are we signing hashed or raw data? */
+    if( md_alg != MBEDTLS_MD_NONE )
+    {
+        /* Gather length of hash to sign */
+        if( mbedtls_oid_get_oid_by_md( md_alg, &oid, &oid_size ) != 0 )
+            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+        mbedtls_get_hash_info( md_alg, &hashlen, &hisi_type);
+
+        /* Double-check that 8 + hashlen + oid_size can be used as a
+         * 1-byte ASN.1 length encoding and that there's no overflow. */
+        if( 8 + hashlen + oid_size  >= 0x80         ||
+            10 + hashlen            <  hashlen      ||
+            10 + hashlen + oid_size <  10 + hashlen )
+            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+        /*
+         * Static bounds check:
+         * - Need 10 bytes for five tag-length pairs.
+         *   (Insist on 1-byte length encodings to protect against variants of
+         *    Bleichenbacher's forgery attack against lax PKCS#1v1.5 verification)
+         * - Need hashlen bytes for hash
+         * - Need oid_size bytes for hash alg OID.
+         */
+        if( nb_pad < 10 + hashlen + oid_size )
+            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+        nb_pad -= 10 + hashlen + oid_size;
+    }
+    else
+    {
+        if( nb_pad < hashlen )
+            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+        nb_pad -= hashlen;
+    }
+
+    /* Need space for signature header and padding delimiter (3 bytes),
+     * and 8 bytes for the minimal padding */
+    if( nb_pad < 3 + 8 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+    nb_pad -= 3;
+
+    /* Now nb_pad is the amount of memory to be filled
+     * with padding, and at least 8 bytes long. */
+
+    /* Write signature header and padding */
+    *p++ = 0;
+    *p++ = MBEDTLS_RSA_SIGN;
+    memset( p, 0xFF, nb_pad );
+    p += nb_pad;
+    *p++ = 0;
+
+    /* Are we signing raw data? */
+    if( md_alg == MBEDTLS_MD_NONE )
+    {
+        memcpy( p, hash, hashlen );
+        return( 0 );
+    }
+
+    /* Signing hashed data, add corresponding ASN.1 structure
+     *
+     * DigestInfo ::= SEQUENCE {
+     *   digestAlgorithm DigestAlgorithmIdentifier,
+     *   digest Digest }
+     * DigestAlgorithmIdentifier ::= AlgorithmIdentifier
+     * Digest ::= OCTET STRING
+     *
+     * Schematic:
+     * TAG-SEQ + LEN [ TAG-SEQ + LEN [ TAG-OID  + LEN [ OID  ]
+     *                                 TAG-NULL + LEN [ NULL ] ]
+     *                 TAG-OCTET + LEN [ HASH ] ]
+     */
+    *p++ = MBEDTLS_ASN1_SEQUENCE | MBEDTLS_ASN1_CONSTRUCTED;
+    *p++ = (unsigned char)( 0x08 + oid_size + hashlen );
+    *p++ = MBEDTLS_ASN1_SEQUENCE | MBEDTLS_ASN1_CONSTRUCTED;
+    *p++ = (unsigned char)( 0x04 + oid_size );
+    *p++ = MBEDTLS_ASN1_OID;
+    *p++ = (unsigned char) oid_size;
+    memcpy( p, oid, oid_size );
+    p += oid_size;
+    *p++ = MBEDTLS_ASN1_NULL;
+    *p++ = 0x00;
+    *p++ = MBEDTLS_ASN1_OCTET_STRING;
+    *p++ = (unsigned char) hashlen;
+    memcpy( p, hash, hashlen );
+    p += hashlen;
+
+    /* Just a sanity-check, should be automatic
+     * after the initial bounds check. */
+    if( p != dst + dst_len )
+    {
+        mbedtls_platform_zeroize( dst, dst_len );
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+    }
+
+    return( 0 );
+}
+
+/*
+ * Do an RSA operation to sign the message digest
+ */
+int mbedtls_rsa_rsassa_pkcs1_v15_sign( mbedtls_rsa_context *ctx,
+                               int (*f_rng)(void *, unsigned char *, size_t),
+                               void *p_rng,
+                               int mode,
+                               mbedtls_md_type_t md_alg,
+                               unsigned int hashlen,
+                               const unsigned char *hash,
+                               unsigned char *sig )
+{
+    int ret;
+
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
+                        hashlen == 0 ) ||
+                      hash != NULL );
+    RSA_VALIDATE_RET( sig != NULL );
+
+    if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V15 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    /*
+     * Prepare PKCS1-v1.5 encoding (padding and hash identifier)
+     */
+
+    if( ( ret = rsa_rsassa_pkcs1_v15_encode( md_alg, hashlen, hash,
+                                             ctx->len, sig ) ) != 0 )
+        return( ret );
+
+    MBEDTLS_MPI_CHK( mbedtls_rsa_private( ctx, f_rng, p_rng, sig, sig ) );
+
+cleanup:
+
+    return( ret );
+}
+#endif /* MBEDTLS_PKCS1_V15 */
+
+/*
+ * Do an RSA operation to sign the message digest
+ */
+int mbedtls_rsa_pkcs1_sign( mbedtls_rsa_context *ctx,
+                    int (*f_rng)(void *, unsigned char *, size_t),
+                    void *p_rng,
+                    int mode,
+                    mbedtls_md_type_t md_alg,
+                    unsigned int hashlen,
+                    const unsigned char *hash,
+                    unsigned char *sig )
+{
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
+                        hashlen == 0 ) ||
+                      hash != NULL );
+    RSA_VALIDATE_RET( sig != NULL );
+
+    switch( ctx->padding )
+    {
+#if defined(MBEDTLS_PKCS1_V15)
+        case MBEDTLS_RSA_PKCS_V15:
+            return mbedtls_rsa_rsassa_pkcs1_v15_sign( ctx, f_rng, p_rng, mode, md_alg,
+                                              hashlen, hash, sig );
+#endif
+
+#if defined(MBEDTLS_PKCS1_V21)
+        case MBEDTLS_RSA_PKCS_V21:
+            return mbedtls_rsa_rsassa_pss_sign( ctx, f_rng, p_rng, mode, md_alg,
+                                        hashlen, hash, sig );
+#endif
+
+        default:
+            return( MBEDTLS_ERR_RSA_INVALID_PADDING );
+    }
+}
+
+#if defined(MBEDTLS_PKCS1_V21)
+/*
+ * Implementation of the PKCS#1 v2.1 RSASSA-PSS-VERIFY function
+ */
+int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
+                               int (*f_rng)(void *, unsigned char *, size_t),
+                               void *p_rng,
+                               int mode,
+                               mbedtls_md_type_t md_alg,
+                               unsigned int hashlen,
+                               const unsigned char *hash,
+                               mbedtls_md_type_t mgf1_hash_id,
+                               int expected_salt_len,
+                               const unsigned char *sig )
+{
+    int ret;
+    size_t siglen;
+    unsigned char *p;
+    unsigned char *hash_start;
+    unsigned char *buf = NULL;
+    unsigned char *result = NULL;
+    unsigned char zeros[8];
+    unsigned int hlen;
+    size_t observed_salt_len, msb;
+    unsigned int hisi_hlen = 0, hashid = 0;
+    hi_cipher_hash_type hisi_type = 0;
+
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( sig != NULL );
+    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
+                        hashlen == 0 ) ||
+                      hash != NULL );
+
+    if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V21 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    siglen = ctx->len;
+
+    if( siglen < 16 || siglen > MBEDTLS_MPI_MAX_SIZE )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    buf = (unsigned char *)mbedtls_calloc(MBEDTLS_MPI_MAX_SIZE,sizeof(unsigned char));
+    if (buf == NULL)
+    {
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+    }
+    memset( buf, 0, sizeof( unsigned char )* MBEDTLS_MPI_MAX_SIZE );
+
+    result = (unsigned char *)mbedtls_calloc(MBEDTLS_MD_MAX_SIZE,sizeof(unsigned char));
+    if (result == NULL)
+    {
+        if (buf != NULL)
+        {
+            mbedtls_free(buf);
+            buf = NULL;
+        }
+
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+    }
+    memset( result, 0, sizeof( unsigned char )* MBEDTLS_MD_MAX_SIZE );
+
+    ret = ( mode == MBEDTLS_RSA_PUBLIC )
+          ? mbedtls_rsa_public(  ctx, sig, buf )
+          : mbedtls_rsa_private( ctx, f_rng, p_rng, sig, buf );
+
+    if( ret != 0 )
+    {
+        goto exit;
+    }
+
+    p = buf;
+
+    if( buf[siglen - 1] != 0xBC )
+    {
+        ret = MBEDTLS_ERR_RSA_INVALID_PADDING;
+        goto exit;
+    }
+
+    if( md_alg != MBEDTLS_MD_NONE )
+    {
+        /* Gather length of hash to sign */
+        mbedtls_get_hash_info( ctx->hash_id, &hashlen, &hisi_type);
+    }
+    hlen = hashlen;
+
+    memset( zeros, 0, 8 );
+
+    /*
+     * Note: EMSA-PSS verification is over the length of N - 1 bits
+     */
+    msb = mbedtls_mpi_bitlen( &ctx->N ) - 1;
+
+    if( buf[0] >> ( 8 - siglen * 8 + msb ) )
+    {
+        ret = MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
+        goto exit;
+    }
+
+    /* Compensate for boundary condition when applying mask */
+    if( msb % 8 == 0 )
+    {
+        p++;
+        siglen -= 1;
+    }
+
+    if( siglen < hlen + 2 )
+    {
+        ret = MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
+        goto exit;
+    }
+
+    hash_start = p + siglen - hlen - 1;
+
+    ret = mgf_mask( p, siglen - hlen - 1, hash_start, hlen, ctx->hash_id );
+    if( ret != 0 )
+        goto exit;
+
+    buf[0] &= 0xFF >> ( siglen * 8 - msb );
+
+    while( p < hash_start - 1 && *p == 0 )
+        p++;
+
+    if( *p++ != 0x01 )
+    {
+        ret = MBEDTLS_ERR_RSA_INVALID_PADDING;
+        goto exit;
+    }
+
+    observed_salt_len = hash_start - p;
+
+    if( expected_salt_len != MBEDTLS_RSA_SALT_LEN_ANY &&
+        observed_salt_len != (size_t) expected_salt_len )
+    {
+        ret = MBEDTLS_ERR_RSA_INVALID_PADDING;
+        goto exit;
+    }
+
+    /*
+     * Generate H = Hash( M' )
+     */
+    ret = kapi_hash_start( &hashid, hisi_type, NULL, 0 );
+    if ( ret != 0 )
+        goto exit;
+    ret = kapi_hash_update( hashid, zeros, 8, HASH_CHUNCK_SRC_LOCAL );
+    if ( ret != 0 )
+        goto exit;
+    ret = kapi_hash_update( hashid, (hi_u8 *)hash, hashlen, HASH_CHUNCK_SRC_LOCAL );
+    if ( ret != 0 )
+        goto exit;
+    ret = kapi_hash_update( hashid, p, observed_salt_len, HASH_CHUNCK_SRC_LOCAL );
+    if ( ret != 0 )
+        goto exit;
+    ret = kapi_hash_finish( hashid, result, &hisi_hlen );
+    if ( ret != 0 )
+        goto exit;
+
+    if( memcmp( hash_start, result, hlen ) != 0 )
+    {
+        ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
+        goto exit;
+    }
+
+    if (buf != NULL)
+    {
+        mbedtls_free(buf);
+        buf = NULL;
+    }
+    if (result != NULL)
+    {
+        mbedtls_free(result);
+        result = NULL;
+    }
+
+    return ( 0 );
+
+exit:
+    if (buf != NULL)
+    {
+        mbedtls_free(buf);
+        buf = NULL;
+    }
+    if (result != NULL)
+    {
+        mbedtls_free(result);
+        result = NULL;
+    }
+
+    return ret;
+}
+
+/*
+ * Simplified PKCS#1 v2.1 RSASSA-PSS-VERIFY function
+ */
+int mbedtls_rsa_rsassa_pss_verify( mbedtls_rsa_context *ctx,
+                           int (*f_rng)(void *, unsigned char *, size_t),
+                           void *p_rng,
+                           int mode,
+                           mbedtls_md_type_t md_alg,
+                           unsigned int hashlen,
+                           const unsigned char *hash,
+                           const unsigned char *sig )
+{
+    mbedtls_md_type_t mgf1_hash_id;
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( sig != NULL );
+    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
+                        hashlen == 0 ) ||
+                      hash != NULL );
+
+    mgf1_hash_id = ( ctx->hash_id != MBEDTLS_MD_NONE )
+                             ? (mbedtls_md_type_t) ctx->hash_id
+                             : md_alg;
+
+    return( mbedtls_rsa_rsassa_pss_verify_ext( ctx, f_rng, p_rng, mode,
+                                       md_alg, hashlen, hash,
+                                       mgf1_hash_id, MBEDTLS_RSA_SALT_LEN_ANY,
+                                       sig ) );
+
+}
+#endif /* MBEDTLS_PKCS1_V21 */
+
+#if defined(MBEDTLS_PKCS1_V15)
+/*
+ * Implementation of the PKCS#1 v2.1 RSASSA-PKCS1-v1_5-VERIFY function
+ */
+int mbedtls_rsa_rsassa_pkcs1_v15_verify( mbedtls_rsa_context *ctx,
+                                 int (*f_rng)(void *, unsigned char *, size_t),
+                                 void *p_rng,
+                                 int mode,
+                                 mbedtls_md_type_t md_alg,
+                                 unsigned int hashlen,
+                                 const unsigned char *hash,
+                                 const unsigned char *sig )
+{
+    int ret = 0;
+    size_t sig_len;
+    unsigned char *encoded = NULL, *encoded_expected = NULL;
+
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( sig != NULL );
+    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
+                        hashlen == 0 ) ||
+                      hash != NULL );
+
+    sig_len = ctx->len;
+
+    if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V15 )
+        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
+
+    /*
+     * Prepare expected PKCS1 v1.5 encoding of hash.
+     */
+
+    if( ( encoded          = mbedtls_calloc( 1, sig_len ) ) == NULL ||
+        ( encoded_expected = mbedtls_calloc( 1, sig_len ) ) == NULL )
+    {
+        ret = MBEDTLS_ERR_MPI_ALLOC_FAILED;
+        goto cleanup;
+    }
+
+    if( ( ret = rsa_rsassa_pkcs1_v15_encode( md_alg, hashlen, hash, sig_len,
+                                             encoded_expected ) ) != 0 )
+        goto cleanup;
+
+    /*
+     * Apply RSA primitive to get what should be PKCS1 encoded hash.
+     */
+
+    ret = ( mode == MBEDTLS_RSA_PUBLIC )
+          ? mbedtls_rsa_public(  ctx, sig, encoded )
+          : mbedtls_rsa_private( ctx, f_rng, p_rng, sig, encoded );
+    if( ret != 0 )
+        goto cleanup;
+
+    /*
+     * Compare
+     */
+
+    if( ( ret = mbedtls_safer_memcmp( encoded, encoded_expected,
+                                      sig_len ) ) != 0 )
+    {
+        ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
+        goto cleanup;
+    }
+
+cleanup:
+
+    if( encoded != NULL )
+    {
+        mbedtls_platform_zeroize( encoded, sig_len );
+        mbedtls_free( encoded );
+    }
+
+    if( encoded_expected != NULL )
+    {
+        mbedtls_platform_zeroize( encoded_expected, sig_len );
+        mbedtls_free( encoded_expected );
+    }
+
+    return( ret );
+}
+#endif /* MBEDTLS_PKCS1_V15 */
+
+/*
+ * Do an RSA operation and check the message digest
+ */
+int mbedtls_rsa_pkcs1_verify( mbedtls_rsa_context *ctx,
+                      int (*f_rng)(void *, unsigned char *, size_t),
+                      void *p_rng,
+                      int mode,
+                      mbedtls_md_type_t md_alg,
+                      unsigned int hashlen,
+                      const unsigned char *hash,
+                      const unsigned char *sig )
+{
+    RSA_VALIDATE_RET( ctx != NULL );
+    RSA_VALIDATE_RET( mode == MBEDTLS_RSA_PRIVATE ||
+                      mode == MBEDTLS_RSA_PUBLIC );
+    RSA_VALIDATE_RET( sig != NULL );
+    RSA_VALIDATE_RET( ( md_alg  == MBEDTLS_MD_NONE &&
+                        hashlen == 0 ) ||
+                      hash != NULL );
+
+    switch( ctx->padding )
+    {
+#if defined(MBEDTLS_PKCS1_V15)
+        case MBEDTLS_RSA_PKCS_V15:
+            return mbedtls_rsa_rsassa_pkcs1_v15_verify( ctx, f_rng, p_rng, mode, md_alg,
+                                                hashlen, hash, sig );
+#endif
+
+#if defined(MBEDTLS_PKCS1_V21)
+        case MBEDTLS_RSA_PKCS_V21:
+            return mbedtls_rsa_rsassa_pss_verify( ctx, f_rng, p_rng, mode, md_alg,
+                                          hashlen, hash, sig );
+#endif
+
+        default:
+            return( MBEDTLS_ERR_RSA_INVALID_PADDING );
+    }
+}
+
+#if defined(MBEDTLS_HI_NO_CUT)
+/*
+ * Copy the components of an RSA key
+ */
+int mbedtls_rsa_copy( mbedtls_rsa_context *dst, const mbedtls_rsa_context *src )
+{
+    int ret;
+    RSA_VALIDATE_RET( dst != NULL );
+    RSA_VALIDATE_RET( src != NULL );
+
+    dst->ver = src->ver;
+    dst->len = src->len;
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->N, &src->N ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->E, &src->E ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->D, &src->D ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->P, &src->P ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->Q, &src->Q ) );
+
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->DP, &src->DP ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->DQ, &src->DQ ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->QP, &src->QP ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->RP, &src->RP ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->RQ, &src->RQ ) );
+#endif
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->RN, &src->RN ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->Vi, &src->Vi ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &dst->Vf, &src->Vf ) );
+
+    dst->padding = src->padding;
+    dst->hash_id = src->hash_id;
+
+cleanup:
+    if( ret != 0 )
+        mbedtls_rsa_free( dst );
+
+    return( ret );
+}
+#endif
+
+/*
+ * Free the components of an RSA key
+ */
+void mbedtls_rsa_free( mbedtls_rsa_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    mbedtls_mpi_free( &ctx->Vi );
+    mbedtls_mpi_free( &ctx->Vf );
+    mbedtls_mpi_free( &ctx->RN );
+    mbedtls_mpi_free( &ctx->D  );
+    mbedtls_mpi_free( &ctx->Q  );
+    mbedtls_mpi_free( &ctx->P  );
+    mbedtls_mpi_free( &ctx->E  );
+    mbedtls_mpi_free( &ctx->N  );
+
+    mbedtls_mpi_free( &ctx->RQ );
+    mbedtls_mpi_free( &ctx->RP );
+    mbedtls_mpi_free( &ctx->QP );
+    mbedtls_mpi_free( &ctx->DQ );
+    mbedtls_mpi_free( &ctx->DP );
+
+#if defined(MBEDTLS_THREADING_C)
+    mbedtls_mutex_free( &ctx->mutex );
+#endif
+}
+
+#endif /* !MBEDTLS_RSA_ALT */
+
+#if defined(MBEDTLS_SELF_TEST)
+
+#include "mbedtls/sha1.h"
+
+/*
+ * Example RSA-1024 keypair, for test purposes
+ */
+#define KEY_LEN 128
+
+#define RSA_N   "9292758453063D803DD603D5E777D788" \
+                "8ED1D5BF35786190FA2F23EBC0848AEA" \
+                "DDA92CA6C3D80B32C4D109BE0F36D6AE" \
+                "7130B9CED7ACDF54CFC7555AC14EEBAB" \
+                "93A89813FBF3C4F8066D2D800F7C38A8" \
+                "1AE31942917403FF4946B0A83D3D3E05" \
+                "EE57C6F5F5606FB5D4BC6CD34EE0801A" \
+                "5E94BB77B07507233A0BC7BAC8F90F79"
+
+#define RSA_E   "10001"
+
+#define RSA_D   "24BF6185468786FDD303083D25E64EFC" \
+                "66CA472BC44D253102F8B4A9D3BFA750" \
+                "91386C0077937FE33FA3252D28855837" \
+                "AE1B484A8A9A45F7EE8C0C634F99E8CD" \
+                "DF79C5CE07EE72C7F123142198164234" \
+                "CABB724CF78B8173B9F880FC86322407" \
+                "AF1FEDFDDE2BEB674CA15F3E81A1521E" \
+                "071513A1E85B5DFA031F21ECAE91A34D"
+
+#define RSA_P   "C36D0EB7FCD285223CFB5AABA5BDA3D8" \
+                "2C01CAD19EA484A87EA4377637E75500" \
+                "FCB2005C5C7DD6EC4AC023CDA285D796" \
+                "C3D9E75E1EFC42488BB4F1D13AC30A57"
+
+#define RSA_Q   "C000DF51A7C77AE8D7C7370C1FF55B69" \
+                "E211C2B9E5DB1ED0BF61D0D9899620F4" \
+                "910E4168387E3C30AA1E00C339A79508" \
+                "8452DD96A9A5EA5D9DCA68DA636032AF"
+
+#define PT_LEN  24
+#define RSA_PT  "\xAA\xBB\xCC\x03\x02\x01\x00\xFF\xFF\xFF\xFF\xFF" \
+                "\x11\x22\x33\x0A\x0B\x0C\xCC\xDD\xDD\xDD\xDD\xDD"
+
+#if defined(MBEDTLS_PKCS1_V15)
+static int myrand( void *rng_state, unsigned char *output, size_t len )
+{
+#if !defined(__OpenBSD__)
+    size_t i;
+
+    if( rng_state != NULL )
+        rng_state  = NULL;
+
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+#else
+    if( rng_state != NULL )
+        rng_state = NULL;
+
+    arc4random_buf( output, len );
+#endif /* !OpenBSD */
+
+    return( 0 );
+}
+#endif /* MBEDTLS_PKCS1_V15 */
+
+/*
+ * Checkup routine
+ */
+int mbedtls_rsa_self_test( int verbose )
+{
+    int ret = 0;
+#if defined(MBEDTLS_PKCS1_V15)
+    size_t len;
+    mbedtls_rsa_context rsa;
+    unsigned char rsa_plaintext[PT_LEN];
+    unsigned char rsa_decrypted[PT_LEN];
+    unsigned char rsa_ciphertext[KEY_LEN];
+#if defined(MBEDTLS_SHA1_C)
+    unsigned char sha1sum[20];
+#endif
+
+    mbedtls_mpi K;
+
+    mbedtls_mpi_init( &K );
+    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, 0 );
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &K, 16, RSA_N  ) );
+    MBEDTLS_MPI_CHK( mbedtls_rsa_import( &rsa, &K, NULL, NULL, NULL, NULL ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &K, 16, RSA_P  ) );
+    MBEDTLS_MPI_CHK( mbedtls_rsa_import( &rsa, NULL, &K, NULL, NULL, NULL ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &K, 16, RSA_Q  ) );
+    MBEDTLS_MPI_CHK( mbedtls_rsa_import( &rsa, NULL, NULL, &K, NULL, NULL ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &K, 16, RSA_D  ) );
+    MBEDTLS_MPI_CHK( mbedtls_rsa_import( &rsa, NULL, NULL, NULL, &K, NULL ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &K, 16, RSA_E  ) );
+    MBEDTLS_MPI_CHK( mbedtls_rsa_import( &rsa, NULL, NULL, NULL, NULL, &K ) );
+
+    MBEDTLS_MPI_CHK( mbedtls_rsa_complete( &rsa ) );
+
+    if( verbose != 0 )
+        mbedtls_printf( "  RSA key validation: " );
+
+    if( mbedtls_rsa_check_pubkey(  &rsa ) != 0 ||
+        mbedtls_rsa_check_privkey( &rsa ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        ret = 1;
+        goto cleanup;
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "passed\n  PKCS#1 encryption : " );
+
+    memcpy( rsa_plaintext, RSA_PT, PT_LEN );
+
+    if( mbedtls_rsa_pkcs1_encrypt( &rsa, myrand, NULL, MBEDTLS_RSA_PUBLIC,
+                                   PT_LEN, rsa_plaintext,
+                                   rsa_ciphertext ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        ret = 1;
+        goto cleanup;
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "passed\n  PKCS#1 decryption : " );
+
+    if( mbedtls_rsa_pkcs1_decrypt( &rsa, myrand, NULL, MBEDTLS_RSA_PRIVATE,
+                                   &len, rsa_ciphertext, rsa_decrypted,
+                                   sizeof(rsa_decrypted) ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        ret = 1;
+        goto cleanup;
+    }
+
+    if( memcmp( rsa_decrypted, rsa_plaintext, len ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        ret = 1;
+        goto cleanup;
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "passed\n" );
+
+#if defined(MBEDTLS_SHA1_C)
+    if( verbose != 0 )
+        mbedtls_printf( "  PKCS#1 data sign  : " );
+
+    if( mbedtls_sha1_ret( rsa_plaintext, PT_LEN, sha1sum ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        return( 1 );
+    }
+
+    if( mbedtls_rsa_pkcs1_sign( &rsa, myrand, NULL,
+                                MBEDTLS_RSA_PRIVATE, MBEDTLS_MD_SHA1, 0,
+                                sha1sum, rsa_ciphertext ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        ret = 1;
+        goto cleanup;
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "passed\n  PKCS#1 sig. verify: " );
+
+    if( mbedtls_rsa_pkcs1_verify( &rsa, NULL, NULL,
+                                  MBEDTLS_RSA_PUBLIC, MBEDTLS_MD_SHA1, 0,
+                                  sha1sum, rsa_ciphertext ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        ret = 1;
+        goto cleanup;
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "passed\n" );
+#endif /* MBEDTLS_SHA1_C */
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+
+cleanup:
+    mbedtls_mpi_free( &K );
+    mbedtls_rsa_free( &rsa );
+#else /* MBEDTLS_PKCS1_V15 */
+    ((void) verbose);
+#endif /* MBEDTLS_PKCS1_V15 */
+    return( ret );
+}
+
+#endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_RSA_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/rsa_internal.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/rsa_internal.c
@@ -1,0 +1,494 @@
+/*
+ *  Helper functions for the RSA module
+ *
+ *  Copyright (C) 2006-2017, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ *
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_RSA_C)
+
+#include "mbedtls/rsa.h"
+#include "mbedtls/bignum.h"
+#include "mbedtls/rsa_internal.h"
+
+#ifdef CIPHER_LITEOS_TEST_SUPPORT
+/*
+ * Compute RSA prime factors from public and private exponents
+ *
+ * Summary of algorithm:
+ * Setting F := lcm(P-1,Q-1), the idea is as follows:
+ *
+ * (a) For any 1 <= X < N with gcd(X,N)=1, we have X^F = 1 modulo N, so X^(F/2)
+ *     is a square root of 1 in Z/NZ. Since Z/NZ ~= Z/PZ x Z/QZ by CRT and the
+ *     square roots of 1 in Z/PZ and Z/QZ are +1 and -1, this leaves the four
+ *     possibilities X^(F/2) = (+-1, +-1). If it happens that X^(F/2) = (-1,+1)
+ *     or (+1,-1), then gcd(X^(F/2) + 1, N) will be equal to one of the prime
+ *     factors of N.
+ *
+ * (b) If we don't know F/2 but (F/2) * K for some odd (!) K, then the same
+ *     construction still applies since (-)^K is the identity on the set of
+ *     roots of 1 in Z/NZ.
+ *
+ * The public and private key primitives (-)^E and (-)^D are mutually inverse
+ * bijections on Z/NZ if and only if (-)^(DE) is the identity on Z/NZ, i.e.
+ * if and only if DE - 1 is a multiple of F, say DE - 1 = F * L.
+ * Splitting L = 2^t * K with K odd, we have
+ *
+ *   DE - 1 = FL = (F/2) * (2^(t+1)) * K,
+ *
+ * so (F / 2) * K is among the numbers
+ *
+ *   (DE - 1) >> 1, (DE - 1) >> 2, ..., (DE - 1) >> ord
+ *
+ * where ord is the order of 2 in (DE - 1).
+ * We can therefore iterate through these numbers apply the construction
+ * of (a) and (b) above to attempt to factor N.
+ *
+ */
+int mbedtls_rsa_deduce_primes( mbedtls_mpi const *N,
+                     mbedtls_mpi const *E, mbedtls_mpi const *D,
+                     mbedtls_mpi *P, mbedtls_mpi *Q )
+{
+    int ret = 0;
+
+    uint16_t attempt;  /* Number of current attempt  */
+    uint16_t iter;     /* Number of squares computed in the current attempt */
+
+    uint16_t order;    /* Order of 2 in DE - 1 */
+
+    mbedtls_mpi T;  /* Holds largest odd divisor of DE - 1     */
+    mbedtls_mpi K;  /* Temporary holding the current candidate */
+
+    const unsigned char primes[] = { 2,
+           3,    5,    7,   11,   13,   17,   19,   23,
+          29,   31,   37,   41,   43,   47,   53,   59,
+          61,   67,   71,   73,   79,   83,   89,   97,
+         101,  103,  107,  109,  113,  127,  131,  137,
+         139,  149,  151,  157,  163,  167,  173,  179,
+         181,  191,  193,  197,  199,  211,  223,  227,
+         229,  233,  239,  241,  251
+    };
+
+    const size_t num_primes = sizeof( primes ) / sizeof( *primes );
+
+    if( P == NULL || Q == NULL || P->p != NULL || Q->p != NULL )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    if( mbedtls_mpi_cmp_int( N, 0 ) <= 0 ||
+        mbedtls_mpi_cmp_int( D, 1 ) <= 0 ||
+        mbedtls_mpi_cmp_mpi( D, N ) >= 0 ||
+        mbedtls_mpi_cmp_int( E, 1 ) <= 0 ||
+        mbedtls_mpi_cmp_mpi( E, N ) >= 0 )
+    {
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+    }
+
+    /*
+     * Initializations and temporary changes
+     */
+
+    mbedtls_mpi_init( &K );
+    mbedtls_mpi_init( &T );
+
+    /* T := DE - 1 */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &T, D,  E ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &T, &T, 1 ) );
+
+    if( ( order = (uint16_t) mbedtls_mpi_lsb( &T ) ) == 0 )
+    {
+        ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
+        goto cleanup;
+    }
+
+    /* After this operation, T holds the largest odd divisor of DE - 1. */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &T, order ) );
+
+    /*
+     * Actual work
+     */
+
+    /* Skip trying 2 if N == 1 mod 8 */
+    attempt = 0;
+    if( N->p[0] % 8 == 1 )
+        attempt = 1;
+
+    for( ; attempt < num_primes; ++attempt )
+    {
+        mbedtls_mpi_lset( &K, primes[attempt] );
+
+        /* Check if gcd(K,N) = 1 */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_gcd( P, &K, N ) );
+        if( mbedtls_mpi_cmp_int( P, 1 ) != 0 )
+            continue;
+
+        /* Go through K^T + 1, K^(2T) + 1, K^(4T) + 1, ...
+         * and check whether they have nontrivial GCD with N. */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &K, &K, &T, N,
+                             Q /* temporarily use Q for storing Montgomery
+                                * multiplication helper values */ ) );
+
+        for( iter = 1; iter <= order; ++iter )
+        {
+            /* If we reach 1 prematurely, there's no point
+             * in continuing to square K */
+            if( mbedtls_mpi_cmp_int( &K, 1 ) == 0 )
+                break;
+
+            MBEDTLS_MPI_CHK( mbedtls_mpi_add_int( &K, &K, 1 ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_gcd( P, &K, N ) );
+
+            if( mbedtls_mpi_cmp_int( P, 1 ) ==  1 &&
+                mbedtls_mpi_cmp_mpi( P, N ) == -1 )
+            {
+                /*
+                 * Have found a nontrivial divisor P of N.
+                 * Set Q := N / P.
+                 */
+
+                MBEDTLS_MPI_CHK( mbedtls_mpi_div_mpi( Q, NULL, N, P ) );
+                goto cleanup;
+            }
+
+            MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &K, &K, 1 ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &K, &K, &K ) );
+            MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &K, &K, N ) );
+        }
+
+        /*
+         * If we get here, then either we prematurely aborted the loop because
+         * we reached 1, or K holds primes[attempt]^(DE - 1) mod N, which must
+         * be 1 if D,E,N were consistent.
+         * Check if that's the case and abort if not, to avoid very long,
+         * yet eventually failing, computations if N,D,E were not sane.
+         */
+        if( mbedtls_mpi_cmp_int( &K, 1 ) != 0 )
+        {
+            break;
+        }
+    }
+
+    ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
+
+cleanup:
+
+    mbedtls_mpi_free( &K );
+    mbedtls_mpi_free( &T );
+    return( ret );
+}
+
+/*
+ * Given P, Q and the public exponent E, deduce D.
+ * This is essentially a modular inversion.
+ */
+int mbedtls_rsa_deduce_private_exponent( mbedtls_mpi const *P,
+                                         mbedtls_mpi const *Q,
+                                         mbedtls_mpi const *E,
+                                         mbedtls_mpi *D )
+{
+    int ret = 0;
+    mbedtls_mpi K, L;
+
+    if( D == NULL || mbedtls_mpi_cmp_int( D, 0 ) != 0 )
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+
+    if( mbedtls_mpi_cmp_int( P, 1 ) <= 0 ||
+        mbedtls_mpi_cmp_int( Q, 1 ) <= 0 ||
+        mbedtls_mpi_cmp_int( E, 0 ) == 0 )
+    {
+        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+    }
+
+    mbedtls_mpi_init( &K );
+    mbedtls_mpi_init( &L );
+
+    /* Temporarily put K := P-1 and L := Q-1 */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &K, P, 1 ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &L, Q, 1 ) );
+
+    /* Temporarily put D := gcd(P-1, Q-1) */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_gcd( D, &K, &L ) );
+
+    /* K := LCM(P-1, Q-1) */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &K, &K, &L ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_div_mpi( &K, NULL, &K, D ) );
+
+    /* Compute modular inverse of E in LCM(P-1, Q-1) */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_inv_mod( D, E, &K ) );
+
+cleanup:
+
+    mbedtls_mpi_free( &K );
+    mbedtls_mpi_free( &L );
+
+    return( ret );
+}
+
+/*
+ * Check that RSA CRT parameters are in accordance with core parameters.
+ */
+int mbedtls_rsa_validate_crt( const mbedtls_mpi *P,  const mbedtls_mpi *Q,
+                              const mbedtls_mpi *D,  const mbedtls_mpi *DP,
+                              const mbedtls_mpi *DQ, const mbedtls_mpi *QP )
+{
+    int ret = 0;
+
+    mbedtls_mpi K, L;
+    mbedtls_mpi_init( &K );
+    mbedtls_mpi_init( &L );
+
+    /* Check that DP - D == 0 mod P - 1 */
+    if( DP != NULL )
+    {
+        if( P == NULL )
+        {
+            ret = MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
+            goto cleanup;
+        }
+
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &K, P, 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &L, DP, D ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &L, &L, &K ) );
+
+        if( mbedtls_mpi_cmp_int( &L, 0 ) != 0 )
+        {
+            ret = MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+            goto cleanup;
+        }
+    }
+
+    /* Check that DQ - D == 0 mod Q - 1 */
+    if( DQ != NULL )
+    {
+        if( Q == NULL )
+        {
+            ret = MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
+            goto cleanup;
+        }
+
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &K, Q, 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( &L, DQ, D ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &L, &L, &K ) );
+
+        if( mbedtls_mpi_cmp_int( &L, 0 ) != 0 )
+        {
+            ret = MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+            goto cleanup;
+        }
+    }
+
+    /* Check that QP * Q - 1 == 0 mod P */
+    if( QP != NULL )
+    {
+        if( P == NULL || Q == NULL )
+        {
+            ret = MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
+            goto cleanup;
+        }
+
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &K, QP, Q ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &K, &K, 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &K, &K, P ) );
+        if( mbedtls_mpi_cmp_int( &K, 0 ) != 0 )
+        {
+            ret = MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+            goto cleanup;
+        }
+    }
+
+cleanup:
+
+    /* Wrap MPI error codes by RSA check failure error code */
+    if( ret != 0 &&
+        ret != MBEDTLS_ERR_RSA_KEY_CHECK_FAILED &&
+        ret != MBEDTLS_ERR_RSA_BAD_INPUT_DATA )
+    {
+        ret += MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+    }
+
+    mbedtls_mpi_free( &K );
+    mbedtls_mpi_free( &L );
+
+    return( ret );
+}
+#endif
+
+/*
+ * Check that core RSA parameters are sane.
+ */
+int mbedtls_rsa_validate_params( const mbedtls_mpi *N, const mbedtls_mpi *P,
+                                 const mbedtls_mpi *Q, const mbedtls_mpi *D,
+                                 const mbedtls_mpi *E,
+                                 int (*f_rng)(void *, unsigned char *, size_t),
+                                 void *p_rng )
+{
+    int ret = 0;
+    mbedtls_mpi K, L;
+
+    mbedtls_mpi_init( &K );
+    mbedtls_mpi_init( &L );
+
+    /*
+     * Step 1: If PRNG provided, check that P and Q are prime
+     */
+
+#if defined(MBEDTLS_GENPRIME)
+    /*
+     * When generating keys, the strongest security we support aims for an error
+     * rate of at most 2^-100 and we are aiming for the same certainty here as
+     * well.
+     */
+    if( f_rng != NULL && P != NULL &&
+        ( ret = mbedtls_mpi_is_prime_ext( P, 50, f_rng, p_rng ) ) != 0 )
+    {
+        ret = MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+        goto cleanup;
+    }
+
+    if( f_rng != NULL && Q != NULL &&
+        ( ret = mbedtls_mpi_is_prime_ext( Q, 50, f_rng, p_rng ) ) != 0 )
+    {
+        ret = MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+        goto cleanup;
+    }
+#else
+    ((void) f_rng);
+    ((void) p_rng);
+#endif /* MBEDTLS_GENPRIME */
+
+    /*
+     * Step 2: Check that 1 < N = P * Q
+     */
+
+    if( P != NULL && Q != NULL && N != NULL )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &K, P, Q ) );
+        if( mbedtls_mpi_cmp_int( N, 1 )  <= 0 ||
+            mbedtls_mpi_cmp_mpi( &K, N ) != 0 )
+        {
+            ret = MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+            goto cleanup;
+        }
+    }
+
+    /*
+     * Step 3: Check and 1 < D, E < N if present.
+     */
+
+    if( N != NULL && D != NULL && E != NULL )
+    {
+        if ( mbedtls_mpi_cmp_int( D, 1 ) <= 0 ||
+             mbedtls_mpi_cmp_int( E, 1 ) <= 0 ||
+             mbedtls_mpi_cmp_mpi( D, N ) >= 0 ||
+             mbedtls_mpi_cmp_mpi( E, N ) >= 0 )
+        {
+            ret = MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+            goto cleanup;
+        }
+    }
+
+    /*
+     * Step 4: Check that D, E are inverse modulo P-1 and Q-1
+     */
+
+    if( P != NULL && Q != NULL && D != NULL && E != NULL )
+    {
+        if( mbedtls_mpi_cmp_int( P, 1 ) <= 0 ||
+            mbedtls_mpi_cmp_int( Q, 1 ) <= 0 )
+        {
+            ret = MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+            goto cleanup;
+        }
+
+        /* Compute DE-1 mod P-1 */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &K, D, E ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &K, &K, 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &L, P, 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &K, &K, &L ) );
+        if( mbedtls_mpi_cmp_int( &K, 0 ) != 0 )
+        {
+            ret = MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+            goto cleanup;
+        }
+
+        /* Compute DE-1 mod Q-1 */
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &K, D, E ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &K, &K, 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &L, Q, 1 ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &K, &K, &L ) );
+        if( mbedtls_mpi_cmp_int( &K, 0 ) != 0 )
+        {
+            ret = MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+            goto cleanup;
+        }
+    }
+
+cleanup:
+
+    mbedtls_mpi_free( &K );
+    mbedtls_mpi_free( &L );
+
+    /* Wrap MPI error codes by RSA check failure error code */
+    if( ret != 0 && ret != MBEDTLS_ERR_RSA_KEY_CHECK_FAILED )
+    {
+        ret += MBEDTLS_ERR_RSA_KEY_CHECK_FAILED;
+    }
+
+    return( ret );
+}
+
+int mbedtls_rsa_deduce_crt( const mbedtls_mpi *P, const mbedtls_mpi *Q,
+                            const mbedtls_mpi *D, mbedtls_mpi *DP,
+                            mbedtls_mpi *DQ, mbedtls_mpi *QP )
+{
+    int ret = 0;
+    mbedtls_mpi K;
+    mbedtls_mpi_init( &K );
+
+    /* DP = D mod P-1 */
+    if( DP != NULL )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &K, P, 1  ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( DP, D, &K ) );
+    }
+
+    /* DQ = D mod Q-1 */
+    if( DQ != NULL )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &K, Q, 1  ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( DQ, D, &K ) );
+    }
+
+    /* QP = Q^{-1} mod P */
+    if( QP != NULL )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_mpi_inv_mod( QP, Q, P ) );
+    }
+
+cleanup:
+    mbedtls_mpi_free( &K );
+
+    return( ret );
+}
+
+#endif /* MBEDTLS_RSA_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/sha1.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/sha1.c
@@ -1,0 +1,569 @@
+/*
+ *  FIPS-180-1 compliant SHA-1 implementation
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+/*
+ *  The SHA-1 standard was published by NIST in 1993.
+ *
+ *  http://www.itl.nist.gov/fipspubs/fip180-1.htm
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_SHA1_C)
+
+#include "mbedtls/sha1.h"
+#include "mbedtls/platform_util.h"
+
+#if defined(MBEDTLS_SELF_TEST)
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#define mbedtls_printf printf
+#endif /* MBEDTLS_PLATFORM_C */
+#endif /* MBEDTLS_SELF_TEST */
+
+#define SHA1_VALIDATE_RET(cond)                             \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_SHA1_BAD_INPUT_DATA )
+
+#define SHA1_VALIDATE(cond)  MBEDTLS_INTERNAL_VALIDATE( cond )
+
+#if !defined(MBEDTLS_SHA1_ALT)
+
+/*
+ * 32-bit integer manipulation macros (big endian)
+ */
+#ifndef GET_UINT32_BE
+#define GET_UINT32_BE(n,b,i)                            \
+{                                                       \
+    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
+        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
+        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
+        | ( (uint32_t) (b)[(i) + 3]       );            \
+}
+#endif
+
+#ifndef PUT_UINT32_BE
+#define PUT_UINT32_BE(n,b,i)                            \
+{                                                       \
+    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
+    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
+    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
+    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
+}
+#endif
+
+void mbedtls_sha1_init( mbedtls_sha1_context *ctx )
+{
+    SHA1_VALIDATE( ctx != NULL );
+
+    memset( ctx, 0, sizeof( mbedtls_sha1_context ) );
+}
+
+void mbedtls_sha1_free( mbedtls_sha1_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_sha1_context ) );
+}
+
+void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
+                         const mbedtls_sha1_context *src )
+{
+    SHA1_VALIDATE( dst != NULL );
+    SHA1_VALIDATE( src != NULL );
+
+    *dst = *src;
+}
+
+/*
+ * SHA-1 context setup
+ */
+int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx )
+{
+    SHA1_VALIDATE_RET( ctx != NULL );
+
+    ctx->total[0] = 0;
+    ctx->total[1] = 0;
+
+    ctx->state[0] = 0x67452301;
+    ctx->state[1] = 0xEFCDAB89;
+    ctx->state[2] = 0x98BADCFE;
+    ctx->state[3] = 0x10325476;
+    ctx->state[4] = 0xC3D2E1F0;
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha1_starts( mbedtls_sha1_context *ctx )
+{
+    mbedtls_sha1_starts_ret( ctx );
+}
+#endif
+
+#if !defined(MBEDTLS_SHA1_PROCESS_ALT)
+int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
+                                   const unsigned char data[64] )
+{
+    uint32_t temp, W[16], A, B, C, D, E;
+
+    SHA1_VALIDATE_RET( ctx != NULL );
+    SHA1_VALIDATE_RET( (const unsigned char *)data != NULL );
+
+    GET_UINT32_BE( W[ 0], data,  0 );
+    GET_UINT32_BE( W[ 1], data,  4 );
+    GET_UINT32_BE( W[ 2], data,  8 );
+    GET_UINT32_BE( W[ 3], data, 12 );
+    GET_UINT32_BE( W[ 4], data, 16 );
+    GET_UINT32_BE( W[ 5], data, 20 );
+    GET_UINT32_BE( W[ 6], data, 24 );
+    GET_UINT32_BE( W[ 7], data, 28 );
+    GET_UINT32_BE( W[ 8], data, 32 );
+    GET_UINT32_BE( W[ 9], data, 36 );
+    GET_UINT32_BE( W[10], data, 40 );
+    GET_UINT32_BE( W[11], data, 44 );
+    GET_UINT32_BE( W[12], data, 48 );
+    GET_UINT32_BE( W[13], data, 52 );
+    GET_UINT32_BE( W[14], data, 56 );
+    GET_UINT32_BE( W[15], data, 60 );
+
+#define S(x,n) ((x << n) | ((x & 0xFFFFFFFF) >> (32 - n)))
+
+#define R(t)                                            \
+(                                                       \
+    temp = W[( t -  3 ) & 0x0F] ^ W[( t - 8 ) & 0x0F] ^ \
+           W[( t - 14 ) & 0x0F] ^ W[  t       & 0x0F],  \
+    ( W[t & 0x0F] = S(temp,1) )                         \
+)
+
+#define P(a,b,c,d,e,x)                                  \
+{                                                       \
+    e += S(a,5) + F(b,c,d) + K + x; b = S(b,30);        \
+}
+
+    A = ctx->state[0];
+    B = ctx->state[1];
+    C = ctx->state[2];
+    D = ctx->state[3];
+    E = ctx->state[4];
+
+#define F(x,y,z) (z ^ (x & (y ^ z)))
+#define K 0x5A827999
+
+    P( A, B, C, D, E, W[0]  );
+    P( E, A, B, C, D, W[1]  );
+    P( D, E, A, B, C, W[2]  );
+    P( C, D, E, A, B, W[3]  );
+    P( B, C, D, E, A, W[4]  );
+    P( A, B, C, D, E, W[5]  );
+    P( E, A, B, C, D, W[6]  );
+    P( D, E, A, B, C, W[7]  );
+    P( C, D, E, A, B, W[8]  );
+    P( B, C, D, E, A, W[9]  );
+    P( A, B, C, D, E, W[10] );
+    P( E, A, B, C, D, W[11] );
+    P( D, E, A, B, C, W[12] );
+    P( C, D, E, A, B, W[13] );
+    P( B, C, D, E, A, W[14] );
+    P( A, B, C, D, E, W[15] );
+    P( E, A, B, C, D, R(16) );
+    P( D, E, A, B, C, R(17) );
+    P( C, D, E, A, B, R(18) );
+    P( B, C, D, E, A, R(19) );
+
+#undef K
+#undef F
+
+#define F(x,y,z) (x ^ y ^ z)
+#define K 0x6ED9EBA1
+
+    P( A, B, C, D, E, R(20) );
+    P( E, A, B, C, D, R(21) );
+    P( D, E, A, B, C, R(22) );
+    P( C, D, E, A, B, R(23) );
+    P( B, C, D, E, A, R(24) );
+    P( A, B, C, D, E, R(25) );
+    P( E, A, B, C, D, R(26) );
+    P( D, E, A, B, C, R(27) );
+    P( C, D, E, A, B, R(28) );
+    P( B, C, D, E, A, R(29) );
+    P( A, B, C, D, E, R(30) );
+    P( E, A, B, C, D, R(31) );
+    P( D, E, A, B, C, R(32) );
+    P( C, D, E, A, B, R(33) );
+    P( B, C, D, E, A, R(34) );
+    P( A, B, C, D, E, R(35) );
+    P( E, A, B, C, D, R(36) );
+    P( D, E, A, B, C, R(37) );
+    P( C, D, E, A, B, R(38) );
+    P( B, C, D, E, A, R(39) );
+
+#undef K
+#undef F
+
+#define F(x,y,z) ((x & y) | (z & (x | y)))
+#define K 0x8F1BBCDC
+
+    P( A, B, C, D, E, R(40) );
+    P( E, A, B, C, D, R(41) );
+    P( D, E, A, B, C, R(42) );
+    P( C, D, E, A, B, R(43) );
+    P( B, C, D, E, A, R(44) );
+    P( A, B, C, D, E, R(45) );
+    P( E, A, B, C, D, R(46) );
+    P( D, E, A, B, C, R(47) );
+    P( C, D, E, A, B, R(48) );
+    P( B, C, D, E, A, R(49) );
+    P( A, B, C, D, E, R(50) );
+    P( E, A, B, C, D, R(51) );
+    P( D, E, A, B, C, R(52) );
+    P( C, D, E, A, B, R(53) );
+    P( B, C, D, E, A, R(54) );
+    P( A, B, C, D, E, R(55) );
+    P( E, A, B, C, D, R(56) );
+    P( D, E, A, B, C, R(57) );
+    P( C, D, E, A, B, R(58) );
+    P( B, C, D, E, A, R(59) );
+
+#undef K
+#undef F
+
+#define F(x,y,z) (x ^ y ^ z)
+#define K 0xCA62C1D6
+
+    P( A, B, C, D, E, R(60) );
+    P( E, A, B, C, D, R(61) );
+    P( D, E, A, B, C, R(62) );
+    P( C, D, E, A, B, R(63) );
+    P( B, C, D, E, A, R(64) );
+    P( A, B, C, D, E, R(65) );
+    P( E, A, B, C, D, R(66) );
+    P( D, E, A, B, C, R(67) );
+    P( C, D, E, A, B, R(68) );
+    P( B, C, D, E, A, R(69) );
+    P( A, B, C, D, E, R(70) );
+    P( E, A, B, C, D, R(71) );
+    P( D, E, A, B, C, R(72) );
+    P( C, D, E, A, B, R(73) );
+    P( B, C, D, E, A, R(74) );
+    P( A, B, C, D, E, R(75) );
+    P( E, A, B, C, D, R(76) );
+    P( D, E, A, B, C, R(77) );
+    P( C, D, E, A, B, R(78) );
+    P( B, C, D, E, A, R(79) );
+
+#undef K
+#undef F
+
+    ctx->state[0] += A;
+    ctx->state[1] += B;
+    ctx->state[2] += C;
+    ctx->state[3] += D;
+    ctx->state[4] += E;
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha1_process( mbedtls_sha1_context *ctx,
+                           const unsigned char data[64] )
+{
+    mbedtls_internal_sha1_process( ctx, data );
+}
+#endif
+#endif /* !MBEDTLS_SHA1_PROCESS_ALT */
+
+/*
+ * SHA-1 process buffer
+ */
+int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
+                             const unsigned char *input,
+                             size_t ilen )
+{
+    int ret;
+    size_t fill;
+    uint32_t left;
+
+    SHA1_VALIDATE_RET( ctx != NULL );
+    SHA1_VALIDATE_RET( ilen == 0 || input != NULL );
+
+    if( ilen == 0 )
+        return( 0 );
+
+    left = ctx->total[0] & 0x3F;
+    fill = 64 - left;
+
+    ctx->total[0] += (uint32_t) ilen;
+    ctx->total[0] &= 0xFFFFFFFF;
+
+    if( ctx->total[0] < (uint32_t) ilen )
+        ctx->total[1]++;
+
+    if( left && ilen >= fill )
+    {
+        memcpy( (void *) (ctx->buffer + left), input, fill );
+
+        if( ( ret = mbedtls_internal_sha1_process( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
+        input += fill;
+        ilen  -= fill;
+        left = 0;
+    }
+
+    while( ilen >= 64 )
+    {
+        if( ( ret = mbedtls_internal_sha1_process( ctx, input ) ) != 0 )
+            return( ret );
+
+        input += 64;
+        ilen  -= 64;
+    }
+
+    if( ilen > 0 )
+        memcpy( (void *) (ctx->buffer + left), input, ilen );
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha1_update( mbedtls_sha1_context *ctx,
+                          const unsigned char *input,
+                          size_t ilen )
+{
+    mbedtls_sha1_update_ret( ctx, input, ilen );
+}
+#endif
+
+/*
+ * SHA-1 final digest
+ */
+int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
+                             unsigned char output[20] )
+{
+    int ret;
+    uint32_t used;
+    uint32_t high, low;
+
+    SHA1_VALIDATE_RET( ctx != NULL );
+    SHA1_VALIDATE_RET( (unsigned char *)output != NULL );
+
+    /*
+     * Add padding: 0x80 then 0x00 until 8 bytes remain for the length
+     */
+    used = ctx->total[0] & 0x3F;
+
+    ctx->buffer[used++] = 0x80;
+
+    if( used <= 56 )
+    {
+        /* Enough room for padding + length in current block */
+        memset( ctx->buffer + used, 0, 56 - used );
+    }
+    else
+    {
+        /* We'll need an extra block */
+        memset( ctx->buffer + used, 0, 64 - used );
+
+        if( ( ret = mbedtls_internal_sha1_process( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
+        memset( ctx->buffer, 0, 56 );
+    }
+
+    /*
+     * Add message length
+     */
+    high = ( ctx->total[0] >> 29 )
+         | ( ctx->total[1] <<  3 );
+    low  = ( ctx->total[0] <<  3 );
+
+    PUT_UINT32_BE( high, ctx->buffer, 56 );
+    PUT_UINT32_BE( low,  ctx->buffer, 60 );
+
+    if( ( ret = mbedtls_internal_sha1_process( ctx, ctx->buffer ) ) != 0 )
+        return( ret );
+
+    /*
+     * Output final state
+     */
+    PUT_UINT32_BE( ctx->state[0], output,  0 );
+    PUT_UINT32_BE( ctx->state[1], output,  4 );
+    PUT_UINT32_BE( ctx->state[2], output,  8 );
+    PUT_UINT32_BE( ctx->state[3], output, 12 );
+    PUT_UINT32_BE( ctx->state[4], output, 16 );
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha1_finish( mbedtls_sha1_context *ctx,
+                          unsigned char output[20] )
+{
+    mbedtls_sha1_finish_ret( ctx, output );
+}
+#endif
+
+#endif /* !MBEDTLS_SHA1_ALT */
+
+/*
+ * output = SHA-1( input buffer )
+ */
+int mbedtls_sha1_ret( const unsigned char *input,
+                      size_t ilen,
+                      unsigned char output[20] )
+{
+    int ret;
+    mbedtls_sha1_context ctx;
+
+    SHA1_VALIDATE_RET( ilen == 0 || input != NULL );
+    SHA1_VALIDATE_RET( (unsigned char *)output != NULL );
+
+    mbedtls_sha1_init( &ctx );
+
+    if( ( ret = mbedtls_sha1_starts_ret( &ctx ) ) != 0 )
+        goto exit;
+
+    if( ( ret = mbedtls_sha1_update_ret( &ctx, input, ilen ) ) != 0 )
+        goto exit;
+
+    if( ( ret = mbedtls_sha1_finish_ret( &ctx, output ) ) != 0 )
+        goto exit;
+
+exit:
+    mbedtls_sha1_free( &ctx );
+
+    return( ret );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha1( const unsigned char *input,
+                   size_t ilen,
+                   unsigned char output[20] )
+{
+    mbedtls_sha1_ret( input, ilen, output );
+}
+#endif
+
+#if defined(MBEDTLS_SELF_TEST)
+/*
+ * FIPS-180-1 test vectors
+ */
+static const unsigned char sha1_test_buf[3][57] =
+{
+    { "abc" },
+    { "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" },
+    { "" }
+};
+
+static const size_t sha1_test_buflen[3] =
+{
+    3, 56, 1000
+};
+
+static const unsigned char sha1_test_sum[3][20] =
+{
+    { 0xA9, 0x99, 0x3E, 0x36, 0x47, 0x06, 0x81, 0x6A, 0xBA, 0x3E,
+      0x25, 0x71, 0x78, 0x50, 0xC2, 0x6C, 0x9C, 0xD0, 0xD8, 0x9D },
+    { 0x84, 0x98, 0x3E, 0x44, 0x1C, 0x3B, 0xD2, 0x6E, 0xBA, 0xAE,
+      0x4A, 0xA1, 0xF9, 0x51, 0x29, 0xE5, 0xE5, 0x46, 0x70, 0xF1 },
+    { 0x34, 0xAA, 0x97, 0x3C, 0xD4, 0xC4, 0xDA, 0xA4, 0xF6, 0x1E,
+      0xEB, 0x2B, 0xDB, 0xAD, 0x27, 0x31, 0x65, 0x34, 0x01, 0x6F }
+};
+
+/*
+ * Checkup routine
+ */
+int mbedtls_sha1_self_test( int verbose )
+{
+    int i, j, buflen, ret = 0;
+    unsigned char buf[1024];
+    unsigned char sha1sum[20];
+    mbedtls_sha1_context ctx;
+
+    mbedtls_sha1_init( &ctx );
+
+    /*
+     * SHA-1
+     */
+    for( i = 0; i < 3; i++ )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "  SHA-1 test #%d: ", i + 1 );
+
+        if( ( ret = mbedtls_sha1_starts_ret( &ctx ) ) != 0 )
+            goto fail;
+
+        if( i == 2 )
+        {
+            memset( buf, 'a', buflen = 1000 );
+
+            for( j = 0; j < 1000; j++ )
+            {
+                ret = mbedtls_sha1_update_ret( &ctx, buf, buflen );
+                if( ret != 0 )
+                    goto fail;
+            }
+        }
+        else
+        {
+            ret = mbedtls_sha1_update_ret( &ctx, sha1_test_buf[i],
+                                           sha1_test_buflen[i] );
+            if( ret != 0 )
+                goto fail;
+        }
+
+        if( ( ret = mbedtls_sha1_finish_ret( &ctx, sha1sum ) ) != 0 )
+            goto fail;
+
+        if( memcmp( sha1sum, sha1_test_sum[i], 20 ) != 0 )
+        {
+            ret = 1;
+            goto fail;
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+
+    goto exit;
+
+fail:
+    if( verbose != 0 )
+        mbedtls_printf( "failed\n" );
+
+exit:
+    mbedtls_sha1_free( &ctx );
+
+    return( ret );
+}
+
+#endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_SHA1_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/sha256.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/sha256.c
@@ -1,0 +1,583 @@
+/*
+ *  FIPS-180-2 compliant SHA-256 implementation
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+/*
+ *  The SHA-256 Secure Hash Standard was published by NIST in 2002.
+ *
+ *  http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_SHA256_C)
+
+#include "mbedtls/sha256.h"
+#include "mbedtls/platform_util.h"
+
+#if defined(MBEDTLS_SELF_TEST)
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#define mbedtls_printf printf
+#define mbedtls_calloc    calloc
+#define mbedtls_free       free
+#endif /* MBEDTLS_PLATFORM_C */
+#endif /* MBEDTLS_SELF_TEST */
+
+#define SHA256_VALIDATE_RET(cond)                           \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_SHA256_BAD_INPUT_DATA )
+#define SHA256_VALIDATE(cond)  MBEDTLS_INTERNAL_VALIDATE( cond )
+
+#if !defined(MBEDTLS_SHA256_ALT)
+
+/*
+ * 32-bit integer manipulation macros (big endian)
+ */
+#ifndef GET_UINT32_BE
+#define GET_UINT32_BE(n,b,i)                            \
+do {                                                    \
+    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
+        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
+        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
+        | ( (uint32_t) (b)[(i) + 3]       );            \
+} while( 0 )
+#endif
+
+#ifndef PUT_UINT32_BE
+#define PUT_UINT32_BE(n,b,i)                            \
+do {                                                    \
+    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
+    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
+    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
+    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
+} while( 0 )
+#endif
+
+void mbedtls_sha256_init( mbedtls_sha256_context *ctx )
+{
+    SHA256_VALIDATE( ctx != NULL );
+
+    memset( ctx, 0, sizeof( mbedtls_sha256_context ) );
+}
+
+void mbedtls_sha256_free( mbedtls_sha256_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_sha256_context ) );
+}
+
+void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
+                           const mbedtls_sha256_context *src )
+{
+    SHA256_VALIDATE( dst != NULL );
+    SHA256_VALIDATE( src != NULL );
+
+    *dst = *src;
+}
+
+/*
+ * SHA-256 context setup
+ */
+int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 )
+{
+    SHA256_VALIDATE_RET( ctx != NULL );
+    SHA256_VALIDATE_RET( is224 == 0 || is224 == 1 );
+
+    ctx->total[0] = 0;
+    ctx->total[1] = 0;
+
+    if( is224 == 0 )
+    {
+        /* SHA-256 */
+        ctx->state[0] = 0x6A09E667;
+        ctx->state[1] = 0xBB67AE85;
+        ctx->state[2] = 0x3C6EF372;
+        ctx->state[3] = 0xA54FF53A;
+        ctx->state[4] = 0x510E527F;
+        ctx->state[5] = 0x9B05688C;
+        ctx->state[6] = 0x1F83D9AB;
+        ctx->state[7] = 0x5BE0CD19;
+    }
+    else
+    {
+        /* SHA-224 */
+        ctx->state[0] = 0xC1059ED8;
+        ctx->state[1] = 0x367CD507;
+        ctx->state[2] = 0x3070DD17;
+        ctx->state[3] = 0xF70E5939;
+        ctx->state[4] = 0xFFC00B31;
+        ctx->state[5] = 0x68581511;
+        ctx->state[6] = 0x64F98FA7;
+        ctx->state[7] = 0xBEFA4FA4;
+    }
+
+    ctx->is224 = is224;
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha256_starts( mbedtls_sha256_context *ctx,
+                            int is224 )
+{
+    mbedtls_sha256_starts_ret( ctx, is224 );
+}
+#endif
+
+#if !defined(MBEDTLS_SHA256_PROCESS_ALT)
+static const uint32_t K[] =
+{
+    0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
+    0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+    0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
+    0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+    0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
+    0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+    0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
+    0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+    0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
+    0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+    0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
+    0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+    0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
+    0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+    0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
+    0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2,
+};
+
+#define  SHR(x,n) ((x & 0xFFFFFFFF) >> n)
+#define ROTR(x,n) (SHR(x,n) | (x << (32 - n)))
+
+#define S0(x) (ROTR(x, 7) ^ ROTR(x,18) ^  SHR(x, 3))
+#define S1(x) (ROTR(x,17) ^ ROTR(x,19) ^  SHR(x,10))
+
+#define S2(x) (ROTR(x, 2) ^ ROTR(x,13) ^ ROTR(x,22))
+#define S3(x) (ROTR(x, 6) ^ ROTR(x,11) ^ ROTR(x,25))
+
+#define F0(x,y,z) ((x & y) | (z & (x | y)))
+#define F1(x,y,z) (z ^ (x & (y ^ z)))
+
+#define R(t)                                    \
+(                                               \
+    W[t] = S1(W[t -  2]) + W[t -  7] +          \
+           S0(W[t - 15]) + W[t - 16]            \
+)
+
+#define P(a,b,c,d,e,f,g,h,x,K)                  \
+{                                               \
+    temp1 = h + S3(e) + F1(e,f,g) + K + x;      \
+    temp2 = S2(a) + F0(a,b,c);                  \
+    d += temp1; h = temp1 + temp2;              \
+}
+
+int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
+                                const unsigned char data[64] )
+{
+    uint32_t temp1, temp2, W[64];
+    uint32_t A[8];
+    unsigned int i;
+
+    SHA256_VALIDATE_RET( ctx != NULL );
+    SHA256_VALIDATE_RET( (const unsigned char *)data != NULL );
+
+    for( i = 0; i < 8; i++ )
+        A[i] = ctx->state[i];
+
+#if defined(MBEDTLS_SHA256_SMALLER)
+    for( i = 0; i < 64; i++ )
+    {
+        if( i < 16 )
+            GET_UINT32_BE( W[i], data, 4 * i );
+        else
+            R( i );
+
+        P( A[0], A[1], A[2], A[3], A[4], A[5], A[6], A[7], W[i], K[i] );
+
+        temp1 = A[7]; A[7] = A[6]; A[6] = A[5]; A[5] = A[4]; A[4] = A[3];
+        A[3] = A[2]; A[2] = A[1]; A[1] = A[0]; A[0] = temp1;
+    }
+#else /* MBEDTLS_SHA256_SMALLER */
+    for( i = 0; i < 16; i++ )
+        GET_UINT32_BE( W[i], data, 4 * i );
+
+    for( i = 0; i < 16; i += 8 )
+    {
+        P( A[0], A[1], A[2], A[3], A[4], A[5], A[6], A[7], W[i+0], K[i+0] );
+        P( A[7], A[0], A[1], A[2], A[3], A[4], A[5], A[6], W[i+1], K[i+1] );
+        P( A[6], A[7], A[0], A[1], A[2], A[3], A[4], A[5], W[i+2], K[i+2] );
+        P( A[5], A[6], A[7], A[0], A[1], A[2], A[3], A[4], W[i+3], K[i+3] );
+        P( A[4], A[5], A[6], A[7], A[0], A[1], A[2], A[3], W[i+4], K[i+4] );
+        P( A[3], A[4], A[5], A[6], A[7], A[0], A[1], A[2], W[i+5], K[i+5] );
+        P( A[2], A[3], A[4], A[5], A[6], A[7], A[0], A[1], W[i+6], K[i+6] );
+        P( A[1], A[2], A[3], A[4], A[5], A[6], A[7], A[0], W[i+7], K[i+7] );
+    }
+
+    for( i = 16; i < 64; i += 8 )
+    {
+        P( A[0], A[1], A[2], A[3], A[4], A[5], A[6], A[7], R(i+0), K[i+0] );
+        P( A[7], A[0], A[1], A[2], A[3], A[4], A[5], A[6], R(i+1), K[i+1] );
+        P( A[6], A[7], A[0], A[1], A[2], A[3], A[4], A[5], R(i+2), K[i+2] );
+        P( A[5], A[6], A[7], A[0], A[1], A[2], A[3], A[4], R(i+3), K[i+3] );
+        P( A[4], A[5], A[6], A[7], A[0], A[1], A[2], A[3], R(i+4), K[i+4] );
+        P( A[3], A[4], A[5], A[6], A[7], A[0], A[1], A[2], R(i+5), K[i+5] );
+        P( A[2], A[3], A[4], A[5], A[6], A[7], A[0], A[1], R(i+6), K[i+6] );
+        P( A[1], A[2], A[3], A[4], A[5], A[6], A[7], A[0], R(i+7), K[i+7] );
+    }
+#endif /* MBEDTLS_SHA256_SMALLER */
+
+    for( i = 0; i < 8; i++ )
+        ctx->state[i] += A[i];
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha256_process( mbedtls_sha256_context *ctx,
+                             const unsigned char data[64] )
+{
+    mbedtls_internal_sha256_process( ctx, data );
+}
+#endif
+#endif /* !MBEDTLS_SHA256_PROCESS_ALT */
+
+/*
+ * SHA-256 process buffer
+ */
+int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
+                               const unsigned char *input,
+                               size_t ilen )
+{
+    int ret;
+    size_t fill;
+    uint32_t left;
+
+    SHA256_VALIDATE_RET( ctx != NULL );
+    SHA256_VALIDATE_RET( ilen == 0 || input != NULL );
+
+    if( ilen == 0 )
+        return( 0 );
+
+    left = ctx->total[0] & 0x3F;
+    fill = 64 - left;
+
+    ctx->total[0] += (uint32_t) ilen;
+    ctx->total[0] &= 0xFFFFFFFF;
+
+    if( ctx->total[0] < (uint32_t) ilen )
+        ctx->total[1]++;
+
+    if( left && ilen >= fill )
+    {
+        memcpy( (void *) (ctx->buffer + left), input, fill );
+
+        if( ( ret = mbedtls_internal_sha256_process( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
+        input += fill;
+        ilen  -= fill;
+        left = 0;
+    }
+
+    while( ilen >= 64 )
+    {
+        if( ( ret = mbedtls_internal_sha256_process( ctx, input ) ) != 0 )
+            return( ret );
+
+        input += 64;
+        ilen  -= 64;
+    }
+
+    if( ilen > 0 )
+        memcpy( (void *) (ctx->buffer + left), input, ilen );
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha256_update( mbedtls_sha256_context *ctx,
+                            const unsigned char *input,
+                            size_t ilen )
+{
+    mbedtls_sha256_update_ret( ctx, input, ilen );
+}
+#endif
+
+/*
+ * SHA-256 final digest
+ */
+int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
+                               unsigned char output[32] )
+{
+    int ret;
+    uint32_t used;
+    uint32_t high, low;
+
+    SHA256_VALIDATE_RET( ctx != NULL );
+    SHA256_VALIDATE_RET( (unsigned char *)output != NULL );
+
+    /*
+     * Add padding: 0x80 then 0x00 until 8 bytes remain for the length
+     */
+    used = ctx->total[0] & 0x3F;
+
+    ctx->buffer[used++] = 0x80;
+
+    if( used <= 56 )
+    {
+        /* Enough room for padding + length in current block */
+        memset( ctx->buffer + used, 0, 56 - used );
+    }
+    else
+    {
+        /* We'll need an extra block */
+        memset( ctx->buffer + used, 0, 64 - used );
+
+        if( ( ret = mbedtls_internal_sha256_process( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
+        memset( ctx->buffer, 0, 56 );
+    }
+
+    /*
+     * Add message length
+     */
+    high = ( ctx->total[0] >> 29 )
+         | ( ctx->total[1] <<  3 );
+    low  = ( ctx->total[0] <<  3 );
+
+    PUT_UINT32_BE( high, ctx->buffer, 56 );
+    PUT_UINT32_BE( low,  ctx->buffer, 60 );
+
+    if( ( ret = mbedtls_internal_sha256_process( ctx, ctx->buffer ) ) != 0 )
+        return( ret );
+
+    /*
+     * Output final state
+     */
+    PUT_UINT32_BE( ctx->state[0], output,  0 );
+    PUT_UINT32_BE( ctx->state[1], output,  4 );
+    PUT_UINT32_BE( ctx->state[2], output,  8 );
+    PUT_UINT32_BE( ctx->state[3], output, 12 );
+    PUT_UINT32_BE( ctx->state[4], output, 16 );
+    PUT_UINT32_BE( ctx->state[5], output, 20 );
+    PUT_UINT32_BE( ctx->state[6], output, 24 );
+
+    if( ctx->is224 == 0 )
+        PUT_UINT32_BE( ctx->state[7], output, 28 );
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha256_finish( mbedtls_sha256_context *ctx,
+                            unsigned char output[32] )
+{
+    mbedtls_sha256_finish_ret( ctx, output );
+}
+#endif
+
+#endif /* !MBEDTLS_SHA256_ALT */
+
+/*
+ * output = SHA-256( input buffer )
+ */
+int mbedtls_sha256_ret( const unsigned char *input,
+                        size_t ilen,
+                        unsigned char output[32],
+                        int is224 )
+{
+    int ret;
+    mbedtls_sha256_context ctx;
+
+    SHA256_VALIDATE_RET( is224 == 0 || is224 == 1 );
+    SHA256_VALIDATE_RET( ilen == 0 || input != NULL );
+    SHA256_VALIDATE_RET( (unsigned char *)output != NULL );
+
+    mbedtls_sha256_init( &ctx );
+
+    if( ( ret = mbedtls_sha256_starts_ret( &ctx, is224 ) ) != 0 )
+        goto exit;
+
+    if( ( ret = mbedtls_sha256_update_ret( &ctx, input, ilen ) ) != 0 )
+        goto exit;
+
+    if( ( ret = mbedtls_sha256_finish_ret( &ctx, output ) ) != 0 )
+        goto exit;
+
+exit:
+    mbedtls_sha256_free( &ctx );
+
+    return( ret );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha256( const unsigned char *input,
+                     size_t ilen,
+                     unsigned char output[32],
+                     int is224 )
+{
+    mbedtls_sha256_ret( input, ilen, output, is224 );
+}
+#endif
+
+#if defined(MBEDTLS_SELF_TEST)
+/*
+ * FIPS-180-2 test vectors
+ */
+static const unsigned char sha256_test_buf[3][57] =
+{
+    { "abc" },
+    { "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" },
+    { "" }
+};
+
+static const size_t sha256_test_buflen[3] =
+{
+    3, 56, 1000
+};
+
+static const unsigned char sha256_test_sum[6][32] =
+{
+    /*
+     * SHA-224 test vectors
+     */
+    { 0x23, 0x09, 0x7D, 0x22, 0x34, 0x05, 0xD8, 0x22,
+      0x86, 0x42, 0xA4, 0x77, 0xBD, 0xA2, 0x55, 0xB3,
+      0x2A, 0xAD, 0xBC, 0xE4, 0xBD, 0xA0, 0xB3, 0xF7,
+      0xE3, 0x6C, 0x9D, 0xA7 },
+    { 0x75, 0x38, 0x8B, 0x16, 0x51, 0x27, 0x76, 0xCC,
+      0x5D, 0xBA, 0x5D, 0xA1, 0xFD, 0x89, 0x01, 0x50,
+      0xB0, 0xC6, 0x45, 0x5C, 0xB4, 0xF5, 0x8B, 0x19,
+      0x52, 0x52, 0x25, 0x25 },
+    { 0x20, 0x79, 0x46, 0x55, 0x98, 0x0C, 0x91, 0xD8,
+      0xBB, 0xB4, 0xC1, 0xEA, 0x97, 0x61, 0x8A, 0x4B,
+      0xF0, 0x3F, 0x42, 0x58, 0x19, 0x48, 0xB2, 0xEE,
+      0x4E, 0xE7, 0xAD, 0x67 },
+
+    /*
+     * SHA-256 test vectors
+     */
+    { 0xBA, 0x78, 0x16, 0xBF, 0x8F, 0x01, 0xCF, 0xEA,
+      0x41, 0x41, 0x40, 0xDE, 0x5D, 0xAE, 0x22, 0x23,
+      0xB0, 0x03, 0x61, 0xA3, 0x96, 0x17, 0x7A, 0x9C,
+      0xB4, 0x10, 0xFF, 0x61, 0xF2, 0x00, 0x15, 0xAD },
+    { 0x24, 0x8D, 0x6A, 0x61, 0xD2, 0x06, 0x38, 0xB8,
+      0xE5, 0xC0, 0x26, 0x93, 0x0C, 0x3E, 0x60, 0x39,
+      0xA3, 0x3C, 0xE4, 0x59, 0x64, 0xFF, 0x21, 0x67,
+      0xF6, 0xEC, 0xED, 0xD4, 0x19, 0xDB, 0x06, 0xC1 },
+    { 0xCD, 0xC7, 0x6E, 0x5C, 0x99, 0x14, 0xFB, 0x92,
+      0x81, 0xA1, 0xC7, 0xE2, 0x84, 0xD7, 0x3E, 0x67,
+      0xF1, 0x80, 0x9A, 0x48, 0xA4, 0x97, 0x20, 0x0E,
+      0x04, 0x6D, 0x39, 0xCC, 0xC7, 0x11, 0x2C, 0xD0 }
+};
+
+/*
+ * Checkup routine
+ */
+int mbedtls_sha256_self_test( int verbose )
+{
+    int i, j, k, buflen, ret = 0;
+    unsigned char *buf;
+    unsigned char sha256sum[32];
+    mbedtls_sha256_context ctx;
+
+    buf = mbedtls_calloc( 1024, sizeof(unsigned char) );
+    if( NULL == buf )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "Buffer allocation failed\n" );
+
+        return( 1 );
+    }
+
+    mbedtls_sha256_init( &ctx );
+
+    for( i = 0; i < 6; i++ )
+    {
+        j = i % 3;
+        k = i < 3;
+
+        if( verbose != 0 )
+            mbedtls_printf( "  SHA-%d test #%d: ", 256 - k * 32, j + 1 );
+
+        if( ( ret = mbedtls_sha256_starts_ret( &ctx, k ) ) != 0 )
+            goto fail;
+
+        if( j == 2 )
+        {
+            memset( buf, 'a', buflen = 1000 );
+
+            for( j = 0; j < 1000; j++ )
+            {
+                ret = mbedtls_sha256_update_ret( &ctx, buf, buflen );
+                if( ret != 0 )
+                    goto fail;
+            }
+
+        }
+        else
+        {
+            ret = mbedtls_sha256_update_ret( &ctx, sha256_test_buf[j],
+                                             sha256_test_buflen[j] );
+            if( ret != 0 )
+                 goto fail;
+        }
+
+        if( ( ret = mbedtls_sha256_finish_ret( &ctx, sha256sum ) ) != 0 )
+            goto fail;
+
+
+        if( memcmp( sha256sum, sha256_test_sum[i], 32 - k * 4 ) != 0 )
+        {
+            ret = 1;
+            goto fail;
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+
+    goto exit;
+
+fail:
+    if( verbose != 0 )
+        mbedtls_printf( "failed\n" );
+
+exit:
+    mbedtls_sha256_free( &ctx );
+    mbedtls_free( buf );
+
+    return( ret );
+}
+
+#endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_SHA256_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/sha512.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/mbedtls/sha512.c
@@ -1,0 +1,634 @@
+/*
+ *  FIPS-180-2 compliant SHA-384/512 implementation
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+/*
+ *  The SHA-512 Secure Hash Standard was published by NIST in 2002.
+ *
+ *  http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_SHA512_C)
+
+#include "mbedtls/sha512.h"
+#include "mbedtls/platform_util.h"
+
+#if defined(_MSC_VER) || defined(__WATCOMC__)
+  #define UL64(x) x##ui64
+#else
+  #define UL64(x) x##ULL
+#endif
+
+#if defined(MBEDTLS_SELF_TEST)
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#define mbedtls_printf printf
+#define mbedtls_calloc    calloc
+#define mbedtls_free       free
+#endif /* MBEDTLS_PLATFORM_C */
+#endif /* MBEDTLS_SELF_TEST */
+
+#define SHA512_VALIDATE_RET(cond)                           \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_SHA512_BAD_INPUT_DATA )
+#define SHA512_VALIDATE(cond)  MBEDTLS_INTERNAL_VALIDATE( cond )
+
+#if !defined(MBEDTLS_SHA512_ALT)
+
+/*
+ * 64-bit integer manipulation macros (big endian)
+ */
+#ifndef GET_UINT64_BE
+#define GET_UINT64_BE(n,b,i)                            \
+{                                                       \
+    (n) = ( (uint64_t) (b)[(i)    ] << 56 )       \
+        | ( (uint64_t) (b)[(i) + 1] << 48 )       \
+        | ( (uint64_t) (b)[(i) + 2] << 40 )       \
+        | ( (uint64_t) (b)[(i) + 3] << 32 )       \
+        | ( (uint64_t) (b)[(i) + 4] << 24 )       \
+        | ( (uint64_t) (b)[(i) + 5] << 16 )       \
+        | ( (uint64_t) (b)[(i) + 6] <<  8 )       \
+        | ( (uint64_t) (b)[(i) + 7]       );      \
+}
+#endif /* GET_UINT64_BE */
+
+#ifndef PUT_UINT64_BE
+#define PUT_UINT64_BE(n,b,i)                            \
+{                                                       \
+    (b)[(i)    ] = (unsigned char) ( (n) >> 56 );       \
+    (b)[(i) + 1] = (unsigned char) ( (n) >> 48 );       \
+    (b)[(i) + 2] = (unsigned char) ( (n) >> 40 );       \
+    (b)[(i) + 3] = (unsigned char) ( (n) >> 32 );       \
+    (b)[(i) + 4] = (unsigned char) ( (n) >> 24 );       \
+    (b)[(i) + 5] = (unsigned char) ( (n) >> 16 );       \
+    (b)[(i) + 6] = (unsigned char) ( (n) >>  8 );       \
+    (b)[(i) + 7] = (unsigned char) ( (n)       );       \
+}
+#endif /* PUT_UINT64_BE */
+
+void mbedtls_sha512_init( mbedtls_sha512_context *ctx )
+{
+    SHA512_VALIDATE( ctx != NULL );
+
+    memset( ctx, 0, sizeof( mbedtls_sha512_context ) );
+}
+
+void mbedtls_sha512_free( mbedtls_sha512_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_sha512_context ) );
+}
+
+void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
+                           const mbedtls_sha512_context *src )
+{
+    SHA512_VALIDATE( dst != NULL );
+    SHA512_VALIDATE( src != NULL );
+
+    *dst = *src;
+}
+
+/*
+ * SHA-512 context setup
+ */
+int mbedtls_sha512_starts_ret( mbedtls_sha512_context *ctx, int is384 )
+{
+    SHA512_VALIDATE_RET( ctx != NULL );
+    SHA512_VALIDATE_RET( is384 == 0 || is384 == 1 );
+
+    ctx->total[0] = 0;
+    ctx->total[1] = 0;
+
+    if( is384 == 0 )
+    {
+        /* SHA-512 */
+        ctx->state[0] = UL64(0x6A09E667F3BCC908);
+        ctx->state[1] = UL64(0xBB67AE8584CAA73B);
+        ctx->state[2] = UL64(0x3C6EF372FE94F82B);
+        ctx->state[3] = UL64(0xA54FF53A5F1D36F1);
+        ctx->state[4] = UL64(0x510E527FADE682D1);
+        ctx->state[5] = UL64(0x9B05688C2B3E6C1F);
+        ctx->state[6] = UL64(0x1F83D9ABFB41BD6B);
+        ctx->state[7] = UL64(0x5BE0CD19137E2179);
+    }
+    else
+    {
+        /* SHA-384 */
+        ctx->state[0] = UL64(0xCBBB9D5DC1059ED8);
+        ctx->state[1] = UL64(0x629A292A367CD507);
+        ctx->state[2] = UL64(0x9159015A3070DD17);
+        ctx->state[3] = UL64(0x152FECD8F70E5939);
+        ctx->state[4] = UL64(0x67332667FFC00B31);
+        ctx->state[5] = UL64(0x8EB44A8768581511);
+        ctx->state[6] = UL64(0xDB0C2E0D64F98FA7);
+        ctx->state[7] = UL64(0x47B5481DBEFA4FA4);
+    }
+
+    ctx->is384 = is384;
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha512_starts( mbedtls_sha512_context *ctx,
+                            int is384 )
+{
+    mbedtls_sha512_starts_ret( ctx, is384 );
+}
+#endif
+
+#if !defined(MBEDTLS_SHA512_PROCESS_ALT)
+
+/*
+ * Round constants
+ */
+static const uint64_t K[80] =
+{
+    UL64(0x428A2F98D728AE22),  UL64(0x7137449123EF65CD),
+    UL64(0xB5C0FBCFEC4D3B2F),  UL64(0xE9B5DBA58189DBBC),
+    UL64(0x3956C25BF348B538),  UL64(0x59F111F1B605D019),
+    UL64(0x923F82A4AF194F9B),  UL64(0xAB1C5ED5DA6D8118),
+    UL64(0xD807AA98A3030242),  UL64(0x12835B0145706FBE),
+    UL64(0x243185BE4EE4B28C),  UL64(0x550C7DC3D5FFB4E2),
+    UL64(0x72BE5D74F27B896F),  UL64(0x80DEB1FE3B1696B1),
+    UL64(0x9BDC06A725C71235),  UL64(0xC19BF174CF692694),
+    UL64(0xE49B69C19EF14AD2),  UL64(0xEFBE4786384F25E3),
+    UL64(0x0FC19DC68B8CD5B5),  UL64(0x240CA1CC77AC9C65),
+    UL64(0x2DE92C6F592B0275),  UL64(0x4A7484AA6EA6E483),
+    UL64(0x5CB0A9DCBD41FBD4),  UL64(0x76F988DA831153B5),
+    UL64(0x983E5152EE66DFAB),  UL64(0xA831C66D2DB43210),
+    UL64(0xB00327C898FB213F),  UL64(0xBF597FC7BEEF0EE4),
+    UL64(0xC6E00BF33DA88FC2),  UL64(0xD5A79147930AA725),
+    UL64(0x06CA6351E003826F),  UL64(0x142929670A0E6E70),
+    UL64(0x27B70A8546D22FFC),  UL64(0x2E1B21385C26C926),
+    UL64(0x4D2C6DFC5AC42AED),  UL64(0x53380D139D95B3DF),
+    UL64(0x650A73548BAF63DE),  UL64(0x766A0ABB3C77B2A8),
+    UL64(0x81C2C92E47EDAEE6),  UL64(0x92722C851482353B),
+    UL64(0xA2BFE8A14CF10364),  UL64(0xA81A664BBC423001),
+    UL64(0xC24B8B70D0F89791),  UL64(0xC76C51A30654BE30),
+    UL64(0xD192E819D6EF5218),  UL64(0xD69906245565A910),
+    UL64(0xF40E35855771202A),  UL64(0x106AA07032BBD1B8),
+    UL64(0x19A4C116B8D2D0C8),  UL64(0x1E376C085141AB53),
+    UL64(0x2748774CDF8EEB99),  UL64(0x34B0BCB5E19B48A8),
+    UL64(0x391C0CB3C5C95A63),  UL64(0x4ED8AA4AE3418ACB),
+    UL64(0x5B9CCA4F7763E373),  UL64(0x682E6FF3D6B2B8A3),
+    UL64(0x748F82EE5DEFB2FC),  UL64(0x78A5636F43172F60),
+    UL64(0x84C87814A1F0AB72),  UL64(0x8CC702081A6439EC),
+    UL64(0x90BEFFFA23631E28),  UL64(0xA4506CEBDE82BDE9),
+    UL64(0xBEF9A3F7B2C67915),  UL64(0xC67178F2E372532B),
+    UL64(0xCA273ECEEA26619C),  UL64(0xD186B8C721C0C207),
+    UL64(0xEADA7DD6CDE0EB1E),  UL64(0xF57D4F7FEE6ED178),
+    UL64(0x06F067AA72176FBA),  UL64(0x0A637DC5A2C898A6),
+    UL64(0x113F9804BEF90DAE),  UL64(0x1B710B35131C471B),
+    UL64(0x28DB77F523047D84),  UL64(0x32CAAB7B40C72493),
+    UL64(0x3C9EBE0A15C9BEBC),  UL64(0x431D67C49C100D4C),
+    UL64(0x4CC5D4BECB3E42B6),  UL64(0x597F299CFC657E2A),
+    UL64(0x5FCB6FAB3AD6FAEC),  UL64(0x6C44198C4A475817)
+};
+
+int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
+                                     const unsigned char data[128] )
+{
+    int i;
+    static uint64_t W[80];
+    uint64_t temp1, temp2;
+    uint64_t A, B, C, D, E, F, G, H;
+
+    SHA512_VALIDATE_RET( ctx != NULL );
+    SHA512_VALIDATE_RET( (const unsigned char *)data != NULL );
+
+#define  SHR(x,n) (x >> n)
+#define ROTR(x,n) (SHR(x,n) | (x << (64 - n)))
+
+#define S0(x) (ROTR(x, 1) ^ ROTR(x, 8) ^  SHR(x, 7))
+#define S1(x) (ROTR(x,19) ^ ROTR(x,61) ^  SHR(x, 6))
+
+#define S2(x) (ROTR(x,28) ^ ROTR(x,34) ^ ROTR(x,39))
+#define S3(x) (ROTR(x,14) ^ ROTR(x,18) ^ ROTR(x,41))
+
+#define F0(x,y,z) ((x & y) | (z & (x | y)))
+#define F1(x,y,z) (z ^ (x & (y ^ z)))
+
+#define P(a,b,c,d,e,f,g,h,x,K)                  \
+{                                               \
+    temp1 = h + S3(e) + F1(e,f,g) + K + x;      \
+    temp2 = S2(a) + F0(a,b,c);                  \
+    d += temp1; h = temp1 + temp2;              \
+}
+
+    for( i = 0; i < 16; i++ )
+    {
+        GET_UINT64_BE( W[i], data, i << 3 );
+    }
+
+    for( ; i < 80; i++ )
+    {
+        W[i] = S1(W[i -  2]) + W[i -  7] +
+               S0(W[i - 15]) + W[i - 16];
+    }
+
+    A = ctx->state[0];
+    B = ctx->state[1];
+    C = ctx->state[2];
+    D = ctx->state[3];
+    E = ctx->state[4];
+    F = ctx->state[5];
+    G = ctx->state[6];
+    H = ctx->state[7];
+    i = 0;
+
+    do
+    {
+        P( A, B, C, D, E, F, G, H, W[i], K[i] ); i++;
+        P( H, A, B, C, D, E, F, G, W[i], K[i] ); i++;
+        P( G, H, A, B, C, D, E, F, W[i], K[i] ); i++;
+        P( F, G, H, A, B, C, D, E, W[i], K[i] ); i++;
+        P( E, F, G, H, A, B, C, D, W[i], K[i] ); i++;
+        P( D, E, F, G, H, A, B, C, W[i], K[i] ); i++;
+        P( C, D, E, F, G, H, A, B, W[i], K[i] ); i++;
+        P( B, C, D, E, F, G, H, A, W[i], K[i] ); i++;
+    }
+    while( i < 80 );
+
+    ctx->state[0] += A;
+    ctx->state[1] += B;
+    ctx->state[2] += C;
+    ctx->state[3] += D;
+    ctx->state[4] += E;
+    ctx->state[5] += F;
+    ctx->state[6] += G;
+    ctx->state[7] += H;
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha512_process( mbedtls_sha512_context *ctx,
+                             const unsigned char data[128] )
+{
+    mbedtls_internal_sha512_process( ctx, data );
+}
+#endif
+#endif /* !MBEDTLS_SHA512_PROCESS_ALT */
+
+/*
+ * SHA-512 process buffer
+ */
+int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
+                               const unsigned char *input,
+                               size_t ilen )
+{
+    int ret;
+    size_t fill;
+    unsigned int left;
+
+    SHA512_VALIDATE_RET( ctx != NULL );
+    SHA512_VALIDATE_RET( ilen == 0 || input != NULL );
+
+    if( ilen == 0 )
+        return( 0 );
+
+    left = (unsigned int) (ctx->total[0] & 0x7F);
+    fill = 128 - left;
+
+    ctx->total[0] += (uint64_t) ilen;
+
+    if( ctx->total[0] < (uint64_t) ilen )
+        ctx->total[1]++;
+
+    if( left && ilen >= fill )
+    {
+        memcpy( (void *) (ctx->buffer + left), input, fill );
+
+        if( ( ret = mbedtls_internal_sha512_process( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
+        input += fill;
+        ilen  -= fill;
+        left = 0;
+    }
+
+    while( ilen >= 128 )
+    {
+        if( ( ret = mbedtls_internal_sha512_process( ctx, input ) ) != 0 )
+            return( ret );
+
+        input += 128;
+        ilen  -= 128;
+    }
+
+    if( ilen > 0 )
+        memcpy( (void *) (ctx->buffer + left), input, ilen );
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha512_update( mbedtls_sha512_context *ctx,
+                            const unsigned char *input,
+                            size_t ilen )
+{
+    mbedtls_sha512_update_ret( ctx, input, ilen );
+}
+#endif
+
+/*
+ * SHA-512 final digest
+ */
+int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
+                               unsigned char output[64] )
+{
+    int ret;
+    unsigned used;
+    uint64_t high, low;
+
+    SHA512_VALIDATE_RET( ctx != NULL );
+    SHA512_VALIDATE_RET( (unsigned char *)output != NULL );
+
+    /*
+     * Add padding: 0x80 then 0x00 until 16 bytes remain for the length
+     */
+    used = ctx->total[0] & 0x7F;
+
+    ctx->buffer[used++] = 0x80;
+
+    if( used <= 112 )
+    {
+        /* Enough room for padding + length in current block */
+        memset( ctx->buffer + used, 0, 112 - used );
+    }
+    else
+    {
+        /* We'll need an extra block */
+        memset( ctx->buffer + used, 0, 128 - used );
+
+        if( ( ret = mbedtls_internal_sha512_process( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
+        memset( ctx->buffer, 0, 112 );
+    }
+
+    /*
+     * Add message length
+     */
+    high = ( ctx->total[0] >> 61 )
+         | ( ctx->total[1] <<  3 );
+    low  = ( ctx->total[0] <<  3 );
+
+    PUT_UINT64_BE( high, ctx->buffer, 112 );
+    PUT_UINT64_BE( low,  ctx->buffer, 120 );
+
+    if( ( ret = mbedtls_internal_sha512_process( ctx, ctx->buffer ) ) != 0 )
+        return( ret );
+
+    /*
+     * Output final state
+     */
+    PUT_UINT64_BE( ctx->state[0], output,  0 );
+    PUT_UINT64_BE( ctx->state[1], output,  8 );
+    PUT_UINT64_BE( ctx->state[2], output, 16 );
+    PUT_UINT64_BE( ctx->state[3], output, 24 );
+    PUT_UINT64_BE( ctx->state[4], output, 32 );
+    PUT_UINT64_BE( ctx->state[5], output, 40 );
+
+    if( ctx->is384 == 0 )
+    {
+        PUT_UINT64_BE( ctx->state[6], output, 48 );
+        PUT_UINT64_BE( ctx->state[7], output, 56 );
+    }
+
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha512_finish( mbedtls_sha512_context *ctx,
+                            unsigned char output[64] )
+{
+    mbedtls_sha512_finish_ret( ctx, output );
+}
+#endif
+
+#endif /* !MBEDTLS_SHA512_ALT */
+
+/*
+ * output = SHA-512( input buffer )
+ */
+int mbedtls_sha512_ret( const unsigned char *input,
+                    size_t ilen,
+                    unsigned char output[64],
+                    int is384 )
+{
+    int ret;
+    mbedtls_sha512_context ctx;
+
+    SHA512_VALIDATE_RET( is384 == 0 || is384 == 1 );
+    SHA512_VALIDATE_RET( ilen == 0 || input != NULL );
+    SHA512_VALIDATE_RET( (unsigned char *)output != NULL );
+
+    mbedtls_sha512_init( &ctx );
+
+    if( ( ret = mbedtls_sha512_starts_ret( &ctx, is384 ) ) != 0 )
+        goto exit;
+
+    if( ( ret = mbedtls_sha512_update_ret( &ctx, input, ilen ) ) != 0 )
+        goto exit;
+
+    if( ( ret = mbedtls_sha512_finish_ret( &ctx, output ) ) != 0 )
+        goto exit;
+
+exit:
+    mbedtls_sha512_free( &ctx );
+
+    return( ret );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_sha512( const unsigned char *input,
+                     size_t ilen,
+                     unsigned char output[64],
+                     int is384 )
+{
+    mbedtls_sha512_ret( input, ilen, output, is384 );
+}
+#endif
+
+#if defined(MBEDTLS_SELF_TEST)
+
+/*
+ * FIPS-180-2 test vectors
+ */
+static const unsigned char sha512_test_buf[3][113] =
+{
+    { "abc" },
+    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" },
+    { "" }
+};
+
+static const size_t sha512_test_buflen[3] =
+{
+    3, 112, 1000
+};
+
+static const unsigned char sha512_test_sum[6][64] =
+{
+    /*
+     * SHA-384 test vectors
+     */
+    { 0xCB, 0x00, 0x75, 0x3F, 0x45, 0xA3, 0x5E, 0x8B,
+      0xB5, 0xA0, 0x3D, 0x69, 0x9A, 0xC6, 0x50, 0x07,
+      0x27, 0x2C, 0x32, 0xAB, 0x0E, 0xDE, 0xD1, 0x63,
+      0x1A, 0x8B, 0x60, 0x5A, 0x43, 0xFF, 0x5B, 0xED,
+      0x80, 0x86, 0x07, 0x2B, 0xA1, 0xE7, 0xCC, 0x23,
+      0x58, 0xBA, 0xEC, 0xA1, 0x34, 0xC8, 0x25, 0xA7 },
+    { 0x09, 0x33, 0x0C, 0x33, 0xF7, 0x11, 0x47, 0xE8,
+      0x3D, 0x19, 0x2F, 0xC7, 0x82, 0xCD, 0x1B, 0x47,
+      0x53, 0x11, 0x1B, 0x17, 0x3B, 0x3B, 0x05, 0xD2,
+      0x2F, 0xA0, 0x80, 0x86, 0xE3, 0xB0, 0xF7, 0x12,
+      0xFC, 0xC7, 0xC7, 0x1A, 0x55, 0x7E, 0x2D, 0xB9,
+      0x66, 0xC3, 0xE9, 0xFA, 0x91, 0x74, 0x60, 0x39 },
+    { 0x9D, 0x0E, 0x18, 0x09, 0x71, 0x64, 0x74, 0xCB,
+      0x08, 0x6E, 0x83, 0x4E, 0x31, 0x0A, 0x4A, 0x1C,
+      0xED, 0x14, 0x9E, 0x9C, 0x00, 0xF2, 0x48, 0x52,
+      0x79, 0x72, 0xCE, 0xC5, 0x70, 0x4C, 0x2A, 0x5B,
+      0x07, 0xB8, 0xB3, 0xDC, 0x38, 0xEC, 0xC4, 0xEB,
+      0xAE, 0x97, 0xDD, 0xD8, 0x7F, 0x3D, 0x89, 0x85 },
+
+    /*
+     * SHA-512 test vectors
+     */
+    { 0xDD, 0xAF, 0x35, 0xA1, 0x93, 0x61, 0x7A, 0xBA,
+      0xCC, 0x41, 0x73, 0x49, 0xAE, 0x20, 0x41, 0x31,
+      0x12, 0xE6, 0xFA, 0x4E, 0x89, 0xA9, 0x7E, 0xA2,
+      0x0A, 0x9E, 0xEE, 0xE6, 0x4B, 0x55, 0xD3, 0x9A,
+      0x21, 0x92, 0x99, 0x2A, 0x27, 0x4F, 0xC1, 0xA8,
+      0x36, 0xBA, 0x3C, 0x23, 0xA3, 0xFE, 0xEB, 0xBD,
+      0x45, 0x4D, 0x44, 0x23, 0x64, 0x3C, 0xE8, 0x0E,
+      0x2A, 0x9A, 0xC9, 0x4F, 0xA5, 0x4C, 0xA4, 0x9F },
+    { 0x8E, 0x95, 0x9B, 0x75, 0xDA, 0xE3, 0x13, 0xDA,
+      0x8C, 0xF4, 0xF7, 0x28, 0x14, 0xFC, 0x14, 0x3F,
+      0x8F, 0x77, 0x79, 0xC6, 0xEB, 0x9F, 0x7F, 0xA1,
+      0x72, 0x99, 0xAE, 0xAD, 0xB6, 0x88, 0x90, 0x18,
+      0x50, 0x1D, 0x28, 0x9E, 0x49, 0x00, 0xF7, 0xE4,
+      0x33, 0x1B, 0x99, 0xDE, 0xC4, 0xB5, 0x43, 0x3A,
+      0xC7, 0xD3, 0x29, 0xEE, 0xB6, 0xDD, 0x26, 0x54,
+      0x5E, 0x96, 0xE5, 0x5B, 0x87, 0x4B, 0xE9, 0x09 },
+    { 0xE7, 0x18, 0x48, 0x3D, 0x0C, 0xE7, 0x69, 0x64,
+      0x4E, 0x2E, 0x42, 0xC7, 0xBC, 0x15, 0xB4, 0x63,
+      0x8E, 0x1F, 0x98, 0xB1, 0x3B, 0x20, 0x44, 0x28,
+      0x56, 0x32, 0xA8, 0x03, 0xAF, 0xA9, 0x73, 0xEB,
+      0xDE, 0x0F, 0xF2, 0x44, 0x87, 0x7E, 0xA6, 0x0A,
+      0x4C, 0xB0, 0x43, 0x2C, 0xE5, 0x77, 0xC3, 0x1B,
+      0xEB, 0x00, 0x9C, 0x5C, 0x2C, 0x49, 0xAA, 0x2E,
+      0x4E, 0xAD, 0xB2, 0x17, 0xAD, 0x8C, 0xC0, 0x9B }
+};
+
+/*
+ * Checkup routine
+ */
+int mbedtls_sha512_self_test( int verbose )
+{
+    int i, j, k, buflen, ret = 0;
+    unsigned char *buf;
+    unsigned char sha512sum[64];
+    mbedtls_sha512_context ctx;
+
+    buf = mbedtls_calloc( 1024, sizeof(unsigned char) );
+    if( NULL == buf )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "Buffer allocation failed\n" );
+
+        return( 1 );
+    }
+
+    mbedtls_sha512_init( &ctx );
+
+    for( i = 0; i < 6; i++ )
+    {
+        j = i % 3;
+        k = i < 3;
+
+        if( verbose != 0 )
+            mbedtls_printf( "  SHA-%d test #%d: ", 512 - k * 128, j + 1 );
+
+        if( ( ret = mbedtls_sha512_starts_ret( &ctx, k ) ) != 0 )
+            goto fail;
+
+        if( j == 2 )
+        {
+            memset( buf, 'a', buflen = 1000 );
+
+            for( j = 0; j < 1000; j++ )
+            {
+                ret = mbedtls_sha512_update_ret( &ctx, buf, buflen );
+                if( ret != 0 )
+                    goto fail;
+            }
+        }
+        else
+        {
+            ret = mbedtls_sha512_update_ret( &ctx, sha512_test_buf[j],
+                                             sha512_test_buflen[j] );
+            if( ret != 0 )
+                goto fail;
+        }
+
+        if( ( ret = mbedtls_sha512_finish_ret( &ctx, sha512sum ) ) != 0 )
+            goto fail;
+
+        if( memcmp( sha512sum, sha512_test_sum[i], 64 - k * 16 ) != 0 )
+        {
+            ret = 1;
+            goto fail;
+        }
+
+        if( verbose != 0 )
+            mbedtls_printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        mbedtls_printf( "\n" );
+
+    goto exit;
+
+fail:
+    if( verbose != 0 )
+        mbedtls_printf( "failed\n" );
+
+exit:
+    mbedtls_sha512_free( &ctx );
+    mbedtls_free( buf );
+
+    return( ret );
+}
+
+#endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_SHA512_C */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_dispatch.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_dispatch.c
@@ -1,0 +1,813 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : kapi_dispatch.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+
+#include "drv_osal_lib.h"
+#include "cryp_symc.h"
+#include "ext_alg.h"
+#include "hi_drv_compat.h"
+
+/*************************** Internal Structure Definition *******************/
+
+/* ! \max pakage numher of symc mutli encrypt */
+#define SYMC_MULTI_MAX_PKG      (0x1000)
+
+#define RSA_PUBLIC_BUFFER_NUM   (0x03)
+#define RSA_PRIVATE_BUFFER_NUM  (0x07)
+
+#define MAX_CENC_SUB_SAMPLE     (100)
+
+typedef hi_s32 (*hi_drv_func)(void *param);
+
+typedef struct {
+    const char *name;
+    hi_drv_func func;
+    hi_u32 cmd;
+} crypto_dispatch_func;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      link*/
+/** @{*/  /** <!-- [link]*/
+
+static hi_s32 dispatch_symc_create_handle(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    symc_create_t *symc_create = argp;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* allocate a aes channel */
+    ret = kapi_symc_create(&symc_create->id);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_create, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_symc_destroy_handle(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    symc_destroy_t *destroy = argp;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = kapi_symc_destroy(destroy->id);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_destroy, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_symc_config(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    symc_config_t *config = argp;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = kapi_symc_config(config->id,
+                           config->hard_key,
+                           config->alg,
+                           config->mode,
+                           config->width,
+                           config->klen,
+                           config->sm1_round_num,
+                           (hi_u8 *)config->fkey,
+                           (hi_u8 *)config->skey,
+                           (hi_u8 *)config->iv,
+                           config->ivlen,
+                           config->iv_usage,
+                           config->aad,
+                           config->alen,
+                           config->tlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_config, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_symc_encrypt(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    symc_encrypt_t *encrypt = argp;
+
+    HI_LOG_FUNC_ENTER();
+
+    if ((encrypt->operation == SYMC_OPERATION_ENCRYPT)
+        || (encrypt->operation == SYMC_OPERATION_DECRYPT)) {
+        ret = cipher_check_mmz_phy_addr(ADDR_U64(encrypt->input), encrypt->length);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("Invalid input mmz phy addr for crypt.\n");
+            HI_LOG_PRINT_FUNC_ERR(cipher_check_mmz_phy_addr, ret);
+            return ret;
+        }
+
+        ret = cipher_check_mmz_phy_addr(ADDR_U64(encrypt->output), encrypt->length);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("Invalid output mmz phy addr for crypt.\n");
+            HI_LOG_PRINT_FUNC_ERR(cipher_check_mmz_phy_addr, ret);
+            return ret;
+        }
+
+        ret = kapi_symc_crypto(encrypt->id,
+                               encrypt->input,
+                               encrypt->output,
+                               encrypt->length,
+                               encrypt->operation,
+                               encrypt->last);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(kapi_symc_crypto, ret);
+            return ret;
+        }
+    } else if ((encrypt->operation == SYMC_OPERATION_ENCRYPT_VIA)
+               || (encrypt->operation == SYMC_OPERATION_DECRYPT_VIA)) {
+        ret = kapi_symc_crypto_via(encrypt->id,
+                                   encrypt->input,
+                                   encrypt->output,
+                                   encrypt->length,
+                                   encrypt->operation,
+                                   encrypt->last,
+                                   HI_TRUE);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(kapi_symc_crypto_via, ret);
+            return ret;
+        }
+    } else {
+        HI_LOG_ERROR("encrypt operation(0x%x) is unsupported.\n", encrypt->operation);
+        return HI_ERR_CIPHER_UNSUPPORTED;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_symc_encrypt_multi(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    symc_encrypt_multi_t *encrypt_mutli = argp;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_DEBUG("operation %d\n", encrypt_mutli->operation);
+    ret = kapi_symc_crypto_multi(encrypt_mutli->id,
+                                 ADDR_VIA(encrypt_mutli->pkg),
+                                 encrypt_mutli->pkg_num,
+                                 encrypt_mutli->operation,
+                                 HI_TRUE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_crypto_multi, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_symc_get_tag(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    aead_tag_t *aead_tag = argp;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = kapi_aead_get_tag(aead_tag->id,
+                            aead_tag->tag,
+                            &aead_tag->taglen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_aead_get_tag, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_symc_get_config(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    symc_get_config_t *get_config = argp;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = kapi_symc_get_config(get_config->id, &get_config->ctrl);
+
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_get_config, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_klad_key(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    klad_key_t *klad = argp;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = klad_encrypt_key(klad->keysel, klad->target, klad->clear, klad->encrypt);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(klad_encrypt_key, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_hash_start(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    hash_start_t *start = argp;
+    hi_u8 *key = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_CHECK_PARAM(start->type >= HI_CIPHER_HASH_TYPE_BUTT);
+
+    if (start->type == HI_CIPHER_HASH_TYPE_SM3) {
+        HI_LOG_ERROR("Sm3 is unsupported.\n");
+        return HI_ERR_CIPHER_UNSUPPORTED;
+    }
+
+    if (start->type == HI_CIPHER_HASH_TYPE_HMAC_SHA1
+        || start->type == HI_CIPHER_HASH_TYPE_HMAC_SHA224
+        || start->type == HI_CIPHER_HASH_TYPE_HMAC_SHA256
+        || start->type == HI_CIPHER_HASH_TYPE_HMAC_SHA384
+        || start->type == HI_CIPHER_HASH_TYPE_HMAC_SHA512) {
+
+        HI_LOG_CHECK_PARAM(start->keylen > MAX_MALLOC_BUF_SIZE);
+        HI_LOG_CHECK_PARAM(ADDR_VIA(start->key) == HI_NULL);
+
+        key = (hi_u8 *)crypto_calloc(1, start->keylen);
+        if (key == HI_NULL) {
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+            HI_LOG_PRINT_FUNC_ERR(crypto_calloc, ret);
+            return HI_ERR_CIPHER_FAILED_MEM;
+        }
+
+        CHECK_EXIT(crypto_copy_from_user(key, ADDR_VIA(start->key), start->keylen));
+    }
+
+    CHECK_EXIT(kapi_hash_start(&start->id, start->type, key, start->keylen));
+
+    if (key != HI_NULL) {
+        crypto_zeroize(key, start->keylen);
+        crypto_free(key);
+        key = HI_NULL;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+exit__:
+    if (key != HI_NULL) {
+        crypto_zeroize(key, start->keylen);
+        crypto_free(key);
+        key = HI_NULL;
+    }
+
+    return ret;
+}
+
+static hi_s32 dispatch_hash_update(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    hash_update_t *update = argp;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ADDR_VIA(update->input) == HI_NULL);
+
+    update->src = HASH_CHUNCK_SRC_USER;
+    ret = kapi_hash_update(update->id,
+                           ADDR_VIA(update->input),
+                           update->length,
+                           update->src);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_hash_update, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_hash_finish(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    hash_finish_t *finish = argp;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = kapi_hash_finish(finish->id, (hi_u8 *)finish->hash, &finish->hashlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_hash_finish, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 rsa_alloc_buffer(cryp_rsa_key *key, rsa_info_t *rsa_info,
+                            hi_u8 **in, hi_u8 **out)
+{
+    hi_u32 size = 0, klen = 0;
+    hi_s32 ret = HI_FAILURE;
+    hi_u8 *buf = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (rsa_info->public == HI_FALSE) {
+        HI_LOG_CHECK_PARAM((ADDR_VIA(rsa_info->d) == HI_NULL)
+                           && ((ADDR_VIA(rsa_info->p) == HI_NULL)
+                               || (ADDR_VIA(rsa_info->q) == HI_NULL)
+                               || (ADDR_VIA(rsa_info->dp) == HI_NULL)
+                               || (ADDR_VIA(rsa_info->dq) == HI_NULL)
+                               || (ADDR_VIA(rsa_info->qp) == HI_NULL)));
+    }
+
+    HI_LOG_CHECK_PARAM(rsa_info->inlen > rsa_info->klen);
+    HI_LOG_CHECK_PARAM(rsa_info->outlen > rsa_info->klen);
+    HI_LOG_CHECK_PARAM(rsa_info->klen < RSA_KEY_BITWIDTH_1024);
+    HI_LOG_CHECK_PARAM(rsa_info->klen > RSA_KEY_BITWIDTH_4096);
+
+    crypto_memset(key, sizeof(cryp_rsa_key), 0, sizeof(cryp_rsa_key));
+
+    key->klen = klen = rsa_info->klen;
+    key->public = rsa_info->public;
+    key->ca_type = rsa_info->ca_type;
+
+    if (rsa_info->public) {
+        HI_LOG_CHECK_PARAM(key->ca_type != HI_CIPHER_KEY_SRC_USER);
+
+        /* buffer size of key, input and output */
+        size = rsa_info->klen * RSA_PUBLIC_BUFFER_NUM;
+
+        buf = crypto_calloc(1, size);
+        if (buf == HI_NULL) {
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+            HI_LOG_PRINT_FUNC_ERR(crypto_calloc, ret);
+            return HI_ERR_CIPHER_FAILED_MEM;
+        }
+
+        key->n = buf;
+        buf += klen;
+        *in  = buf;
+        buf += klen;
+        *out = buf;
+        buf += klen;
+        key->bufsize = size;
+
+        CHECK_EXIT(crypto_copy_from_user(key->n, ADDR_VIA(rsa_info->n), klen));
+        CHECK_EXIT(crypto_copy_from_user(*in, ADDR_VIA(rsa_info->in), klen));
+        key->e = rsa_info->e;
+    } else {
+        /* n + d or n + p + q + dP + dQ + qp
+         * the length of n/d is klen,
+         * the length of p/q/dP/dQ/qp is klen/2,
+         * the length of input is klen
+         * the length of output is klen
+         */
+        size = klen * RSA_PRIVATE_BUFFER_NUM;
+
+        buf = crypto_calloc(1, size);
+        HI_LOG_CHECK_PARAM(buf == HI_NULL);
+
+        key->n  = buf;
+        buf += klen;
+        key->d  = buf;
+        buf += klen;
+        key->p  = buf;
+        buf += klen / 2;
+        key->q  = buf;
+        buf += klen / 2;
+        key->dp = buf;
+        buf += klen / 2;
+        key->dq = buf;
+        buf += klen / 2;
+        key->qp = buf;
+        buf += klen / 2;
+        key->e  = rsa_info->e;
+        key->bufsize = size;
+
+        if (ADDR_VIA(rsa_info->n) != HI_NULL) {
+            CHECK_EXIT(crypto_copy_from_user(key->n, ADDR_VIA(rsa_info->n), klen));
+        }
+
+        if (ADDR_VIA(rsa_info->d) != HI_NULL) {
+            CHECK_EXIT(crypto_copy_from_user(key->d, ADDR_VIA(rsa_info->d), klen));
+        } else {
+            CHECK_EXIT(crypto_copy_from_user(key->p, ADDR_VIA(rsa_info->p), klen / 2));
+            CHECK_EXIT(crypto_copy_from_user(key->q, ADDR_VIA(rsa_info->q), klen / 2));
+            CHECK_EXIT(crypto_copy_from_user(key->dp, ADDR_VIA(rsa_info->dp), klen / 2));
+            CHECK_EXIT(crypto_copy_from_user(key->dq, ADDR_VIA(rsa_info->dq), klen / 2));
+            CHECK_EXIT(crypto_copy_from_user(key->qp, ADDR_VIA(rsa_info->qp), klen / 2));
+            key->d = HI_NULL;
+        }
+
+        *in  = buf;
+        buf += klen;
+        *out = buf;
+        buf += klen;
+
+        if (ADDR_VIA(rsa_info->in) != HI_NULL) {
+            CHECK_EXIT(crypto_copy_from_user(*in, ADDR_VIA(rsa_info->in), rsa_info->inlen));
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+exit__:
+    if (key->n != HI_NULL) {
+        crypto_zeroize(key->n, key->bufsize);
+        crypto_free(key->n);
+        key->n = HI_NULL;
+    }
+
+    HI_LOG_ERROR("error, copy rsa key from user failed\n");
+    HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_FAILED_MEM);
+
+    return HI_ERR_CIPHER_FAILED_MEM;
+}
+
+static void rsa_free_buffer(cryp_rsa_key *key)
+{
+    HI_LOG_FUNC_ENTER();
+
+    if (key->n != HI_NULL) {
+        crypto_zeroize(key->n, key->bufsize);
+        crypto_free(key->n);
+        key->n = HI_NULL;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return;
+}
+
+static hi_s32 dispatch_rsa_encrypt(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    rsa_info_t *rsa_info = argp;
+    hi_u8 *in = HI_NULL;
+    hi_u8 *out = HI_NULL;
+    cryp_rsa_key key;
+
+    HI_LOG_FUNC_ENTER();
+
+    crypto_memset(&key, sizeof(cryp_rsa_key), 0, sizeof(cryp_rsa_key));
+
+    ret = rsa_alloc_buffer(&key, rsa_info, &in, &out);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, rsa_alloc_key failed\n");
+        HI_LOG_PRINT_FUNC_ERR(rsa_alloc_buffer, ret);
+        return ret;
+    }
+
+    ret = kapi_rsa_encrypt(&key, rsa_info->scheme, in, rsa_info->inlen,
+                           out, &rsa_info->outlen);
+    if (ret != HI_SUCCESS) {
+        rsa_free_buffer(&key);
+        HI_LOG_PRINT_FUNC_ERR(kapi_rsa_encrypt, ret);
+        return ret;
+    }
+
+    ret = crypto_copy_to_user(ADDR_VIA(rsa_info->out), out, rsa_info->outlen);
+    if (ret != HI_SUCCESS) {
+        rsa_free_buffer(&key);
+        HI_LOG_PRINT_FUNC_ERR(crypto_copy_to_user, ret);
+        return ret;
+    }
+
+    rsa_free_buffer(&key);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_rsa_decrypt(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    rsa_info_t *rsa_info = argp;
+    hi_u8 *in = HI_NULL;
+    hi_u8 *out = HI_NULL;
+    cryp_rsa_key key;
+
+    HI_LOG_FUNC_ENTER();
+
+    crypto_memset(&key, sizeof(cryp_rsa_key), 0, sizeof(cryp_rsa_key));
+
+    ret = rsa_alloc_buffer(&key, rsa_info, &in, &out);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, rsa_alloc_key failed\n");
+        HI_LOG_PRINT_FUNC_ERR(rsa_alloc_buffer, ret);
+        return ret;
+    }
+
+    ret = kapi_rsa_decrypt(&key, rsa_info->scheme,
+                           in, rsa_info->inlen, out, &rsa_info->outlen);
+    if (ret != HI_SUCCESS) {
+        rsa_free_buffer(&key);
+        HI_LOG_PRINT_FUNC_ERR(kapi_rsa_decrypt, ret);
+        return ret;
+    }
+
+    ret = crypto_copy_to_user(ADDR_VIA(rsa_info->out), out, rsa_info->outlen);
+    if (ret != HI_SUCCESS) {
+        rsa_free_buffer(&key);
+        HI_LOG_PRINT_FUNC_ERR(crypto_copy_to_user, ret);
+        return ret;
+    }
+
+    rsa_free_buffer(&key);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_rsa_sign_hash(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    rsa_info_t *rsa_info = argp;
+    hi_u8 *in = HI_NULL;
+    hi_u8 *out = HI_NULL;
+    cryp_rsa_key key;
+
+    HI_LOG_FUNC_ENTER();
+
+    crypto_memset(&key, sizeof(cryp_rsa_key), 0, sizeof(cryp_rsa_key));
+
+    ret = rsa_alloc_buffer(&key, rsa_info, &in, &out);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, rsa alloc key buffer failed\n");
+        HI_LOG_PRINT_FUNC_ERR(rsa_alloc_buffer, ret);
+        return ret;
+    }
+
+    ret = kapi_rsa_sign_hash(&key, rsa_info->scheme, in,
+                             rsa_info->inlen, out, &rsa_info->outlen);
+    if (ret != HI_SUCCESS) {
+        rsa_free_buffer(&key);
+        HI_LOG_PRINT_FUNC_ERR(kapi_rsa_sign_hash, ret);
+        return ret;
+    }
+
+    ret = crypto_copy_to_user(ADDR_VIA(rsa_info->out), out, rsa_info->outlen);
+    if (ret != HI_SUCCESS) {
+        rsa_free_buffer(&key);
+        HI_LOG_PRINT_FUNC_ERR(crypto_copy_to_user, ret);
+        return ret;
+    }
+
+    rsa_free_buffer(&key);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 dispatch_rsa_verify_hash(void *argp)
+{
+    hi_s32 ret = HI_FAILURE;
+    rsa_info_t *rsa_info = argp;
+    hi_u8 *in = HI_NULL;
+    hi_u8 *out = HI_NULL;
+    cryp_rsa_key key;
+
+    HI_LOG_FUNC_ENTER();
+
+    crypto_memset(&key, sizeof(cryp_rsa_key), 0, sizeof(cryp_rsa_key));
+
+    ret = rsa_alloc_buffer(&key, rsa_info, &in, &out);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, rsa_alloc_key failed\n");
+        HI_LOG_PRINT_FUNC_ERR(rsa_alloc_buffer, ret);
+        return ret;
+    }
+
+    /* copy hash value from user */
+    CHECK_EXIT(crypto_copy_from_user(out, ADDR_VIA(rsa_info->out), rsa_info->outlen));
+    CHECK_EXIT(kapi_rsa_verify_hash(&key,
+                                    rsa_info->scheme,
+                                    out,
+                                    rsa_info->outlen,
+                                    in,
+                                    rsa_info->inlen));
+    rsa_free_buffer(&key);
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+exit__:
+    rsa_free_buffer(&key);
+
+    return ret;
+}
+
+static hi_s32 dispatch_trng_get_random(void *argp)
+{
+    trng_t *trng = argp;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = kapi_trng_get_random(&trng->randnum, trng->timeout);
+    if (ret != HI_SUCCESS) {
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static crypto_dispatch_func dispatch_func[CRYPTO_CMD_COUNT] = {
+    {"CreateHandle",  dispatch_symc_create_handle,  CRYPTO_CMD_SYMC_CREATEHANDLE},
+    {"DestroyHandle", dispatch_symc_destroy_handle, CRYPTO_CMD_SYMC_DESTROYHANDLE},
+    {"ConfigChn",     dispatch_symc_config,         CRYPTO_CMD_SYMC_CONFIGHANDLE},
+    {"Encrypt",       dispatch_symc_encrypt,        CRYPTO_CMD_SYMC_ENCRYPT},
+    {"EncryptMulti",  dispatch_symc_encrypt_multi,  CRYPTO_CMD_SYMC_ENCRYPTMULTI},
+    {"GetTag",        dispatch_symc_get_tag,        CRYPTO_CMD_SYMC_GETTAG},
+    {"HashStart",     dispatch_hash_start,          CRYPTO_CMD_HASH_START},
+    {"HashUpdate",    dispatch_hash_update,         CRYPTO_CMD_HASH_UPDATE},
+    {"HashFinish",    dispatch_hash_finish,         CRYPTO_CMD_HASH_FINISH},
+    {"RsaEncrypt",    dispatch_rsa_encrypt,         CRYPTO_CMD_RSA_ENC},
+    {"RsaDecrypt",    dispatch_rsa_decrypt,         CRYPTO_CMD_RSA_DEC},
+    {"RsaSign",       dispatch_rsa_sign_hash,       CRYPTO_CMD_RSA_SIGN},
+    {"RsaVerify",     dispatch_rsa_verify_hash,     CRYPTO_CMD_RSA_VERIFY},
+    {"TRNG",          dispatch_trng_get_random,     CRYPTO_CMD_TRNG},
+    {"GetSymcConfig", dispatch_symc_get_config,     CRYPTO_CMD_SYMC_GET_CONFIG},
+    {"KladKey",       dispatch_klad_key,            CRYPTO_CMD_KLAD_KEY},
+};
+
+hi_s32 crypto_ioctl(hi_u32 cmd, hi_void *argp)
+{
+    hi_u32 nr = 0;
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    nr = CRYPTO_IOC_NR (cmd);
+    HI_LOG_CHECK_PARAM(argp == HI_NULL);
+    HI_LOG_CHECK_PARAM(nr >= CRYPTO_CMD_COUNT);
+    HI_LOG_CHECK_PARAM(cmd != dispatch_func[nr].cmd);
+
+    HI_LOG_DEBUG("cmd 0x%x, nr %d, size %d, local cmd 0x%x\n",
+                 cmd, nr, CRYPTO_IOC_SIZE(cmd), dispatch_func[nr].cmd);
+
+    HI_LOG_INFO("Link Func NR %d, Name:  %s\n", nr, dispatch_func[nr].name);
+    ret = dispatch_func[nr].func(argp);
+    if (ret != HI_SUCCESS) {
+        /*TRNG may be empty in FIFO, don't report error, try to read it again */
+        if (cmd != CRYPTO_CMD_TRNG) {
+            HI_LOG_ERROR("error, call dispatch_fun fun failed!\n");
+            HI_LOG_PRINT_FUNC_ERR(crypto_dispatch_func, ret);
+        }
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 crypto_entry(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    crypto_mem_init();
+
+    ret = module_addr_map();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("module addr map failed\n");
+        HI_LOG_PRINT_FUNC_ERR(module_addr_map, ret);
+        return ret;
+    }
+
+    ret = kapi_symc_init();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("kapi symc init failed\n");
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_init, ret);
+        goto error;
+    }
+
+    ret = kapi_hash_init();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("kapi hash init failed\n");
+        HI_LOG_PRINT_FUNC_ERR(kapi_hash_init, ret);
+        goto error1;
+    }
+
+    ret = kapi_rsa_init();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("kapi rsa init failed\n");
+        HI_LOG_PRINT_FUNC_ERR(kapi_rsa_init, ret);
+        goto error2;
+    }
+
+    ret = hi_drv_compat_init();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_drv_compat_init, ret);
+        goto error3;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+error3:
+    kapi_rsa_deinit();
+error2:
+    kapi_hash_deinit();
+error1:
+    kapi_symc_deinit();
+error:
+    module_addr_unmap();
+
+    return ret;
+
+}
+
+hi_s32 crypto_exit(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = kapi_symc_deinit();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_deinit, ret);
+        return ret;
+    }
+
+    ret = kapi_hash_deinit();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_hash_deinit, ret);
+        return ret;
+    }
+
+    ret = kapi_rsa_deinit();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_rsa_deinit, ret);
+        return ret;
+    }
+
+    ret = hi_drv_compat_deinit();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(hi_drv_compat_deinit, ret);
+        return ret;
+    }
+
+    ret = module_addr_unmap();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(module_addr_unmap, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+
+hi_s32 crypto_release(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    ret = kapi_symc_release();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_release, ret);
+        return ret;
+    }
+
+    ret = kapi_hash_release();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_hash_release, ret);
+        return ret;
+    }
+
+    return HI_SUCCESS;
+}
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_hash.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_hash.c
@@ -1,0 +1,633 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : kapi_hash.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "cryp_hash.h"
+#include "ext_alg.h"
+
+#ifdef MHASH_NONSUPPORT
+#define HASH_SOFT_CHANNEL_MAX            (0x01)
+#define HASH_SOFT_CHANNEL_MASK           (0x01)
+#else
+#define HASH_SOFT_CHANNEL_MAX            (0x08)
+#define HASH_SOFT_CHANNEL_MASK           (0xFF)
+#endif
+
+/*! /hmac ipad byte */
+#define HMAC_IPAD_BYTE                   (0x36)
+
+/*! /hmac opad byte */
+#define HMAC_OPAD_BYTE                   (0x5C)
+
+#define HMAC_HASH                        (0x01)
+#define HMAC_AESCBC                      (0x02)
+
+typedef struct {
+    hash_func *func;                   /*!<  HASH function */
+    void *cryp_ctx;                    /*!<  Context of cryp instance */
+    hi_u32 hmac;                          /*!<  HMAC or not */
+    hi_u32 mac_id;                        /*!<  CMAC handle */
+    hi_u8 hmac_ipad[HASH_BLOCK_SIZE_128]; /*!<  hmac ipad */
+    hi_u8 hmac_opad[HASH_BLOCK_SIZE_128]; /*!<  hmac opad */
+    crypto_owner owner;                /*!<  user ID */
+} kapi_hash_ctx;
+
+/*! Context of cipher */
+static channel_context hash_ctx[HASH_SOFT_CHANNEL_MAX];
+
+/*! hash mutex */
+static crypto_mutex hash_mutex;
+
+#define kapi_check_hash_handle(handle)   \
+    do \
+    { \
+        if((HI_HANDLE_GET_MODID(handle) != HI_ID_CIPHER) \
+           || (HI_HANDLE_GET_PriDATA(handle) != 0)) \
+        { \
+            HI_LOG_ERROR("invalid handle 0x%x!\n", handle); \
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA); \
+            return HI_ERR_CIPHER_INVALID_HANDLE; \
+        } \
+        if (HI_HANDLE_GET_CHNID(handle) >= HASH_SOFT_CHANNEL_MAX) \
+        { \
+            HI_LOG_ERROR("chan %d is too large, max: %d\n", HI_HANDLE_GET_CHNID(handle), HASH_SOFT_CHANNEL_MAX); \
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA); \
+            return HI_ERR_CIPHER_INVALID_HANDLE; \
+        } \
+        if (hash_ctx[HI_HANDLE_GET_CHNID(handle)].open == HI_FALSE) \
+        { \
+            HI_LOG_ERROR("chan %d is not open\n", HI_HANDLE_GET_CHNID(handle)); \
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA); \
+            return HI_ERR_CIPHER_INVALID_HANDLE; \
+        } \
+    } while (0)
+
+#define KAPI_HASH_LOCK()   \
+    ret = crypto_mutex_lock(&hash_mutex);  \
+    if (ret != HI_SUCCESS)        \
+    {\
+        HI_LOG_ERROR("error, hash lock failed\n");\
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_BUSY); \
+        return HI_ERR_CIPHER_BUSY;\
+    }
+
+#define KAPI_HASH_UNLOCK()   crypto_mutex_unlock(&hash_mutex)
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      hash */
+/** @{*/  /** <!-- [kapi]*/
+
+hi_s32 kapi_hash_init(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_INFO("HASH init\n");
+
+    crypto_mutex_init(&hash_mutex);
+
+    ret = cryp_hash_init();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, cryp_hash_init failed\n");
+        HI_LOG_PRINT_FUNC_ERR(cryp_hash_init, ret);
+        return ret;
+    }
+
+    /* Initialize soft channel list */
+    ret = crypto_channel_init(hash_ctx, HASH_SOFT_CHANNEL_MAX, sizeof(kapi_hash_ctx));
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, hash channel list init failed\n");
+        HI_LOG_PRINT_FUNC_ERR(crypto_channel_init, ret);
+        cryp_hash_deinit();
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_hash_deinit(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = crypto_channel_deinit(hash_ctx, HASH_SOFT_CHANNEL_MAX);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, hash channel list deinit failed\n");
+        HI_LOG_PRINT_FUNC_ERR(crypto_channel_deinit, ret);
+        return ret;
+    }
+
+    cryp_hash_deinit();
+
+    crypto_mutex_destroy(&hash_mutex);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static kapi_hash_ctx *kapi_hash_get_ctx(hi_u32 id)
+{
+    return crypto_channel_get_context(hash_ctx, HASH_SOFT_CHANNEL_MAX, id);
+}
+
+static hi_s32 kapi_hash_create(hi_u32 *id)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 chn = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    /* allocate a hash channel */
+    ret = crypto_channel_alloc(hash_ctx, HASH_SOFT_CHANNEL_MAX, HASH_SOFT_CHANNEL_MASK, &chn);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, allocate hash channel failed\n");
+        HI_LOG_PRINT_FUNC_ERR(crypto_channel_alloc, ret);
+        return ret;
+    }
+
+    *id = chn;
+
+    HI_LOG_DEBUG("kapi create soft chn %d\n", chn);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 kapi_hash_destroy(hi_u32 id)
+{
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(HASH_SOFT_CHANNEL_MAX <= id);
+
+    /* Free soft channel */
+    crypto_channel_free(hash_ctx, HASH_SOFT_CHANNEL_MAX, id);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 kpai_hash_mode_transform(hi_cipher_hash_type type,
+                                    hash_mode *mode, hi_u32 *hmac)
+{
+    *hmac = HI_FALSE;
+
+    /* transform hash mode */
+    switch (type) {
+        case HI_CIPHER_HASH_TYPE_HMAC_SHA1: {
+            *hmac = HMAC_HASH;
+            *mode = HASH_MODE_SHA1;
+            break;
+        }
+        case HI_CIPHER_HASH_TYPE_SHA1: {
+            *mode = HASH_MODE_SHA1;
+            break;
+        }
+        case HI_CIPHER_HASH_TYPE_HMAC_SHA224: {
+            *hmac = HMAC_HASH;
+            *mode = HASH_MODE_SHA224;
+            break;
+        }
+        case HI_CIPHER_HASH_TYPE_SHA224: {
+            *mode = HASH_MODE_SHA224;
+            break;
+        }
+        case HI_CIPHER_HASH_TYPE_HMAC_SHA256: {
+            *hmac = HMAC_HASH;
+            *mode = HASH_MODE_SHA256;
+            break;
+        }
+        case HI_CIPHER_HASH_TYPE_SHA256: {
+            *mode = HASH_MODE_SHA256;
+            break;
+        }
+        case HI_CIPHER_HASH_TYPE_HMAC_SHA384: {
+            *hmac = HMAC_HASH;
+            *mode = HASH_MODE_SHA384;
+            break;
+        }
+        case HI_CIPHER_HASH_TYPE_SHA384: {
+            *mode = HASH_MODE_SHA384;
+            break;
+        }
+        case HI_CIPHER_HASH_TYPE_HMAC_SHA512: {
+            *hmac = HMAC_HASH;
+            *mode = HASH_MODE_SHA512;
+            break;
+        }
+        case HI_CIPHER_HASH_TYPE_SHA512: {
+            *mode = HASH_MODE_SHA512;
+            break;
+        }
+        case HI_CIPHER_HASH_TYPE_SM3: {
+            *mode = HASH_MODE_SM3;
+            break;
+        }
+        default: {
+            HI_LOG_ERROR("error, invalid hash type %d\n", type);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 kapi_hmac_start(kapi_hash_ctx *ctx, hi_u8 *key, hi_u32 keylen)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u8 sum[HASH_RESULT_MAX_SIZE] = {0};
+    hi_u32 len = 0;
+    hi_u32 i;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(key == HI_NULL);
+
+    /* clean ipad and opad */
+    crypto_memset(ctx->hmac_ipad, HASH_BLOCK_SIZE_128, 0x00, ctx->func->block_size);
+    crypto_memset(ctx->hmac_opad, HASH_BLOCK_SIZE_128, 0x00, ctx->func->block_size);
+
+    /* compute K0 */
+
+    if (keylen <= ctx->func->block_size) {
+        /* If the length of K = B: set K0 = K.
+         *
+         * If the length of K > B: hash K to obtain an L byte string,
+         * then append (B-L) zeros to create a B-byte
+         * string K0 (i.e., K0 = H(K) || 00...00).
+         */
+        crypto_memcpy(ctx->hmac_ipad, HASH_BLOCK_SIZE_128, key, keylen);
+        crypto_memcpy(ctx->hmac_opad, HASH_BLOCK_SIZE_128, key, keylen);
+    } else {
+        /* If the length of K > B: hash K to obtain an L byte string,
+         * then append (B-L) zeros to create a B-byte
+         * string K0 (i.e., K0 = H(K) || 00...00).
+         */
+
+        /* H(K) */
+        ctx->cryp_ctx = ctx->func->create(ctx->func->mode);
+        if (ctx->cryp_ctx == HI_NULL) {
+            HI_LOG_PRINT_FUNC_ERR(ctx->func->create, 0);
+            return HI_ERR_CIPHER_BUSY;
+        }
+
+        /* update key */
+        CHECK_EXIT(ctx->func->update(ctx->cryp_ctx, key,
+                                     keylen, HASH_CHUNCK_SRC_LOCAL));
+
+        /* sum */
+        CHECK_EXIT(ctx->func->finish(ctx->cryp_ctx, sum, &len));
+        ctx->func->destroy(ctx->cryp_ctx);
+        ctx->cryp_ctx = HI_NULL;
+
+        /* K0 = H(K) || 00...00 */
+        crypto_memcpy(ctx->hmac_ipad, HASH_BLOCK_SIZE_128, sum, len);
+        crypto_memcpy(ctx->hmac_opad, HASH_BLOCK_SIZE_128, sum, len);
+    }
+
+    /* Exclusive-Or K0 with ipad/opad byte to produce K0 ^ ipad and K0 ^ opad */
+    for (i = 0; i < ctx->func->block_size; i++) {
+        ctx->hmac_ipad[i] ^= HMAC_IPAD_BYTE;
+        ctx->hmac_opad[i] ^= HMAC_OPAD_BYTE;
+    }
+
+    /* H(K0 ^ ipad) */
+    ctx->cryp_ctx = ctx->func->create(ctx->func->mode);
+    if (ctx->cryp_ctx == HI_NULL) {
+        HI_LOG_PRINT_FUNC_ERR(ctx->func->create, 0);
+        return HI_ERR_CIPHER_BUSY;
+    }
+    CHECK_EXIT(ctx->func->update(ctx->cryp_ctx, ctx->hmac_ipad,
+                                 ctx->func->block_size, HASH_CHUNCK_SRC_LOCAL));
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+exit__:
+    ctx->func->destroy(ctx->cryp_ctx);
+    ctx->cryp_ctx = HI_NULL;
+    crypto_memset(ctx->hmac_ipad, sizeof(ctx->hmac_ipad), 0, sizeof(ctx->hmac_ipad));
+    crypto_memset(ctx->hmac_opad, sizeof(ctx->hmac_opad), 0, sizeof(ctx->hmac_opad));
+
+    return ret;
+}
+
+static hi_s32 kapi_hmac_finish(kapi_hash_ctx *ctx, hi_u8 *hash, hi_u32 *hashlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u8 sum[HASH_RESULT_MAX_SIZE] = {0};
+
+    HI_LOG_FUNC_ENTER();
+
+    /* sum = H((K0 ^ ipad) || text). */
+    ctx->func->finish(ctx->cryp_ctx, sum, hashlen);
+    ctx->func->destroy(ctx->cryp_ctx);
+    ctx->cryp_ctx = HI_NULL;
+
+    /* H((K0 ^ opad)|| sum). */
+    ctx->cryp_ctx = ctx->func->create(ctx->func->mode);
+    if (ctx->cryp_ctx == HI_NULL) {
+        HI_LOG_PRINT_FUNC_ERR(ctx->func->create, 0);
+        return HI_ERR_CIPHER_BUSY;
+    }
+
+    /* update(K0 ^ opad) */
+    ret = ctx->func->update(ctx->cryp_ctx, ctx->hmac_opad,
+                            ctx->func->block_size, HASH_CHUNCK_SRC_LOCAL);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(ctx->func->update, ret);
+        return ret;
+    }
+
+    /* update(sum) */
+    ret = ctx->func->update(ctx->cryp_ctx, sum,
+                            ctx->func->size, HASH_CHUNCK_SRC_LOCAL);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(ctx->func->update, ret);
+        return ret;
+    }
+
+    /* H */
+    ret = ctx->func->finish(ctx->cryp_ctx, hash, hashlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(ctx->func->finish, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_hash_start(hi_u32 *id, hi_cipher_hash_type type,
+                    hi_u8 *key, hi_u32 keylen)
+{
+    hi_s32 ret = HI_FAILURE;
+    kapi_hash_ctx *ctx = HI_NULL;
+    hash_mode mode = 0x00;
+    hi_u32 hmac = 0;
+    hi_u32 soft_hash_id = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(id == HI_NULL);
+
+    /* transform hash mode */
+    ret = kpai_hash_mode_transform(type, &mode, &hmac);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kpai_hash_mode_transform, ret);
+        return ret;
+    }
+
+    KAPI_HASH_LOCK();
+
+    /* Create hash channel */
+    ret = kapi_hash_create(&soft_hash_id);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, kapi_hash_create failed\n");
+        HI_LOG_PRINT_FUNC_ERR(kapi_hash_create, ret);
+        KAPI_HASH_UNLOCK();
+        return ret;
+    }
+
+    ctx = kapi_hash_get_ctx(soft_hash_id);
+    if (ctx == HI_NULL) {
+        HI_LOG_ERROR("error, kapi_hash_get_ctx failed\n");
+        HI_LOG_PRINT_FUNC_ERR(kapi_hash_get_ctx, 0);
+        ret = HI_ERR_CIPHER_BUSY;
+        goto error1;
+    }
+
+    crypto_memset(ctx, sizeof(kapi_hash_ctx), 0, sizeof(kapi_hash_ctx));
+    /* record owner */
+    crypto_get_owner(&ctx->owner);
+    ctx->hmac = hmac;
+
+    /* Clone the function from template of hash engine*/
+    ctx->cryp_ctx = HI_NULL;
+    ctx->func = cryp_get_hash(mode);
+    if (ctx->func == HI_NULL) {
+        HI_LOG_ERROR("error, cryp_get_hash failed\n");
+        HI_LOG_PRINT_FUNC_ERR(cryp_get_hash, 0);
+        ret = HI_ERR_CIPHER_INVALID_PARA;
+        goto error1;
+    }
+
+    if ((ctx->func->create == HI_NULL)
+        || (ctx->func->update == HI_NULL)
+        || (ctx->func->finish == HI_NULL)
+        || (ctx->func->destroy == HI_NULL)) {
+        HI_LOG_ERROR("error, cryp hash func is HI_NULL\n");
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_UNSUPPORTED);
+        ret = HI_ERR_CIPHER_UNSUPPORTED;
+        goto error1;
+    }
+
+    if (ctx->hmac) {
+        ret = kapi_hmac_start(ctx, key, keylen);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("error, kapi_hmac_start failed\n");
+            HI_LOG_PRINT_FUNC_ERR(kapi_hmac_start, ret);
+            goto error1;
+        }
+    } else {
+        ctx->cryp_ctx = ctx->func->create(mode);
+        if (ctx->cryp_ctx == HI_NULL) {
+            HI_LOG_ERROR("error, hash context for hash engine failed\n");
+            HI_LOG_PRINT_FUNC_ERR(ctx->func->create, 0);
+            ret = HI_ERR_CIPHER_BUSY;
+            goto error1;
+        }
+    }
+
+    *id = HI_HANDLE_MAKEHANDLE(HI_ID_CIPHER, 0, soft_hash_id);
+
+    KAPI_HASH_UNLOCK();
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+error1:
+    kapi_hash_destroy(soft_hash_id);
+
+    KAPI_HASH_UNLOCK();
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+
+}
+
+hi_s32 kapi_hash_update(hi_u32 id, hi_u8 *input, hi_u32 length,
+                     hash_chunk_src src)
+{
+    hi_s32 ret = HI_FAILURE;
+    kapi_hash_ctx *ctx = HI_NULL;
+    hi_u32 soft_hash_id = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    kapi_check_hash_handle(id);
+    soft_hash_id = HI_HANDLE_GET_CHNID(id);
+
+    ctx = kapi_hash_get_ctx(soft_hash_id);
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+    HI_LOG_CHECK_PARAM(input > input + length); /* check overflow */
+
+    CHECK_OWNER(&ctx->owner);
+
+    HI_LOG_CHECK_PARAM(ctx->func == HI_NULL);
+    HI_LOG_CHECK_PARAM(ctx->func->update == HI_NULL);
+
+    KAPI_HASH_LOCK();
+
+    ret = ctx->func->update(ctx->cryp_ctx, input, length, src);
+
+    /* release resource */
+    if (ret != HI_SUCCESS) {
+        ctx->func->destroy(ctx->cryp_ctx);
+        ctx->cryp_ctx = HI_NULL;
+        kapi_hash_destroy(soft_hash_id);
+        HI_LOG_PRINT_FUNC_ERR(ctx->func->update, ret);
+        KAPI_HASH_UNLOCK();
+        return ret;
+    }
+
+    KAPI_HASH_UNLOCK();
+
+    HI_LOG_FUNC_EXIT();
+
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_hash_finish(hi_u32 id, hi_u8 *hash, hi_u32 *hashlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    kapi_hash_ctx *ctx = HI_NULL;
+    hi_u32 soft_hash_id = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    kapi_check_hash_handle(id);
+    soft_hash_id = HI_HANDLE_GET_CHNID(id);
+
+    HI_LOG_CHECK_PARAM(hash == HI_NULL);
+    HI_LOG_CHECK_PARAM(hashlen == HI_NULL);
+
+    ctx = kapi_hash_get_ctx(soft_hash_id);
+    HI_LOG_CHECK_PARAM(ctx == HI_NULL);
+
+    CHECK_OWNER(&ctx->owner);
+
+#if defined(HASH_CMAC_SUPPORT)
+    if (ctx->hmac == HMAC_AESCBC) {
+        ret = kapi_hash_cbcmac_finish(ctx->mac_id, hash, hashlen);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(kapi_hash_cbcmac_finish, ret);
+            kapi_hash_destroy(soft_hash_id);
+            return ret;
+        }
+        kapi_hash_destroy(soft_hash_id);
+        HI_LOG_FUNC_EXIT();
+        return HI_SUCCESS;
+    }
+#endif
+
+    HI_LOG_CHECK_PARAM(ctx->func == HI_NULL);
+    HI_LOG_CHECK_PARAM(ctx->func->destroy == HI_NULL);
+
+    KAPI_HASH_LOCK();
+
+    if (ctx->hmac) {
+        ret = kapi_hmac_finish(ctx, hash, hashlen);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(kapi_hmac_finish, ret);
+            ctx->func->destroy(ctx->cryp_ctx);
+            ctx->cryp_ctx = HI_NULL;
+            kapi_hash_destroy(soft_hash_id);
+            KAPI_HASH_UNLOCK();
+            return ret;
+        }
+    } else {
+        ret = ctx->func->finish(ctx->cryp_ctx, hash, hashlen);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(ctx->func->finish, ret);
+            ctx->func->destroy(ctx->cryp_ctx);
+            ctx->cryp_ctx = HI_NULL;
+            kapi_hash_destroy(soft_hash_id);
+            KAPI_HASH_UNLOCK();
+            return ret;
+        }
+    }
+
+    /* release resource */
+    ctx->func->destroy(ctx->cryp_ctx);
+    ctx->cryp_ctx = HI_NULL;
+    kapi_hash_destroy(soft_hash_id);
+
+    KAPI_HASH_UNLOCK();
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+hi_s32 kapi_hash_release(void)
+{
+    hi_u32 i = 0;
+    hi_s32 ret = HI_FAILURE;
+    kapi_hash_ctx *ctx = HI_NULL;
+    crypto_owner owner;
+
+    HI_LOG_FUNC_ENTER();
+
+    crypto_get_owner(&owner);
+
+    HI_LOG_INFO("hash release owner 0x%x\n", owner);
+
+    /* destroy the channel which are created by current user */
+    for (i = 0; i < HASH_SOFT_CHANNEL_MAX; i++) {
+        if (hash_ctx[i].open == HI_TRUE) {
+            ctx = kapi_hash_get_ctx(i);
+            if (ctx == HI_NULL) {
+                HI_LOG_ERROR("kapi hash get ctx failed,point is null.\n");
+                HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_POINT);
+                return HI_ERR_CIPHER_INVALID_POINT;
+            }
+            if (memcmp(&owner, &ctx->owner, sizeof(owner)) == 0) {
+                HI_LOG_INFO("hash release chn %d\n", i);
+
+                if ((ctx->func != HI_NULL)
+                    && (ctx->func->destroy != HI_NULL)
+                    && (ctx->cryp_ctx != HI_NULL)) {
+                    ctx->func->destroy(ctx->cryp_ctx);
+                }
+                ctx->cryp_ctx = HI_NULL;
+                ret = kapi_hash_destroy(i);
+                if (ret != HI_SUCCESS) {
+                    HI_LOG_PRINT_FUNC_ERR(kapi_hash_destroy, ret);
+                    return ret;
+                }
+            }
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_rsa.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_rsa.c
@@ -1,0 +1,133 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : kapi_rsa.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "cryp_rsa.h"
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      rsa */
+/** @{*/  /** <!-- [kapi]*/
+
+/**
+\brief   Kapi Init.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_rsa_init(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = cryp_rsa_init();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_rsa_init, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/**
+\brief   Kapi Deinitialize.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 kapi_rsa_deinit(void)
+{
+    HI_LOG_FUNC_ENTER();
+
+    cryp_rsa_deinit();
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_rsa_encrypt(cryp_rsa_key *key,
+                     hi_cipher_rsa_enc_scheme scheme,
+                     hi_u8 *in, hi_u32 inlen,
+                     hi_u8 *out, hi_u32 *outlen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = cryp_rsa_encrypt(key, scheme, in, inlen, out, outlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_rsa_encrypt, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_rsa_decrypt(cryp_rsa_key *key,
+                     hi_cipher_rsa_enc_scheme scheme,
+                     hi_u8 *in, hi_u32 inlen,
+                     hi_u8 *out, hi_u32 *outlen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = cryp_rsa_decrypt(key, scheme, in, inlen, out, outlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_rsa_decrypt, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_rsa_sign_hash(cryp_rsa_key *key,
+                       hi_cipher_rsa_sign_scheme scheme,
+                       hi_u8 *hash, hi_u32 hlen,
+                       hi_u8 *sign, hi_u32 *signlen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = cryp_rsa_sign_hash(key, scheme, hash, hlen, sign, signlen, hlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_rsa_sign_hash, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_rsa_verify_hash(cryp_rsa_key *key,
+                         hi_cipher_rsa_sign_scheme scheme,
+                         hi_u8 *hash, hi_u32 hlen,
+                         hi_u8 *sign, hi_u32 signlen)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = cryp_rsa_verify_hash(key, scheme, hash, hlen, sign, signlen, hlen);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_rsa_verify_hash, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_symc.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_symc.c
@@ -1,0 +1,956 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : kapi_symc.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "cryp_symc.h"
+#include "hi_drv_compat.h"
+
+/* max number of nodes */
+#define MAX_PKG_NUMBER              (100000)
+
+/* max length of CCM/GCM AAD */
+#define MAX_AEAD_A_LEN              (0x100000)
+
+typedef struct {
+    hi_u32 open   : 1;                  /*!<  open or close */
+    hi_u32 config : 1;                  /*!<  aleardy config or not */
+    symc_func *func;
+    void *cryp_ctx;                  /*!<  Context of cryp instance */
+    crypto_owner owner;              /*!<  user ID */
+    hi_cipher_ctrl  ctrl;        /*!<  control infomation */
+} kapi_symc_ctx;
+
+/*! Context of cipher */
+static kapi_symc_ctx kapi_ctx[CRYPTO_HARD_CHANNEL_MAX];
+
+/* symc mutex */
+static crypto_mutex symc_mutex;
+
+#define KAPI_SYMC_CHECK_HANDLE(handle)   \
+    do \
+    { \
+        if((HI_HANDLE_GET_MODID(handle) != HI_ID_CIPHER) \
+           || (HI_HANDLE_GET_PriDATA(handle) != 0)) \
+        { \
+            HI_LOG_ERROR("Invalid handle 0x%x!\n", handle); \
+            return HI_ERR_CIPHER_INVALID_HANDLE; \
+        } \
+        if (HI_HANDLE_GET_CHNID(handle) >= CRYPTO_HARD_CHANNEL_MAX) \
+        { \
+            HI_LOG_ERROR("chan %d is too large, max: %d\n", HI_HANDLE_GET_CHNID(handle), CRYPTO_HARD_CHANNEL_MAX); \
+            return HI_ERR_CIPHER_INVALID_HANDLE; \
+        } \
+        if (kapi_ctx[HI_HANDLE_GET_CHNID(handle)].open == HI_FALSE) \
+        { \
+            HI_LOG_ERROR("chan %d is not open\n", HI_HANDLE_GET_CHNID(handle)); \
+            return HI_ERR_CIPHER_INVALID_HANDLE; \
+        } \
+    } while (0)
+
+#define KAPI_SYMC_LOCK()   \
+    ret = crypto_mutex_lock(&symc_mutex);  \
+    if (ret != HI_SUCCESS)        \
+    {\
+        HI_LOG_ERROR("error, symc lock failed\n");\
+        HI_LOG_PRINT_FUNC_ERR(crypto_mutex_lock, ret);\
+        return ret;\
+    }
+
+#define KAPI_SYMC_UNLOCK()   crypto_mutex_unlock(&symc_mutex)
+#define AES_CCM_MIN_TAG_LEN     (4)
+#define AES_CCM_MAX_TAG_LEN     (16)
+#define AES_GCM_MIN_TAG_LEN     (1)
+#define AES_GCM_MAX_TAG_LEN     (16)
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      symc */
+/** @{*/  /** <!-- [kapi]*/
+
+hi_s32 kapi_symc_init(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_INFO("kapi_symc_init()\n");
+
+    HI_LOG_FUNC_ENTER();
+
+    crypto_mutex_init(&symc_mutex);
+
+    crypto_memset(kapi_ctx, sizeof(kapi_ctx), 0, sizeof(kapi_ctx));
+
+    ret = cryp_symc_init();
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_symc_init, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_symc_deinit(void)
+{
+    HI_LOG_INFO("kapi_symc_deinit()\n");
+
+    HI_LOG_FUNC_ENTER();
+
+    cryp_symc_deinit();
+
+    crypto_mutex_destroy(&symc_mutex);
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_symc_release(void)
+{
+    hi_u32 i = 0, chn = 0;
+    hi_s32 ret = HI_FAILURE;
+    kapi_symc_ctx *ctx = HI_NULL;
+    crypto_owner owner;
+
+    HI_LOG_FUNC_ENTER();
+
+    crypto_get_owner(&owner);
+
+    HI_LOG_INFO("symc release owner 0x%x\n", owner);
+
+    /* destroy the channel which are created by current user */
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        ctx = &kapi_ctx[i];
+        if (ctx->open == HI_TRUE) {
+            if (memcmp(&owner, &ctx->owner, sizeof(owner)) == 0) {
+                chn = HI_HANDLE_MAKEHANDLE(HI_ID_CIPHER, 0, i);
+                HI_LOG_INFO("symc release chn %d\n", chn);
+                ret = kapi_symc_destroy(chn);
+                if (ret != HI_SUCCESS) {
+                    HI_LOG_PRINT_FUNC_ERR(kapi_symc_destroy, ret);
+                    return ret;
+                }
+            }
+        }
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+
+hi_s32 kapi_symc_create(hi_u32 *id)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 chn = 0;
+    kapi_symc_ctx *ctx = HI_NULL;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(id == HI_NULL);
+
+    KAPI_SYMC_LOCK();
+
+    /* allocate a aes soft channel for hard channel allocted */
+    ret = cryp_symc_alloc_chn(&chn);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("error, allocate symc channel failed\n");
+        HI_LOG_PRINT_FUNC_ERR(cryp_symc_alloc_chn, ret);
+        KAPI_SYMC_UNLOCK();
+        return ret;
+    }
+    ctx = &kapi_ctx[chn];
+
+    crypto_memset(ctx, sizeof(kapi_symc_ctx), 0, sizeof(kapi_symc_ctx));
+    crypto_get_owner(&ctx->owner);
+
+    *id = HI_HANDLE_MAKEHANDLE(HI_ID_CIPHER, 0, chn);
+    ctx->open = HI_TRUE;
+    ctx->config = HI_FALSE;
+
+    HI_LOG_INFO("kapi_symc_create()- chn %d\n", chn);
+
+    KAPI_SYMC_UNLOCK();
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_symc_destroy(hi_u32 id)
+{
+    hi_s32 ret = HI_FAILURE;
+    kapi_symc_ctx *ctx = HI_NULL;
+    hi_u32 soft_id = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    KAPI_SYMC_CHECK_HANDLE(id);
+    soft_id = HI_HANDLE_GET_CHNID(id);
+    ctx = &kapi_ctx[soft_id];
+    CHECK_OWNER(&ctx->owner);
+
+    KAPI_SYMC_LOCK();
+
+    cryp_symc_free_chn(soft_id);
+
+    /* Destroy the attached instance of Symmetric cipher engine */
+    if ((ctx->func != HI_NULL) && (ctx->func->destroy != HI_NULL)) {
+        ret = ctx->func->destroy(ctx->cryp_ctx);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(ctx->func->destroy, ret);
+            KAPI_SYMC_UNLOCK();
+            return ret;
+        }
+        ctx->cryp_ctx = HI_NULL;
+    }
+
+    ctx->open = HI_FALSE;
+
+    HI_LOG_INFO("kapi_symc_destroy()- chn 0x%x\n", id);
+
+    KAPI_SYMC_UNLOCK();
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 kapi_symc_width_check(hi_cipher_alg alg, hi_cipher_work_mode mode, hi_u32 width, hi_u32 round)
+{
+    /* the bit width depend on alg and mode, which limit to hardware
+     * des/3des with cfb/ofb support bit1, bit8, bit 64.
+     * aes with cfb/ofb only support bit128.
+     * sm1 with ofb only support bit128, cfb support bit1, bit8, bit 64.
+     */
+
+    HI_LOG_FUNC_ENTER();
+
+    if ((alg == HI_CIPHER_ALG_3DES) || (alg == HI_CIPHER_ALG_DES)) {
+#ifndef CHIP_DES_SUPPORT
+        if (alg == HI_CIPHER_ALG_DES) {
+            HI_LOG_ERROR("Invalid alg, unsupport des.\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+#endif
+#ifndef CHIP_3DES_SUPPORT
+        if (alg == HI_CIPHER_ALG_3DES) {
+            HI_LOG_ERROR("Invalid alg, unsupport 3des.\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+#endif
+        if (mode > HI_CIPHER_WORK_MODE_OFB) {
+            HI_LOG_ERROR("Invalid alg %d and mode %d\n", alg, mode);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+
+        if ((mode == HI_CIPHER_WORK_MODE_CFB) || (mode == HI_CIPHER_WORK_MODE_OFB)) {
+            if ((width != SYMC_DAT_WIDTH_64)
+                && (width != SYMC_DAT_WIDTH_8)
+                && (width != SYMC_DAT_WIDTH_1)) {
+                HI_LOG_ERROR("Invalid mode %d and bit width %d\n", mode, width);
+                HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+                return HI_ERR_CIPHER_INVALID_PARA;
+            }
+        }
+    }
+
+    if (alg == HI_CIPHER_ALG_AES) {
+        if (mode > HI_CIPHER_WORK_MODE_BUTT) {
+            HI_LOG_ERROR("Invalid alg %d and mode %d\n", alg, mode);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+
+        if ((mode == HI_CIPHER_WORK_MODE_CFB)
+            && (width != SYMC_DAT_WIDTH_1)
+            && (width != SYMC_DAT_WIDTH_8)
+            && (width != SYMC_DAT_WIDTH_128)) {
+            HI_LOG_ERROR("Invalid alg %d mode %d and width %d\n", alg, mode, width);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+
+        if ((mode == HI_CIPHER_WORK_MODE_OFB)
+            && (width != SYMC_DAT_WIDTH_128)) {
+            HI_LOG_ERROR("Invalid alg %d mode %d and width %d\n", alg, mode, width);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+
+    if (alg == HI_CIPHER_ALG_SM1) {
+        if (mode > HI_CIPHER_WORK_MODE_OFB) {
+            HI_LOG_ERROR("Invalid alg %d and mode %d\n", alg, mode);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+
+        if ((mode == HI_CIPHER_WORK_MODE_OFB)
+            && (width != SYMC_DAT_WIDTH_128)) {
+            HI_LOG_ERROR("Invalid alg %d mode %d and width %d\n", alg, mode, width);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+
+        if ((mode == HI_CIPHER_WORK_MODE_CFB)
+            && (width >= SYMC_DAT_WIDTH_COUNT)) {
+            HI_LOG_ERROR("Invalid alg %d mode %d and width %d\n", alg, mode, width);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+
+    if ((alg == HI_CIPHER_ALG_SM4)
+        && (mode != HI_CIPHER_WORK_MODE_ECB)
+        && (mode != HI_CIPHER_WORK_MODE_CBC)
+        && (mode != HI_CIPHER_WORK_MODE_CTR)) {
+        HI_LOG_ERROR("Invalid alg %d and mode %d\n", alg, mode);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    if ((alg == HI_CIPHER_ALG_SM1) && (round >= HI_CIPHER_SM1_ROUND_BUTT)) {
+        HI_LOG_ERROR("Invalid alg %d and Sm1Round %d\n", alg, round);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    if (alg >= HI_CIPHER_ALG_BUTT) {
+        HI_LOG_ERROR("Invalid alg %d .\n", alg);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    if (width >= SYMC_DAT_WIDTH_COUNT) {
+        HI_LOG_ERROR("Invalid mode %d\n", width);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 kapi_symc_match_width(hi_cipher_work_mode work_mode,
+                                    hi_cipher_bit_width bit_width,
+                                    symc_width *width)
+{
+    HI_LOG_FUNC_ENTER();
+
+    /* set the bit width which depend on alg and mode */
+    if ((HI_CIPHER_WORK_MODE_CFB == work_mode)
+        || (HI_CIPHER_WORK_MODE_OFB == work_mode)) {
+        switch (bit_width) {
+            case HI_CIPHER_BIT_WIDTH_64BIT: {
+                *width = SYMC_DAT_WIDTH_64;
+                break;
+            }
+            case HI_CIPHER_BIT_WIDTH_8BIT: {
+                *width = SYMC_DAT_WIDTH_8;
+                break;
+            }
+            case HI_CIPHER_BIT_WIDTH_1BIT: {
+                *width = SYMC_DAT_WIDTH_1;
+                break;
+            }
+            case HI_CIPHER_BIT_WIDTH_128BIT: {
+                *width = SYMC_DAT_WIDTH_128;
+                break;
+            }
+            default: {
+                HI_LOG_ERROR("Invalid width: 0x%x, mode 0x%x\n",
+                             bit_width, work_mode);
+                HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+                return HI_ERR_CIPHER_INVALID_PARA;
+            }
+        }
+    } else {
+        *width = SYMC_DAT_WIDTH_128;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 kapi_symc_check_param(hi_u32 hard_key, hi_u32 iv_usage,
+                                    hi_cipher_alg alg,
+                                    hi_cipher_work_mode work_mode,
+                                    hi_cipher_bit_width bit_width,
+                                    hi_cipher_key_length key_len,
+                                    hi_cipher_sm1_round sm1_round_num,
+                                    symc_width *width)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    if (alg == HI_CIPHER_ALG_DMA) {
+        HI_LOG_INFO("Alg is DMA.\n");
+        HI_DBG_PRINT_U32(alg);
+        return HI_SUCCESS;
+    }
+
+    if ((hard_key != HI_TRUE)  && (hard_key != HI_FALSE)) {
+        HI_LOG_ERROR("Invalid hard_key: 0x%x\n", hard_key);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+    if (key_len > HI_CIPHER_KEY_DES_2KEY) {
+        HI_LOG_ERROR("Invalid key len: 0x%x\n", key_len);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    /* set the bit width which depend on alg and mode */
+    ret = kapi_symc_match_width(work_mode, bit_width, width);
+    if (ret != HI_SUCCESS) {
+        HI_ERR_PRINT_U32(work_mode);
+        HI_ERR_PRINT_U32(bit_width);
+        HI_ERR_PRINT_U32(*width);
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_match_width, ret);
+        return ret;
+    }
+
+    ret = kapi_symc_width_check(alg, work_mode, *width, sm1_round_num);
+    if (ret != HI_SUCCESS) {
+        HI_ERR_PRINT_U32(alg);
+        HI_ERR_PRINT_U32(work_mode);
+        HI_ERR_PRINT_U32(*width);
+        HI_ERR_PRINT_U32(sm1_round_num);
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_width_check, ret);
+        return ret;
+    }
+
+    if (iv_usage > CIPHER_IV_CHANGE_ALL_PKG) {
+        HI_LOG_ERROR("Invalid IV Change Flags: 0x%x\n", iv_usage);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    if ((iv_usage == CIPHER_IV_CHANGE_ALL_PKG)
+        && ((work_mode == HI_CIPHER_WORK_MODE_CCM)
+            || (work_mode == HI_CIPHER_WORK_MODE_GCM))) {
+        HI_LOG_ERROR("Invalid IV Change Flags: 0x%x\n", iv_usage);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 kapi_symc_check_ccm_gcm_taglen(hi_cipher_alg alg, hi_cipher_work_mode work_mode, hi_u32 tlen)
+{
+    HI_LOG_CHECK_PARAM(alg != HI_CIPHER_ALG_AES);
+
+    if (work_mode == HI_CIPHER_WORK_MODE_CCM) {
+        /* the parameter t denotes the octet length of T(tag)
+         * t is an element of  { 4, 6, 8, 10, 12, 14, 16}
+         * here t is pConfig->u32TagLen
+         */
+        if ((tlen & 0x01)
+            || (tlen < AES_CCM_MIN_TAG_LEN)
+            || (tlen > AES_CCM_MAX_TAG_LEN)) {
+            HI_LOG_ERROR("Invalid ccm tag len, tlen = 0x%x.\n", tlen);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    } else if (work_mode == HI_CIPHER_WORK_MODE_GCM) {
+        if ((tlen < AES_GCM_MIN_TAG_LEN) || (tlen > AES_GCM_MAX_TAG_LEN)) {
+            HI_LOG_ERROR("Invalid gcm tag len, tlen = 0x%x.\n", tlen);
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    } else {
+        HI_LOG_ERROR("Aes with invalid work mode 0x%x for check tag length.\n", work_mode);
+        HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_symc_config(hi_u32 id,
+                     hi_u32 hard_key,
+                     hi_cipher_alg alg,
+                     hi_cipher_work_mode work_mode,
+                     hi_cipher_bit_width bit_width,
+                     hi_cipher_key_length key_len,
+                     hi_cipher_sm1_round sm1_round_num,
+                     hi_u8 *fkey, hi_u8 *skey,
+                     hi_u8 *iv, hi_u32 ivlen, hi_u32 iv_usage,
+                     compat_addr aad, hi_u32 alen, hi_u32 tlen)
+{
+    hi_s32 ret = HI_FAILURE;
+    kapi_symc_ctx *ctx = HI_NULL;
+    symc_width width = SYMC_DAT_WIDTH_COUNT;
+    hi_u32 soft_id = 0;
+    hi_u32 byca = HI_FALSE;
+    hi_u32 ca_type = 0;
+    hi_u32 klen = key_len;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(fkey == HI_NULL);
+    HI_LOG_CHECK_PARAM(alen > MAX_AEAD_A_LEN);
+    HI_LOG_CHECK_PARAM(ADDR_L32(aad) + alen < alen);
+
+    KAPI_SYMC_CHECK_HANDLE(id);
+    soft_id = HI_HANDLE_GET_CHNID(id);
+    ctx = &kapi_ctx[soft_id];
+    CHECK_OWNER(&ctx->owner);
+
+    /***
+    hard_key: bit[0~7]  flag of hard key or not
+              bit[8~31] ca type
+    */
+    byca = hard_key & 0xFF;
+    ca_type = hard_key >> BITS_IN_BYTE;
+
+    ret = kapi_symc_check_param(byca, iv_usage, alg, work_mode,
+                                bit_width, key_len, sm1_round_num, &width);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("hard_key 0x%x\n", hard_key);
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_check_param, ret);
+        return ret;
+    }
+
+    KAPI_SYMC_LOCK();
+
+    /* Destroy the last attached instance of Symmetric cipher engine */
+    if ((ctx->func != HI_NULL) && (ctx->func->destroy != HI_NULL)) {
+        (void)ctx->func->destroy(ctx->cryp_ctx);
+    }
+    ctx->cryp_ctx = HI_NULL;
+
+    /* Clone the function from template of symc engine*/
+    ctx->func = cryp_get_symc_op(alg, work_mode);
+
+    if (ctx->func == HI_NULL) {
+        HI_LOG_ERROR("error, get symc function failed, alg %d, work_mode %d\n",
+                     alg, work_mode);
+        HI_LOG_PRINT_FUNC_ERR(cryp_get_symc_op, ret);
+        KAPI_SYMC_UNLOCK();
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    /* null means can ignore the function */
+    if (ctx->func->create) {
+        /* Create a instance from template of engine */
+        ctx->cryp_ctx = ctx->func->create(soft_id);
+        if (ctx->cryp_ctx == HI_NULL) {
+            HI_LOG_ERROR("attach contxet buffer to soft_id %d failed\n", soft_id);
+            HI_LOG_PRINT_FUNC_ERR(cryp_symc_create, ret);
+            goto exit__;
+        }
+    }
+
+    /* set mode and alg */
+    if (ctx->func->setmode) {
+        ctx->func->setmode(ctx->cryp_ctx, ctx->func->alg, ctx->func->mode, width);
+    }
+
+    /* Set even key, may be also need set odd key */
+    if (ctx->func->setkey) {
+        if (byca == HI_TRUE) {
+            CHECK_EXIT(ctx->func->setkey(ctx->cryp_ctx, HI_NULL, HI_NULL, &klen));
+
+            if (key_len == HI_CIPHER_KEY_AES_192BIT) {
+                klen = AES_KEY_256BIT;
+            }
+
+            CHECK_EXIT(klad_load_hard_key(id, ca_type, fkey, klen));
+        } else {
+            CHECK_EXIT(ctx->func->setkey(ctx->cryp_ctx, fkey, skey, &klen));
+        }
+    }
+
+    /* Set IV */
+    if (ctx->func->setiv) {
+        CHECK_EXIT(ctx->func->setiv(ctx->cryp_ctx, iv, ivlen, iv_usage));
+    }
+
+    /* set sm1 round num */
+    if (ctx->func->setround) {
+        CHECK_EXIT(ctx->func->setround(ctx->cryp_ctx, sm1_round_num));
+    }
+
+    /* Set AAD */
+    if (ctx->func->setadd) {
+        ret = cipher_check_mmz_phy_addr(ADDR_U64(aad), alen);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("Invalid aad mmz phy addr.\n");
+            HI_LOG_PRINT_FUNC_ERR(cipher_check_mmz_phy_addr, ret);
+            goto exit__;
+        }
+
+        HI_LOG_INFO("set add, phy 0x%x, alen %d, tlen %d\n", ADDR_L32(aad), alen, tlen);
+        CHECK_EXIT(kapi_symc_check_ccm_gcm_taglen(alg, work_mode, tlen));
+        CHECK_EXIT(ctx->func->setadd(ctx->cryp_ctx, aad, alen, tlen));
+    }
+
+    /* save crtl */
+    crypto_memset(&ctx->ctrl, sizeof(hi_cipher_ctrl), 0, sizeof(hi_cipher_ctrl));
+    ctx->ctrl.key_by_ca = byca;
+    ctx->ctrl.alg = alg;
+    ctx->ctrl.bit_width = bit_width;
+    ctx->ctrl.ca_type = ca_type;
+    ctx->ctrl.key_len = key_len;
+    ctx->ctrl.work_mode = work_mode;
+    ctx->ctrl.change_flags.bit1_iv = iv_usage;
+
+    if (iv != HI_NULL) {
+        if (ivlen > AES_IV_SIZE) {
+            HI_LOG_ERROR("Invalid iv len.\n");
+            ret = HI_ERR_CIPHER_INVALID_PARA;
+            goto exit__;
+        }
+
+        crypto_memcpy(ctx->ctrl.iv, AES_IV_SIZE, iv, ivlen);
+    }
+    if (fkey != HI_NULL) {
+        if (klen > AES_KEY_256BIT) {
+            HI_LOG_ERROR("Invalid key len.\n");
+            ret = HI_ERR_CIPHER_INVALID_PARA;
+            goto exit__;
+        }
+
+        crypto_memcpy(ctx->ctrl.key, AES_KEY_256BIT, fkey, klen);
+    }
+
+    ctx->config = HI_TRUE;
+
+    KAPI_SYMC_UNLOCK();
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+
+exit__:
+    KAPI_SYMC_UNLOCK();
+
+    return ret;
+}
+
+hi_s32 kapi_symc_get_config(hi_u32 id, hi_cipher_ctrl *ctrl)
+{
+    hi_s32 ret = HI_FAILURE;
+    kapi_symc_ctx *ctx = HI_NULL;
+    hi_u32 soft_id = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctrl == HI_NULL);
+
+    KAPI_SYMC_CHECK_HANDLE(id);
+    soft_id = HI_HANDLE_GET_CHNID(id);
+    ctx = &kapi_ctx[soft_id];
+    CHECK_OWNER(&ctx->owner);
+    HI_LOG_CHECK_PARAM(ctx->config != HI_TRUE);
+
+    KAPI_SYMC_LOCK();
+
+    crypto_memcpy(ctrl, sizeof(hi_cipher_ctrl), &ctx->ctrl, sizeof(hi_cipher_ctrl));
+    crypto_zeroize(ctrl->key, sizeof(ctrl->key));
+
+    KAPI_SYMC_UNLOCK();
+
+    HI_LOG_FUNC_EXIT();
+
+    return ret;
+}
+
+hi_s32 kapi_symc_crypto(hi_u32 id, compat_addr input,
+                     compat_addr output, hi_u32 length,
+                     hi_u32 operation, hi_u32 last)
+{
+    hi_s32 ret = HI_FAILURE;
+    symc_node_usage usage;
+    kapi_symc_ctx *ctx = HI_NULL;
+    hi_u32 soft_id = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    KAPI_SYMC_CHECK_HANDLE(id);
+    soft_id = HI_HANDLE_GET_CHNID(id);
+    ctx = &kapi_ctx[soft_id];
+    CHECK_OWNER(&ctx->owner);
+    HI_LOG_CHECK_PARAM(ADDR_U64(input) + length < length);
+    HI_LOG_CHECK_PARAM(ADDR_U64(output) + length < length);
+    HI_LOG_CHECK_PARAM(ctx->func == HI_NULL);
+    HI_LOG_CHECK_PARAM(ctx->func->crypto == HI_NULL);
+    HI_LOG_CHECK_PARAM(ctx->config != HI_TRUE);
+    HI_LOG_CHECK_PARAM((operation != 0x00) && (operation != 0x01));
+
+    HI_LOG_INFO("src/dest phyaddr information.\n");
+    HI_DBG_PRINT_U32(operation);
+    HI_DBG_PRINT_H32(ADDR_L32(input));
+    HI_DBG_PRINT_H32(ADDR_L32(output));
+    HI_DBG_PRINT_H32(length);
+
+    usage = SYMC_NODE_USAGE_NORMAL;
+
+    KAPI_SYMC_LOCK();
+
+    ret = ctx->func->crypto(ctx->cryp_ctx, operation, &input,
+                            &output, &length, &usage, 1, HI_TRUE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(ctx->func->crypto, ret);
+        KAPI_SYMC_UNLOCK();
+        return ret;
+    }
+
+    KAPI_SYMC_UNLOCK();
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_symc_crypto_via(hi_u32 id, compat_addr input,
+                         compat_addr output, hi_u32 length,
+                         hi_u32 operation, hi_u32 last, hi_u32 is_from_user)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_s32 ret_exit = HI_FAILURE;
+    crypto_mem mem = {0};
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ADDR_VIA(input) == HI_NULL);
+    HI_LOG_CHECK_PARAM(ADDR_VIA(output) == HI_NULL);
+    HI_LOG_CHECK_PARAM(length == 0x00);
+
+    ret = crypto_mem_create(&mem, SEC_MMZ, "AES_IN", length);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(crypto_mem_create, ret);
+        return ret;
+    }
+
+    if (is_from_user == HI_TRUE) {
+        ret = crypto_copy_from_user(mem.dma_virt, ADDR_VIA(input), length);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(crypto_copy_from_user, ret);
+            goto exit;
+        }
+    } else {
+        crypto_memcpy(mem.dma_virt, length, ADDR_VIA(input), length);
+    }
+
+    ret = kapi_symc_crypto(id, mem.dma_addr, mem.dma_addr, length, operation & 0x01, last);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_crypto, ret);
+        goto exit;
+    }
+
+    if (is_from_user == HI_TRUE) {
+        ret = crypto_copy_to_user(ADDR_VIA(output), mem.dma_virt, length);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(crypto_copy_to_user, ret);
+            goto exit;
+        }
+    } else {
+        crypto_memcpy(ADDR_VIA(output), length, mem.dma_virt, length);
+    }
+
+exit:
+    ret_exit = crypto_mem_destory(&mem);
+    if (ret_exit != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(crypto_mem_destory, ret_exit);
+        HI_ERR_PRINT_S32(ret);
+        return ret_exit;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return ret;
+}
+
+static hi_s32 kapi_symc_crypto_multi_start(kapi_symc_ctx *ctx, const void *pkg, hi_u32 pkg_num, hi_u32 operation, hi_u32 wait)
+{
+    hi_s32 ret = HI_FAILURE;
+    void *buf = HI_NULL, *temp = HI_NULL;
+    compat_addr *input = HI_NULL;
+    compat_addr *output = HI_NULL;
+    symc_node_usage *usage = HI_NULL;
+    hi_cipher_data pkg_tmp;
+    hi_u32 *length = HI_NULL;
+    hi_u32 size = 0;
+    hi_u32 i;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(ctx->func == HI_NULL);
+    HI_LOG_CHECK_PARAM(ctx->func->crypto == HI_NULL);
+    HI_LOG_CHECK_PARAM(pkg == HI_NULL);
+    HI_LOG_CHECK_PARAM(pkg_num > MAX_PKG_NUMBER);
+    HI_LOG_CHECK_PARAM(pkg_num == 0x00);
+
+    /* size of input:output:usage:length */
+    size = (sizeof(compat_addr) + sizeof(compat_addr) + sizeof(hi_u32) + sizeof(hi_u32)) * pkg_num;
+
+    buf = crypto_malloc(size);
+    if (buf == HI_NULL) {
+        HI_LOG_ERROR("Malloc for pkg failed.\n");
+        HI_LOG_PRINT_FUNC_ERR(crypto_malloc, ret);
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    temp = buf;
+    input = (compat_addr *)temp;
+    temp = (hi_u8 *)temp + sizeof(compat_addr) * pkg_num; /*buf + input*/
+    output = (compat_addr *)temp;
+    temp = (hi_u8 *)temp + sizeof(compat_addr) * pkg_num; /*buf + input + output*/
+    usage = temp;
+    temp = (hi_u8 *)temp + sizeof(hi_u32) * pkg_num; /*buf + input + output + usage*/
+    length = temp;
+
+    /*Compute and check the nodes length*/
+    for (i = 0; i < pkg_num; i++) {
+        /*copy node list from user space to kernel*/
+        ret = crypto_copy_from_user(&pkg_tmp, (hi_u8 *)pkg + sizeof(hi_cipher_data) * i,
+                                    sizeof(hi_cipher_data));
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("copy data from user fail!\n");
+            HI_LOG_PRINT_FUNC_ERR(crypto_copy_from_user, ret);
+            crypto_free(buf);
+            buf = HI_NULL;
+            return ret;
+        }
+
+        if (pkg_tmp.src_phy_addr + pkg_tmp.byte_length < pkg_tmp.byte_length) {
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            crypto_free(buf);
+            buf = HI_NULL;
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+
+        if (pkg_tmp.dest_phy_addr + pkg_tmp.byte_length < pkg_tmp.byte_length) {
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            crypto_free(buf);
+            buf = HI_NULL;
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+
+        if ((pkg_tmp.odd_key != HI_TRUE) && (pkg_tmp.odd_key != HI_FALSE)) {
+            HI_LOG_ERROR("invalid odd key for multicipher crypt!\n");
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);
+            crypto_free(buf);
+            buf = HI_NULL;
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+
+        ret = cipher_check_mmz_phy_addr(pkg_tmp.src_phy_addr, pkg_tmp.byte_length);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("Invalid output mmz phy addr for multicipher crypt.\n");
+            HI_LOG_PRINT_FUNC_ERR(cipher_check_mmz_phy_addr, ret);
+            crypto_free(buf);
+            buf = HI_NULL;
+            return ret;
+        }
+
+        ret = cipher_check_mmz_phy_addr(pkg_tmp.dest_phy_addr, pkg_tmp.byte_length);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("Invalid output mmz phy addr for multicipher crypt.\n");
+            HI_LOG_PRINT_FUNC_ERR(cipher_check_mmz_phy_addr, ret);
+            crypto_free(buf);
+            buf = HI_NULL;
+            return ret;
+        }
+
+        ADDR_U64(input[i]) = pkg_tmp.src_phy_addr;
+        ADDR_U64(output[i]) = pkg_tmp.dest_phy_addr;
+        length[i] = pkg_tmp.byte_length;
+        usage[i] = SYMC_NODE_USAGE_EVEN_KEY;
+
+        HI_LOG_DEBUG("pkg %d, in 0x%x, out 0x%x, length 0x%x, usage 0x%x\n", i,
+                     ADDR_L32(input[i]), ADDR_L32(output[i]), length[i], usage[i]);
+    }
+
+    ret = ctx->func->crypto(ctx->cryp_ctx, operation, input,
+                            output, length, usage, pkg_num, wait);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(cryp_symc_crypto, ret);
+        crypto_free(buf);
+        buf = HI_NULL;
+        return ret;
+    }
+
+    crypto_free(buf);
+    buf = HI_NULL;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_symc_crypto_multi(hi_u32 id, const void *pkg, hi_u32 pkg_num, hi_u32 operation, hi_u32 last)
+{
+    hi_s32 ret = HI_FAILURE;
+    kapi_symc_ctx *ctx = HI_NULL;
+    hi_u32 soft_id = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    KAPI_SYMC_CHECK_HANDLE(id);
+    soft_id = HI_HANDLE_GET_CHNID(id);
+    ctx = &kapi_ctx[soft_id];
+    CHECK_OWNER(&ctx->owner);
+    HI_LOG_CHECK_PARAM(ctx->func == HI_NULL);
+    HI_LOG_CHECK_PARAM(ctx->config != HI_TRUE);
+    HI_LOG_CHECK_PARAM((operation != 0x00) && (operation != 0x01));
+
+    KAPI_SYMC_LOCK();
+
+    ret = kapi_symc_crypto_multi_start(ctx, pkg, pkg_num, operation, HI_TRUE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_crypto_multi_start, ret);
+        KAPI_SYMC_UNLOCK();
+        return ret;
+    }
+
+    KAPI_SYMC_UNLOCK();
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_aead_get_tag(hi_u32 id, hi_u32 tag[AEAD_TAG_SIZE_IN_WORD], hi_u32 *taglen)
+{
+    hi_s32 ret = HI_FAILURE;
+    kapi_symc_ctx *ctx = HI_NULL;
+    hi_u32 soft_id = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(tag == HI_NULL);
+    HI_LOG_CHECK_PARAM(taglen == HI_NULL);
+    HI_LOG_CHECK_PARAM(*taglen != AES_CCM_MAX_TAG_LEN);
+
+    KAPI_SYMC_CHECK_HANDLE(id);
+    soft_id = HI_HANDLE_GET_CHNID(id);
+    ctx = &kapi_ctx[soft_id];
+    CHECK_OWNER(&ctx->owner);
+    HI_LOG_CHECK_PARAM(ctx->func == HI_NULL);
+    HI_LOG_CHECK_PARAM(ctx->func->gettag == HI_NULL);
+
+    KAPI_SYMC_LOCK();
+
+    if (ctx->func->gettag) {
+        ret = ctx->func->gettag(ctx->cryp_ctx, tag, taglen);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(cryp_aead_get_tag, ret);
+            KAPI_SYMC_UNLOCK();
+            return ret;
+        }
+    }
+
+    KAPI_SYMC_UNLOCK();
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_trng.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_trng.c
@@ -1,0 +1,41 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : kapi_trng.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "cryp_trng.h"
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+
+/******************************* API Code *****************************/
+/** \addtogroup      trng */
+/** @{*/  /** <!-- [kapi]*/
+
+hi_s32 kapi_trng_get_random(hi_u32 *randnum, hi_u32 timeout)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    HI_LOG_FUNC_ENTER();
+
+    HI_LOG_CHECK_PARAM(randnum == HI_NULL);
+
+    ret = cryp_trng_get_random(randnum, timeout);
+    if (ret != HI_SUCCESS) {
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/build.mak
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/build.mak
@@ -1,0 +1,10 @@
+CIPHER_CFLAGS += -I$(CIPHER_DIR)/drv/cipher_v1.0/osal/include
+
+ifeq ($(OSTYPE),liteos)
+CIPHER_OBJS   += drv/cipher_v1.0/osal/drv_osal_init_liteos.o
+CIPHER_OBJS   += drv/cipher_v1.0/osal/drv_osal_sys_liteos.o
+else
+CIPHER_OBJS   += drv/cipher_v1.0/osal/drv_osal_init_linux.o
+CIPHER_OBJS   += drv/cipher_v1.0/osal/drv_osal_sys_linux.o
+endif
+

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/drv_osal_init_linux.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/drv_osal_init_linux.c
@@ -1,0 +1,283 @@
+/******************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : ext_aead.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include <linux/proc_fs.h>
+#include <linux/module.h>
+#include <linux/signal.h>
+#include <linux/spinlock.h>
+#include <linux/personality.h>
+#include <linux/ptrace.h>
+#include <linux/kallsyms.h>
+#include <linux/init.h>
+#include <linux/pci.h>
+#include <linux/seq_file.h>
+#include <linux/version.h>
+#include <linux/sched.h>
+#include <linux/interrupt.h>
+#include <linux/mm_types.h>
+#include <linux/mm.h>
+#include <asm/atomic.h>
+#include <asm/cacheflush.h>
+#include <asm/io.h>
+#include <asm/uaccess.h>
+#include <asm/unistd.h>
+#include <asm/traps.h>
+#include <linux/miscdevice.h>
+#include <linux/delay.h>
+#include <linux/of_device.h>
+#include "drv_osal_lib.h"
+#include "drv_symc.h"
+#include "drv_hash.h"
+
+/************************ Internal Structure Definition *********************/
+
+#define CIPHER_PROC_NAME    "driver/hi_cipher"
+
+extern hi_s32 crypto_ioctl(hi_u32 cmd, hi_void *argp);
+extern hi_s32 crypto_entry(void);
+extern hi_s32 crypto_exit(void);
+hi_s32 crypto_release(void);
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      link*/
+/** @{*/  /** <!-- [link]*/
+
+/******* proc function begin ********/
+#if (1 == HI_PROC_SUPPORT)
+hi_s32 symc_proc_read(struct seq_file *p, hi_void *v)
+{
+    symc_chn_status *status = HI_NULL;
+    int i = 0;
+    hi_s32 ret = HI_SUCCESS;
+
+    seq_printf(p, "\n------------------------------------------"
+               "CIPHER STATUS-------------------------------"
+               "--------------------------------------------"
+               "--------------------\n");
+    seq_printf(p, "Chnid   Status   Decrypt   Alg   Mode   KeyLen    "
+               "Addr in/out      KeyFrom  INT-RAW in/out  INT-EN "
+               "in/out INT_OCNTCFG    IVOUT\n");
+
+    status = (symc_chn_status *)crypto_malloc(8 * sizeof(symc_chn_status));
+    if (status == HI_NULL) {
+        return HI_FAILURE;
+    }
+
+    crypto_memset(status, 8 * sizeof(symc_chn_status), 0, 8 * sizeof(symc_chn_status));
+    for (i = 0; i < 8; i++) {
+        status[i].id = i;
+    }
+
+    ret = drv_symc_proc_status(status);
+    if (ret != HI_SUCCESS) {
+        seq_printf(p, "CIPHER_ProcGetStatus failed!\n");
+        crypto_free(status);
+        status = NULL;
+        return HI_FAILURE;
+    }
+
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        seq_printf(p, " %d       %s      %d      %s  %s    %03d    %08x/%08x   "
+                   " %s           %d/%d            %d/%d        %08x     %s\n",
+                   i,
+                   status[i].open,
+                   status[i].decrypt,
+                   status[i].alg,
+                   status[i].mode,
+                   status[i].klen,
+                   status[i].inaddr,
+                   status[i].outaddr,
+                   status[i].ksrc,
+                   status[i].inraw,
+                   status[i].outraw,
+                   status[i].inten,
+                   status[i].outen,
+                   status[i].outintcnt,
+                   status[i].iv);
+    }
+
+#ifdef KAPI_TEST_SUPPORT
+    {
+        extern hi_s32 kapi_test_main(void);
+
+        kapi_test_main();
+    }
+#endif
+
+    crypto_free(status);
+    status = NULL;
+
+    return HI_SUCCESS;
+}
+
+static int symc_proc_open(struct inode *inode, struct file *file)
+{
+    return single_open(file, symc_proc_read, NULL);
+}
+
+static const struct file_operations DRV_CIPHER_ProcFops = {
+    .owner		= THIS_MODULE,
+    .open		= symc_proc_open,
+    .read		= seq_read,
+    .llseek		= seq_lseek,
+    .release	= single_release,
+};
+
+static hi_void symc_proc_init(hi_void)
+{
+    struct proc_dir_entry *proc_entry = HI_NULL;
+
+    proc_entry = proc_create(CIPHER_PROC_NAME, 0, NULL, &DRV_CIPHER_ProcFops);
+    if (proc_entry == NULL) {
+        HI_LOG_ERROR("cipher: can't create %s.\n", CIPHER_PROC_NAME);
+    }
+}
+
+static hi_void symc_proc_deinit(hi_void)
+{
+    remove_proc_entry(CIPHER_PROC_NAME, NULL);
+}
+#endif
+/******* proc function end ********/
+
+
+hi_s32 _crypto_ioctl(struct inode *inode, struct file *file,
+                     hi_u32 cmd, hi_void *arg)
+{
+    return crypto_ioctl(cmd, arg);
+}
+
+static hi_s32 hi_cipher_open(struct inode *inode, struct file *file)
+{
+    if ((!capable(CAP_SYS_RAWIO)) || (!capable(CAP_SYS_ADMIN))) {
+        return -EPERM;
+    }
+    return HI_SUCCESS;
+}
+
+static long hi_cipher_ioctl(struct file *ffile, unsigned int cmd, unsigned long arg)
+{
+    long ret = HI_SUCCESS;
+    hi_u8 unCmdParam[256] = {0};
+
+    if ((ffile == HI_NULL) || (ffile->f_path.dentry == HI_NULL) || (arg == 0x00)) {
+        HI_LOG_ERROR("Invalid cmd param size!\n");
+        return HI_ERR_CIPHER_INVALID_POINT;
+    }
+
+    if (_IOC_SIZE(cmd) > sizeof(unCmdParam)) {
+        HI_LOG_ERROR("Invalid cmd param size %d!\n", _IOC_SIZE(cmd));
+        return HI_ERR_CIPHER_INVALID_PARA;
+    }
+
+    if (((CRYPTO_IOC_DIR(cmd) == CRYPTO_IOC_W) || (CRYPTO_IOC_DIR(cmd) == CRYPTO_IOC_RW))
+        && (_IOC_SIZE(cmd) != 0)) {
+        ret = copy_from_user((hi_void *)unCmdParam, (void __user *)(HI_UINTPTR_T)arg, _IOC_SIZE(cmd));
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("copy data from user failed, ret:0x%lx!\n", ret);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+
+    ret = _crypto_ioctl(ffile->f_path.dentry->d_inode, ffile, cmd, (hi_void *)unCmdParam);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("copy data from user failed, ret:0x%lx!\n", ret);
+        return ret;
+    }
+
+    if (((CRYPTO_IOC_DIR(cmd) == CRYPTO_IOC_R) || (CRYPTO_IOC_DIR(cmd) == CRYPTO_IOC_RW))
+        && (_IOC_SIZE(cmd) != 0)) {
+        ret = copy_to_user((void __user *)(HI_UINTPTR_T)arg, (const hi_void *)unCmdParam, _IOC_SIZE(cmd));
+        if (ret != HI_SUCCESS) {
+            HI_LOG_ERROR("copy data to user fail, ret:0x%lx!\n", ret);
+            return HI_ERR_CIPHER_INVALID_PARA;
+        }
+    }
+    return HI_SUCCESS;
+}
+
+static hi_s32 hi_cipher_release(struct inode *inode, struct file *file)
+{
+    return crypto_release();
+}
+
+static struct file_operations dev_cipher_fops = {
+    .owner            = THIS_MODULE,
+    .open             = hi_cipher_open,
+    .unlocked_ioctl   = hi_cipher_ioctl,
+#ifdef CONFIG_COMPAT
+    .compat_ioctl     = hi_cipher_ioctl,
+#endif
+    .release          = hi_cipher_release,
+};
+
+static struct miscdevice cipher_dev = {
+    .minor      = MISC_DYNAMIC_MINOR,
+    .name       = UMAP_DEVNAME_CIPHER,
+    .fops       = &dev_cipher_fops,
+};
+
+void *cipher_get_device(void)
+{
+    return (void *)cipher_dev.this_device;
+}
+
+int cipher_drv_mod_init(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    if (misc_register(&cipher_dev)) {
+        HI_LOG_ERROR("ERROR: could not register cipher devices\n");
+        return -1;
+    }
+
+    /* dma data structure shall be initialised before being used in Kernel 4.9
+     * or else call dma_set_coherent_mask/dma_alloc_coherent will return error
+     */
+    of_dma_configure(cipher_dev.this_device, cipher_dev.this_device->of_node);
+
+    ret = crypto_entry();
+    if (ret != HI_SUCCESS) {
+        misc_deregister(&cipher_dev);
+        return HI_FAILURE;
+    }
+
+    /******* proc function begin ********/
+#if (1 == HI_PROC_SUPPORT)
+    symc_proc_init();
+#endif
+    /******* proc function end ********/
+
+#ifdef MODULE
+    HI_PRINT("Load hi_cipher.ko success.\n");
+#endif
+
+    return HI_SUCCESS;
+}
+
+void cipher_drv_mod_exit(void)
+{
+    /******* proc function begin ********/
+#if (1 == HI_PROC_SUPPORT)
+    symc_proc_deinit();
+#endif
+    /******* proc function end ********/
+    misc_deregister(&cipher_dev);
+    crypto_exit();
+
+    return ;
+}
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/drv_osal_init_linux.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/drv_osal_init_linux.c
@@ -127,6 +127,14 @@ static int symc_proc_open(struct inode *inode, struct file *file)
     return single_open(file, symc_proc_read, NULL);
 }
 
+#ifdef COMPAT_USE_PROC_OPS
+static const struct proc_ops DRV_CIPHER_ProcFops = {
+    .proc_open		= symc_proc_open,
+    .proc_read		= seq_read,
+    .proc_lseek		= seq_lseek,
+    .proc_release	= single_release,
+};
+#else
 static const struct file_operations DRV_CIPHER_ProcFops = {
     .owner		= THIS_MODULE,
     .open		= symc_proc_open,
@@ -134,6 +142,7 @@ static const struct file_operations DRV_CIPHER_ProcFops = {
     .llseek		= seq_lseek,
     .release	= single_release,
 };
+#endif
 
 static hi_void symc_proc_init(hi_void)
 {
@@ -246,7 +255,11 @@ int cipher_drv_mod_init(void)
     /* dma data structure shall be initialised before being used in Kernel 4.9
      * or else call dma_set_coherent_mask/dma_alloc_coherent will return error
      */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
+    of_dma_configure(cipher_dev.this_device, cipher_dev.this_device->of_node, true);
+#else
     of_dma_configure(cipher_dev.this_device, cipher_dev.this_device->of_node);
+#endif
 
     ret = crypto_entry();
     if (ret != HI_SUCCESS) {

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/drv_osal_init_liteos.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/drv_osal_init_liteos.c
@@ -1,0 +1,181 @@
+/******************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : ext_aead.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include "drv_symc.h"
+#include "drv_hash.h"
+
+/************************ Internal Structure Definition *********************/
+
+extern hi_s32 crypto_ioctl(hi_u32 cmd, hi_void *argp);
+extern hi_s32 crypto_entry(void);
+extern hi_s32 crypto_exit(void);
+extern hi_s32 crypto_recover_hdcp_key(void);
+
+static osal_dev_t    *cipher_device;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      link*/
+/** @{*/  /** <!-- [link]*/
+
+/******* proc function begin ********/
+#if (1 == HI_PROC_SUPPORT)
+hi_s32 symc_proc_read(struct osal_proc_dir_entry *p)
+{
+    symc_chn_status *status = HI_NULL;
+    int i = 0;
+    hi_s32 ret = HI_SUCCESS;
+
+    PROC_PRINT(p, "\n------------------------------------------"
+               "CIPHER STATUS-------------------------------"
+               "--------------------------------------------"
+               "--------------------\n");
+    PROC_PRINT(p, "Chnid   Status   Decrypt   Alg   Mode   KeyLen    "
+               "Addr in/out      KeyFrom  INT-RAW in/out  INT-EN "
+               "in/out INT_OCNTCFG    IVOUT\n");
+
+    status = (symc_chn_status *)crypto_malloc(sizeof(symc_chn_status) * 8);
+    if (status == HI_NULL) {
+        PROC_PRINT(p, "crypto malloc for status buff failed!\n");
+        return HI_FAILURE;
+    }
+
+    crypto_memset(status, sizeof(symc_chn_status) * 8, 0, sizeof(symc_chn_status) * 8);
+    for (i = 0; i < 8; i++) {
+        status[i].id = i;
+    }
+
+    ret = drv_symc_proc_status(status);
+    if (ret != HI_SUCCESS) {
+        PROC_PRINT(p, "CIPHER_ProcGetStatus failed!\n");
+        crypto_free(status);
+        status = HI_NULL;
+        return HI_FAILURE;
+    }
+
+    for (i = 0; i < CRYPTO_HARD_CHANNEL_MAX; i++) {
+        PROC_PRINT(p, " %d       %s      %d      %s  %s    %03d    %08x/%08x   "
+                   " %s           %d/%d            %d/%d        %08x     %s\n",
+                   i,
+                   status[i].open,
+                   status[i].decrypt,
+                   status[i].alg,
+                   status[i].mode,
+                   status[i].klen,
+                   status[i].inaddr,
+                   status[i].outaddr,
+                   status[i].ksrc,
+                   status[i].inraw,
+                   status[i].outraw,
+                   status[i].inten,
+                   status[i].outen,
+                   status[i].outintcnt,
+                   status[i].iv);
+    }
+    crypto_free(status);
+    status = HI_NULL;
+
+    return HI_SUCCESS;
+}
+
+static hi_void symc_proc_init(hi_void)
+{
+    osal_proc_entry_t *proc_entry = HI_NULL;
+
+    proc_entry = osal_create_proc_entry(UMAP_DEVNAME_CIPHER, HI_NULL);
+    if (proc_entry == HI_NULL) {
+        HI_LOG_ERROR("cipher: can't create proc.\n");
+        return;
+    }
+    proc_entry->read = symc_proc_read;
+}
+
+static hi_void symc_proc_deinit(hi_void)
+{
+    osal_remove_proc_entry(UMAP_DEVNAME_CIPHER, NULL);
+}
+#endif
+/******* proc function end ********/
+
+static long hi_cipher_ioctl(hi_u32 cmd,  unsigned long arg, void *private_data)
+{
+    return crypto_ioctl(cmd, (void *)arg);
+}
+
+static osal_fileops_t dev_cipher_fops = {
+    .open             = HI_NULL,
+    .unlocked_ioctl   = hi_cipher_ioctl,
+#ifdef CONFIG_COMPAT
+    .compat_ioctl     = hi_cipher_ioctl,
+#endif
+    .release          = HI_NULL,
+};
+
+int cipher_drv_mod_init(void)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    cipher_device = osal_createdev(UMAP_DEVNAME_CIPHER);
+    cipher_device->fops = &dev_cipher_fops;
+    cipher_device->minor = UMAP_MIN_MINOR_CIPHER;
+
+
+    ret = osal_registerdevice(cipher_device);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("register CIPHER failed.\n");
+        return ret;
+    }
+
+    ret = crypto_entry();
+    if (ret != HI_SUCCESS) {
+        goto error;
+    }
+
+    /******* proc function begin ********/
+#if (1 == HI_PROC_SUPPORT)
+    symc_proc_init();
+#endif
+    /******* proc function end ********/
+
+#ifdef MODULE
+    HI_PRINT("Load hi_cipher.ko success.\n");
+#endif
+
+    return HI_SUCCESS;
+
+error:
+    osal_deregisterdevice(cipher_device);
+    osal_destroydev(cipher_device);
+
+    return ret;
+}
+
+void cipher_drv_mod_exit(void)
+{
+
+    /******* proc function begin ********/
+#if (1 == HI_PROC_SUPPORT)
+    symc_proc_deinit();
+#endif
+    /******* proc function end ********/
+
+    (hi_void)crypto_exit();
+    osal_deregisterdevice(cipher_device);
+    osal_destroydev(cipher_device);
+
+    return ;
+}
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/drv_osal_sys_linux.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/drv_osal_sys_linux.c
@@ -1,0 +1,516 @@
+/******************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_osal_sys_linux.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+#include <linux/dmapool.h>
+#include <asm/cacheflush.h>
+
+/************************* Internal Structure Definition *********************/
+/** \addtogroup      base type*/
+/** @{*/  /** <!-- [base]*/
+
+
+/* under TEE, we only can malloc secure mmz at system steup,
+ * then map the mmz to Smmu, but the smmu can't map to cpu address,
+ * so we must save the cpu address in a static table when malloc and map mmz.
+ * when call crypto_mem_map, we try to query the table to get cpu address firstly,
+ * if can't get cpu address from the table, then call system api to map it.
+ */
+#define CRYPTO_MEM_MAP_TABLE_DEPTH      32
+#define DMA_ALLOC_MAX_SIZE              (1024 * 256)
+
+typedef struct {
+    hi_u32      valid;
+    compat_addr dma;
+    void        *via;
+} crypto_mem_map_table;
+
+static crypto_mem_map_table loacl_map_table[CRYPTO_MEM_MAP_TABLE_DEPTH];
+
+#ifdef CONFIG_64BIT
+#define crypto_flush_dcache_area        __flush_dcache_area
+#else
+#define crypto_flush_dcache_area        __cpuc_flush_dcache_area
+#endif
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      base*/
+/** @{*/  /** <!--[base]*/
+
+/*****************************************************************
+ *                       mmz/mmu api                             *
+ *****************************************************************/
+static hi_s32 cipher_dma_set_mask(struct device *dev)
+{
+    hi_s32 ret = HI_FAILURE;
+
+    ret = dma_set_coherent_mask(dev, DMA_BIT_MASK(64));
+    if (ret == HI_SUCCESS) {
+        return ret;
+    }
+
+    ret = dma_set_coherent_mask(dev, DMA_BIT_MASK(32));
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("Failed to set DMA mask %d.\n", ret);
+        return ret;
+    }
+
+    return HI_SUCCESS;
+}
+
+static hi_s32  cipher_dma_alloc_coherent(crypto_mem *mem, hi_u32 type, char const *name, hi_u32 size)
+{
+    struct device *dev = HI_NULL;
+    hi_s32 ret = HI_FAILURE;
+    hi_s32 i;
+
+    if (mem == HI_NULL) {
+        HI_LOG_ERROR("mem is null.\n");
+        return HI_FAILURE;
+    }
+
+    if (size >= DMA_ALLOC_MAX_SIZE) {
+        HI_LOG_ERROR("dma alloc coherent with invalid size(0x%x).\n", size);
+        return HI_FAILURE;
+    }
+
+    dev = (struct device *)cipher_get_device();
+    if (dev == HI_NULL) {
+        HI_LOG_ERROR("cipher_get_device error.\n");
+        return HI_FAILURE;
+    }
+
+    ret = cipher_dma_set_mask(dev);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("cipher dma set mask failed.\n");
+        return ret;
+    }
+
+    mem->dma_size = size;
+    mem->dma_virt = dma_alloc_coherent(dev, mem->dma_size, (dma_addr_t *)(&ADDR_U64(mem->dma_addr)), GFP_ATOMIC);
+    if (mem->dma_virt == HI_NULL) {
+        HI_LOG_ERROR("dma_alloc_coherent error.\n");
+        return HI_FAILURE;
+    }
+    ADDR_U64(mem->mmz_addr) = ADDR_U64(mem->dma_addr);
+
+    /* save the map info */
+    for (i = 0; i < CRYPTO_MEM_MAP_TABLE_DEPTH; i++) {
+        if (loacl_map_table[i].valid == HI_FALSE) {
+            ADDR_U64(loacl_map_table[i].dma) = ADDR_U64(mem->dma_addr);
+            loacl_map_table[i].via = mem->dma_virt;
+            loacl_map_table[i].valid = HI_TRUE;
+            HI_LOG_DEBUG("map local map %d, dam 0x%x, via 0x%p\n",
+                         i, ADDR_U64(mem->dma_addr), mem->dma_virt);
+            break;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 cipher_dma_free_coherent(crypto_mem *mem)
+{
+    struct device *dev = HI_NULL;
+    hi_s32 ret = HI_FAILURE;
+    hi_s32 i = 0;
+    crypto_mem mem_temp;
+
+    if (mem == HI_NULL) {
+        HI_LOG_ERROR("mem is null.\n");
+        return HI_FAILURE;
+    }
+
+    crypto_memset(&mem_temp, sizeof(mem_temp), 0, sizeof(mem_temp));
+    crypto_memcpy(&mem_temp, sizeof(mem_temp), mem, sizeof(crypto_mem));
+
+    dev = (struct device *)cipher_get_device();
+    if (dev == NULL) {
+        HI_LOG_ERROR("cipher_get_device error.\n");
+        return HI_FAILURE;
+    }
+
+    ret = cipher_dma_set_mask(dev);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("cipher dma set mask failed.\n");
+        return ret;
+    }
+
+    dma_free_coherent(dev, mem->dma_size, mem->dma_virt, ADDR_U64(mem->dma_addr));
+
+    /* remove the map info */
+    for (i = 0; i < CRYPTO_MEM_MAP_TABLE_DEPTH; i++) {
+        if ( loacl_map_table[i].valid &&
+             ADDR_U64(loacl_map_table[i].dma) == ADDR_U64(mem_temp.dma_addr)) {
+            ADDR_U64(loacl_map_table[i].dma) = 0x00;
+            loacl_map_table[i].via = HI_NULL;
+            loacl_map_table[i].valid = HI_FALSE;
+            HI_LOG_DEBUG("unmap local map %d, dam 0x%x, via 0x%p\n",
+                         i, ADDR_U64(mem_temp.dma_addr), mem_temp.dma_virt);
+            break;
+        }
+    }
+    crypto_memset(mem, sizeof(crypto_mem), 0, sizeof(crypto_mem));
+
+    return HI_SUCCESS;
+}
+
+/*brief allocate and map a mmz or smmu memory
+* we can't allocate smmu directly during TEE boot period.
+* in addition, the buffer of cipher node list must be mmz.
+* so here we have to allocate a mmz memory then map to smmu if necessary.
+*/
+static hi_s32 hash_mem_alloc_remap(crypto_mem *mem, hi_u32 type, char const *name, hi_u32 size)
+{
+    hi_u32 i;
+    crypto_memset(mem, sizeof(crypto_mem), 0, sizeof(crypto_mem));
+
+    HI_LOG_DEBUG("mem_alloc_remap()- name %s, size 0x%x\n", name, size);
+
+    mem->dma_size = size;
+    mem->dma_virt = kzalloc(size, GFP_KERNEL);
+    if (mem->dma_virt == NULL) {
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    ADDR_U64(mem->mmz_addr) = virt_to_phys(mem->dma_virt);
+    if (0 == ADDR_U64(mem->mmz_addr)) {
+        if (mem->dma_virt != HI_NULL) {
+            kfree(mem->dma_virt);
+            mem->dma_virt = HI_NULL;
+        }
+
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    ADDR_U64(mem->dma_addr) = ADDR_U64(mem->mmz_addr);
+
+    HI_LOG_DEBUG("MMZ/MMU malloc, MMZ 0x%x, MMZ/MMU 0x%x, VIA 0x%p, SIZE 0x%x\n",
+                 ADDR_U64(mem->mmz_addr), ADDR_U64(mem->dma_addr), mem->dma_virt, size);
+
+    mem->user_buf = HI_NULL;
+
+    /* save the map info */
+    for (i = 0; i < CRYPTO_MEM_MAP_TABLE_DEPTH; i++) {
+        if (loacl_map_table[i].valid == HI_FALSE) {
+            ADDR_U64(loacl_map_table[i].dma) = ADDR_U64(mem->dma_addr);
+            loacl_map_table[i].via = mem->dma_virt;
+            loacl_map_table[i].valid = HI_TRUE;
+            HI_LOG_DEBUG("map local map %d, dam 0x%x, via 0x%p\n",
+                         i, ADDR_U64(mem->dma_addr), mem->dma_virt);
+            break;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+/*brief release and unmap a mmz or smmu memory */
+static hi_s32 hash_mem_release_unmap(crypto_mem *mem)
+{
+    hi_u32 i;
+
+    kfree(mem->dma_virt);
+    mem->dma_virt = HI_NULL;
+
+    /* remove the map info */
+    for (i = 0; i < CRYPTO_MEM_MAP_TABLE_DEPTH; i++) {
+        if ( loacl_map_table[i].valid &&
+             ADDR_U64(loacl_map_table[i].dma) == ADDR_U64(mem->dma_addr)) {
+            ADDR_U64(loacl_map_table[i].dma) = 0x00;
+            loacl_map_table[i].via = HI_NULL;
+            loacl_map_table[i].valid = HI_FALSE;
+            HI_LOG_DEBUG("unmap local map %d, dam 0x%x, via 0x%p\n",
+                         i, ADDR_U64(mem->dma_addr), mem->dma_virt);
+            break;
+        }
+    }
+    crypto_memset(mem, sizeof(crypto_mem), 0, sizeof(crypto_mem));
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 crypto_mem_alloc_remap(crypto_mem *mem, hi_u32 type, char const *name, hi_u32 size)
+{
+    return cipher_dma_alloc_coherent(mem, type, name, size);
+}
+
+/*brief release and unmap a mmz or smmu memory */
+static hi_s32 crypto_mem_release_unmap(crypto_mem *mem)
+{
+    return cipher_dma_free_coherent(mem);
+}
+
+/*brief map a mmz or smmu memory */
+static hi_s32 crypto_mem_map(crypto_mem *mem)
+{
+    hi_u32 i;
+
+    HI_LOG_DEBUG("crypto_mem_map()- dma 0x%x, size 0x%x\n",
+                 ADDR_U64(mem->dma_addr), mem->dma_size);
+
+    /* try to query the table to get cpu address firstly,
+     * if can't get cpu address from the table, then call system api to map it.
+     */
+    for (i = 0; i < CRYPTO_MEM_MAP_TABLE_DEPTH; i++) {
+        if ( loacl_map_table[i].valid &&
+             ADDR_U64(loacl_map_table[i].dma) == ADDR_U64(mem->dma_addr)) {
+            mem->dma_virt = loacl_map_table[i].via;
+            HI_LOG_DEBUG("local map %d, dam 0x%x, via 0x%p\n",
+                         i, ADDR_U64(mem->dma_addr), mem->dma_virt);
+            return HI_SUCCESS;
+        }
+    }
+
+    mem->dma_virt = (hi_u8 *)phys_to_virt(ADDR_U64(mem->dma_addr));
+    if (mem->dma_virt == HI_NULL) {
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    HI_LOG_INFO("crypto_mem_map()- via 0x%p\n", mem->dma_virt);
+
+    return HI_SUCCESS;
+
+}
+
+/*brief unmap a mmz or smmu memory */
+static hi_s32 crypto_mem_unmap(crypto_mem *mem)
+{
+    hi_u32 i;
+
+    HI_LOG_DEBUG("crypto_mem_unmap()- dma 0x%x, size 0x%x\n",
+                 ADDR_U64(mem->dma_addr), mem->dma_size);
+
+    /* try to query the table to ummap cpu address firstly,
+     * if can't get cpu address from the table, then call system api to unmap it.
+     */
+    for (i = 0; i < CRYPTO_MEM_MAP_TABLE_DEPTH; i++) {
+        if ( loacl_map_table[i].valid &&
+             ADDR_U64(loacl_map_table[i].dma) == ADDR_U64(mem->dma_addr)) {
+            /* this api can't unmap the dma within the map table */
+            HI_LOG_DEBUG("local unmap %d, dam 0x%x, via 0x%p\n",
+                         i, ADDR_U64(mem->dma_addr), mem->dma_virt);
+            return HI_SUCCESS;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+void crypto_cpuc_flush_dcache_area(void *kvir, hi_u32 length)
+{
+    crypto_flush_dcache_area(kvir, length);
+}
+
+void crypto_mem_init(void)
+{
+    crypto_memset(&loacl_map_table, sizeof(loacl_map_table), 0, sizeof(loacl_map_table));
+}
+
+void crypto_mem_deinit(void)
+{
+
+}
+
+hi_s32 crypto_mem_create(crypto_mem *mem, hi_u32 type, const char *name, hi_u32 size)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    return crypto_mem_alloc_remap(mem, type, name, size);
+}
+
+hi_s32 crypto_mem_destory(crypto_mem *mem)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    return crypto_mem_release_unmap(mem);
+}
+
+hi_s32 hash_mem_create(crypto_mem *mem, hi_u32 type, const char *name, hi_u32 size)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    return hash_mem_alloc_remap(mem, type, name, size);
+}
+
+hi_s32 hash_mem_destory(crypto_mem *mem)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    return hash_mem_release_unmap(mem);
+}
+
+hi_s32 crypto_mem_open(crypto_mem *mem, compat_addr dma_addr, hi_u32 dma_size)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    mem->dma_addr = dma_addr;
+    mem->dma_size = dma_size;
+
+    return crypto_mem_map(mem);
+}
+
+hi_s32 crypto_mem_close(crypto_mem *mem)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    return crypto_mem_unmap(mem);;
+}
+
+hi_s32 crypto_mem_attach(crypto_mem *mem, void *buffer)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    mem->user_buf = buffer;
+
+    return HI_SUCCESS;
+}
+
+hi_s32 crypto_mem_flush(crypto_mem *mem, hi_u32 dma2user, hi_u32 offset, hi_u32 data_size)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+    HI_LOG_CHECK_PARAM(mem->dma_virt == HI_NULL);
+    HI_LOG_CHECK_PARAM(mem->user_buf == HI_NULL);
+    HI_LOG_CHECK_PARAM(data_size + offset < data_size);
+    HI_LOG_CHECK_PARAM(data_size + offset > mem->dma_size);
+
+    if (dma2user) {
+        crypto_memcpy((hi_u8 *)mem->user_buf + offset, data_size,
+                      (hi_u8 *)mem->dma_virt + offset, data_size);
+    } else {
+        crypto_memcpy((hi_u8 *)mem->dma_virt + offset, data_size,
+                      (hi_u8 *)mem->user_buf + offset, data_size);
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_s32 crypto_mem_phys(crypto_mem *mem, compat_addr *dma_addr)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    dma_addr->phy = ADDR_U64(mem->dma_addr);
+
+    return HI_SUCCESS;
+}
+
+void *crypto_mem_virt(crypto_mem *mem)
+{
+    if (mem == HI_NULL) {
+        return HI_NULL;
+    }
+
+    return mem->dma_virt;
+}
+
+hi_s32 crypto_copy_from_user(void *to, const void  *from, unsigned long n)
+{
+    if (n == 0) {
+        return HI_SUCCESS;
+    }
+
+    HI_LOG_CHECK_PARAM(to == HI_NULL);
+    HI_LOG_CHECK_PARAM(from == HI_NULL);
+    HI_LOG_CHECK_PARAM(n > MAX_COPY_FROM_USER_SIZE);
+
+    return copy_from_user(to, from, n);
+}
+
+hi_s32 crypto_copy_to_user(void *to, const void  *from, unsigned long n)
+{
+    if (n == 0) {
+        return HI_SUCCESS;
+    }
+
+    HI_LOG_CHECK_PARAM(to == HI_NULL);
+    HI_LOG_CHECK_PARAM(from == HI_NULL);
+    HI_LOG_CHECK_PARAM(n > MAX_COPY_FROM_USER_SIZE);
+
+    return copy_to_user(to, from, n);
+}
+
+hi_u32 crypto_is_sec_cpu(void)
+{
+    return module_get_secure();
+}
+
+void smmu_get_table_addr(hi_u64 *rdaddr, hi_u64 *wraddr, hi_u64 *table)
+{
+#ifdef CRYPTO_SMMU_SUPPORT
+    hi_u32 smmu_e_raddr, smmu_e_waddr, mmu_pgtbl;
+    HI_DRV_SMMU_GetPageTableAddr(&mmu_pgtbl, &smmu_e_raddr, &smmu_e_waddr);
+
+    *rdaddr = smmu_e_raddr;
+    *wraddr = smmu_e_waddr;
+    *table = mmu_pgtbl;
+#else
+    *rdaddr = 0x00;
+    *wraddr = 0x00;
+    *table  = 0x00;
+#endif
+}
+
+hi_s32 crypto_waitdone_callback(void *param)
+{
+    hi_u32 *done = param;
+
+    return (*done != HI_FALSE);
+}
+
+hi_s32 cipher_check_mmz_phy_addr(hi_u64 phy_addr, hi_u64 length)
+{
+#ifdef CIPHER_CHECK_MMZ_PHY
+    hil_mmb_t *mmb = HI_NULL;
+    unsigned long mmb_offset = 0;
+
+    /* Check wether the start address is within the MMZ range of the current system. */
+    mmb = hil_mmb_getby_phys_2(phy_addr, &mmb_offset);
+    if (mmb != NULL) {
+        /* Check wether the end address is within the MMZ range of the current system */
+        mmb = hil_mmb_getby_phys_2(phy_addr + length - 1, &mmb_offset);
+        if (mmb == NULL) {
+            HI_LOG_PRINT_FUNC_ERR(hil_mmb_getby_phys_2, HI_FAILURE);
+            return HI_FAILURE;
+        }
+    } else { /* Whether the starting address is within the MMZ range of other systems */
+        if (hil_map_mmz_check_phys(phy_addr, length)) {
+            HI_LOG_PRINT_FUNC_ERR(hil_map_mmz_check_phys, HI_FAILURE);
+            return HI_FAILURE;
+        }
+    }
+#endif
+
+#ifdef CIPHER_BUILDIN
+    /*check physical addr is ram region*/
+    if (pfn_valid(phy_addr >> PAGE_SHIFT) || pfn_valid(length + (phy_addr >> PAGE_SHIFT))) {
+#if defined(CONFIG_CMA) && defined(CONFIG_ARCH_HISI_BVT)
+        if (is_hicma_address(phy_addr, length)) {
+            return HI_SUCCESS;
+        } else {
+            HI_LOG_PRINT_FUNC_ERR(is_hicma_address, HI_FAILURE);
+            return HI_FAILURE;
+        }
+#endif
+        HI_LOG_ERROR("physical addr is ram region.\n");
+        return HI_FAILURE;
+    } else {
+        return HI_SUCCESS;
+    }
+#endif
+
+    return HI_SUCCESS;
+}
+
+/** @}*/  /** <!-- ==== API Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/drv_osal_sys_liteos.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/drv_osal_sys_liteos.c
@@ -1,0 +1,416 @@
+/******************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : drv_osal_sys_liteos.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+
+/************************* Internal Structure Definition *********************/
+/** \addtogroup      base type*/
+/** @{*/  /** <!-- [base]*/
+
+/* under TEE, we only can malloc secure mmz at system steup,
+ * then map the mmz to Smmu, but the smmu can't map to cpu address,
+ * so we must save the cpu address in a static table when malloc and map mmz.
+ * when call crypto_mem_map, we try to query the table to get cpu address firstly,
+ * if can't get cpu address from the table, then call system api to map it.
+ */
+#define CRYPTO_MEM_MAP_TABLE_DEPTH      32
+
+typedef struct {
+    hi_u32      valid;
+    compat_addr dma;
+    void        *via;
+} crypto_mem_map_table;
+
+static crypto_mem_map_table loacl_map_table[CRYPTO_MEM_MAP_TABLE_DEPTH];
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/******************************* API Code *****************************/
+/** \addtogroup      base*/
+/** @{*/  /** <!--[base]*/
+
+/*****************************************************************
+ *                       mmz/mmu api                             *
+ *****************************************************************/
+
+/*brief allocate and map a mmz or smmu memory
+* we can't allocate smmu directly during TEE boot period.
+* in addition, the buffer of cipher node list must be mmz.
+* so here we have to allocate a mmz memory then map to smmu if necessary.
+*/
+hi_s32  crypto_mmz_malloc_nocache(hi_char* mmz_name, hi_char* buf_name,
+                                  hi_u64* phy_addr, hi_void** vir_addr,
+                                  hi_ulong length)
+{
+    hil_mmb_t *pmmb = NULL;
+
+    pmmb = hil_mmb_alloc(buf_name, length, 0, 0, mmz_name);
+    if (pmmb == NULL) {
+        HI_LOG_PRINT_FUNC_ERR(hil_mmb_alloc, HI_ERR_CIPHER_FAILED_MEM);
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    /* The buffer alloced by mmz is 4k align. */
+    *phy_addr = hil_mmb_phys(pmmb);
+    if (*phy_addr == 0) {
+        hil_mmb_free(pmmb);
+        pmmb = NULL;
+        HI_LOG_PRINT_FUNC_ERR(hil_mmb_phys, HI_ERR_CIPHER_FAILED_MEM);
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    *vir_addr = hil_mmb_map2kern(pmmb);
+    if (*vir_addr == NULL) {
+        hil_mmb_free(pmmb);
+        pmmb = NULL;
+        HI_LOG_PRINT_FUNC_ERR(hil_mmb_map2kern, HI_ERR_CIPHER_FAILED_MEM);
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_void crypto_mmz_free(hi_u64 phy_addr, hi_void* vir_addr)
+{
+    if (vir_addr != NULL) {
+        hil_mmb_t *pmmb = hil_mmb_getby_kvirt(vir_addr);
+
+        if (pmmb != NULL) {
+            hil_mmb_unmap(pmmb);
+            pmmb = NULL;
+        }
+    }
+
+    if (phy_addr != 0) {
+        hil_mmb_freeby_phys(phy_addr);
+    }
+}
+
+static hi_s32 crypto_mem_alloc_remap(crypto_mem *mem, hi_u32 type, char const *name, hi_u32 size)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u32 i;
+    crypto_memset(mem, sizeof(crypto_mem), 0, sizeof(crypto_mem));
+
+    HI_LOG_DEBUG("mem_alloc_remap()- name %s, size 0x%x\n", name, size);
+
+    ret = crypto_mmz_malloc_nocache(NULL, (char *)name, &ADDR_U64(mem->mmz_addr), (void **)&mem->dma_virt, size);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(crypto_mmz_malloc_nocache, ret);
+        return ret;
+    }
+    ADDR_U64(mem->dma_addr) = ADDR_U64(mem->mmz_addr);
+    mem->dma_size = size;
+
+    HI_LOG_DEBUG("MMZ/MMU malloc, MMZ 0x%x, MMZ/MMU 0x%x, VIA 0x%p, SIZE 0x%x\n",
+                 ADDR_U64(mem->mmz_addr), ADDR_U64(mem->dma_addr), mem->dma_virt, size);
+
+    mem->user_buf = HI_NULL;
+
+    /* save the map info */
+    for (i = 0; i < CRYPTO_MEM_MAP_TABLE_DEPTH; i++) {
+        if (loacl_map_table[i].valid == HI_FALSE) {
+            ADDR_U64(loacl_map_table[i].dma) = ADDR_U64(mem->dma_addr);
+            loacl_map_table[i].via = mem->dma_virt;
+            loacl_map_table[i].valid = HI_TRUE;
+            HI_LOG_DEBUG("map local map %d, dam 0x%x, via 0x%p\n",
+                         i, ADDR_U64(mem->dma_addr), mem->dma_virt);
+            break;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+/*brief release and unmap a mmz or smmu memory */
+static hi_s32 crypto_mem_release_unmap(crypto_mem *mem)
+{
+    hi_u32 i;
+    crypto_mmz_free(ADDR_U64(mem->mmz_addr), mem->dma_virt);
+
+    /* remove the map info */
+    for (i = 0; i < CRYPTO_MEM_MAP_TABLE_DEPTH; i++) {
+        if ( loacl_map_table[i].valid &&
+             ADDR_U64(loacl_map_table[i].dma) == ADDR_U64(mem->dma_addr)) {
+            ADDR_U64(loacl_map_table[i].dma) = 0x00;
+            loacl_map_table[i].via = HI_NULL;
+            loacl_map_table[i].valid = HI_FALSE;
+            HI_LOG_DEBUG("unmap local map %d, dam 0x%x, via 0x%p\n",
+                         i, ADDR_U64(mem->dma_addr), mem->dma_virt);
+            break;
+        }
+    }
+    crypto_memset(mem, sizeof(crypto_mem), 0, sizeof(crypto_mem));
+
+    return HI_SUCCESS;
+}
+
+/*brief map a mmz or smmu memory */
+static hi_s32 crypto_mem_map(crypto_mem *mem)
+{
+    hi_u32 i;
+
+    HI_LOG_DEBUG("crypto_mem_map()- dma 0x%x, size 0x%x\n",
+                 ADDR_U64(mem->dma_addr), mem->dma_size);
+
+    /* try to query the table to get cpu address firstly,
+     * if can't get cpu address from the table, then call system api to map it.
+     */
+    for (i = 0; i < CRYPTO_MEM_MAP_TABLE_DEPTH; i++) {
+        if ( loacl_map_table[i].valid &&
+             ADDR_U64(loacl_map_table[i].dma) == ADDR_U64(mem->dma_addr)) {
+            mem->dma_virt = loacl_map_table[i].via;
+            HI_LOG_DEBUG("local map %d, dam 0x%x, via 0x%p\n",
+                         i, ADDR_U64(mem->dma_addr), mem->dma_virt);
+            return HI_SUCCESS;
+        }
+    }
+
+    mem->dma_virt = (hi_u8 *)crypto_osal_ioremap_nocache(ADDR_U64(mem->dma_addr), mem->dma_size);
+    if (mem->dma_virt == HI_NULL) {
+        return HI_ERR_CIPHER_FAILED_MEM;
+    }
+
+    HI_LOG_INFO("crypto_mem_map()- via 0x%p\n", mem->dma_virt);
+
+    return HI_SUCCESS;
+
+}
+
+/*brief unmap a mmz or smmu memory */
+static hi_s32 crypto_mem_unmap(crypto_mem *mem)
+{
+    hi_u32 i;
+
+    HI_LOG_DEBUG("crypto_mem_unmap()- dma 0x%x, size 0x%x\n",
+                 ADDR_U64(mem->dma_addr), mem->dma_size);
+
+    /* try to query the table to ummap cpu address firstly,
+     * if can't get cpu address from the table, then call system api to unmap it.
+     */
+    for (i = 0; i < CRYPTO_MEM_MAP_TABLE_DEPTH; i++) {
+        if ( loacl_map_table[i].valid &&
+             ADDR_U64(loacl_map_table[i].dma) == ADDR_U64(mem->dma_addr)) {
+            /* this api can't unmap the dma within the map table */
+            HI_LOG_DEBUG("local unmap %d, dam 0x%x, via 0x%p\n",
+                         i, ADDR_U64(mem->dma_addr), mem->dma_virt);
+            return HI_SUCCESS;
+        }
+    }
+
+    crypto_osal_iounmap(mem->dma_virt);
+
+    return HI_SUCCESS;
+}
+
+void crypto_mem_init(void)
+{
+    crypto_memset(&loacl_map_table, sizeof(loacl_map_table), 0, sizeof(loacl_map_table));
+}
+
+void crypto_mem_deinit(void)
+{
+
+}
+
+void crypto_cpuc_flush_dcache_area(void *kvir, hi_u32 length)
+{
+
+}
+
+hi_s32 crypto_mem_create(crypto_mem *mem, hi_u32 type, const char *name, hi_u32 size)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    return crypto_mem_alloc_remap(mem, type, name, size);
+}
+
+hi_s32 crypto_mem_destory(crypto_mem *mem)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    return crypto_mem_release_unmap(mem);
+}
+
+hi_s32 hash_mem_create(crypto_mem *mem, hi_u32 type, const char *name, hi_u32 size)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    return crypto_mem_alloc_remap(mem, type, name, size);
+}
+
+hi_s32 hash_mem_destory(crypto_mem *mem)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    return crypto_mem_release_unmap(mem);
+}
+
+hi_s32 crypto_mem_open(crypto_mem *mem, compat_addr dma_addr, hi_u32 dma_size)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    mem->dma_addr = dma_addr;
+    mem->dma_size = dma_size;
+
+    return crypto_mem_map(mem);
+}
+
+hi_s32 crypto_mem_close(crypto_mem *mem)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    return crypto_mem_unmap(mem);;
+}
+
+hi_s32 crypto_mem_attach(crypto_mem *mem, void *buffer)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    mem->user_buf = buffer;
+
+    return HI_SUCCESS;
+}
+
+hi_s32 crypto_mem_flush(crypto_mem *mem, hi_u32 dma2user, hi_u32 offset, hi_u32 data_size)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+    HI_LOG_CHECK_PARAM(mem->dma_virt == HI_NULL);
+    HI_LOG_CHECK_PARAM(mem->user_buf == HI_NULL);
+    HI_LOG_CHECK_PARAM(data_size + offset < data_size);
+    HI_LOG_CHECK_PARAM(data_size + offset > mem->dma_size);
+
+    if (dma2user) {
+        crypto_memcpy((hi_u8 *)mem->user_buf + offset, data_size,
+                      (hi_u8 *)mem->dma_virt + offset, data_size);
+    } else {
+        crypto_memcpy((hi_u8 *)mem->dma_virt + offset, data_size,
+                      (hi_u8 *)mem->user_buf + offset, data_size);
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_s32 crypto_mem_phys(crypto_mem *mem, compat_addr *dma_addr)
+{
+    HI_LOG_CHECK_PARAM(mem == HI_NULL);
+
+    dma_addr->phy = ADDR_U64(mem->dma_addr);
+
+    return HI_SUCCESS;
+}
+
+void *crypto_mem_virt(crypto_mem *mem)
+{
+    if (mem == HI_NULL) {
+        return HI_NULL;
+    }
+
+    return mem->dma_virt;
+}
+
+hi_s32 crypto_copy_from_user(void *to, const void  *from, unsigned long n)
+{
+    if (n == 0) {
+        return HI_SUCCESS;
+    }
+
+    HI_LOG_CHECK_PARAM(to == HI_NULL);
+    HI_LOG_CHECK_PARAM(from == HI_NULL);
+
+    return osal_copy_from_user(to, from, n);
+}
+
+hi_s32 crypto_copy_to_user(void *to, const void  *from, unsigned long n)
+{
+    if (n == 0) {
+        return HI_SUCCESS;
+    }
+
+    HI_LOG_CHECK_PARAM(to == HI_NULL);
+    HI_LOG_CHECK_PARAM(from == HI_NULL);
+
+    return osal_copy_to_user(to, from, n);
+}
+
+hi_u32 crypto_is_sec_cpu(void)
+{
+    return module_get_secure();
+}
+
+void smmu_get_table_addr(hi_u64 *rdaddr, hi_u64 *wraddr, hi_u64 *table)
+{
+#ifdef CRYPTO_SMMU_SUPPORT
+    hi_u32 smmu_e_raddr, smmu_e_waddr, mmu_pgtbl;
+    HI_DRV_SMMU_GetPageTableAddr(&mmu_pgtbl, &smmu_e_raddr, &smmu_e_waddr);
+
+    *rdaddr = smmu_e_raddr;
+    *wraddr = smmu_e_waddr;
+    *table = mmu_pgtbl;
+#else
+    *rdaddr = 0x00;
+    *wraddr = 0x00;
+    *table  = 0x00;
+#endif
+}
+
+hi_s32 crypto_waitdone_callback(void *param)
+{
+    hi_u32 *pbDone = param;
+
+    return  *pbDone != HI_FALSE;
+}
+
+hi_s32 cipher_check_mmz_phy_addr(hi_u64 phy_addr, hi_u64 length)
+{
+#ifndef CIPHER_BUILDIN
+    hil_mmb_t *mmb = HI_NULL;
+    unsigned long mmb_offset = 0;
+
+    /* Check wether the start address is within the MMZ range of the current system. */
+    mmb = hil_mmb_getby_phys_2(phy_addr, &mmb_offset);
+    if (mmb != NULL) {
+        /* Check wether the end address is within the MMZ range of the current system */
+        mmb = hil_mmb_getby_phys_2(phy_addr + length - 1, &mmb_offset);
+        if (mmb == NULL) {
+            HI_LOG_PRINT_FUNC_ERR(hil_mmb_getby_phys_2, HI_FAILURE);
+            return HI_FAILURE;
+        }
+    } else { /* Whether the starting address is within the MMZ range of other systems */
+        if (hil_map_mmz_check_phys(phy_addr, length)) {
+            HI_LOG_PRINT_FUNC_ERR(hil_map_mmz_check_phys, HI_FAILURE);
+            return HI_FAILURE;
+        }
+    }
+#else
+
+    /*check physical addr is ram region*/
+    if (pfn_valid(phy_addr >> PAGE_SHIFT) || pfn_valid(length + (phy_addr >> PAGE_SHIFT))) {
+#if defined(CONFIG_CMA) && defined(CONFIG_ARCH_HISI_BVT)
+        if (is_hicma_address(phy_addr, length)) {
+            return HI_SUCCESS;
+        } else {
+            HI_LOG_PRINT_FUNC_ERR(is_hicma_address, HI_FAILURE);
+            return HI_FAILURE;
+        }
+#endif
+        HI_LOG_ERROR("physical addr is ram region.\n");
+        return HI_FAILURE;
+    } else {
+        return HI_SUCCESS;
+    }
+#endif
+
+    return HI_SUCCESS;
+}
+/** @}*/  /** <!-- ==== API Code end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/include/drv_osal_hi3516ev200.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/include/drv_osal_hi3516ev200.h
@@ -1,0 +1,185 @@
+#ifndef __DRV_OSAL_HI3516EV200_H__
+#define __DRV_OSAL_HI3516EV200_H__
+
+/* the total cipher hard channel which we can used*/
+#define CIPHER_HARD_CHANNEL_CNT         (0x02)
+/* mask which cipher channel we can used, bit0 means channel 0*/
+#define CIPHER_HARD_CHANNEL_MASK        (0x06)
+
+/* the total hash hard channel which we can used*/
+#define HASH_HARD_CHANNEL_CNT           (0x01)
+
+/* mask which cipher channel we can used, bit0 means channel 0*/
+#define HASH_HARD_CHANNEL_MASK          (0x02)
+#define HASH_HARD_CHANNEL               (0x01)
+
+/* the total cipher hard key channel which we can used*/
+#define CIPHER_HARD_KEY_CHANNEL_CNT     (0x04)
+
+/* mask which cipher hard key channel we can used, bit0 means channel 0*/
+#define CIPHER_HARD_KEY_CHANNEL_MASK    (0xF0)
+
+/* support read IRQ number from DTS */
+#define IRQ_DTS_SUPPORT
+
+/* support OTP load key */
+#define OTP_SUPPORT
+
+/* support smmu*/
+//#define CRYPTO_SMMU_SUPPORT
+
+#ifndef __HuaweiLite__
+/* support interrupt*/
+#define CRYPTO_OS_INT_SUPPORT
+#endif
+
+/* RSA RAND Mask*/
+//#define RSA_RAND_MASK
+
+/* secure cpu*/
+#define CRYPTO_SEC_CPU
+
+/* the hardware version */
+#define CHIP_SYMC_VER_V200
+#define CHIP_HASH_VER_V200
+#define CHIP_TRNG_VER_V200
+#define CHIP_IFEP_RSA_VER_V100
+//#define CHIP_SM2_VER_V100
+
+/* support des */
+//#define CHIP_DES_SUPPORT
+
+/* support 3des */
+//#define CHIP_3DES_SUPPORT
+
+/* supoort odd key */
+//#define CHIP_SYMC_ODD_KEY_SUPPORT
+
+/* supoort SM1 */
+//#define CHIP_SYMC_SM1_SUPPORT
+
+/* the hardware capacity */
+//#define CHIP_AES_CCM_GCM_SUPPORT
+
+/* the software capacity */
+//#define SOFT_AES_SUPPORT
+//#define SOFT_TDES_SUPPORT
+//#define SOFT_AES_CCM_GCM_SUPPORT
+//#define SOFT_SHA1_SUPPORT
+//#define SOFT_SHA256_SUPPORT
+//#define SOFT_SHA512_SUPPORT
+//#define SOFT_SM2_SUPPORT
+//#define SOFT_SM3_SUPPORT
+//#define SOFT_ECC_SUPPORT
+//#define SOFT_AES_CTS_SUPPORT
+
+/* SMP version linux is sec config */
+/* moudle unsupport, we need set the table*/
+#define BASE_TABLE_NULL    {\
+        .reset_valid = 0,  \
+        .clk_valid = 0, \
+        .phy_valid = 0, \
+        .crg_valid = 0, \
+        .ver_valid = 0, \
+        .int_valid = 0, \
+    }
+
+/* define initial value of struct sys_arch_boot_dts for cipher*/
+#define HARD_INFO_CIPHER {\
+        .name = "cipher",  \
+        .reset_valid = 1,  \
+        .clk_valid = 1, \
+        .phy_valid = 1, \
+        .crg_valid = 1, \
+        .ver_valid = 1, \
+        .int_valid = 1, \
+        .int_num = 66, \
+        .reset_bit = 8, \
+        .clk_bit = 9, \
+        .version_reg = 0x308, \
+        .version_val = 0x2018121, \
+        .reg_addr_phy = 0x10050000, \
+        .reg_addr_size = 0x4000,    \
+        .crg_addr_phy = 0x120101A0, \
+    }
+
+/* define initial value of struct sys_arch_boot_dts for cipher*/
+#define HARD_INFO_HASH {\
+        .name = "hash",  \
+        .reset_valid = 0,  \
+        .clk_valid = 0, \
+        .phy_valid = 1, \
+        .crg_valid = 0, \
+        .ver_valid = 1, \
+        .int_valid = 1, \
+        .int_num = 66, \
+        .reset_bit = 8, \
+        .clk_bit = 9, \
+        .version_reg = 0x308, \
+        .version_val = 0x2018121, \
+        .reg_addr_phy = 0x10050000, \
+        .reg_addr_size = 0x4000, \
+        .crg_addr_phy = 0x120101A0, \
+    }
+
+/* define initial value of struct sys_arch_boot_dts for HASH*/
+#define HARD_INFO_TRNG {\
+        .name = "trng",  \
+        .reset_valid = 1,  \
+        .clk_valid = 1, \
+        .phy_valid = 1, \
+        .crg_valid = 1, \
+        .ver_valid = 0, \
+        .int_valid = 0, \
+        .reset_bit = 2, \
+        .clk_bit = 3, \
+        .reg_addr_phy = 0x10080200,  \
+        .reg_addr_size = 0x100,   \
+        .crg_addr_phy = 0x120101A0, \
+    }
+
+/* define sec rsa1 for SMP VERSION */
+#define HARD_INFO_IFEP_RSA {\
+        .name = "rsa0",  \
+        .reset_valid = 1,  \
+        .clk_valid = 1, \
+        .phy_valid = 1, \
+        .crg_valid = 1, \
+        .ver_valid = 1, \
+        .int_valid = 0, \
+        .reg_addr_phy = 0x10070000,  \
+        .reg_addr_size = 0x1000,\
+        .crg_addr_phy = 0x120101A0, \
+        .reset_bit = 4, \
+        .clk_bit = 5, \
+        .version_reg = 0x90, \
+        .version_val = 0, \
+    }
+
+#define KLAD_REG_BASE_ADDR_PHY          (0x10060000)
+#define OTP_REG_BASE_ADDR_PHY           (0x10090000)
+#define KLAD_CRG_ADDR_PHY               (0x120101A0)
+#define REG_SYS_OTP_CLK_ADDR_PHY        (0x120101BC)
+
+#define OTP_CRG_CLOCK_BIT               (0x01 << 1)
+
+#define KLAD_CRG_CLOCK_BIT              (0x01 << 1)
+#define KLAD_CRG_RESET_BIT              (0x01 << 0)
+
+#define HARD_INFO_SMMU                BASE_TABLE_NULL
+#define HARD_INFO_SIC_RSA             BASE_TABLE_NULL
+#define HARD_INFO_CIPHER_KEY          BASE_TABLE_NULL
+#define HARD_INFO_SM4                 BASE_TABLE_NULL
+#define HARD_INFO_SM2                 BASE_TABLE_NULL
+
+#define NSEC_HARD_INFO_CIPHER              BASE_TABLE_NULL
+#define NSEC_HARD_INFO_HASH                BASE_TABLE_NULL
+#define NSEC_HARD_INFO_IFEP_RSA            BASE_TABLE_NULL
+#define NSEC_HARD_INFO_SMMU                BASE_TABLE_NULL
+#define NSEC_HARD_INFO_SIC_RSA             BASE_TABLE_NULL
+#define NSEC_HARD_INFO_CIPHER_KEY          BASE_TABLE_NULL
+#define NSEC_HARD_INFO_SM4                 BASE_TABLE_NULL
+#define NSEC_HARD_INFO_SM2                 BASE_TABLE_NULL
+#define NSEC_HARD_INFO_TRNG                BASE_TABLE_NULL
+
+#endif /* __DRV_OSAL_HI3516EV200_H__ */

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/include/drv_osal_lib.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/include/drv_osal_lib.h
@@ -1,0 +1,470 @@
+/******************************************************************************
+
+  Copyright (C), 2011-2014, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : drv_osal_lib.h
+  Version       : Initial Draft
+  Author        : Hisilicon hisecurity team
+  Created       :
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __DRV_OSAL_LIB_H__
+#define __DRV_OSAL_LIB_H__
+
+#ifdef __HuaweiLite__
+#include "drv_osal_lib_liteos.h"
+#else
+#include "drv_osal_lib_linux.h"
+#endif
+
+#define CIPHER_CHECK_MMZ_PHY
+
+#ifdef CIPHER_CHECK_MMZ_PHY
+#include "osal_mmz.h"
+extern hil_mmb_t *hil_mmb_getby_phys_2(unsigned long addr, unsigned long *out_offset);
+#endif
+
+#ifdef CIPHER_BUILDIN
+extern int is_hicma_address(phys_addr_t phys, unsigned long size);
+#endif
+
+/*! \return uuid */
+#define CHECK_OWNER(local) \
+    do { \
+        crypto_owner owner;\
+        crypto_get_owner(&owner); \
+        if (0 != memcmp(&owner, local, sizeof(owner))) { \
+            HI_LOG_ERROR("return user uuid failed\n"); \
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_ILLEGAL_UUID);\
+            return HI_ERR_CIPHER_ILLEGAL_UUID; \
+        } \
+    } while (0)
+
+/*! \max length module name */
+#define CRYPTO_MODULE_NAME_LEN            (16)
+
+/*! \the max cipher hard channel count*/
+#define CRYPTO_HARD_CHANNEL_MAX         (0x08)
+
+/*! \serure mmz or not, not used */
+#define SEC_MMZ                         (0x00)
+
+#ifdef DISABLE_DEBUG_INFO
+#define HI_PROC_SUPPORT                 0
+#else
+#define HI_PROC_SUPPORT                 1
+#endif
+
+/*! \struct channel
+ * the context of hardware channel.
+*/
+typedef struct {
+    /*the state of instance, open or closed.*/
+    hi_u32 open;
+
+    /*the context of channel, which is defined by specific module*/
+    hi_void *ctx;
+} channel_context;
+
+/*! \struct of crypto_mem*/
+typedef struct {
+    compat_addr dma_addr;    /*!<  dam addr, may be mmz or smmu */
+    compat_addr mmz_addr;    /*!<  mmz addr, sometimes the smmu must maped from mmz */
+    hi_void *dma_virt;         /*!<  cpu virtual addr maped from dam addr */
+    hi_u32 dma_size;           /*!<  dma memory size */
+    hi_void *user_buf;         /*!<  buffer of user */
+} crypto_mem;
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/
+
+/*! \****************************** API Declaration *****************************/
+/*! \addtogroup    osal lib */
+/** @{ */  /** <!--[osal]*/
+
+hi_s32 cipher_check_mmz_phy_addr(hi_u64 phy_addr, hi_u64 length);
+
+/**
+\brief  cipher get device.
+*/
+hi_void *cipher_get_device(hi_void);
+
+/**
+\brief  init dma memory.
+*/
+hi_void crypto_mem_init(hi_void);
+
+/**
+\brief  deinit dma memory.
+*/
+hi_void crypto_mem_deinit(hi_void);
+
+/**
+\brief  crypto cpuc flush dcache area.
+*/
+hi_void crypto_cpuc_flush_dcache_area(hi_void *kvir, hi_u32 length);
+
+/**
+\brief  allocate and map a dma memory.
+\param[in] mem  The struct of crypto_mem.
+\param[in] size The size of mem.
+\param[in] name The name of mem.
+\return         HI_SUCCESS if successful, or HI_BASE_ERR_MALLOC_FAILED.
+*/
+hi_s32 crypto_mem_create(crypto_mem *mem, hi_u32 type, const char *name, hi_u32 size);
+
+/**
+\brief  destory and unmap a dma memory.
+\param[in] mem  The struct of crypto_mem.
+\return         0 if successful, or HI_BASE_ERR_UNMAP_FAILED.
+*/
+hi_s32 crypto_mem_destory(crypto_mem *mem);
+
+/**
+\brief  allocate and map a dma memory.
+\param[in] mem  The struct of crypto_mem.
+\param[in] size The size of mem.
+\param[in] name The name of mem.
+\return         HI_SUCCESS if successful, or HI_BASE_ERR_MALLOC_FAILED.
+*/
+hi_s32 hash_mem_create(crypto_mem *mem, hi_u32 type, const char *name, hi_u32 size);
+
+/**
+\brief  destory and unmap a dma memory.
+\param[in] mem  The struct of crypto_mem.
+\return         0 if successful, or HI_BASE_ERR_UNMAP_FAILED.
+*/
+hi_s32 hash_mem_destory(crypto_mem *mem);
+
+/**
+\brief  map a dma memory.
+\param[in] mem  The struct of crypto_mem.
+\param[in] dma_ddr The address of dma mem.
+\param[in] dma_size The size of dma mem.
+\return         HI_SUCCESS if successful, or HI_BASE_ERR_MAP_FAILED.
+*/
+hi_s32 crypto_mem_open(crypto_mem *mem, compat_addr dma_ddr, hi_u32 dma_size);
+
+/**
+\brief  unmap a dma memory.
+\param[in] mem  The struct of crypto_mem.
+\param[in] dma_ddr The address of dma mem.
+\return         HI_SUCCESS if successful, or HI_BASE_ERR_UNMAP_FAILED.
+*/
+hi_s32 crypto_mem_close(crypto_mem *mem);
+
+/**
+\brief  attach a cpu buffer with dma memory.
+\param[in] mem  The struct of crypto_mem.
+\param[in] buffer The user's buffer.
+\return         HI_SUCCESS if successful, or HI_FAILURE.
+*/
+hi_s32 crypto_mem_attach(crypto_mem *mem, hi_void *buffer);
+
+/**
+\brief  flush dma memory,
+*\param[in] mem The struct of crypto_mem.
+*\param[in] dma2user 1-data from dma to user, 0-data from user to dma.
+*\param[in] offset The offset of data to be flush.
+*\param[in] data_size The size of data to be flush.
+\return         HI_SUCCESS if successful, or HI_FAILURE.
+*/
+hi_s32 crypto_mem_flush(crypto_mem *mem, hi_u32 dma2user, hi_u32 offset, hi_u32 data_size);
+
+/**
+\brief  get dma memory physical address
+*\param[in] mem The struct of crypto_mem.
+\return         dma_addr if successful, or zero.
+*/
+hi_s32 crypto_mem_phys(crypto_mem *mem, compat_addr *dma_addr);
+
+/**
+\brief  get dma memory virtual address
+*\param[in] mem The struct of crypto_mem.
+\return         dma_addr if successful, or zero.
+*/
+hi_void *crypto_mem_virt(crypto_mem *mem);
+
+/**
+\brief  check whether cpu is secure or not.
+\retval secure cpu, true is returned otherwise false is returned.
+*/
+hi_u32 crypto_is_sec_cpu(hi_void);
+
+/**
+\brief  map the physics addr to cpu within the base table, contains the base addr and crg addr.
+\retval    on success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.*/
+hi_s32 module_addr_map(hi_void);
+
+/**
+\brief  unmap the physics addr to cpu within the base table, contains the base addr and crg addr.
+\retval    on success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.*/
+hi_s32 module_addr_unmap(hi_void);
+
+/**
+\brief  get secure cpu type.
+*/
+hi_u32 module_get_secure(hi_void);
+
+/**
+\brief  enable a module, open clock  and remove reset signal.
+\param[in]  id The module id.
+\retval    NA */
+hi_void module_enable(module_id id);
+
+/**
+\brief  disable a module, close clock and set reset signal.
+\param[in] id The module id.
+\retval    NA */
+hi_void module_disable(module_id id);
+
+/**
+\brief  get attribute of module.
+\param[in]  id The module id.
+\param[out] int_valid enable interrupt or not.
+\param[out] int_num interrupt number of module.
+\param[out] name name of module.
+\retval    on success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.*/
+hi_void module_get_attr(module_id id, hi_u32 *int_valid, hi_u32 *int_num, const char **name);
+
+/**
+\brief  set irq number.
+\param[in]  id The module id.
+\param[in]  irq irq numbert.
+\retval    NA.*/
+hi_void module_set_irq(module_id id, hi_u32 irq);
+
+/**
+\brief  read a register.
+\param[in]  id The module id.
+\param[in]  offset The module id.
+\retval    the value of register*/
+hi_u32 module_reg_read(module_id id, hi_u32 offset);
+
+/**
+\brief  hex to string.
+\param[in]  buf The string buffer.
+\param[in]  val The value of hex.
+\retval    NA */
+hi_void hex2str(char buf[2], hi_u8 val);
+
+/**
+\brief  Implementation that should never be optimized out by the compiler
+\param[in]  buf The string buffer.
+\param[in]  the length of the buf.
+\retval    NA */
+hi_void crypto_zeroize( hi_void *buf, hi_u32 len );
+
+/**
+\brief  write a register.
+\param[in]  id The module id.
+\retval    NA */
+hi_void module_reg_write(module_id id, hi_u32 offset, hi_u32 val);
+
+/* cipher module read and write a register */
+#define SYMC_READ(offset)         module_reg_read(CRYPTO_MODULE_ID_SYMC, offset)
+#define SYMC_WRITE(offset, val)   module_reg_write(CRYPTO_MODULE_ID_SYMC, offset, val)
+
+/* hash module read and write a register */
+#define HASH_READ(offset)         module_reg_read(CRYPTO_MODULE_ID_HASH, offset)
+#define HASH_WRITE(offset, val)   module_reg_write(CRYPTO_MODULE_ID_HASH, offset, val)
+
+/* rsa module read and write a register */
+#define IFEP_RSA_READ(offset)       module_reg_read(CRYPTO_MODULE_ID_IFEP_RSA, offset)
+#define IFEP_RSA_WRITE(offset, val) module_reg_write(CRYPTO_MODULE_ID_IFEP_RSA, offset, val)
+
+/* trng module read and write a register */
+#define TRNG_READ(offset)         module_reg_read(CRYPTO_MODULE_ID_TRNG, offset)
+#define TRNG_WRITE(offset, val)   module_reg_write(CRYPTO_MODULE_ID_TRNG, offset, val)
+
+/* sm2 module read and write a register */
+#define SM2_READ(offset)         module_reg_read(CRYPTO_MODULE_ID_SM2, offset)
+#define SM2_WRITE(offset, val)   module_reg_write(CRYPTO_MODULE_ID_SM2, offset, val)
+
+/* smmu module read and write a register */
+#define SMMU_READ(offset)         module_reg_read(CRYPTO_MODULE_ID_SMMU, offset)
+#define SMMU_WRITE(offset, val)   module_reg_write(CRYPTO_MODULE_ID_SMMU, offset, val)
+
+/**
+\brief  Initialize the channel list.
+\param[in]  ctx The context of channel.
+\param[in]  num The channel numbers, max is 32.
+\param[in]  ctx_size The size of context.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 crypto_channel_init(channel_context *ctx, hi_u32 num, hi_u32 ctx_size);
+
+/**
+\brief  Deinitialize the channel list.
+\param[in]  ctx The context of channel.
+\param[in]  num The channel numbers, max is 32.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 crypto_channel_deinit(channel_context *ctx, hi_u32 num);
+
+/**
+\brief  allocate a channel.
+\param[in]  ctx The context of channel.
+\param[in]  num The channel numbers, max is 32.
+\param[in]  mask Mask whick channel allowed be alloc, max is 32.
+\param[out] id The id of channel.
+\retval     On success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_s32 crypto_channel_alloc(channel_context *ctx, hi_u32 num, hi_u32 mask, hi_u32 *id);
+
+/**
+\brief  free a channel.
+\param[in]  ctx The context of channel.
+\param[in]  num The channel numbers, max is 32.
+\param[in] id The id of channel.
+\retval    on success, HI_SUCCESS is returned.  On error, HI_FAILURE is returned.
+*/
+hi_void crypto_channel_free(channel_context *ctx, hi_u32 num, hi_u32 id);
+
+/**
+\brief  get the private data of hard channel.
+\param[in] ctx The context of channel.
+\param[in] num The channel numbers, max is 32.
+\param[in] id The id of channel.
+\retval    on success, the address of context is returned.  On error, NULL is returned..
+*/
+hi_void *crypto_channel_get_context(channel_context *ctx, hi_u32 num, hi_u32 id);
+
+/**
+\brief  get the rang.
+\retval    random number.
+*/
+hi_u32 get_rand(hi_void);
+
+hi_void smmu_get_table_addr(hi_u64 *rdaddr, hi_u64 *wraddr, hi_u64 *table);
+
+/**< allow modules to modify, default value is HI_ID_STB, the general module id*/
+#define LOG_D_MODULE_ID             HI_ID_CIPHER
+#define LOG_D_FUNCTRACE             (0)
+#define LOG_D_UNFTRACE              (0)
+
+/**< allow modules to define internel error code, from 0x1000*/
+#define LOG_ERRCODE_DEF(errid)      (hi_u32)(((LOG_D_MODULE_ID) << 16)  | (errid))
+
+/**< General Error Code, All modules can extend according to the rule */
+#define HI_LOG_ERR_MEM              LOG_ERRCODE_DEF(0x0001)      /**< Memory Operation Error */
+#define HI_LOG_ERR_SEM              LOG_ERRCODE_DEF(0x0002)      /**< Semaphore Operation Error */
+#define HI_LOG_ERR_FILE             LOG_ERRCODE_DEF(0x0003)      /**< File Operation Error */
+#define HI_LOG_ERR_LOCK             LOG_ERRCODE_DEF(0x0004)      /**< Lock Operation Error */
+#define HI_LOG_ERR_PARAM            LOG_ERRCODE_DEF(0x0005)      /**< Invalid Parameter */
+#define HI_LOG_ERR_TIMER            LOG_ERRCODE_DEF(0x0006)      /**< Timer error */
+#define HI_LOG_ERR_THREAD           LOG_ERRCODE_DEF(0x0007)      /**< Thread Operation Error */
+#define HI_LOG_ERR_TIMEOUT          LOG_ERRCODE_DEF(0x0008)      /**< Time Out Error */
+#define HI_LOG_ERR_DEVICE           LOG_ERRCODE_DEF(0x0009)      /**< Device Operation Error */
+#define HI_LOG_ERR_STATUS           LOG_ERRCODE_DEF(0x0010)      /**< Status Error */
+#define HI_LOG_ERR_IOCTRL           LOG_ERRCODE_DEF(0x0011)      /**< IO Operation Error */
+#define HI_LOG_ERR_INUSE            LOG_ERRCODE_DEF(0x0012)      /**< In use */
+#define HI_LOG_ERR_EXIST            LOG_ERRCODE_DEF(0x0013)      /**< Have exist */
+#define HI_LOG_ERR_NOEXIST          LOG_ERRCODE_DEF(0x0014)      /**< no exist */
+#define HI_LOG_ERR_UNSUPPORTED      LOG_ERRCODE_DEF(0x0015)      /**< Unsupported */
+#define HI_LOG_ERR_UNAVAILABLE      LOG_ERRCODE_DEF(0x0016)      /**< Unavailable */
+#define HI_LOG_ERR_UNINITED         LOG_ERRCODE_DEF(0x0017)      /**< Uninited */
+#define HI_LOG_ERR_DATABASE         LOG_ERRCODE_DEF(0x0018)      /**< Database Operation Error */
+#define HI_LOG_ERR_OVERFLOW         LOG_ERRCODE_DEF(0x0019)      /**< Overflow */
+#define HI_LOG_ERR_EXTERNAL         LOG_ERRCODE_DEF(0x0020)      /**< External Error */
+#define HI_LOG_ERR_UNKNOWNED        LOG_ERRCODE_DEF(0x0021)      /**< Unknow Error */
+#define HI_LOG_ERR_FLASH            LOG_ERRCODE_DEF(0x0022)      /**< Flash Operation Error*/
+#define HI_LOG_ERR_ILLEGAL_IMAGE    LOG_ERRCODE_DEF(0x0023)      /**< Illegal Image */
+#define HI_LOG_ERR_ILLEGAL_UUID     LOG_ERRCODE_DEF(0x0023)      /**< Illegal UUID */
+#define HI_LOG_ERR_NOPERMISSION     LOG_ERRCODE_DEF(0x0023)      /**< No Permission */
+
+/**< Function trace log, strictly prohibited to expand */
+#define HI_LOG_PRINT_FUNC_WAR(Func, ErrCode)  HI_LOG_WARN("Call %s return [0x%08X]\n", #Func, (unsigned int)ErrCode);
+#define HI_LOG_PRINT_FUNC_ERR(Func, ErrCode)  HI_LOG_ERROR("Call %s return [0x%08X]\n", #Func, (unsigned int)ErrCode);
+#define HI_LOG_PRINT_ERR_CODE(ErrCode)        HI_LOG_ERROR("Error Code: [0x%08X]\n", (unsigned int)ErrCode);
+
+/**< Used for displaying more detailed error information */
+#define HI_ERR_PRINT_S32(val)                HI_LOG_ERROR("%s = %d\n",        #val, val)
+#define HI_ERR_PRINT_U32(val)                HI_LOG_ERROR("%s = %u\n",        #val, val)
+#define HI_ERR_PRINT_S64(val)                HI_LOG_ERROR("%s = %lld\n",      #val, val)
+#define HI_ERR_PRINT_U64(val)                HI_LOG_ERROR("%s = %llu\n",      #val, val)
+#define HI_ERR_PRINT_H32(val)                HI_LOG_ERROR("%s = 0x%08X\n",    #val, val)
+#define HI_ERR_PRINT_H64(val)                HI_LOG_ERROR("%s = 0x%016llX\n", #val, val)
+#define HI_ERR_PRINT_STR(val)                HI_LOG_ERROR("%s = %s\n",        #val, val)
+#define HI_ERR_PRINT_VOID(val)               HI_LOG_ERROR("%s = %p\n",        #val, val)
+#define HI_ERR_PRINT_FLOAT(val)              HI_LOG_ERROR("%s = %f\n",        #val, val)
+#define HI_ERR_PRINT_INFO(val)               HI_LOG_ERROR("<%s>\n", val)
+
+/**< Used for displaying more detailed warning information */
+#define HI_LOG_PRINT_S32(val)                HI_LOG_WARN("%s = %d\n",        #val, val)
+#define HI_LOG_PRINT_U32(val)                HI_LOG_WARN("%s = %u\n",        #val, val)
+#define HI_LOG_PRINT_S64(val)                HI_LOG_WARN("%s = %lld\n",      #val, val)
+#define HI_LOG_PRINT_U64(val)                HI_LOG_WARN("%s = %llu\n",      #val, val)
+#define HI_LOG_PRINT_H32(val)                HI_LOG_WARN("%s = 0x%08X\n",    #val, val)
+#define HI_LOG_PRINT_H64(val)                HI_LOG_WARN("%s = 0x%016llX\n", #val, val)
+#define HI_LOG_PRINT_STR(val)                HI_LOG_WARN("%s = %s\n",        #val, val)
+#define HI_LOG_PRINT_VOID(val)               HI_LOG_WARN("%s = %p\n",        #val, val)
+#define HI_LOG_PRINT_FLOAT(val)              HI_LOG_WARN("%s = %f\n",        #val, val)
+#define HI_LOG_PRINT_INFO(val)               HI_LOG_WARN("<%s>\n", val)
+
+/**< Only used for self debug, Can be expanded as needed */
+#define HI_DBG_PRINT_S32(val)                HI_LOG_DEBUG("%s = %d\n",       #val, val)
+#define HI_DBG_PRINT_U32(val)                HI_LOG_DEBUG("%s = %u\n",       #val, val)
+#define HI_DBG_PRINT_S64(val)                HI_LOG_DEBUG("%s = %lld\n",     #val, val)
+#define HI_DBG_PRINT_U64(val)                HI_LOG_DEBUG("%s = %llu\n",     #val, val)
+#define HI_DBG_PRINT_H32(val)                HI_LOG_DEBUG("%s = 0x%08X\n",   #val, val)
+#define HI_DBG_PRINT_H64(val)                HI_LOG_DEBUG("%s = 0x%016llX\n",#val, val)
+#define HI_DBG_PRINT_STR(val)                HI_LOG_DEBUG("%s = %s\n",       #val, val)
+#define HI_DBG_PRINT_VOID(val)               HI_LOG_DEBUG("%s = %p\n",       #val, val)
+#define HI_DBG_PRINT_FLOAT(val)              HI_LOG_DEBUG("%s = %f\n",       #val, val)
+#define HI_DBG_PRINT_INFO(val)               HI_LOG_DEBUG("<%s>\n", val)
+
+#if (LOG_D_FUNCTRACE == 1) || (LOG_D_UNFTRACE == 1)
+#define HI_UNF_FUNC_ENTER()                  HI_LOG_DEBUG(" >>>>>>[Enter]\n")    /**< Only used for unf interface */
+#define HI_UNF_FUNC_EXIT()                   HI_LOG_DEBUG(" <<<<<<[Exit]\n")     /**< Only used for unf interface */
+#else
+#define HI_UNF_FUNC_ENTER()
+#define HI_UNF_FUNC_EXIT()
+#endif
+
+#if LOG_D_FUNCTRACE
+#define HI_LOG_FUNC_ENTER()                  HI_LOG_DEBUG(" =====>[Enter]\n")    /**< Used for all interface except unf */
+#define HI_LOG_FUNC_EXIT()                   HI_LOG_DEBUG(" =====>[Exit]\n")     /**< Used for all interface except unf */
+#else
+#define HI_LOG_FUNC_ENTER()
+#define HI_LOG_FUNC_EXIT()
+#endif
+
+#define HI_LOG_CHECK(fn_func)                                 \
+    do                                                        \
+    {                                                         \
+        hi_s32 _ierr_code = fn_func;                          \
+        if (HI_SUCCESS != _ierr_code)                         \
+        {                                                     \
+            HI_LOG_PRINT_FUNC_ERR(#fn_func, _ierr_code);      \
+        }                                                     \
+    } while (0)
+
+
+#define HI_LOG_CHECK_PARAM(_val)                              \
+    do                                                        \
+    {                                                         \
+        if (_val)                                             \
+        {                                                     \
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_INVALID_PARA);\
+            return HI_ERR_CIPHER_INVALID_PARA;                \
+        }                                                     \
+    } while (0)
+
+
+#define HI_LOG_CHECK_INITED(_init_count)                      \
+    do                                                        \
+    {                                                         \
+        if (0 == _init_count)                                 \
+        {                                                     \
+            HI_LOG_PRINT_ERR_CODE(HI_ERR_CIPHER_NOT_INIT);    \
+            return HI_ERR_CIPHER_NOT_INIT;                    \
+        }                                                     \
+    } while (0)
+
+#define HI_LOG_PRINT_BLOCK(data, length)
+
+#endif  /* End of #ifndef __DRV_OSAL_LIB_H__*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/include/drv_osal_lib_linux.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/include/drv_osal_lib_linux.h
@@ -1,0 +1,131 @@
+/******************************************************************************
+
+  Copyright (C), 2011-2014, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : drv_osal_lib_linux.h
+  Version       : Initial Draft
+  Author        : Hisilicon hisecurity team
+  Created       :
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __DRV_OSAL_LIB_LINUX_H__
+#define __DRV_OSAL_LIB_LINUX_H__
+#include <linux/proc_fs.h>
+#include <linux/module.h>
+#include <linux/signal.h>
+#include <linux/spinlock.h>
+#include <linux/personality.h>
+#include <linux/ptrace.h>
+#include <linux/kallsyms.h>
+#include <linux/init.h>
+#include <linux/pci.h>
+#include <linux/seq_file.h>
+#include <linux/version.h>
+#include <linux/sched.h>
+#include <linux/interrupt.h>
+#include <asm/atomic.h>
+#include <asm/cacheflush.h>
+#include <asm/io.h>
+#include <asm/uaccess.h>
+#include <asm/unistd.h>
+#include <asm/traps.h>
+#include <linux/miscdevice.h>
+#include <linux/delay.h>
+#include <asm/page.h>
+#include "hi_types.h"
+#include "drv_osal_chip.h"
+#include "drv_cipher_kapi.h"
+
+#define crypto_memset(s, sn, c, n)    \
+    do { \
+        if (sn >= n) { \
+            memset(s, c, n); \
+        }else { \
+            HI_LOG_ERROR("error, memset overflow\n"); \
+        }\
+    }while(0)
+
+#define crypto_memcpy(s, sn, c, n)    \
+    do { \
+        if (sn >= n) { \
+            memcpy(s, c, n); \
+        }else { \
+            HI_LOG_ERROR("error, memcpy overflow\n"); \
+        } \
+    }while(0)
+
+#define crypto_ioremap_nocache(addr, size)  ioremap_nocache(addr, size)
+#define crypto_iounmap(addr, size)          iounmap(addr)
+
+#define crypto_read(addr)       readl(addr)
+#define crypto_write(addr, val) writel(val, addr)
+
+#define crypto_msleep(msec)     msleep(msec)
+#define crypto_udelay(msec)     udelay(msec)
+
+#define MAX_MALLOC_BUF_SIZE     (0x10000)
+hi_void *crypto_calloc(size_t n, size_t size);
+#define crypto_malloc(x)        ((x) > 0 ? kzalloc((x), GFP_KERNEL) : HI_NULL)
+#define crypto_free(x) \
+    do { \
+        if ((x) != HI_NULL) { \
+            kfree((x)); \
+        }\
+    }while(0)
+
+#define MAX_COPY_FROM_USER_SIZE    (0x20000000)  /* 512M */
+hi_s32 crypto_copy_from_user(hi_void *to, const hi_void *from, unsigned long n);
+hi_s32 crypto_copy_to_user(hi_void  *to, const hi_void *from, unsigned long n);
+hi_u32 get_rand(hi_void);
+
+#define crypto_queue_head       wait_queue_head_t
+#define crypto_queue_init(x)    init_waitqueue_head(x)
+#define crypto_queue_wait_up(x) wake_up_interruptible(x)
+
+/*
+* Returns of crypto_queue_wait_timeout:
+* 0 if the @condition evaluated to %false after the @timeout elapsed,
+* 1 if the @condition evaluated to %true after the @timeout elapsed,
+* the remaining jiffies (at least 1) if the @condition evaluated
+* to %true before the @timeout elapsed, or -%ERESTARTSYS if it was
+* interrupted by a signal.
+*/
+#define crypto_queue_wait_timeout(head, con, time) \
+    wait_event_interruptible_timeout(head, *(con), time)
+
+#define crypto_request_irq(irq, func, name) \
+    request_irq(irq, func, IRQF_SHARED, name, (hi_void*)name)
+
+#define crypto_free_irq(irq, name)          \
+    free_irq(irq, (hi_void*)name)
+
+typedef struct semaphore                     crypto_mutex;
+#define crypto_mutex_init(x)                 sema_init(x, 1)
+#define crypto_mutex_lock(x)                 down_interruptible(x)
+#define crypto_mutex_unlock(x)               up(x)
+#define crypto_mutex_destroy(x)
+
+#define crypto_owner                         pid_t
+#define crypto_get_owner(x)                  *x = task_tgid_nr(current)
+
+#define HI_PRINT(fmt...)                     printk(fmt)
+#define HI_LOG_FATAL(fmt...) \
+    do{ \
+        printk("[FATAL-HI_CIPHER]:%s[%d]:",(hi_u8*)__FUNCTION__,__LINE__); \
+        printk(fmt); \
+    }while(0)
+#define HI_LOG_ERROR(fmt...) \
+    do{ \
+        printk("[ERROR-HI_CIPHER]:%s[%d]:",(hi_u8*)__FUNCTION__,__LINE__); \
+        printk(fmt); \
+    }while(0)
+
+#define HI_LOG_WARN(fmt...)
+#define HI_LOG_INFO(fmt...)
+#define HI_LOG_DEBUG(fmt...)
+
+#endif  /* End of #ifndef __DRV_OSAL_LIB_LINUX_H__*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/include/drv_osal_lib_liteos.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/osal/include/drv_osal_lib_liteos.h
@@ -1,0 +1,107 @@
+/******************************************************************************
+
+  Copyright (C), 2011-2014, Hisilicon Tech. Co., Ltd.
+
+ ******************************************************************************
+  File Name     : drv_osal_lib_liteos.h
+  Version       : Initial Draft
+  Author        : Hisilicon hisecurity team
+  Created       :
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#ifndef __DRV_OSAL_LIB_LITEOS_H__
+#define __DRV_OSAL_LIB_LITEOS_H__
+#include "hi_types.h"
+#include "hi_osal.h"
+#include "drv_osal_chip.h"
+#include "drv_cipher_kapi.h"
+#include "hi_math.h"
+#include "hi_common.h"
+#include "osal_mmz.h"
+
+/* osal_ioremap_nocache is adpat to ioremap_wc wiith cache in Linux */
+#define crypto_ioremap_nocache(addr, size)  osal_ioremap_nocache(addr, size)
+#define crypto_iounmap(addr, size)          osal_iounmap(addr)
+
+#define crypto_memset(s, sn, c, n)          { if (sn >= n) memset(s, c, n); else HI_LOG_ERROR("error, memset overflow\n");}
+#define crypto_memcpy(s, sn, c, n)          { if (sn >= n) memcpy(s, c, n); else HI_LOG_ERROR("error, memcpy overflow\n");}
+
+#define crypto_read(addr)                 (*(volatile unsigned int *)(addr))
+#define crypto_write(addr, val)           (*(volatile unsigned int *)(addr) = (val))
+#define crypto_read_fifo(id, addr)        crypto_read((hi_u8*)(module_get_base_address(id) + addr))
+#define crypto_write_fifo(id, addr, val)  crypto_write((hi_u8*)(module_get_base_address(id)+ addr), val)
+
+hi_s32  crypto_mmz_malloc_nocache(hi_char* mmz_name, hi_char* buf_name,
+                                  hi_u64* phy_addr, hi_void** vir_addr,
+                                  hi_ulong length);
+
+hi_void crypto_mmz_free(hi_u64 phy_addr, hi_void* vir_addr);
+
+#define crypto_msleep(msec)         osal_msleep(msec)
+#define crypto_udelay(msec)         osal_udelay(msec)
+
+#define MAX_MALLOC_BUF_SIZE       (0x10000)
+hi_void *crypto_calloc(size_t n, size_t size);
+#define crypto_malloc(x)          ((x) > 0 ? osal_kmalloc(x, osal_gfp_atomic) : HI_NULL)
+#define crypto_free(x)            {if ((x) != HI_NULL) osal_kfree(x);}
+
+#define copy_from_user     osal_copy_from_user
+#define copy_to_user       osal_copy_to_user
+
+hi_s32 crypto_copy_from_user(hi_void *to, const hi_void *from, unsigned long n);
+hi_s32 crypto_copy_to_user(hi_void  *to, const hi_void *from, unsigned long n);
+hi_u32 get_rand(hi_void);
+hi_s32 crypto_waitdone_callback(hi_void *param);
+
+#define crypto_queue_head                          osal_wait_t
+#define crypto_queue_init(x)                       osal_wait_init(x)
+#define crypto_queue_wait_up(x)                    osal_wakeup(x)
+#define crypto_queue_wait_timeout(head, con, time) osal_wait_event_timeout_interruptible(&head, crypto_waitdone_callback, con, time)
+
+#define crypto_request_irq(irq, func, name)  request_irq(irq, (irq_handler_t)func, IRQF_SHARED, name, (hi_void*)name)
+#define crypto_free_irq(irq, name)           osal_free_irq(irq, (hi_void*)name)
+
+#define crypto_mutex                         osal_mutex_t
+#define crypto_mutex_init(x)                 osal_mutex_init(x)
+#define crypto_mutex_lock(x)                 osal_mutex_lock_interruptible(x)
+#define crypto_mutex_unlock(x)               osal_mutex_unlock(x)
+#define crypto_mutex_destroy(x)
+
+#define crypto_osal_ioremap_nocache(phy_addr, size) osal_ioremap_nocache(phy_addr, ALIGN_UP(size, 4));
+#define crypto_osal_iounmap(vir_addr)               osal_iounmap(vir_addr)
+#define flush_cache()
+
+#define crypto_owner                         hi_u32
+#define crypto_get_owner(x)                  *x = 0
+
+#define PROC_PRINT                           osal_seq_printf
+
+#define irqreturn_t                          int
+#define IRQ_HANDLED                          OSAL_IRQ_HANDLED
+#define IRQ_NONE                             OSAL_IRQ_NONE
+
+#define HI_PRINT(fmt...)                     osal_printk(fmt)
+#define HI_LOG_FATAL(fmt...) \
+    do{ \
+        osal_printk("[FATAL-HI_CIPHER]:%s[%d]:",(hi_u8*)__FUNCTION__,__LINE__); \
+        osal_printk(fmt); \
+    }while(0)
+#define HI_LOG_ERROR(fmt...) \
+    do{ \
+        osal_printk("[ERROR-HI_CIPHER]:%s[%d]:",(hi_u8*)__FUNCTION__,__LINE__); \
+        osal_printk(fmt); \
+    }while(0)
+#define HI_LOG_WARN(fmt...)
+#define HI_LOG_INFO(fmt...)
+#define HI_LOG_DEBUG(fmt...)
+
+/* auto test for cipher_test */
+//#define HI_CIPHER_TEST_SUPPORT
+#ifdef HI_CIPHER_TEST_SUPPORT
+#define CIPHER_LITEOS_TEST_SUPPORT
+#endif
+
+#endif  /* End of #ifndef __DRV_OSAL_LIB_LITEOS_H__*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/test/build.mak
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/test/build.mak
@@ -1,0 +1,7 @@
+CIPHER_CFLAGS += -I$(CIPHER_DIR)/drv/cipher_v1.0/test
+CIPHER_CFLAGS += -DKAPI_TEST_SUPPORT
+
+CIPHER_OBJS   += drv/cipher_v1.0/test/kapi_test_main.o
+CIPHER_OBJS   += drv/cipher_v1.0/test/kapi_symc_test.o
+
+

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/test/kapi_symc_test.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/test/kapi_symc_test.c
@@ -1,0 +1,222 @@
+/*****************************************************************************
+
+    Copyright (C), 2017, Hisilicon Tech. Co., Ltd.
+
+******************************************************************************
+  File Name     : kapi_symc_test.c
+  Version       : Initial Draft
+  Created       : 2017
+  Last Modified :
+  Description   :
+  Function List :
+  History       :
+******************************************************************************/
+#include "drv_osal_lib.h"
+
+/* kapi_test end*/
+static hi_s32 set_cipher_config(hi_handle handle,
+                                hi_bool key_by_ca,
+                                hi_cipher_ca_type ca_type,
+                                hi_cipher_alg alg,
+                                hi_cipher_work_mode mode,
+                                hi_cipher_key_length keyLen,
+                                const hi_u8 key_buf[16],
+                                const hi_u8 iv_buf[16])
+{
+    hi_u32 ivlen = AES_IV_SIZE;
+    hi_s32 ret = HI_SUCCESS;
+    hi_u32 hard_key = 0;
+    hi_cipher_ctrl cipher_ctrl;
+    compat_addr aad;
+
+    memset(&cipher_ctrl, 0, sizeof(hi_cipher_ctrl));
+    cipher_ctrl.alg = alg;
+    cipher_ctrl.work_mode = mode;
+    cipher_ctrl.bit_width = HI_CIPHER_BIT_WIDTH_128BIT;
+    cipher_ctrl.key_len = keyLen;
+    cipher_ctrl.key_by_ca = key_by_ca;
+    cipher_ctrl.ca_type = ca_type;
+    if (cipher_ctrl.work_mode != HI_CIPHER_WORK_MODE_ECB) {
+        cipher_ctrl.change_flags.bit1_iv = 1;  //must set for CBC , CFB mode
+        memcpy(cipher_ctrl.iv, iv_buf, 16);
+    }
+
+    memcpy(cipher_ctrl.key, key_buf, 16);
+
+    if (HI_TRUE == cipher_ctrl.key_by_ca) {
+        if (HI_CIPHER_KEY_SRC_BUTT <= cipher_ctrl.ca_type) {
+            pr_err("Invalid ca_type with key_by_ca is HI_TRUE.\n");
+            return HI_ERR_CIPHER_INVALID_PARA;
+
+        }
+        hard_key  = (cipher_ctrl.ca_type & 0xFF) << BITS_IN_BYTE;
+        hard_key |= 0x01;
+    }
+
+    ADDR_U64(aad) = 0x00;
+
+    if ((cipher_ctrl.alg == HI_CIPHER_ALG_3DES)
+        || (cipher_ctrl.alg == HI_CIPHER_ALG_DES)) {
+        ivlen = DES_IV_SIZE;
+    }
+
+    ret = kapi_symc_config(handle, hard_key,
+                           cipher_ctrl.alg, cipher_ctrl.work_mode,
+                           cipher_ctrl.bit_width, cipher_ctrl.key_len,
+                           0, (hi_u8 *)cipher_ctrl.key, HI_NULL,
+                           (hi_u8 *)cipher_ctrl.iv, ivlen,
+                           cipher_ctrl.change_flags.bit1_iv,
+                           aad, 0, 0);
+    if (HI_SUCCESS != ret) {
+        return HI_FAILURE;
+    }
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 set_cipher_crypt(hi_handle handle, hi_size_t src_phy_addr,
+                               hi_size_t dest_phy_addr, hi_u32 byte_length,
+                               hi_u32 operation)
+{
+    compat_addr input;
+    compat_addr output;
+    hi_s32 ret = HI_FAILURE;
+
+    ADDR_U64(input) = src_phy_addr;
+    ADDR_U64(output) = dest_phy_addr;
+
+    ret = kapi_symc_crypto_via(handle, input, output, byte_length, operation, 0, 0);
+    if (ret != HI_SUCCESS) {
+        return ret;
+    }
+
+    return HI_SUCCESS;
+}
+
+static hi_s32 cipher_aes_decrypt(hi_bool key_by_ca,
+                                 hi_cipher_work_mode mode,
+                                 const unsigned char *key,
+                                 const unsigned char *iv,
+                                 const unsigned char *in_buf,
+                                 const unsigned char *out_buf,
+                                 const unsigned char *expect_buf,
+                                 const unsigned int buf_len)
+{
+    int ret = 0;
+    hi_handle test_chnid;
+
+    ret = kapi_symc_create(&test_chnid);
+    if (0 != ret) {
+        HI_LOG_ERROR("Error: CreateHandle failed!\n");
+        return HI_FAILURE;
+    }
+
+    /* For decrypt */
+
+    ret = set_cipher_config(test_chnid,
+                            key_by_ca,
+                            HI_CIPHER_KEY_SRC_KLAD_1,
+                            HI_CIPHER_ALG_AES,
+                            mode,
+                            HI_CIPHER_KEY_AES_128BIT,
+                            key,
+                            iv);
+    if (0 != ret) {
+        HI_LOG_ERROR("Set config info failed.\n");
+        goto __CIPHER_EXIT__;
+    }
+
+    ret = set_cipher_crypt(test_chnid, (hi_size_t)in_buf, (hi_size_t)out_buf,
+                           buf_len, SYMC_OPERATION_DECRYPT);
+    if (0 != ret) {
+        HI_LOG_ERROR("[5]wrong data!\n");
+        ret = -1;
+        goto __CIPHER_EXIT__;
+    }
+
+    /* compare */
+    if ( 0 != memcmp(out_buf, expect_buf, 16) ) {
+        HI_LOG_ERROR("Memcmp failed!\n");
+        ret = HI_FAILURE;
+        goto __CIPHER_EXIT__;
+    }
+
+__CIPHER_EXIT__:
+    kapi_symc_destroy(test_chnid);
+
+    return ret;
+}
+
+/* otp key is be written, then excute tihs test */
+static hi_s32 kapi_test1(void)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u8 aes_128_enc_key[16] = {0xc1, 0x1b, 0x54, 0x4a, 0x12, 0x9c, 0x08, 0xa5,
+                                0xcc, 0xd3, 0xeb, 0xec, 0x7a, 0x3b, 0x00, 0x2b};
+    hi_u8 aes_128_cbc_IV[16] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                               0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    hi_u8 aes_128_src_buf[16] = {0x6B, 0xC1, 0xBE, 0xE2, 0x2E, 0x40, 0x9F, 0x96,
+                                0xE9, 0x3D, 0x7E, 0x11, 0x73, 0x93, 0x17, 0x2A};
+    hi_u8 aes_128_dst_buf[16] = {0xb0, 0x1b, 0x77, 0x09, 0xe8, 0xdc, 0xf9, 0xef,
+                                0x37, 0x13, 0x0b, 0x13, 0xda, 0x11, 0xbf, 0x24};
+    hi_u8 aes_128_src2_buf[16] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                                0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+
+    HI_LOG_ERROR("klad test!\n");
+    ret = cipher_aes_decrypt(HI_TRUE,
+                             HI_CIPHER_WORK_MODE_CBC,
+                             aes_128_enc_key,
+                             aes_128_cbc_IV,
+                             aes_128_dst_buf,
+                             aes_128_src2_buf,
+                             aes_128_src_buf,
+                             16);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("klad failed!\n");
+        return -1;
+    }
+
+    HI_LOG_ERROR("klad success!\n");
+    return HI_SUCCESS;
+}
+
+static hi_s32 kapi_test2(void)
+{
+    hi_s32 ret = HI_FAILURE;
+    hi_u8 aes_key[16] = {0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6,
+        0xAB, 0xF7, 0x15, 0x88, 0x09, 0xCF, 0x4F, 0x3C};
+    hi_u8 aes_IV[16]  = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    hi_u8 aes_src[16] = {0x6B, 0xC1, 0xBE, 0xE2, 0x2E, 0x40, 0x9F, 0x96,
+        0xE9, 0x3D, 0x7E, 0x11, 0x73, 0x93, 0x17, 0x2A};
+    hi_u8 aes_dst[16] = {0x76, 0x49, 0xAB, 0xAC, 0x81, 0x19, 0xB2, 0x46,
+        0xCE, 0xE9, 0x8E, 0x9B, 0x12, 0xE9, 0x19, 0x7D};
+    hi_u8 aes_src2[16]  = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+
+    HI_LOG_ERROR("cbc test!\n");
+    ret = cipher_aes_decrypt(
+              HI_FALSE,
+              HI_CIPHER_WORK_MODE_CBC,
+              aes_key, aes_IV,
+              aes_dst, aes_src2,
+              aes_src,
+              16);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_ERROR("cbc failed!\n");
+        return -1;
+    }
+
+    HI_LOG_ERROR("cbc success!\n");
+    return HI_SUCCESS;
+}
+
+void kapi_test(void)
+{
+    kapi_test1();
+    kapi_test2();
+}
+
+/* kapi_test end */
+
+/** @}*/  /** <!-- ==== Structure Definition end ====*/

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/test/kapi_test_main.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/test/kapi_test_main.c
@@ -1,0 +1,10 @@
+#include "drv_osal_lib.h"
+
+extern hi_void kapi_test(hi_void);
+
+hi_s32 kapi_test_main(hi_void)
+{
+    kapi_test();
+
+    return 0;
+}

--- a/kernel/osal/include/osal_mmz.h
+++ b/kernel/osal/include/osal_mmz.h
@@ -307,4 +307,34 @@ int mmz_userdev_init(void);
 void mmz_userdev_exit(void);
 int mmz_flush_dcache_all(void);
 
+/*
+ * hil_ compatibility, the compile-time half of what EXPORT_COMPAT_MMZ does at
+ * link time in mmz/media-mem.c.
+ *
+ * Those aliases were enough while the only consumers were vendor .o blobs,
+ * which reference hil_ symbols and carry no headers. A driver built from
+ * vendor SOURCE needs the names to exist for the compiler too: kernel/cipher/
+ * hi3516ev200 is the first of those, and its drv_osal_lib.h opens with
+ * `#include "osal_mmz.h"` followed by a bare hil_mmb_t.
+ *
+ * Aliases only. Every name here is the mmz_ one under its vendor spelling,
+ * and nothing below allocates, frees or otherwise behaves differently. The
+ * per-chip headers under kernel/include/<chip>/osal_mmz.h already carry these
+ * names natively; a chip using one of those never reaches this file, because
+ * the two share a basename and the include path picks one.
+ */
+typedef mmz_mmb_t hil_mmb_t;
+
+#define hil_mmb_phys(p)		mmz_mmb_phys(p)
+#define hil_mmb_freeby_phys(a)	mmz_mmb_freeby_phys(a)
+
+#define hil_mmb_alloc		mmz_mmb_alloc
+#define hil_mmb_free		mmz_mmb_free
+#define hil_mmb_getby_phys	mmz_mmb_getby_phys
+#define hil_mmb_getby_phys_2	mmz_mmb_getby_phys_2
+#define hil_mmb_getby_kvirt	mmz_mmb_getby_kvirt
+#define hil_mmb_map2kern	mmz_mmb_map2kern
+#define hil_mmb_unmap		mmz_mmb_unmap
+#define hil_map_mmz_check_phys	mmz_map_mmz_check_phys
+
 #endif

--- a/kernel/osal/include/osal_mmz.h
+++ b/kernel/osal/include/osal_mmz.h
@@ -325,16 +325,30 @@ int mmz_flush_dcache_all(void);
  */
 typedef mmz_mmb_t hil_mmb_t;
 
+/*
+ * The functions are declarations, not #defines, and that distinction is not
+ * cosmetic. On 6.4+ EXPORT_COMPAT_MMZ emits
+ *
+ *	typeof(mmz_x) hil_x __attribute__((alias("mmz_x")));
+ *
+ * which writes hil_x as a real identifier. A #define would rewrite that token
+ * and redefine mmz_x on top of itself -- media-mem.c stops compiling, and only
+ * on 6.4+, because the pre-6.4 branch builds its aliases out of strings and
+ * never spells hil_x as an identifier at all.
+ *
+ * typeof() rather than repeating each prototype, so these cannot drift from
+ * the definitions above.
+ */
 #define hil_mmb_phys(p)		mmz_mmb_phys(p)
 #define hil_mmb_freeby_phys(a)	mmz_mmb_freeby_phys(a)
 
-#define hil_mmb_alloc		mmz_mmb_alloc
-#define hil_mmb_free		mmz_mmb_free
-#define hil_mmb_getby_phys	mmz_mmb_getby_phys
-#define hil_mmb_getby_phys_2	mmz_mmb_getby_phys_2
-#define hil_mmb_getby_kvirt	mmz_mmb_getby_kvirt
-#define hil_mmb_map2kern	mmz_mmb_map2kern
-#define hil_mmb_unmap		mmz_mmb_unmap
-#define hil_map_mmz_check_phys	mmz_map_mmz_check_phys
+extern typeof(mmz_mmb_alloc) hil_mmb_alloc;
+extern typeof(mmz_mmb_free) hil_mmb_free;
+extern typeof(mmz_mmb_getby_phys) hil_mmb_getby_phys;
+extern typeof(mmz_mmb_getby_phys_2) hil_mmb_getby_phys_2;
+extern typeof(mmz_mmb_getby_kvirt) hil_mmb_getby_kvirt;
+extern typeof(mmz_mmb_map2kern) hil_mmb_map2kern;
+extern typeof(mmz_mmb_unmap) hil_mmb_unmap;
+extern typeof(mmz_map_mmz_check_phys) hil_map_mmz_check_phys;
 
 #endif

--- a/kernel/osal/linux/kernel/mmz/media-mem.c
+++ b/kernel/osal/linux/kernel/mmz/media-mem.c
@@ -773,7 +773,15 @@ mmz_mmb_t *mmz_mmb_getby_phys_2(unsigned long addr, unsigned long *Outoffset)
 	up(&mmz_lock);
 	return p;
 }
-EXPORT_SYMBOL(mmz_mmb_getby_phys_2);
+/*
+ * EXPORT_COMPAT_MMZ, like every other mmb_ function above and below, rather
+ * than a plain EXPORT_SYMBOL: the hil_ spelling is the name vendor drivers
+ * link against. The per-chip osal_mmz.h headers declare hil_mmb_getby_phys_2
+ * and the cipher driver calls it, so without the alias open_cipher.ko cannot
+ * load at all ("Unknown symbol hil_mmb_getby_phys_2") on any chip whose osal
+ * comes from this generic tree.
+ */
+EXPORT_COMPAT_MMZ(mmb_getby_phys_2);
 
 mmz_mmz_t *mmz_mmz_find(unsigned long gfp, const char *mmz_name)
 {


### PR DESCRIPTION
hi3516ev200 (and so hi3516ev300) is the one HiSilicon family whose OpenIPC image ships no cipher module at all. hi3516av300 and hi3516cv300 both package one and simply never load it; here there is nothing to load.

Two commits, because the first is a bug in its own right.

### `osal: give the hil_ MMZ names to source builds, not just to blobs`

`mmz/media-mem.c` already exports every `mmb_` function under both spellings via `EXPORT_COMPAT_MMZ` — `mmz_` for this tree, `hil_` for the vendor drivers that link against it. Two gaps in that:

- `mmz_mmb_getby_phys_2` was the one `mmb_` function left on a plain `EXPORT_SYMBOL`, so `hil_mmb_getby_phys_2` was never aliased. Every sibling above and below it uses the compat macro; this looks like an oversight rather than a decision. The symptom is a vendor cipher driver refusing to load with `Unknown symbol hil_mmb_getby_phys_2`, which is how it was found.
- `osal_mmz.h` carries no `hil_` names at all. That was enough while the only consumers were prebuilt `.o` blobs — they reference symbols and bring no headers. A driver built from vendor **source** needs the names at compile time too: its `drv_osal_lib.h` opens with `#include "osal_mmz.h"` and then a bare `hil_mmb_t`.

The header half is aliases only — a typedef and nine defines onto the `mmz_` names, nothing that allocates, frees or behaves differently. Chips whose osal comes from `kernel/include/<chip>/osal_mmz.h` already have these names natively and never reach this file, because the two share a basename and the include path picks one.

### `cipher: build open_cipher.ko for hi3516ev200`

The tree is the SDK's own (Hi3516EV200_SDK_V1.0.1.2), `include/` and `src/` only, without its `sample/`, `buildin/` and `patch/` directories.

Reusing `cipher/hi3516cv500/src` with `-DCHIP_TYPE_hi3516ev200` was tried first and is worse than it looks: cv500's is a later SDK vintage, the two differ by some 30k lines, and it carries no `drv_osal_hi3516ev200.h`. Borrowing cv500's headers is a trap of its own — `include/hi3516cv500/hi_types.h` shadows this tree's, which is where the `HI_HANDLE_*` macros live, and its `hi_type.h` declares `HI_PHYS_ADDR_T` unsigned where ev200 has it signed. The tree here is self-contained instead, `hi_type.h` included.

Built through the generic branch of `kernel/Kbuild` via a new `kernel/cipher/Kbuild`, guarded on `CHIPARCH` so only hi3516ev200 picks it up.

## Testing

On an hi3516ev300 (kernel 4.9.37), against the mbedTLS 2.25 the rootfs ships:

- module loads (`Load hi_cipher.ko success`), `/dev/cipher` appears
- a userspace harness drives it through **600 differential AES-CTR cases** — every length from 1 byte to 2048, byte-identical to mbedTLS, with nothing written past the requested length
- known-answer checks pass: NIST SP 800-38A F.5.1, and a vector across a 32-bit counter wrap (an engine that carries only the low 32 bits agrees with software for every IV that is not near a wrap, so a single ordinary vector would not catch it)
- at 1100-byte buffers, an SRTP-sized workload: **86.0 µs of CPU in software against 41.9 through the engine**, a 51% cut. More is saved in CPU than in wall clock, because the driver sleeps on its completion interrupt and gives the core back while the block works.

Build-checked that `CHIPARCH=gk7205v200` still produces no cipher module, and that hi3516cv500 — which has its own kbuild and its own cipher — is untouched.

## Not included

Not built for gk7205v200, which shares the generic branch: same generation on paper, but Goke ships its cipher as a differently-named module against a different userspace, and none of the above has been measured on one.