### PR TITLE
cipher: build open_cipher.ko for gk7205v200

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -61,8 +61,8 @@ include $(src)/sensor_i2c/Kbuild
 include $(src)/sensor_spi/Kbuild
 include $(src)/mipi_rx/Kbuild
 include $(src)/openipc_frame_ts/Kbuild
-# Guarded on CHIPARCH inside; only hi3516ev200 builds a cipher module here,
-# and hi3516cv500 builds its own from hi3516cv500.kbuild.
+# Guarded on CHIPARCH inside; the V4 pair (hi3516ev200, gk7205v200) builds a
+# cipher module here, and hi3516cv500 builds its own from hi3516cv500.kbuild.
 include $(src)/cipher/Kbuild
 #+user
 

--- a/kernel/cipher/Kbuild
+++ b/kernel/cipher/Kbuild
@@ -3,8 +3,9 @@
 # branch of kernel/Kbuild rather than by their own <chip>.kbuild.
 #
 # hi3516cv500 builds this module from its own kbuild and does not come through
-# here. This file exists for hi3516ev200 (and so hi3516ev300), whose firmware
-# has never packaged a cipher module at all: the vendor prebuilt from the
+# here. This file exists for hi3516ev200 (and so hi3516ev300) and for
+# gk7205v200 (and so gk7205v300, gk7202v300, gk7605v100), whose firmware has
+# never packaged a cipher module at all: the vendor prebuilt from the
 # Hi3516EV200 SDK cannot load against an OpenIPC rootfs, and there was no
 # source build to fall back on.
 #
@@ -19,19 +20,57 @@
 # trees are not built here.
 #
 # WHAT IT IS FOR. AES-128-CTR at SRTP packet sizes, where a userspace streamer
-# would otherwise do it on the CPU. Measured on an hi3516ev300 against the
-# mbedTLS 2.25 the rootfs ships, 1100-byte buffers: 87.6 us of CPU in software
-# against 42.0 through the engine, a 52% cut. More is saved in CPU than in
-# wall clock, because the driver sleeps on its completion interrupt and hands
-# the core back while the block works -- which is the scarce resource on these
-# parts. The engine also carries a TRNG and RSA that nothing uses yet.
+# would otherwise do it on the CPU, plus a TRNG and an RSA block that nothing
+# uses yet. Read the next paragraph before assuming the first of those is a
+# win.
 #
-# Not built for gk7205v200, which shares this branch: it is the same
-# generation on paper, but Goke ships its cipher as a differently-named module
-# against a different userspace, and nothing here has been measured on one.
+# WHAT IT IS WORTH DEPENDS ON HOW IT IS DRIVEN, and this file used to claim
+# more than the evidence carried. Per 1100-byte packet the engine costs half
+# the CPU of mbedTLS -- 86.4 us against 42.6 on a gk7205v200, 87.6 against
+# 42.0 on an hi3516ev300 -- because the driver sleeps on its completion
+# interrupt instead of spinning. That figure is taken with the streamer
+# stopped, and it does not survive a busy camera: on the lab gk7205v200 with
+# one WebRTC viewer at 4 Mbit/s the whole-camera saving is zero, 19.76% of a
+# core against 19.68%. The user time the engine saves comes back as system
+# time almost exactly, because these kernels have no IRQ_TIME_ACCOUNTING and
+# the completion interrupt is billed to whichever thread was running -- with
+# the streamer stopped, the idle task, which is why an idle measurement never
+# sees it.
+#
+# THE COST IS THE TRIP, NOT THE CIPHER: two ioctls, a DMA allocation, a
+# hardware start and a sleep for every packet, against about 44 us of actual
+# AES. Amortising that over a burst is what makes the engine pay, and it is
+# a change of its own -- this one builds the module, correct and available,
+# and leaves what loads it to the change that makes loading it worthwhile.
+# So nothing in a Goke image modprobes it yet, and that is the state this
+# commit intends rather than an oversight.
+#
+# gk7205v200 IS THE SAME SILICON and builds the same tree. Not "the same
+# generation on paper", which is what this file used to say and what kept it
+# off the Goke branch: the cipher block is at 0x10050000 on both, behind the
+# same CRG word at 0x120101A0, on the same SPI 34, and gk7205v200.dtsi's node
+# is byte-for-byte hi3516ev200.dtsi's but for one string -- "goke,cipher"
+# where HiSilicon says "hisilicon,hisi-cipher". That single difference is the
+# whole port, and it lives in cipher_initdevice.c's match table, spelled
+# through the PLATFORM_NAME/HISI_PRX pair that kernel/compat/compat.h already
+# keeps for exactly this.
+#
+# The "different userspace" was never an objection either. Nothing in a Goke
+# rootfs opens /dev/cipher: majestic talks to the ioctls directly rather than
+# through libhi_cipher.so, so the consumer is the same binary on both
+# families and the ABI it expects is this module's, not Goke's.
+#
+# CHECKED ON THE SILICON, lab gk7205v200 (imx307, kernel 4.9.37): the module
+# loads, /dev/cipher appears, the version register reads the same 0x2018121
+# the HiSilicon part does, and 600 differential AES-CTR cases against the
+# rootfs's own mbedTLS 2.25 -- 50 each at lengths 1 through 2048 -- come back
+# byte-identical with nothing written past the requested length. A WebRTC
+# session driven from a browser carried 1080p20 with /proc/interrupts showing
+# 499 cipher completions a second against 500 packets, so the engine really
+# was doing every packet rather than quietly falling back.
 #
 
-ifeq ($(CHIPARCH),hi3516ev200)
+ifneq ($(filter $(CHIPARCH),hi3516ev200 gk7205v200),)
 
 EV200_CIPHER = cipher/hi3516ev200/src
 
@@ -84,6 +123,9 @@ ccflags-y += -I$(src)/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/core/includ
 ccflags-y += -I$(src)/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include
 ccflags-y += -I$(src)/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/extend/include
 ccflags-y += -I$(src)/cipher/hi3516ev200/src/drv/cipher_v1.0/compat
+# hi3516ev200 here names the silicon and the SDK the tree came from, not the
+# CHIPARCH being built: on gk7205v200 this is still the part it selects
+# drv_osal_hi3516ev200.h for, and still the right one.
 ccflags-y += -DCHIP_TYPE_hi3516ev200 -DAMP_NONSECURE_VERSION
 
 obj-m += $(PREFIX)cipher.o

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_initdevice.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_initdevice.c
@@ -1,5 +1,6 @@
 #include "hi_types.h"
 #include "drv_osal_lib.h"
+#include "../../../../compat/compat.h"
 
 extern int  cipher_drv_mod_init(void);
 extern void cipher_drv_mod_exit(void);
@@ -70,8 +71,13 @@ static compat_platform_remove_ret hi35xx_cipher_remove(struct platform_device *p
     compat_platform_remove_return;
 }
 
+/* "hisilicon,hisi-cipher" on HiSilicon, "goke,cipher" on Goke -- the same node
+ * at the same address with the same interrupt, renamed. Spelled through the
+ * compat.h pair rather than listed twice so it cannot drift: HISI_PRX is
+ * "hisi-" on one family and empty on the other, which is the entire
+ * difference between the two DT bindings. */
 static const struct of_device_id hi35xx_cipher_match[] = {
-    { .compatible = "hisilicon,hisi-cipher" },
+    { .compatible = PLATFORM_NAME "," HISI_PRX "cipher" },
     {},
 };
 MODULE_DEVICE_TABLE(of, hi35xx_cipher_match);


### PR DESCRIPTION
`open_cipher.ko` has never been built for the Goke parts. PR #214 built it for
hi3516ev200 and stopped there, on the grounds that gk7205v200 "is the same
generation on paper, but Goke ships its cipher as a differently-named module
against a different userspace, and nothing here has been measured on one."

All three halves of that turn out to be wrong, and the port is one string.

### It is not the same generation, it is the same silicon

The block is at `0x10050000` on both, behind the same CRG word at `0x120101A0`,
on the same SPI 34. `gk7205v200.dtsi`'s node is byte-for-byte
`hi3516ev200.dtsi`'s except for the compatible:

| | hi3516ev200.dtsi | gk7205v200.dtsi |
|---|---|---|
| `reg` | `0x10050000 0x10000` | identical |
| `interrupts` | `<0 34 4>, <0 34 4>` | identical |
| `interrupt-names` | `"cipher", "hash"` | identical |
| **`compatible`** | `hisilicon,hisi-cipher` | **`goke,cipher`** |

`kernel/compat/compat.h` already keeps the pair that spells both — `HISI_PRX`
is `"hisi-"` on one family and empty on the other — so the match table becomes
`PLATFORM_NAME "," HISI_PRX "cipher"` and cannot drift apart again. Rebuilt for
hi3516ev200 from the same sources, the `.ko` still carries
`hisilicon,hisi-cipher`.

### Nor is the userspace different in the way that mattered

Nothing in a Goke rootfs opens `/dev/cipher` either. majestic drives the ioctls
directly rather than linking `libhi_cipher.so`, so the consumer is the same
binary on both families and the ABI it expects is this module's.

### One thing worth knowing while reading the probe

It demands an `"rsa"` IRQ that **neither** DTS declares, and survives only
because `irq_num` is `hi_u32`, so `platform_get_irq_byname()`'s negative error
reads as a huge positive and the `<= 0` test passes. `HARD_INFO_IFEP_RSA` has
`int_valid = 0` and the value is never used. That is why hi3516ev200 works too;
it is not a Goke quirk.

## Checked on the silicon

Lab gk7205v200 (Xiongmai `IPC_GK7205V200_50H20AI_S38`, imx307, kernel 4.9.37):

- module loads, `/dev/cipher` appears, version register reads the same
  `0x2018121` as the HiSilicon part
- **600 differential AES-CTR cases** against the rootfs's own mbedTLS 2.25 —
  50 each at lengths 1, 15, 16, 17, 63, 64, 65, 1099, 1100, 1101, 1124 and
  2048 — byte-identical, with the bytes past the requested length poisoned and
  checked untouched
- a browser-driven WebRTC session carried 1080p20 while `/proc/interrupts`
  showed **499 cipher completions a second against 500 SRTP packets**, so the
  engine was doing every packet rather than quietly falling back

## What it is worth, and why nothing loads it yet

The third claim — "nothing has been measured on one" — is the one that took the
longest, because measuring it did not go the way the feature assumes. Per
packet the engine costs half the CPU of mbedTLS (86.4 µs against 42.6),
reproducing hi3516ev300's figure almost exactly. On a camera that is actually
busy that saving is not there: **one WebRTC viewer at 4 Mbit/s is 19.76% of a
core with the engine against 19.68% without.** The user time saved comes back
as system time almost exactly, because these kernels have no
`IRQ_TIME_ACCOUNTING` and the completion interrupt is billed to whichever
thread was running — with the streamer stopped, the idle task, which is why the
idle figure reads as a win.

So the cost is the trip and not the cipher: two ioctls, a DMA allocation, a
hardware start and a sleep per packet, against about 44 µs of actual AES.
Amortising it over a burst is what makes the engine pay, and that is a change
of its own. **This one stops at building the module** — correct, available, and
not yet modprobed by anything in a Goke image, which is the state it intends
rather than an oversight.

## Build

Both `CHIPARCH` values built from these sources and the compatible string
checked in each `.ko`:

```
CHIPARCH=gk7205v200    goke,cipher
CHIPARCH=hi3516ev200   hisilicon,hisi-cipher
```
