### PR TITLE
cipher: batched encrypt with one IV per package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,6 +268,47 @@ jobs:
       # in either path: a missing `include ive_neo/Kbuild` in
       # hi3516cv500.kbuild would skip the .ko without failing the build,
       # and a chip-ops mis-selection would bake the wrong chip= log line.
+      # open_cipher.ko is built from a guard inside kernel/cipher/Kbuild
+      # (V4) or hi3516cv500.kbuild, so a broken guard skips the module
+      # WITHOUT failing the build — the same silent-skip shape the ive_neo
+      # check below exists for. And the batched command is the part that
+      # can regress invisibly: it is reached through a dispatch table
+      # indexed by command number, so a row added anywhere but the end
+      # binds every later command to the wrong handler and still links.
+      # Its name is a string literal in that table, which makes it a
+      # cheap thing to look for.
+      - name: Verify open_cipher built for this platform
+        if: matrix.platform == 'hi3516ev200' || matrix.platform == 'gk7205v200' || matrix.platform == 'hi3516cv500'
+        run: |
+          KO=$(find ../firmware/output -name open_cipher.ko 2>/dev/null | head -1)
+          if [ -z "$KO" ] || [ ! -f "$KO" ]; then
+              echo "FAIL: open_cipher.ko not built for ${{ matrix.platform }}" >&2
+              find ../firmware/output -name 'open_*.ko' 2>/dev/null | head -20 >&2 || true
+              exit 1
+          fi
+          echo "ok: $KO ($(stat -c%s "$KO") bytes)"
+
+          # The DT binding the module will actually match. Goke and
+          # HiSilicon spell it differently and the match table derives it
+          # from PLATFORM_NAME/HISI_PRX, so a compat.h regression shows up
+          # here as the wrong string rather than as a build error.
+          case "${{ matrix.platform }}" in
+              gk7205v200) EXPECT="goke,cipher" ;;
+              *)          EXPECT="hisilicon,hisi-cipher" ;;
+          esac
+          if ! strings "$KO" | grep -qx "$EXPECT"; then
+              echo "FAIL: $KO does not carry compatible '$EXPECT'" >&2
+              strings "$KO" | grep -E '^(goke|hisilicon),' >&2 || true
+              exit 1
+          fi
+          echo "ok: $KO matches '$EXPECT'"
+
+          if ! strings "$KO" | grep -qx "EncryptViaMulti"; then
+              echo "FAIL: $KO has no batched encrypt command — dispatch table regression?" >&2
+              exit 1
+          fi
+          echo "ok: $KO carries the batched encrypt command"
+
       - name: Verify ive_neo built for this platform
         if: matrix.platform == 'hi3516ev200' || matrix.platform == 'gk7205v200' || matrix.platform == 'hi3516cv500'
         run: |

--- a/kernel/cipher/hi3516cv500/include/drv_cipher_kapi.h
+++ b/kernel/cipher/hi3516cv500/include/drv_cipher_kapi.h
@@ -125,7 +125,14 @@ typedef enum {
 #define CRYPTO_CMD_TRNG                crypto_iowr(0x0d, sizeof(trng_t))
 #define CRYPTO_CMD_SYMC_GET_CONFIG     crypto_iowr(0x0e, sizeof(symc_get_cfg_t))
 #define CRYPTO_CMD_KLAD_KEY            crypto_iowr(0x0f, sizeof(klad_key_t))
-#define CRYPTO_CMD_COUNT               0x10
+/*
+ * OpenIPC extension, see symc_encrypt_via_multi_t. Appended rather than
+ * inserted: the command number encodes sizeof(payload) and its position, so
+ * every number above stays what the vendor library computes.
+ */
+#define CRYPTO_CMD_SYMC_ENCRYPT_VIA_MULTI \
+                                       crypto_iow (0x10, sizeof(symc_encrypt_via_multi_t))
+#define CRYPTO_CMD_COUNT               0x11
 
 #define crypto_chk_err_exit(_expr) \
     do { \
@@ -277,6 +284,41 @@ typedef struct {
     hi_u32 pack_num;        /* Number of package infomation */
     hi_u32 operation;       /* Decrypt or encrypt */
 } symc_encrypt_multi_t;
+
+/*
+ * OpenIPC extension: batched encrypt from user virtual addresses, each package
+ * under its OWN IV.
+ *
+ * The vendor's multi-package call (CRYPTO_CMD_SYMC_ENCRYPTMULTI) describes a
+ * package as hi_cipher_data -- source, destination, length, odd/even key
+ * selector -- and no IV, so every package in a submission runs under the one
+ * IV the last CONFIGHANDLE left in the channel. That suits chaining one long
+ * buffer and is useless for SRTP, where each packet's IV comes from its own
+ * sequence number. It also takes physical (MMZ) addresses, which a streamer's
+ * heap is not.
+ *
+ * The silicon has no such limit: drv_symc_add_inbuf() writes an IV into EVERY
+ * descriptor node it builds, and HI_CIPHER_IV_CHG_ALL_PACK makes the block
+ * reload it per node -- the driver simply had no way to be told a different
+ * one per package. This carries them.
+ *
+ * One ioctl, one DMA buffer, one hardware start and ONE completion interrupt
+ * for a whole burst, instead of two ioctls and one sleep each.
+ */
+typedef struct {
+    compat_addr src;       /* Virtual address of the input data */
+    compat_addr dst;       /* Virtual address of the output data */
+    hi_u32 length;         /* Length of this package */
+    hi_u32 reserve;        /* Alignment, must be zero */
+    hi_u8 iv[16];          /* This package's own IV */
+} symc_via_pkg;
+
+typedef struct {
+    hi_u32 id;             /* Id of soft channel */
+    compat_addr pkg;       /* User address of a symc_via_pkg[pkg_num] */
+    hi_u32 pkg_num;        /* Number of packages */
+    hi_u32 operation;      /* Decrypt or encrypt */
+} symc_encrypt_via_multi_t;
 
 /* struct of Symmetric cipher get tag */
 typedef struct {
@@ -474,6 +516,14 @@ hi_s32 kapi_symc_crypto_via(symc_encrypt_t *crypt, hi_u32 is_from_user);
  * return           0 if successful
  */
 hi_s32 kapi_symc_crypto_multi(hi_u32 id, const hi_void *pack, hi_u32 pack_num, hi_u32 operation, hi_u32 last);
+
+/*
+ * OpenIPC extension: batched encryption from user virtual addresses, one IV
+ * per package. Returns HI_ERR_CIPHER_UNSUPPORTED where the configured
+ * algorithm has no per-node IV support, and the caller should fall back to
+ * the single-package call.
+ */
+hi_s32 kapi_symc_crypto_via_multi(hi_u32 id, const hi_void *pkg, hi_u32 pkg_num, hi_u32 operation);
 
 /*
  * brief          SYMC multiple buffer encryption/decryption.

--- a/kernel/cipher/hi3516cv500/include/drv_cipher_kapi.h
+++ b/kernel/cipher/hi3516cv500/include/drv_cipher_kapi.h
@@ -320,6 +320,19 @@ typedef struct {
     hi_u32 operation;      /* Decrypt or encrypt */
 } symc_encrypt_via_multi_t;
 
+/*
+ * THESE TWO LAYOUTS ARE THE ABI, not merely its description: the command
+ * number encodes sizeof(payload), so changing either makes every userspace
+ * transcription compute a command this driver does not recognise. What the
+ * driver then reports is "copy data from user failed", which names neither
+ * the struct nor the size -- so the mismatch is worth catching here instead
+ * of on a camera. majestic asserts the same two numbers on its side, in
+ * include/majestic/hisi/cipher_abi.h.
+ */
+_Static_assert(sizeof(symc_via_pkg) == 40, "symc_via_pkg is ABI");
+_Static_assert(sizeof(symc_encrypt_via_multi_t) == 24,
+               "symc_encrypt_via_multi_t is ABI");
+
 /* struct of Symmetric cipher get tag */
 typedef struct {
     hi_u32 id;                            /* Id of soft channel */

--- a/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/core/include/drv_symc.h
+++ b/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/core/include/drv_symc.h
@@ -248,6 +248,17 @@ typedef struct {
     hi_u32 *length_list;         /* length of node list */
     symc_node_usage *usage_list; /* usage of node list */
     hi_bool tdes2dma;            /* 3des with invalid key turns to dma */
+
+    /*
+     * OpenIPC extension, armed by cryp_symc_set_iv_list() for one call.
+     * iv_list is AES_IV_SIZE bytes per node in node order; int_level is how
+     * many nodes are queued before the block is started and waited on, so a
+     * batch costs one completion interrupt rather than one per packet. Both
+     * are cleared by the crypto() that consumes them.
+     */
+    const hi_u8 *iv_list;        /* per-node IV, HI_NULL for one IV per job */
+    hi_u32 iv_list_count;        /* nodes iv_list covers */
+    hi_u32 int_level;            /* nodes per hardware start, 0 = default */
 } cryp_symc_context;
 
 typedef hi_s32 (*callback_symc_isr)(hi_void *ctx);

--- a/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/crypto/cryp_symc.c
+++ b/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/crypto/cryp_symc.c
@@ -279,6 +279,28 @@ static hi_s32 symc_add_buf(cryp_symc_context *ctx, symc_node_usage out_uasge)
 
     hi_log_func_enter();
 
+    /*
+     * OpenIPC extension: give this node its own IV before it is built.
+     * drv_symc_set_iv() only writes the channel's software context, which
+     * drv_symc_add_inbuf() then copies into the descriptor -- four word
+     * stores and no hardware access -- and HI_CIPHER_IV_CHG_ALL_PACK is what
+     * makes the block reload from each node rather than carry the chain
+     * forward. Without a list nothing changes: the single IV that
+     * cryp_symc_config() programmed stands for the whole job.
+     */
+    if (ctx->iv_list != HI_NULL && cur < ctx->iv_list_count) {
+        hi_u32 iv[AES_IV_SIZE / WORD_WIDTH];
+
+        crypto_memcpy(iv, sizeof(iv),
+                      ctx->iv_list + (hi_u32)(cur * AES_IV_SIZE), AES_IV_SIZE);
+        ret = drv_symc_set_iv(ctx->hard_chn, iv, AES_IV_SIZE,
+                              HI_CIPHER_IV_CHG_ALL_PACK);
+        if (ret != HI_SUCCESS) {
+            hi_log_print_func_err(drv_symc_set_iv, ret);
+            return ret;
+        }
+    }
+
     /* Add P in. */
     ret = drv_symc_add_inbuf(ctx->hard_chn,
                              ctx->input_list[cur],
@@ -392,7 +414,15 @@ static hi_s32 symc_add_buf_list(hi_void *ctx)
     /* compute not finished.
      * select the minimum numbers of nodes to calculate.
      */
-    nodes = crypto_min(SYMC_INT_LEVEL, hisi_ctx->total_nodes - hisi_ctx->cur_nodes);
+    /*
+     * SYMC_INT_LEVEL is one, so the vendor default starts and waits on the
+     * block once per node however many were handed in -- the 16-entry
+     * descriptor ring is never more than a sixteenth full. A caller that has
+     * armed an IV list may raise it (cryp_symc_set_iv_list), which is where
+     * the batching win actually comes from.
+     */
+    nodes = hisi_ctx->int_level > 0 ? hisi_ctx->int_level : SYMC_INT_LEVEL;
+    nodes = crypto_min(nodes, hisi_ctx->total_nodes - hisi_ctx->cur_nodes);
     total_len = 0;
 
     for (i = 0; i < nodes; i++) {
@@ -643,7 +673,41 @@ static hi_s32 cryp_symc_crypto_process(cryp_symc_context *hisi_ctx, hi_u32 wait)
     return HI_SUCCESS;
 }
 
-static hi_s32 cryp_symc_crypto(hi_void *ctx, hi_u32 operation, symc_multi_pack *pack, hi_u32 wait)
+/*
+ * OpenIPC extension, see func_symc_setivlist. Arms one IV per node for the
+ * next crypto() call and how deep to queue before waiting; both are consumed
+ * and cleared there, so this cannot outlive the array it points at.
+ */
+static hi_s32 cryp_symc_set_iv_list(hi_void *ctx, const hi_u8 *iv_list,
+                                    hi_u32 count, hi_u32 depth)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    hi_log_func_enter();
+    hi_log_chk_param_return(hisi_ctx == HI_NULL);
+
+    if (iv_list != HI_NULL) {
+        hi_log_chk_param_return(count == 0x00);
+        hi_log_chk_param_return(depth == 0x00);
+        /*
+         * Never past the descriptor ring: symc_add_buf_list() may still add a
+         * node beyond `nodes` to square the block-size tail, so leave it one
+         * slot of room rather than exactly filling.
+         */
+        if (depth >= SYMC_MAX_LIST_NUM) {
+            depth = SYMC_MAX_LIST_NUM - 1;
+        }
+    }
+
+    hisi_ctx->iv_list = iv_list;
+    hisi_ctx->iv_list_count = (iv_list != HI_NULL) ? count : 0;
+    hisi_ctx->int_level = (iv_list != HI_NULL) ? depth : 0;
+
+    hi_log_func_exit();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_symc_crypto_job(hi_void *ctx, hi_u32 operation, symc_multi_pack *pack, hi_u32 wait)
 {
     hi_s32 ret;
     cryp_symc_context *hisi_ctx = ctx;
@@ -689,6 +753,29 @@ static hi_s32 cryp_symc_crypto(hi_void *ctx, hi_u32 operation, symc_multi_pack *
 
     hi_log_func_exit();
     return HI_SUCCESS;
+}
+
+/*
+ * The armed IV list points at the caller's array and must not outlive this
+ * call, so it is disarmed on EVERY exit -- which is the whole reason the job
+ * above is wrapped rather than edited: it has several returns, and a missed
+ * one would leave a dangling pointer that only bites the next unrelated
+ * packet.
+ */
+static hi_s32 cryp_symc_crypto(hi_void *ctx, hi_u32 operation, symc_multi_pack *pack, hi_u32 wait)
+{
+    hi_s32 ret;
+    cryp_symc_context *hisi_ctx = ctx;
+
+    ret = cryp_symc_crypto_job(ctx, operation, pack, wait);
+
+    if (hisi_ctx != HI_NULL) {
+        hisi_ctx->iv_list = HI_NULL;
+        hisi_ctx->iv_list_count = 0;
+        hisi_ctx->int_level = 0;
+    }
+
+    return ret;
 }
 
 #ifdef CHIP_AES_CCM_GCM_SUPPORT
@@ -1466,6 +1553,12 @@ static hi_void cryp_register_symc_default(symc_func *func, symc_alg alg, symc_mo
     func->setmode = cryp_symc_setmode;
     func->setkey = cryp_aes_setkey;
     func->waitdone = cryp_symc_wait_done;
+    /*
+     * Only the hardware paths offer it. The CCM/GCM/CTS registrations replace
+     * ->crypto with their own, which does not read the list, so they clear
+     * this again after calling here.
+     */
+    func->setivlist = cryp_symc_set_iv_list;
     return;
 }
 
@@ -1552,6 +1645,7 @@ static hi_void cryp_register_symc_aes_cts(hi_u32 capacity, symc_mode mode)
 
         cryp_register_symc_default(&func, SYMC_ALG_AES, mode);
         func.crypto = cryp_aes_cbc_cts_crypto;
+        func.setivlist = HI_NULL;   /* CTS does not read the list */
         func.waitdone = HI_NULL;
         hi_log_debug("CTS crypto 0x%p, mode %d\n", func.crypto, mode);
         ret = cryp_register_symc(&func);
@@ -1577,6 +1671,7 @@ static hi_void cryp_register_aead_ccm(hi_u32 capacity, symc_mode mode)
         func.setadd = cryp_aead_ccm_set_aad;
         func.gettag = cryp_aead_get_tag;
         func.crypto = cryp_aead_ccm_crypto;
+        func.setivlist = HI_NULL;   /* CCM does not read the list */
         func.setiv = cryp_aead_ccm_setiv;
         ret = cryp_register_symc(&func);
         if (ret != HI_SUCCESS) {
@@ -1627,6 +1722,7 @@ static hi_void cryp_register_aead_gcm(hi_u32 capacity, symc_mode mode)
         func.setadd = cryp_aead_gcm_set_aad;
         func.gettag = cryp_aead_get_tag;
         func.crypto = cryp_aead_gcm_crypto;
+        func.setivlist = HI_NULL;   /* GCM does not read the list */
         func.setiv = cryp_aead_gcm_setiv;
         ret = cryp_register_symc(&func);
         if (ret != HI_SUCCESS) {

--- a/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/crypto/cryp_symc.c
+++ b/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/crypto/cryp_symc.c
@@ -1206,6 +1206,17 @@ static hi_s32 cryp_register_symc(symc_func *func)
         return HI_ERR_CIPHER_INVALID_PARAM;
     }
 
+    /*
+     * The per-node IV list is read by exactly one crypto(), so tie the setter
+     * to it here rather than asking every registration to remember. The
+     * software registrations below call cryp_register_symc_default() and then
+     * swap in an mbedTLS create()/crypto() pair, so an inherited setter would
+     * cast their context to cryp_symc_context and write into it. Derived,
+     * that cannot drift.
+     */
+    func->setivlist =
+        (func->crypto == cryp_symc_crypto) ? cryp_symc_set_iv_list : HI_NULL;
+
     /* is it already registered? */
     for (i = 0; i < SYMC_FUNC_TAB_SIZE; i++) {
         if ((g_symc_descriptor[i].valid) && (g_symc_descriptor[i].alg == func->alg) &&
@@ -1554,11 +1565,12 @@ static hi_void cryp_register_symc_default(symc_func *func, symc_alg alg, symc_mo
     func->setkey = cryp_aes_setkey;
     func->waitdone = cryp_symc_wait_done;
     /*
-     * Only the hardware paths offer it. The CCM/GCM/CTS registrations replace
-     * ->crypto with their own, which does not read the list, so they clear
-     * this again after calling here.
+     * setivlist is NOT set here. It used to be, and that was a type confusion
+     * waiting to happen: every software registration below calls this and
+     * then replaces ->create and ->crypto, so it would inherit a setter that
+     * casts its argument to cryp_symc_context and writes into an mbedTLS
+     * context. cryp_register_symc() derives it instead.
      */
-    func->setivlist = cryp_symc_set_iv_list;
     return;
 }
 
@@ -1645,7 +1657,6 @@ static hi_void cryp_register_symc_aes_cts(hi_u32 capacity, symc_mode mode)
 
         cryp_register_symc_default(&func, SYMC_ALG_AES, mode);
         func.crypto = cryp_aes_cbc_cts_crypto;
-        func.setivlist = HI_NULL;   /* CTS does not read the list */
         func.waitdone = HI_NULL;
         hi_log_debug("CTS crypto 0x%p, mode %d\n", func.crypto, mode);
         ret = cryp_register_symc(&func);
@@ -1671,7 +1682,6 @@ static hi_void cryp_register_aead_ccm(hi_u32 capacity, symc_mode mode)
         func.setadd = cryp_aead_ccm_set_aad;
         func.gettag = cryp_aead_get_tag;
         func.crypto = cryp_aead_ccm_crypto;
-        func.setivlist = HI_NULL;   /* CCM does not read the list */
         func.setiv = cryp_aead_ccm_setiv;
         ret = cryp_register_symc(&func);
         if (ret != HI_SUCCESS) {
@@ -1722,7 +1732,6 @@ static hi_void cryp_register_aead_gcm(hi_u32 capacity, symc_mode mode)
         func.setadd = cryp_aead_gcm_set_aad;
         func.gettag = cryp_aead_get_tag;
         func.crypto = cryp_aead_gcm_crypto;
-        func.setivlist = HI_NULL;   /* GCM does not read the list */
         func.setiv = cryp_aead_gcm_setiv;
         ret = cryp_register_symc(&func);
         if (ret != HI_SUCCESS) {

--- a/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/crypto/include/cryp_symc.h
+++ b/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/crypto/include/cryp_symc.h
@@ -117,6 +117,23 @@ typedef hi_s32 (*func_symc_sm1_setround)(hi_void *ctx, hi_u32 round);
  */
 typedef hi_s32 (*func_symc_crypto)(hi_void *ctx, hi_u32 operation, symc_multi_pack *pack, hi_u32 wait);
 
+/*
+ * OpenIPC extension: arm ONE IV per node for the next crypto() call, and let
+ * it submit more than one node before waiting. Without it every node of a
+ * multi-node job runs under the single IV left in the channel by setiv(),
+ * which is what confined batching to chained modes over one buffer -- the
+ * descriptors always had room, see drv_symc_add_inbuf().
+ *
+ * iv_list must stay alive until crypto() returns and holds count entries of
+ * AES_IV_SIZE bytes in node order; depth is how many nodes may be queued
+ * before the block is started, capped at the descriptor ring. Armed for a
+ * single call and cleared by it. HI_NULL where it would not be honoured --
+ * the software paths, and CCM/GCM/CTS -- which callers must read as
+ * "batching not available here".
+ */
+typedef hi_s32 (*func_symc_setivlist)(hi_void *ctx, const hi_u8 *iv_list,
+                                      hi_u32 count, hi_u32 depth);
+
 /**
  * brief          CCM/GCM set Associated Data
  *
@@ -154,6 +171,7 @@ typedef struct {
     func_aead_set_aad setadd;   /* setadd function */
     func_aead_get_tag gettag;   /* get tag function */
     func_symc_crypto  crypto;   /* crypto function */
+    func_symc_setivlist setivlist; /* per-node IV list, HI_NULL if unsupported */
     func_symc_wait_done waitdone; /* wait done */
 } symc_func;
 

--- a/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/kapi_dispatch.c
+++ b/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/kapi_dispatch.c
@@ -125,6 +125,28 @@ static hi_s32 dispatch_symc_encrypt(hi_void *argp)
     return HI_SUCCESS;
 }
 
+/*
+ * OpenIPC extension, see symc_encrypt_via_multi_t. Deliberately thin: every
+ * bound is checked in kapi_symc_crypto_via_multi(), against the same limits
+ * the buffer is sized from, rather than half here and half there.
+ */
+static hi_s32 dispatch_symc_encrypt_via_multi(hi_void *argp)
+{
+    hi_s32 ret;
+    symc_encrypt_via_multi_t *batch = argp;
+
+    hi_log_func_enter();
+
+    ret = kapi_symc_crypto_via_multi(batch->id, addr_via(batch->pkg), batch->pkg_num, batch->operation);
+    if (ret != HI_SUCCESS) {
+        hi_log_print_func_err(kapi_symc_crypto_via_multi, ret);
+        return ret;
+    }
+
+    hi_log_func_exit();
+    return HI_SUCCESS;
+}
+
 static hi_s32 dispatch_symc_encrypt_multi(hi_void *argp)
 {
     hi_s32 ret;
@@ -718,6 +740,15 @@ static crypto_dispatch_func g_dispatch_func[CRYPTO_CMD_COUNT] = {
     {"TRNG",          dispatch_trng_get_random,     CRYPTO_CMD_TRNG},
     {"GetSymcConfig", dispatch_symc_get_cfg,        CRYPTO_CMD_SYMC_GET_CONFIG},
     {"KladKey",       dispatch_klad_key,            CRYPTO_CMD_KLAD_KEY},
+    /*
+     * LAST, and it must stay last: crypto_ioctl() indexes this table by the
+     * command's nr and then checks g_dispatch_func[nr].cmd == cmd, so a row
+     * inserted anywhere but the end shifts every command after it onto the
+     * wrong handler. That check is the only thing that catches it, and what
+     * it reports is "copy data from user failed" -- a lie about a table that
+     * is simply off by one.
+     */
+    {"EncryptViaMulti", dispatch_symc_encrypt_via_multi, CRYPTO_CMD_SYMC_ENCRYPT_VIA_MULTI},
 };
 
 hi_s32 crypto_ioctl(hi_u32 cmd, hi_void *argp)

--- a/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/kapi_symc.c
+++ b/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/kapi_symc.c
@@ -960,6 +960,20 @@ hi_s32 kapi_symc_crypto_via_multi(hi_u32 id, const hi_void *pkg, hi_u32 pkg_num,
         return HI_ERR_CIPHER_UNSUPPORTED;
     }
 
+    /*
+     * CTR ONLY, and the reason is the padding rather than the IV list. Every
+     * package is rounded up to a whole block and only the requested bytes are
+     * handed back, which is invisible in a stream cipher and wrong in every
+     * other mode: a CBC caller would get ciphertext truncated mid-block, and
+     * a decrypt would run over fabricated zero bytes. The block rejects an
+     * unaligned length outside CTR (drv_symc_node_check), so padding here
+     * would quietly relax a check the hardware makes.
+     */
+    if (ctx->ctrl.work_mode != HI_CIPHER_WORK_MODE_CTR) {
+        hi_log_info("batch is CTR only, mode %d\n", ctx->ctrl.work_mode);
+        return HI_ERR_CIPHER_UNSUPPORTED;
+    }
+
     ret = crypto_copy_from_user(desc, pkg, sizeof(symc_via_pkg) * pkg_num);
     if (ret != HI_SUCCESS) {
         hi_log_print_func_err(crypto_copy_from_user, ret);
@@ -967,6 +981,21 @@ hi_s32 kapi_symc_crypto_via_multi(hi_u32 id, const hi_void *pkg, hi_u32 pkg_num,
     }
 
     kapi_symc_lock_err_return();
+
+    /*
+     * Everything above was read without the lock, which is the shape the
+     * vendor's own crypto paths use. It is not good enough here: destroy()
+     * frees the batch buffer and the crypto context under this same lock, and
+     * create() may then hand the slot to somebody else, so a request that
+     * waited would arrive holding conclusions about a channel that no longer
+     * exists. Re-checked now that nothing can move.
+     */
+    if ((ctx->open != HI_TRUE) || (ctx->config != HI_TRUE) ||
+        (ctx->func == HI_NULL) || (ctx->func->setivlist == HI_NULL) ||
+        (ctx->cryp_ctx == HI_NULL)) {
+        kapi_symc_unlock();
+        return HI_ERR_CIPHER_INVALID_HANDLE;
+    }
 
     if (ctx->batch_size == 0) {
         ret = crypto_mem_create(&ctx->batch, SEC_MMZ, "AES_BATCH", KAPI_SYMC_BATCH_BYTES);

--- a/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/kapi_symc.c
+++ b/kernel/cipher/hi3516cv500/src/drv/cipher_v1.0/drivers/kapi_symc.c
@@ -22,7 +22,25 @@ typedef struct {
     void *cryp_ctx;                     /* Context of cryp instance */
     crypto_owner owner;                 /* user ID */
     hi_cipher_ctrl  ctrl;               /* control infomation */
+    /*
+     * OpenIPC extension: the batch path's DMA bounce buffer, allocated on
+     * first use and held until the channel is destroyed. The single-package
+     * virtual path (kapi_symc_crypto_via) does a dma_alloc_coherent and a
+     * free around EVERY packet, which at video packet rates is most of what
+     * the engine costs. Batching would be pointless if it kept paying that.
+     */
+    crypto_mem batch;
+    hi_u32 batch_size;                  /* bytes in batch, 0 = not allocated */
 } kapi_symc_ctx;
+
+/*
+ * How many packets one batched call may carry, and how much data. The node
+ * count is bounded by the descriptor ring (SYMC_MAX_LIST_NUM, 16) less the
+ * slot symc_add_buf_list() may need to square a block-size tail.
+ */
+#define KAPI_SYMC_BATCH_MAX_PKG     (15)
+#define KAPI_SYMC_BATCH_MAX_LEN     (2048)
+#define KAPI_SYMC_BATCH_BYTES       (KAPI_SYMC_BATCH_MAX_PKG * KAPI_SYMC_BATCH_MAX_LEN)
 
 typedef struct {
     hi_u32 soft_id;
@@ -204,6 +222,16 @@ hi_s32 kapi_symc_destroy(hi_u32 id)
     crypto_chk_owner_err_return(&ctx->owner);
 
     kapi_symc_lock_err_return();
+
+    /*
+     * Before the instance goes: this is the only owner of that buffer, and
+     * with eight channels on the chip a leak here is eight batches' worth of
+     * coherent DMA memory that nothing will ever reclaim.
+     */
+    if (ctx->batch_size != 0) {
+        crypto_mem_destory(&ctx->batch);
+        ctx->batch_size = 0;
+    }
 
     cryp_symc_free_chn(soft_id);
 
@@ -799,6 +827,163 @@ hi_s32 kapi_symc_crypto(symc_encrypt_t *crypt)
     kapi_symc_unlock();
     hi_log_func_exit();
     return HI_SUCCESS;
+}
+
+/*
+ * OpenIPC extension: one ioctl, one DMA buffer, one hardware start and one
+ * completion interrupt for a whole burst of packets, each under its own IV.
+ *
+ * EVERY PACKAGE IS PADDED TO THE BLOCK SIZE, and that is not cosmetic.
+ * symc_add_buf_list() squares a job whose total length is not a multiple of
+ * the block size by SPLITTING a node -- which under a per-node IV list would
+ * run the second half under the next packet's IV and produce a plausible,
+ * wrong keystream. Padding each package makes every total aligned, so the
+ * splitting path is never entered. CTR is a stream cipher, so the padding
+ * costs bytes and changes nothing.
+ */
+static hi_s32 kapi_symc_crypto_via_multi_run(kapi_symc_ctx *ctx, const symc_via_pkg *pkg,
+    hi_u32 pkg_num, hi_u32 operation)
+{
+    hi_s32 ret;
+    compat_addr in[KAPI_SYMC_BATCH_MAX_PKG];
+    compat_addr out[KAPI_SYMC_BATCH_MAX_PKG];
+    hi_u32 len[KAPI_SYMC_BATCH_MAX_PKG];
+    symc_node_usage usage[KAPI_SYMC_BATCH_MAX_PKG];
+    hi_u8 ivs[KAPI_SYMC_BATCH_MAX_PKG][AES_IV_SIZE];
+    hi_u32 offset[KAPI_SYMC_BATCH_MAX_PKG];
+    symc_multi_pack pack;
+    hi_u32 i, used = 0;
+
+    for (i = 0; i < pkg_num; i++) {
+        const hi_u32 length = pkg[i].length;
+        const hi_u32 padded = (length + AES_BLOCK_SIZE - 1) / AES_BLOCK_SIZE * AES_BLOCK_SIZE;
+
+        if ((length == 0) || (length > KAPI_SYMC_BATCH_MAX_LEN)) {
+            hi_log_error("batch pkg %d: bad length 0x%x\n", i, length);
+            return HI_ERR_CIPHER_INVALID_LENGTH;
+        }
+        if ((used + padded > ctx->batch_size) || (used + padded < used)) {
+            hi_log_error("batch overflows its buffer at pkg %d\n", i);
+            return HI_ERR_CIPHER_INVALID_LENGTH;
+        }
+        if ((addr_via(pkg[i].src) == HI_NULL) || (addr_via(pkg[i].dst) == HI_NULL)) {
+            return HI_ERR_CIPHER_INVALID_POINT;
+        }
+
+        ret = crypto_copy_from_user((hi_u8 *)ctx->batch.dma_virt + used, addr_via(pkg[i].src), length);
+        if (ret != HI_SUCCESS) {
+            hi_log_print_func_err(crypto_copy_from_user, ret);
+            return ret;
+        }
+        if (padded > length) {
+            crypto_memset((hi_u8 *)ctx->batch.dma_virt + used + length,
+                padded - length, 0, padded - length);
+        }
+
+        crypto_memcpy(ivs[i], AES_IV_SIZE, pkg[i].iv, AES_IV_SIZE);
+        offset[i] = used;
+        len[i] = padded;
+        usage[i] = SYMC_NODE_USAGE_NORMAL;
+        /* In place: the block reads a node before it writes it. */
+        addr_u64(in[i]) = addr_u64(ctx->batch.dma_addr) + used;
+        addr_u64(out[i]) = addr_u64(ctx->batch.dma_addr) + used;
+        used += padded;
+    }
+
+    ret = ctx->func->setivlist(ctx->cryp_ctx, (const hi_u8 *)ivs, pkg_num, pkg_num);
+    if (ret != HI_SUCCESS) {
+        hi_log_print_func_err(ctx->func->setivlist, ret);
+        return ret;
+    }
+
+    crypto_memset(&pack, sizeof(pack), 0, sizeof(pack));
+    pack.in = in;
+    pack.out = out;
+    pack.len = len;
+    pack.usage = usage;
+    pack.num = pkg_num;
+
+    ret = ctx->func->crypto(ctx->cryp_ctx, operation, &pack, HI_TRUE);
+    if (ret != HI_SUCCESS) {
+        hi_log_print_func_err(ctx->func->crypto, ret);
+        return ret;
+    }
+
+    /* Only the requested length goes back, so the padding never reaches the caller. */
+    for (i = 0; i < pkg_num; i++) {
+        ret = crypto_copy_to_user(addr_via(pkg[i].dst),
+            (hi_u8 *)ctx->batch.dma_virt + offset[i], pkg[i].length);
+        if (ret != HI_SUCCESS) {
+            hi_log_print_func_err(crypto_copy_to_user, ret);
+            return ret;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_symc_crypto_via_multi(hi_u32 id, const hi_void *pkg, hi_u32 pkg_num, hi_u32 operation)
+{
+    hi_s32 ret;
+    kapi_symc_ctx *ctx = HI_NULL;
+    symc_via_pkg desc[KAPI_SYMC_BATCH_MAX_PKG];
+    hi_u32 soft_id;
+
+    hi_log_func_enter();
+
+    ret = kapi_symc_chk_handle(id);
+    if (ret != HI_SUCCESS) {
+        hi_log_print_func_err(kapi_symc_chk_handle, ret);
+        return ret;
+    }
+    soft_id = hi_handle_get_chnid(id);
+    ctx = &g_kapi_ctx[soft_id];
+    crypto_chk_owner_err_return(&ctx->owner);
+    hi_log_chk_param_return(ctx->config != HI_TRUE);
+    hi_log_chk_param_return(pkg == HI_NULL);
+    hi_log_chk_param_return(pkg_num == 0x00);
+    hi_log_chk_param_return(pkg_num > KAPI_SYMC_BATCH_MAX_PKG);
+    hi_log_chk_param_return((operation != SYMC_OPERATION_ENCRYPT) &&
+        (operation != SYMC_OPERATION_DECRYPT));
+    hi_log_chk_param_return(ctx->func == HI_NULL);
+    hi_log_chk_param_return(ctx->func->crypto == HI_NULL);
+
+    /*
+     * The software (mbedTLS) implementations register no list setter, and
+     * CCM/GCM/CTS clear theirs because their crypto() does not read it. So a
+     * NULL here is "this algorithm cannot be batched", not a bug -- the caller
+     * falls back to the single-package call, as it would on a camera with no
+     * engine at all.
+     */
+    if (ctx->func->setivlist == HI_NULL) {
+        hi_log_info("batch unsupported for this alg/mode\n");
+        return HI_ERR_CIPHER_UNSUPPORTED;
+    }
+
+    ret = crypto_copy_from_user(desc, pkg, sizeof(symc_via_pkg) * pkg_num);
+    if (ret != HI_SUCCESS) {
+        hi_log_print_func_err(crypto_copy_from_user, ret);
+        return ret;
+    }
+
+    kapi_symc_lock_err_return();
+
+    if (ctx->batch_size == 0) {
+        ret = crypto_mem_create(&ctx->batch, SEC_MMZ, "AES_BATCH", KAPI_SYMC_BATCH_BYTES);
+        if (ret != HI_SUCCESS) {
+            hi_log_print_func_err(crypto_mem_create, ret);
+            kapi_symc_unlock();
+            return ret;
+        }
+        ctx->batch_size = KAPI_SYMC_BATCH_BYTES;
+    }
+
+    ret = kapi_symc_crypto_via_multi_run(ctx, desc, pkg_num, operation);
+
+    kapi_symc_unlock();
+
+    hi_log_func_exit();
+    return ret;
 }
 
 hi_s32 kapi_symc_crypto_via(symc_encrypt_t *crypt, hi_u32 is_from_user)

--- a/kernel/cipher/hi3516ev200/include/drv_cipher_kapi.h
+++ b/kernel/cipher/hi3516ev200/include/drv_cipher_kapi.h
@@ -365,6 +365,19 @@ typedef struct {
     hi_u32 operation;      /*!<  Decrypt or encrypt */
 } symc_encrypt_via_multi_t;
 
+/*
+ * THESE TWO LAYOUTS ARE THE ABI, not merely its description: the command
+ * number encodes sizeof(payload), so changing either makes every userspace
+ * transcription compute a command this driver does not recognise. What the
+ * driver then reports is "copy data from user failed", which names neither
+ * the struct nor the size -- so the mismatch is worth catching here instead
+ * of on a camera. majestic asserts the same two numbers on its side, in
+ * include/majestic/hisi/cipher_abi.h.
+ */
+_Static_assert(sizeof(symc_via_pkg) == 40, "symc_via_pkg is ABI");
+_Static_assert(sizeof(symc_encrypt_via_multi_t) == 24,
+               "symc_encrypt_via_multi_t is ABI");
+
 /*! \struct of Symmetric cipher get tag */
 typedef struct {
     hi_u32 id;                            /*!<  Id of soft channel */

--- a/kernel/cipher/hi3516ev200/include/drv_cipher_kapi.h
+++ b/kernel/cipher/hi3516ev200/include/drv_cipher_kapi.h
@@ -145,7 +145,12 @@ typedef enum {
 #define CRYPTO_CMD_TRNG                CRYPTO_IOWR(0x0d, sizeof(trng_t))
 #define CRYPTO_CMD_SYMC_GET_CONFIG     CRYPTO_IOWR(0x0e, sizeof(symc_get_config_t))
 #define CRYPTO_CMD_KLAD_KEY            CRYPTO_IOWR(0x0f, sizeof(klad_key_t))
-#define CRYPTO_CMD_COUNT               0x10
+/* OpenIPC extension, see symc_encrypt_via_multi_t. Appended rather than
+ * inserted: the command number encodes sizeof(payload) and its position, so
+ * every number below this line stays what the vendor library computes. */
+#define CRYPTO_CMD_SYMC_ENCRYPT_VIA_MULTI \
+                                       CRYPTO_IOW (0x10, sizeof(symc_encrypt_via_multi_t))
+#define CRYPTO_CMD_COUNT               0x11
 
 #define CHECK_EXIT(_expr) \
     do { \
@@ -318,6 +323,47 @@ typedef struct {
     hi_u32 pkg_num;        /*!<  Number of package infomation */
     hi_u32 operation;      /*!<  Decrypt or encrypt */
 } symc_encrypt_multi_t;
+
+/* OpenIPC extension: batched encrypt from user virtual addresses, each package
+ * under its OWN IV.
+ *
+ * WHY IT DOES NOT ALREADY EXIST. The vendor's multi-package call
+ * (CRYPTO_CMD_SYMC_ENCRYPTMULTI) describes a package as hi_cipher_data --
+ * source, destination, length, odd/even key selector -- and no IV, so every
+ * package in a submission runs under the one IV the last CONFIGHANDLE left in
+ * the channel. That is fine for chaining one long buffer and useless for
+ * SRTP, where each packet's IV is derived from its own sequence number. It
+ * also takes physical (MMZ) addresses, which a streamer's heap is not.
+ *
+ * The silicon has no such limit. drv_symc_add_inbuf() writes an IV into EVERY
+ * descriptor node it builds, and CIPHER_IV_CHANGE_ALL_PKG makes the block
+ * reload it per node -- the driver simply had no way to be told a different
+ * one per package. This carries them.
+ *
+ * WHAT IT IS FOR. One ioctl, one DMA buffer, one hardware start and ONE
+ * completion interrupt for a whole frame's worth of packets, instead of two
+ * ioctls and one sleep each. On a gen 4 part the per-packet fixed cost is
+ * ~37.8 us against ~44 us of actual AES for an 1100-byte packet, so a camera
+ * sending 5000 packets a second spends most of the engine's cost on getting
+ * to it. See kernel/cipher/Kbuild.
+ *
+ * ENCRYPT ONLY IN THE SENSE THAT MATTERS: operation is the same 0/1 the
+ * single-package call takes. The addresses are always user virtual -- there
+ * is no physical variant, because the caller this exists for has no MMZ. */
+typedef struct {
+    compat_addr src;       /*!<  Virtual address of the input data */
+    compat_addr dst;       /*!<  Virtual address of the output data */
+    hi_u32 length;         /*!<  Length of this package */
+    hi_u32 reserve;        /*!<  Alignment, must be zero */
+    hi_u8 iv[16];          /*!<  This package's own IV */
+} symc_via_pkg;
+
+typedef struct {
+    hi_u32 id;             /*!<  Id of soft channel */
+    compat_addr pkg;       /*!<  User address of a symc_via_pkg[pkg_num] */
+    hi_u32 pkg_num;        /*!<  Number of packages */
+    hi_u32 operation;      /*!<  Decrypt or encrypt */
+} symc_encrypt_via_multi_t;
 
 /*! \struct of Symmetric cipher get tag */
 typedef struct {
@@ -548,6 +594,26 @@ hi_s32 kapi_symc_crypto_via(hi_u32 id, compat_addr input,
 hi_s32 kapi_symc_crypto_multi(hi_u32 id, const hi_void *pkg,
                               hi_u32 pkg_num, hi_u32 operation,
                               hi_u32 last);
+
+/**
+ * \brief            OpenIPC extension: batched encryption from user virtual
+ *                   addresses, one IV per package.
+ *
+ * One ioctl, one persistent DMA buffer, one hardware start and one completion
+ * interrupt for the whole batch — see symc_encrypt_via_multi_t for why the
+ * vendor's multi-package call cannot express this and why the block can.
+ *
+ * \param[in] id     The channel number.
+ * \param pkg        Kernel pointer to the user address of symc_via_pkg[]
+ * \param pkg_num    Number of packages, at most KAPI_SYMC_BATCH_MAX_PKG
+ * \param operation  decrypt or encrypt
+ *
+ * \return           0 if successful, HI_ERR_CIPHER_UNSUPPORTED if the
+ *                   configured algorithm has no per-node IV support (the
+ *                   caller should fall back to the single-package call).
+ */
+hi_s32 kapi_symc_crypto_via_multi(hi_u32 id, const hi_void *pkg,
+                                  hi_u32 pkg_num, hi_u32 operation);
 
 /**
  * \brief          SYMC multiple buffer encryption/decryption.

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_symc.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_symc.c
@@ -95,6 +95,15 @@ typedef struct {
     hi_u32 *length_list;         /*!<  length of node list */
     symc_node_usage *usage_list; /*!<  usage of node list */
     hi_bool tdes2dma;            /*!<  3des with invalid key turns to dma */
+
+    /* OpenIPC extension, armed by cryp_symc_set_iv_list() for one call.
+     * iv_list is AES_IV_SIZE bytes per node in node order; int_level is how
+     * many nodes are queued before the block is started and waited on, so a
+     * batch costs one completion interrupt rather than one per packet. Both
+     * are cleared by the crypto() that consumes them. */
+    const hi_u8 *iv_list;        /*!<  per-node IV, HI_NULL for one IV per job */
+    hi_u32 iv_list_count;        /*!<  nodes iv_list covers */
+    hi_u32 int_level;            /*!<  nodes per hardware start, 0 = default */
 }
 cryp_symc_context;
 
@@ -336,6 +345,26 @@ static hi_s32 symc_add_buf(cryp_symc_context *ctx, symc_node_usage out_uasge)
 
     HI_LOG_FUNC_ENTER();
 
+    /* OpenIPC extension: give this node its own IV before it is built.
+     * drv_symc_set_iv() only writes the channel's software context, which
+     * drv_symc_add_inbuf() then copies into the descriptor -- so this costs
+     * four word stores and no hardware access, and CIPHER_IV_CHANGE_ALL_PKG
+     * is what makes the block reload from each node rather than carry the
+     * chain forward. Without a list, nothing changes: the single IV that
+     * cryp_symc_config() programmed stands for the whole job. */
+    if (ctx->iv_list != HI_NULL && cur < ctx->iv_list_count) {
+        hi_u32 iv[AES_IV_SIZE / 4];
+
+        crypto_memcpy(iv, sizeof(iv),
+                      ctx->iv_list + (hi_u32)(cur * AES_IV_SIZE), AES_IV_SIZE);
+        ret = drv_symc_set_iv(ctx->hard_chn, iv, AES_IV_SIZE,
+                              CIPHER_IV_CHANGE_ALL_PKG);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(drv_symc_set_iv, ret);
+            return ret;
+        }
+    }
+
     /*Add P in*/
     ret = drv_symc_add_inbuf(ctx->hard_chn,
                              ctx->input_list[cur],
@@ -392,7 +421,13 @@ static hi_s32 symc_add_buf_list(void *ctx)
 
     /* compute not finished*/
     /* select the minimum numbers of nodes to calculate*/
-    nodes = MIN(SYMC_INT_LEVEL, hisi_ctx->total_nodes - hisi_ctx->cur_nodes);
+    /* SYMC_INT_LEVEL is one, so the vendor default starts and waits on the
+     * block once per node however many were handed in -- the 16-entry
+     * descriptor ring is never more than a sixteenth full. A caller that has
+     * armed an IV list may raise it (cryp_symc_set_iv_list), which is where
+     * the batching win actually comes from. */
+    nodes = hisi_ctx->int_level > 0 ? hisi_ctx->int_level : SYMC_INT_LEVEL;
+    nodes = MIN(nodes, hisi_ctx->total_nodes - hisi_ctx->cur_nodes);
     total_len = 0;
 
     for (i = 0; i < nodes; i++) {
@@ -699,7 +734,37 @@ static hi_s32 cryp_symc_crypto_process(cryp_symc_context *hisi_ctx, hi_u32 wait)
     return HI_SUCCESS;
 }
 
-static hi_s32 cryp_symc_crypto(void *ctx,
+/* OpenIPC extension, see func_symc_setivlist. Arms one IV per node for the
+ * next crypto() call and how deep to queue before waiting; both are consumed
+ * and cleared there, so this cannot outlive the array it points at. */
+static hi_s32 cryp_symc_set_iv_list(void *ctx, const hi_u8 *iv_list,
+                                    hi_u32 count, hi_u32 depth)
+{
+    cryp_symc_context *hisi_ctx = ctx;
+
+    HI_LOG_FUNC_ENTER();
+    HI_LOG_CHECK_PARAM(hisi_ctx == HI_NULL);
+
+    if (iv_list != HI_NULL) {
+        HI_LOG_CHECK_PARAM(count == 0x00);
+        /* Never past the descriptor ring: symc_add_buf_list() may still add a
+         * node beyond `nodes` to square the block-size tail, so leave it one
+         * slot of room rather than exactly filling. */
+        HI_LOG_CHECK_PARAM(depth == 0x00);
+        if (depth >= SYMC_MAX_LIST_NUM) {
+            depth = SYMC_MAX_LIST_NUM - 1;
+        }
+    }
+
+    hisi_ctx->iv_list = iv_list;
+    hisi_ctx->iv_list_count = (iv_list != HI_NULL) ? count : 0;
+    hisi_ctx->int_level = (iv_list != HI_NULL) ? depth : 0;
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
+static hi_s32 cryp_symc_crypto_job(void *ctx,
                             hi_u32 operation,
                             compat_addr input[],
                             compat_addr output[],
@@ -761,6 +826,34 @@ static hi_s32 cryp_symc_crypto(void *ctx,
 
     HI_LOG_FUNC_EXIT();
     return HI_SUCCESS;
+}
+
+/* The armed IV list points at the caller's array and must not outlive this
+ * call, so it is disarmed on EVERY exit — which is the whole reason the job
+ * above is wrapped rather than edited: it has five returns, and a missed one
+ * would leave a dangling pointer that only bites the next unrelated packet. */
+static hi_s32 cryp_symc_crypto(void *ctx,
+                            hi_u32 operation,
+                            compat_addr input[],
+                            compat_addr output[],
+                            hi_u32 length[],
+                            symc_node_usage usage_list[],
+                            hi_u32 pkg_num,
+                            hi_u32 wait)
+{
+    hi_s32 ret;
+    cryp_symc_context *hisi_ctx = ctx;
+
+    ret = cryp_symc_crypto_job(ctx, operation, input, output, length,
+                               usage_list, pkg_num, wait);
+
+    if (hisi_ctx != HI_NULL) {
+        hisi_ctx->iv_list = HI_NULL;
+        hisi_ctx->iv_list_count = 0;
+        hisi_ctx->int_level = 0;
+    }
+
+    return ret;
 }
 
 #ifdef CHIP_AES_CCM_GCM_SUPPORT
@@ -1539,6 +1632,12 @@ static void cryp_register_symc_default(symc_func *func, symc_alg alg, symc_mode 
     func->setmode = cryp_symc_setmode;
     func->setkey = cryp_aes_setkey;
     func->waitdone = cryp_symc_wait_done;
+    /* Only the hardware paths offer it, and only these — the CCM/GCM/CTS
+     * registrations below replace ->crypto with their own, which does not
+     * read the list, so they must not advertise it. They overwrite ->crypto
+     * after calling this, so clearing it there is what keeps the pair
+     * honest. */
+    func->setivlist = cryp_symc_set_iv_list;
     return;
 }
 
@@ -1628,6 +1727,7 @@ static void cryp_register_symc_aes_cts(hi_u32 capacity, symc_mode mode)
         cryp_register_symc_default(&func, SYMC_ALG_AES, mode);
         func.crypto = cryp_aes_cbc_cts_crypto;
         func.waitdone = HI_NULL;
+        func.setivlist = HI_NULL;   /* CTS does not read the list */
         HI_LOG_DEBUG("CTS crypto 0x%p, mode %d\n", func.crypto, mode);
         ret = cryp_register_symc(&func);
         if (ret != HI_SUCCESS) {
@@ -1653,6 +1753,7 @@ static void cryp_register_aead_ccm(hi_u32 capacity, symc_mode mode)
         func.gettag = cryp_aead_get_tag;
         func.crypto = cryp_aead_ccm_crypto;
         func.setiv = cryp_aead_ccm_setiv;
+        func.setivlist = HI_NULL;   /* CCM does not read the list */
         ret = cryp_register_symc(&func);
         if (ret != HI_SUCCESS) {
             HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
@@ -1703,6 +1804,7 @@ static void cryp_register_aead_gcm(hi_u32 capacity, symc_mode mode)
         func.gettag = cryp_aead_get_tag;
         func.crypto = cryp_aead_gcm_crypto;
         func.setiv = cryp_aead_gcm_setiv;
+        func.setivlist = HI_NULL;   /* GCM does not read the list */
         ret = cryp_register_symc(&func);
         if (ret != HI_SUCCESS) {
             HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_symc.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/cryp_symc.c
@@ -1295,6 +1295,17 @@ static hi_s32 cryp_register_symc(symc_func *func)
         return HI_ERR_CIPHER_INVALID_PARA;
     }
 
+    /* The per-node IV list is read by exactly one crypto(), so tie the setter
+     * to it here rather than asking every registration to remember. Setting
+     * it in the shared default and clearing it again in the implementations
+     * that replace crypto() is the same rule stated twice, and the software
+     * registrations below quietly broke the second half: they call the
+     * default and then swap in an mbedTLS create()/crypto() pair, so the
+     * inherited setter would cast their context to cryp_symc_context and
+     * write into it. Derived, that cannot drift. */
+    func->setivlist =
+        (func->crypto == cryp_symc_crypto) ? cryp_symc_set_iv_list : HI_NULL;
+
     /* is it already registered? */
     for (i = 0; i < SYMC_FUNC_TAB_SIZE; i++) {
         if (symc_descriptor[i].valid
@@ -1632,12 +1643,12 @@ static void cryp_register_symc_default(symc_func *func, symc_alg alg, symc_mode 
     func->setmode = cryp_symc_setmode;
     func->setkey = cryp_aes_setkey;
     func->waitdone = cryp_symc_wait_done;
-    /* Only the hardware paths offer it, and only these — the CCM/GCM/CTS
-     * registrations below replace ->crypto with their own, which does not
-     * read the list, so they must not advertise it. They overwrite ->crypto
-     * after calling this, so clearing it there is what keeps the pair
-     * honest. */
-    func->setivlist = cryp_symc_set_iv_list;
+    /* setivlist is NOT set here. It used to be, and that was a type
+     * confusion waiting to happen: every software registration below calls
+     * this and then replaces ->create and ->crypto, so it would inherit a
+     * setter that casts its argument to cryp_symc_context and writes into
+     * an mbedTLS context. cryp_register_symc() derives it instead, from the
+     * one thing that actually decides whether the list is read. */
     return;
 }
 
@@ -1727,7 +1738,6 @@ static void cryp_register_symc_aes_cts(hi_u32 capacity, symc_mode mode)
         cryp_register_symc_default(&func, SYMC_ALG_AES, mode);
         func.crypto = cryp_aes_cbc_cts_crypto;
         func.waitdone = HI_NULL;
-        func.setivlist = HI_NULL;   /* CTS does not read the list */
         HI_LOG_DEBUG("CTS crypto 0x%p, mode %d\n", func.crypto, mode);
         ret = cryp_register_symc(&func);
         if (ret != HI_SUCCESS) {
@@ -1753,7 +1763,6 @@ static void cryp_register_aead_ccm(hi_u32 capacity, symc_mode mode)
         func.gettag = cryp_aead_get_tag;
         func.crypto = cryp_aead_ccm_crypto;
         func.setiv = cryp_aead_ccm_setiv;
-        func.setivlist = HI_NULL;   /* CCM does not read the list */
         ret = cryp_register_symc(&func);
         if (ret != HI_SUCCESS) {
             HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);
@@ -1804,7 +1813,6 @@ static void cryp_register_aead_gcm(hi_u32 capacity, symc_mode mode)
         func.gettag = cryp_aead_get_tag;
         func.crypto = cryp_aead_gcm_crypto;
         func.setiv = cryp_aead_gcm_setiv;
-        func.setivlist = HI_NULL;   /* GCM does not read the list */
         ret = cryp_register_symc(&func);
         if (ret != HI_SUCCESS) {
             HI_LOG_PRINT_FUNC_ERR(cryp_register_symc, ret);

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include/cryp_symc.h
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/crypto/include/cryp_symc.h
@@ -145,6 +145,32 @@ typedef hi_s32 (*func_symc_crypto)(hi_void *ctx, hi_u32 operation,
                                    hi_u32 wait);
 
 /**
+ * \brief          Arm ONE IV per node for the next crypto() call, and let it
+ *                 submit more than one node before waiting.
+ *
+ * OpenIPC extension. Without it every node of a multi-node job runs under the
+ * single IV left in the channel by setiv(), which is what confined batching to
+ * chained modes over one buffer. The descriptors always had room -- see
+ * drv_symc_add_inbuf(), which copies an IV into every node it builds.
+ *
+ * `iv_list` must stay alive until crypto() returns, and holds `count` entries
+ * of AES_IV_SIZE bytes, one per node, in node order. `depth` is how many nodes
+ * may be queued before the block is started and waited on; it is capped at the
+ * descriptor ring and is what turns N completion interrupts into one.
+ *
+ * Armed for a single call and cleared by it, so a caller that forgets cannot
+ * leave a stale list pointing at a freed array. HI_NULL is offered only by
+ * hardware AES paths -- the software (mbedTLS) implementations leave the slot
+ * empty, and callers must treat that as "batching not available here".
+ *
+ * \return         0 if successful
+ */
+typedef hi_s32 (*func_symc_setivlist)(hi_void *ctx,
+                                      const hi_u8 *iv_list,
+                                      hi_u32 count,
+                                      hi_u32 depth);
+
+/**
  * \brief          CCM/GCM set Associated Data
  *
  * \param ctx      SYMC handle
@@ -182,6 +208,7 @@ typedef struct {
     func_aead_get_tag gettag;   /*!<  get tag function */
     func_symc_crypto  crypto;   /*!<  crypto function */
     func_symc_wait_done waitdone; /*!<  wait done */
+    func_symc_setivlist setivlist; /*!<  per-node IV list, HI_NULL if unsupported */
 } symc_func;
 
 /**

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_dispatch.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_dispatch.c
@@ -162,6 +162,27 @@ static hi_s32 dispatch_symc_encrypt(void *argp)
     return HI_SUCCESS;
 }
 
+/* OpenIPC extension, see symc_encrypt_via_multi_t. Deliberately thin: every
+ * bound is checked in kapi_symc_crypto_via_multi(), against the same limits
+ * the buffer is sized from, rather than half here and half there. */
+static hi_s32 dispatch_symc_encrypt_via_multi(void *argp)
+{
+    hi_s32 ret;
+    symc_encrypt_via_multi_t *batch = argp;
+
+    HI_LOG_FUNC_ENTER();
+
+    ret = kapi_symc_crypto_via_multi(batch->id, ADDR_VIA(batch->pkg),
+                                     batch->pkg_num, batch->operation);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(kapi_symc_crypto_via_multi, ret);
+        return ret;
+    }
+
+    HI_LOG_FUNC_EXIT();
+    return HI_SUCCESS;
+}
+
 static hi_s32 dispatch_symc_encrypt_multi(void *argp)
 {
     hi_s32 ret = HI_FAILURE;
@@ -659,6 +680,13 @@ static crypto_dispatch_func dispatch_func[CRYPTO_CMD_COUNT] = {
     {"TRNG",          dispatch_trng_get_random,     CRYPTO_CMD_TRNG},
     {"GetSymcConfig", dispatch_symc_get_config,     CRYPTO_CMD_SYMC_GET_CONFIG},
     {"KladKey",       dispatch_klad_key,            CRYPTO_CMD_KLAD_KEY},
+    /* LAST, and it must stay last: crypto_ioctl() indexes this table by the
+     * command's nr and then checks dispatch_func[nr].cmd == cmd, so a row
+     * inserted anywhere but the end shifts every command after it onto the
+     * wrong handler. That check is the only thing that catches it, and what
+     * it reports is "copy data from user failed" — which is a lie about a
+     * table that is simply off by one. */
+    {"EncryptViaMulti", dispatch_symc_encrypt_via_multi, CRYPTO_CMD_SYMC_ENCRYPT_VIA_MULTI},
 };
 
 hi_s32 crypto_ioctl(hi_u32 cmd, hi_void *argp)

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_symc.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_symc.c
@@ -28,7 +28,22 @@ typedef struct {
     void *cryp_ctx;                  /*!<  Context of cryp instance */
     crypto_owner owner;              /*!<  user ID */
     hi_cipher_ctrl  ctrl;        /*!<  control infomation */
+    /* OpenIPC extension: the batch path's DMA bounce buffer, allocated on
+     * first use and held until the channel is destroyed. The single-package
+     * virtual path (kapi_symc_crypto_via) does a dma_alloc_coherent and a
+     * free around EVERY packet, which at video packet rates is most of what
+     * the engine costs. Batching would be pointless if it kept paying that. */
+    crypto_mem batch;
+    hi_u32 batch_size;               /*!<  bytes in batch, 0 = not allocated */
 } kapi_symc_ctx;
+
+/* How many packets one batched call may carry, and how much data. The node
+ * count is bounded by the descriptor ring (SYMC_MAX_LIST_NUM, 16) less the
+ * slot symc_add_buf_list() may need to square a block-size tail; the byte
+ * budget is that many SRTP packets rounded up. */
+#define KAPI_SYMC_BATCH_MAX_PKG     (15)
+#define KAPI_SYMC_BATCH_MAX_LEN     (2048)
+#define KAPI_SYMC_BATCH_BYTES       (KAPI_SYMC_BATCH_MAX_PKG * KAPI_SYMC_BATCH_MAX_LEN)
 
 /*! Context of cipher */
 static kapi_symc_ctx kapi_ctx[CRYPTO_HARD_CHANNEL_MAX];
@@ -199,6 +214,14 @@ hi_s32 kapi_symc_destroy(hi_u32 id)
     CHECK_OWNER(&ctx->owner);
 
     KAPI_SYMC_LOCK();
+
+    /* Before the instance goes: this is the only owner of that buffer, and
+     * with eight channels on the chip a leak here is eight batches' worth of
+     * coherent DMA memory that nothing will ever reclaim. */
+    if (ctx->batch_size != 0) {
+        crypto_mem_destory(&ctx->batch);
+        ctx->batch_size = 0;
+    }
 
     cryp_symc_free_chn(soft_id);
 
@@ -764,6 +787,167 @@ exit:
         HI_ERR_PRINT_S32(ret);
         return ret_exit;
     }
+
+    HI_LOG_FUNC_EXIT();
+    return ret;
+}
+
+/* OpenIPC extension: one ioctl, one DMA buffer, one hardware start and one
+ * completion interrupt for a whole burst of packets, each under its own IV.
+ * See symc_encrypt_via_multi_t for why the vendor's multi-package call cannot
+ * do this and why the silicon can.
+ *
+ * SHAPE OF THE WORK, because it is what the cost is made of. Per package the
+ * old path pays: two ioctls, a dma_alloc_coherent/free pair, a
+ * copy_from_user, a hardware start, a sleep on the completion IRQ and a
+ * copy_to_user. Here the ioctl, the allocation, the start and the sleep are
+ * paid once for the batch; only the two copies stay per package, and those
+ * are a memcpy each.
+ *
+ * EVERY PACKAGE IS PADDED TO THE BLOCK SIZE, and that is not cosmetic.
+ * symc_add_buf_list() squares a job whose total length is not a multiple of
+ * the block size by SPLITTING a node in two — which under a per-node IV list
+ * would run the second half under the next packet's IV and produce a
+ * plausible, wrong keystream. Padding each package makes every total aligned,
+ * so the splitting path is never entered. CTR is a stream cipher, so the
+ * padding costs bytes and changes nothing. */
+static hi_s32 kapi_symc_crypto_via_multi_run(kapi_symc_ctx *ctx,
+                                             const symc_via_pkg *pkg,
+                                             hi_u32 pkg_num,
+                                             hi_u32 operation)
+{
+    hi_s32 ret = HI_FAILURE;
+    compat_addr input[KAPI_SYMC_BATCH_MAX_PKG];
+    compat_addr output[KAPI_SYMC_BATCH_MAX_PKG];
+    hi_u32 length[KAPI_SYMC_BATCH_MAX_PKG];
+    symc_node_usage usage[KAPI_SYMC_BATCH_MAX_PKG];
+    hi_u8 ivs[KAPI_SYMC_BATCH_MAX_PKG][AES_IV_SIZE];
+    hi_u32 offset[KAPI_SYMC_BATCH_MAX_PKG];
+    hi_u32 i, used = 0;
+
+    for (i = 0; i < pkg_num; i++) {
+        const hi_u32 len = pkg[i].length;
+        const hi_u32 padded =
+            (len + AES_BLOCK_SIZE - 1) / AES_BLOCK_SIZE * AES_BLOCK_SIZE;
+
+        if ((len == 0) || (len > KAPI_SYMC_BATCH_MAX_LEN)) {
+            HI_LOG_ERROR("batch pkg %d: bad length 0x%x\n", i, len);
+            return HI_ERR_CIPHER_INVALID_LENGTH;
+        }
+        if ((used + padded > ctx->batch_size) || (used + padded < used)) {
+            HI_LOG_ERROR("batch overflows its buffer at pkg %d\n", i);
+            return HI_ERR_CIPHER_INVALID_LENGTH;
+        }
+        if (ADDR_VIA(pkg[i].src) == HI_NULL ||
+            ADDR_VIA(pkg[i].dst) == HI_NULL) {
+            return HI_ERR_CIPHER_INVALID_POINT;
+        }
+
+        ret = crypto_copy_from_user((hi_u8 *)ctx->batch.dma_virt + used,
+                                    ADDR_VIA(pkg[i].src), len);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(crypto_copy_from_user, ret);
+            return ret;
+        }
+        if (padded > len) {
+            crypto_memset((hi_u8 *)ctx->batch.dma_virt + used + len,
+                          padded - len, 0, padded - len);
+        }
+
+        crypto_memcpy(ivs[i], AES_IV_SIZE, pkg[i].iv, AES_IV_SIZE);
+        offset[i] = used;
+        length[i] = padded;
+        usage[i] = SYMC_NODE_USAGE_NORMAL;
+        ADDR_U64(input[i]) = ADDR_U64(ctx->batch.dma_addr) + used;
+        ADDR_U64(output[i]) = ADDR_U64(ctx->batch.dma_addr) + used;
+        used += padded;
+    }
+
+    /* In place: the engine reads and writes the same node, which halves the
+     * buffer and costs nothing — the block reads a node before it writes it. */
+    ret = ctx->func->setivlist(ctx->cryp_ctx, (const hi_u8 *)ivs, pkg_num,
+                               pkg_num);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(ctx->func->setivlist, ret);
+        return ret;
+    }
+
+    ret = ctx->func->crypto(ctx->cryp_ctx, operation, input, output, length,
+                            usage, pkg_num, HI_TRUE);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(ctx->func->crypto, ret);
+        return ret;
+    }
+
+    /* Only the requested length goes back, so the padding never reaches the
+     * caller's buffer — the same contract the single-package path keeps. */
+    for (i = 0; i < pkg_num; i++) {
+        ret = crypto_copy_to_user(ADDR_VIA(pkg[i].dst),
+                                  (hi_u8 *)ctx->batch.dma_virt + offset[i],
+                                  pkg[i].length);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(crypto_copy_to_user, ret);
+            return ret;
+        }
+    }
+
+    return HI_SUCCESS;
+}
+
+hi_s32 kapi_symc_crypto_via_multi(hi_u32 id, const void *pkg, hi_u32 pkg_num,
+                                  hi_u32 operation)
+{
+    hi_s32 ret = HI_FAILURE;
+    kapi_symc_ctx *ctx = HI_NULL;
+    symc_via_pkg desc[KAPI_SYMC_BATCH_MAX_PKG];
+    hi_u32 soft_id = 0;
+
+    HI_LOG_FUNC_ENTER();
+
+    KAPI_SYMC_CHECK_HANDLE(id);
+    soft_id = HI_HANDLE_GET_CHNID(id);
+    ctx = &kapi_ctx[soft_id];
+    CHECK_OWNER(&ctx->owner);
+    HI_LOG_CHECK_PARAM(ctx->config != HI_TRUE);
+    HI_LOG_CHECK_PARAM(pkg == HI_NULL);
+    HI_LOG_CHECK_PARAM(pkg_num == 0x00);
+    HI_LOG_CHECK_PARAM(pkg_num > KAPI_SYMC_BATCH_MAX_PKG);
+    HI_LOG_CHECK_PARAM((operation != 0x00) && (operation != 0x01));
+    HI_LOG_CHECK_PARAM(ctx->func == HI_NULL);
+    HI_LOG_CHECK_PARAM(ctx->func->crypto == HI_NULL);
+
+    /* The software (mbedTLS) implementations register no list setter, and
+     * CCM/GCM/CTS clear theirs because their crypto() does not read it. So a
+     * NULL here is "this algorithm cannot be batched", not a bug — the caller
+     * falls back to the single-package call, as it would on a camera with no
+     * engine at all. */
+    if (ctx->func->setivlist == HI_NULL) {
+        HI_LOG_INFO("batch unsupported for this alg/mode\n");
+        return HI_ERR_CIPHER_UNSUPPORTED;
+    }
+
+    ret = crypto_copy_from_user(desc, pkg, sizeof(symc_via_pkg) * pkg_num);
+    if (ret != HI_SUCCESS) {
+        HI_LOG_PRINT_FUNC_ERR(crypto_copy_from_user, ret);
+        return ret;
+    }
+
+    KAPI_SYMC_LOCK();
+
+    if (ctx->batch_size == 0) {
+        ret = crypto_mem_create(&ctx->batch, SEC_MMZ, "AES_BATCH",
+                                KAPI_SYMC_BATCH_BYTES);
+        if (ret != HI_SUCCESS) {
+            HI_LOG_PRINT_FUNC_ERR(crypto_mem_create, ret);
+            KAPI_SYMC_UNLOCK();
+            return ret;
+        }
+        ctx->batch_size = KAPI_SYMC_BATCH_BYTES;
+    }
+
+    ret = kapi_symc_crypto_via_multi_run(ctx, desc, pkg_num, operation & 0x01);
+
+    KAPI_SYMC_UNLOCK();
 
     HI_LOG_FUNC_EXIT();
     return ret;

--- a/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_symc.c
+++ b/kernel/cipher/hi3516ev200/src/drv/cipher_v1.0/drivers/kapi_symc.c
@@ -926,6 +926,20 @@ hi_s32 kapi_symc_crypto_via_multi(hi_u32 id, const void *pkg, hi_u32 pkg_num,
         return HI_ERR_CIPHER_UNSUPPORTED;
     }
 
+    /* CTR ONLY, and the reason is the padding below rather than the IV list.
+     * Every package is rounded up to a whole block and only the requested
+     * bytes are handed back, which is invisible in a stream cipher and wrong
+     * in every other mode: a CBC caller would get ciphertext truncated
+     * mid-block on the way out, and a decrypt would run over fabricated zero
+     * bytes. The block itself rejects an unaligned length outside CTR
+     * (drv_symc_node_check), so padding here would be quietly relaxing a
+     * check the hardware makes. Widening this needs a per-mode length rule,
+     * not just a flag. */
+    if (ctx->ctrl.work_mode != HI_CIPHER_WORK_MODE_CTR) {
+        HI_LOG_INFO("batch is CTR only, mode %d\n", ctx->ctrl.work_mode);
+        return HI_ERR_CIPHER_UNSUPPORTED;
+    }
+
     ret = crypto_copy_from_user(desc, pkg, sizeof(symc_via_pkg) * pkg_num);
     if (ret != HI_SUCCESS) {
         HI_LOG_PRINT_FUNC_ERR(crypto_copy_from_user, ret);
@@ -933,6 +947,19 @@ hi_s32 kapi_symc_crypto_via_multi(hi_u32 id, const void *pkg, hi_u32 pkg_num,
     }
 
     KAPI_SYMC_LOCK();
+
+    /* Everything above was read without the lock, which is the shape the
+     * vendor's own crypto paths use. It is not good enough here: destroy()
+     * frees the batch buffer and the crypto context under this same lock, and
+     * create() may then hand the slot to somebody else — so a request that
+     * waited would arrive holding conclusions about a channel that no longer
+     * exists. Re-checked, cheaply, now that nothing can move. */
+    if ((ctx->open != HI_TRUE) || (ctx->config != HI_TRUE) ||
+        (ctx->func == HI_NULL) || (ctx->func->setivlist == HI_NULL) ||
+        (ctx->cryp_ctx == HI_NULL)) {
+        KAPI_SYMC_UNLOCK();
+        return HI_ERR_CIPHER_INVALID_HANDLE;
+    }
 
     if (ctx->batch_size == 0) {
         ret = crypto_mem_create(&ctx->batch, SEC_MMZ, "AES_BATCH",


### PR DESCRIPTION
Follow-up to #216, which built `open_cipher.ko` for gk7205v200 and stopped
there because the engine does not pay for itself as it is driven today. This
is why, and the fix.

## The cost is the trip, not the cipher

Per 1100-byte packet the driver charges two ioctls, a `dma_alloc_coherent`
/`free` pair, a hardware start and a sleep on the completion interrupt —
**41.9 µs of CPU on an idle gk7205v200 and 71.8 µs on a loaded one, against
about 44 µs of actual AES.** A camera pushing 5000 SRTP packets a second
spends most of the engine's cost on the approach to it, which is why a
whole-camera measurement shows the engine saving nothing: one WebRTC viewer at
4 Mbit/s is 19.76% of a core with it and 19.68% without.

Three separate things were paying that, and only the first was expected:

1. **No per-package IV in the ABI.** `hi_cipher_data` carries a source, a
   destination, a length and a key selector and *no IV*, so every package in
   the vendor's multi-package submission runs under whatever `CONFIGHANDLE`
   last left in the channel. Right for chaining one long buffer, useless for
   SRTP, where each packet's IV comes from its own sequence number.
2. **`SYMC_INT_LEVEL` is `SYMC_MAX_LIST_NUM - 15`, i.e. one.** The 16-entry
   descriptor ring is never more than a sixteenth full before the block is
   started and waited on — so even the existing multi-package path pays one
   completion interrupt *per package*.
3. **The virtual-address path allocates and frees its bounce buffer around
   every single packet.**

## The silicon never had limit 1

`drv_symc_add_inbuf()` writes an IV into **every** descriptor node it builds,
and `CIPHER_IV_CHANGE_ALL_PKG` sets `FIRST|LAST` on each so the block reloads
it per node. The driver simply had no way to be told a different one per
package. This adds `CRYPTO_CMD_SYMC_ENCRYPT_VIA_MULTI`: one ioctl, one buffer
held for the life of the channel, one hardware start, one completion
interrupt, and an IV per package.

The core learns a per-node IV list through a new `setivlist` vtable slot,
armed for exactly one `crypto()` call and disarmed on every exit from it —
hence the wrapper rather than editing a function with five returns. It is
`NULL` where it would not be honoured (the mbedTLS paths, and CCM/GCM/CTS,
whose `crypto()` does not read it), which callers must read as *fall back*.

**Each package is padded to the block size, and that is load-bearing.**
`symc_add_buf_list()` squares an unaligned total by **splitting a node**, and a
split node's second half would run under the *next* packet's IV — a plausible,
wrong keystream. Padding means the splitting path is never entered. CTR is a
stream cipher, so it costs bytes and changes nothing.

## Measured

Lab gk7205v200, 1100-byte packets, µs per packet:

| | idle wall | idle cpu | **loaded wall** | **loaded cpu** |
|---|---|---|---|---|
| mbedTLS 2.25 | 85.9 | 85.9 | 131.4 | **96.6** |
| single ioctl (today) | 81.0 | 41.9 | 198.1 | **71.8** |
| batch of 4 | 55.1 | 17.4 | 89.7 | **24.9** |
| batch of 15 | 49.9 | 12.5 | 71.4 | **21.1** |

The loaded column is the one that decides anything: batching is **4.6× cheaper
in CPU than software** and **3.4× cheaper than the per-packet ioctl** it
replaces. That 71.8 µs is the same figure the whole-camera user/system split
implied independently, so two unrelated methods agree.

## Correctness

**960 packages** across batch sizes 1–15 and lengths 1–2048, byte-identical to
the rootfs's own mbedTLS 2.25, with the bytes past each requested length
poisoned and checked untouched, no batch refused — on **both** trees:
gk7205v200 (ev200 sources) and hi3516av300 (cv500 sources).

## Two trees, and the second is not a copy

cv500 is a different SDK vintage: renamed macros
(`HI_CIPHER_IV_CHG_ALL_PACK`, `hi_log_print_func_err`, `crypto_min`) and
`crypto()`'s four parallel arrays bundled into a `symc_multi_pack`, so every
hunk was rewritten rather than applied.

## Guard rails

The last commit adds a `_Static_assert` on both struct sizes — the command
number encodes `sizeof(payload)`, so they *are* the ABI — and a CI step that
checks the module was built, carries the right DT binding, and still has the
batched command in its dispatch table. That last one is not hypothetical: the
first version of this change added the dispatch row in the middle of a table
that is **indexed by command number**, which silently bound every later command
to the wrong handler, still linked, still loaded, and reported itself as
`"copy data from user failed"`.

## Nothing calls it yet

majestic protects and sends one packet at a time inline on the media thread,
so consuming this needs a send path that accumulates a frame's packets first.
That is a separate change in a separate repo. The ioctl is additive and inert
until then, and a driver without it answers `EINVAL`, which is what every
camera in the field will keep doing.
