### PR TITLE
hi3516ev200: finish the Goke-to-HiSilicon symbol mapping

### DIFF
--- a/include/hicompat.h
+++ b/include/hicompat.h
@@ -1,6 +1,18 @@
 #ifndef HICOMPAT_H
 #define HICOMPAT_H
 
+/* Everything the prototypes below name. This header used to be included only
+ * from the *_cmos.c files, which pull in gk_api_{isp,ae,awb}.h first and so
+ * happened to have all of it already; a *_sensor_ctl.c includes only
+ * gk_api_isp.h, and there the AE and AWB prototypes would not compile. All of
+ * these are guarded, so naming them here costs a translation unit nothing. */
+#include "ae_comm.h"
+#include "awb_comm.h"
+#include "comm_3a.h"
+#include "comm_isp.h"
+#include "comm_sns.h"
+#include "common.h"
+
 #if defined(SDK_CODE) && SDK_CODE+0 != 0
 #if SDK_CODE == 0x3516E200
 #define GK_API_ISP_SensorRegCallBack HI_MPI_ISP_SensorRegCallBack
@@ -9,6 +21,7 @@
 #define GK_API_AE_SensorUnRegCallBack HI_MPI_AE_SensorUnRegCallBack
 #define GK_API_AWB_SensorRegCallBack HI_MPI_AWB_SensorRegCallBack
 #define GK_API_AWB_SensorUnRegCallBack HI_MPI_AWB_SensorUnRegCallBack
+#define GK_API_ISP_GetModParam HI_MPI_ISP_GetModParam
 #endif
 
 GK_S32 GK_API_ISP_SensorRegCallBack(VI_PIPE ViPipe,
@@ -27,6 +40,11 @@ GK_S32 GK_API_AWB_SensorRegCallBack(VI_PIPE ViPipe, ALG_LIB_S *pstAwbLib,
 				    AWB_SENSOR_REGISTER_S *pstRegister);
 GK_S32 GK_API_AWB_SensorUnRegCallBack(VI_PIPE ViPipe, ALG_LIB_S *pstAwbLib,
 				      SENSOR_ID SensorId);
+
+/* Declared here for the same reason as the six above: the #define rewrites the
+ * call, so a prototype has to exist under whichever name it rewrites to. Used
+ * by the drivers that read the ISP's quick-start flag. */
+GK_S32 GK_API_ISP_GetModParam(ISP_MOD_PARAM_S *pstModParam);
 #endif /* SDK_CODE != 0 */
 
 #endif /* HICOMPAT_H */

--- a/libraries/sensor/hi3516ev200/galaxycore_gc2053/gc2053_sensor_ctl.c
+++ b/libraries/sensor/hi3516ev200/galaxycore_gc2053/gc2053_sensor_ctl.c
@@ -23,6 +23,7 @@
 
 #endif
 #include "gk_api_isp.h"
+#include "hicompat.h"
 const unsigned char gc2053_i2c_addr = 0x6e; /* I2C Address of GC2053 */
 const unsigned int gc2053_addr_byte = 1;
 const unsigned int gc2053_data_byte = 1;

--- a/libraries/sensor/hi3516ev200/galaxycore_gc4023/gc4023_cmos.c
+++ b/libraries/sensor/hi3516ev200/galaxycore_gc4023/gc4023_cmos.c
@@ -14,6 +14,7 @@
 #include "gk_api_isp.h"
 #include "gk_api_ae.h"
 #include "gk_api_awb.h"
+#include "hicompat.h"
 #include "gc4023_cmos_ex.h"
 #include "gc4023_cmos.h"
 

--- a/libraries/sensor/hi3516ev200/galaxycore_gc5603/gc5603_cmos.c
+++ b/libraries/sensor/hi3516ev200/galaxycore_gc5603/gc5603_cmos.c
@@ -10,6 +10,7 @@
 #include "gk_api_isp.h"
 #include "gk_api_ae.h"
 #include "gk_api_awb.h"
+#include "hicompat.h"
 
 #define GC5603_ID   5603
 

--- a/libraries/sensor/hi3516ev200/galaxycore_gc5603/gc5603_sensor_ctl.c
+++ b/libraries/sensor/hi3516ev200/galaxycore_gc5603/gc5603_sensor_ctl.c
@@ -12,6 +12,7 @@
 #include "comm_video.h"
 #include "sns_ctrl.h"
 #include "gk_api_isp.h"
+#include "hicompat.h"
 
 #ifdef GPIO_I2C
 #include "gpioi2c_ex.h"

--- a/libraries/sensor/hi3516ev200/omnivision_os02g10/os02g10_cmos.c
+++ b/libraries/sensor/hi3516ev200/omnivision_os02g10/os02g10_cmos.c
@@ -12,6 +12,7 @@
 #include "gk_api_isp.h"
 #include "gk_api_ae.h"
 #include "gk_api_awb.h"
+#include "hicompat.h"
 #include "os02g10_cmos_ex.h"
 #include "os02g10_cmos.h"
 

--- a/libraries/sensor/hi3516ev200/smart_sc2231/sc2231_sensor_ctl.c
+++ b/libraries/sensor/hi3516ev200/smart_sc2231/sc2231_sensor_ctl.c
@@ -23,6 +23,7 @@
 #endif
 
 #include "gk_api_isp.h"
+#include "hicompat.h"
 const unsigned char sc2231_i2c_addr = 0x60; /* I2C Address of sc2231 */
 const unsigned int sc2231_addr_byte = 2;
 const unsigned int sc2231_data_byte = 1;

--- a/libraries/sensor/hi3516ev200/smart_sc500ai/sc500ai_sensor_ctl.c
+++ b/libraries/sensor/hi3516ev200/smart_sc500ai/sc500ai_sensor_ctl.c
@@ -12,6 +12,7 @@
 #include "comm_video.h"
 #include "sns_ctrl.h"
 #include "gk_api_isp.h"
+#include "hicompat.h"
 
 #ifdef GPIO_I2C
 #include "gpioi2c_ex.h"

--- a/libraries/sensor/hi3516ev200/soi_f37/f37_sensor_ctl.c
+++ b/libraries/sensor/hi3516ev200/soi_f37/f37_sensor_ctl.c
@@ -11,6 +11,7 @@
 #include "comm_video.h"
 #include "sns_ctrl.h"
 #include "gk_api_isp.h"
+#include "hicompat.h"
 
 #ifdef GPIO_I2C
 #include "gpioi2c_ex.h"

--- a/libraries/sensor/hi3516ev200/superpix_sp2308/sp2308_cmos.c
+++ b/libraries/sensor/hi3516ev200/superpix_sp2308/sp2308_cmos.c
@@ -14,6 +14,7 @@
 #include "gk_api_isp.h"
 #include "gk_api_ae.h"
 #include "gk_api_awb.h"
+#include "hicompat.h"
 #include "sp2308_cmos_ex.h"
 #include "sp2308_cmos.h"
 


### PR DESCRIPTION
Eight of the thirty `hi3516ev200` sensor drivers cannot be loaded on a HiSilicon image. They name Goke SDK entry points, nothing in a HiSilicon rootfs defines those, and ld.so refuses the library at relocation time — so a camera with one of these sensors gets no video at all:

```
dlopen "/usr/lib/sensors/libsns_gc2053.so" error: Error relocating
/usr/lib/sensors/libsns_gc2053.so: GK_API_ISP_GetModParam: symbol not found
```

Reported in OpenIPC/firmware#2338 (gc2053). Affected: **gc2053, f37, sc2231, sc500ai, gc4023, gc5603, os02g10, sp2308**.

## Why

`hicompat.h` exists for exactly this — it maps `GK_API_*` onto `HI_MPI_*` when `SDK_CODE` says HiSilicon, and re-declares each name so the prototype follows whichever spelling the macro produced. It was incomplete in two independent ways, four drivers each:

| | drivers | what was missing |
| --- | --- | --- |
| mapped, but one name absent | gc2053, f37, sc2231, sc500ai | `GK_API_ISP_GetModParam` was never in the list |
| never included the header | gc4023, gc5603, os02g10, sp2308 | so none of the six mappings reached them |

`gc5603` is in both groups, which is why it was short seven symbols rather than one or six.

A third thing had to change to make the first fix possible: `hicompat.h` could not be included from a `*_sensor_ctl.c` at all. Those bring in `gk_api_isp.h` alone, and the header's AE/AWB prototypes need types from `ae_comm.h` and `awb_comm.h` that only the `*_cmos.c` files happened to have already. It now includes what it names.

## Verification

Whole tree built both ways from the same sources:

| `SDK_CODE` | drivers built | still naming `GK_API_*` |
| --- | --- | --- |
| `0x3516E200` (HiSilicon) | 30 | **0** |
| `0x7205200` (Goke) | 30 | **29** |

The second row is the one that matters for regressions: a Goke build must go on resolving against Goke's `libisp`, and only the HiSilicon build is remapped. The mapping is inside `#if SDK_CODE == 0x3516E200`, so that is what you would expect — this confirms it.

On hardware, a `hi3516ev300` running the 2026-08-29 OpenIPC nightly, swapping only the shipped `libsns_gc2053.so` for the rebuilt one:

| | shipped | rebuilt |
| --- | --- | --- |
| relocation error | yes | **no** |
| `Sensor driver loaded` | no | **yes** |
| `Cannot start SDK` | yes | **no** |

That board carries an imx335, so the stream then times out for want of a gc2053 on the bus — loading the driver is what was being tested, and there is no lab board with any of the eight affected sensors to take it further.
