### PR TITLE
ci: don't gate QEMU boot on the racy 'Starting crond: OK' line

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1166,7 +1166,11 @@ jobs:
           # those rmmods fail silently. The previous QEMU assertion (just "crond
           # reached userspace") missed it because the script exits cleanly when
           # SENSOR=unknown and crond starts regardless.
-          if grep -qE "^rmmod: can't unload" qemu-output.txt; then
+          # Unanchored (and -a) for the same reason as the mod-count grep
+          # below: console writers interleave, so a real "rmmod: can't
+          # unload" can arrive with another daemon's output already on the
+          # line. A ^-anchored pattern would then miss the regression.
+          if grep -qaE "rmmod: can't unload" qemu-output.txt; then
               fail_with "rmmod failure during boot — vendor name does not match loaded module name (#62)"
           fi
           if grep -qF "Error: There's something wrong, please check!" qemu-output.txt; then
@@ -1178,8 +1182,9 @@ jobs:
           # OpenIPC/firmware#2059: load_hisilicon mis-parses kernel cmdline
           # mem=NM as os_mem_size on V4+CMA boards (where mem= is total RAM,
           # not the OS-only slice), trips the "os_mem >= total_mem" guard, and
-          # exits before any insmod. Manifests with this exact stderr line.
-          if grep -qE "^\[err\] os_mem\[[0-9]+\], over total_mem\[[0-9]+\]" qemu-output.txt; then
+          # exits before any insmod. Manifests with this exact stderr line
+          # (unanchored for the interleave reason noted above).
+          if grep -qaE "\[err\] os_mem\[[0-9]+\], over total_mem\[[0-9]+\]" qemu-output.txt; then
               fail_with "load_hisilicon: cmdline mem= misread as OS-only memory (firmware#2059)"
           fi
 
@@ -1217,10 +1222,35 @@ jobs:
               fi
           fi
 
-          if grep -qE "Starting crond: OK" qemu-output.txt; then
+          # Final gate: the boot reached userspace. Two accepted markers,
+          # because the obvious one is a race — OpenIPC/openhisilicon#218.
+          #
+          # The init script prints "Starting crond: ", forks the daemon, then
+          # prints "OK". busybox crond writes its own startup banner to the
+          # same console from the forked child, so whether that banner lands
+          # *between* the two writes is a coin flip. When it does, the tokens
+          # are no longer on one line and a single-line grep misses them on a
+          # fully booted image:
+          #
+          #   pass:  Starting crond: OK
+          #          crond[344]: crond (busybox 1.36.1) started, log level 8
+          #   fail:  Starting crond: crond[344]: crond (busybox 1.36.1) ...
+          #          OK
+          #
+          # Same image, same crond, same PID. Seen on hi3516av100_neo (a row
+          # with no allow-failure, so it gated every PR) at main@001096ae and
+          # twice on #217. The daemon's own banner is the stronger evidence
+          # anyway — printed by crond itself rather than by the wrapper — so
+          # accept either. Not every platform reaches the console with it
+          # (syslogd may swallow it), hence the OR rather than a swap.
+          #
+          # General shape to watch for: any "Starting X: OK" is two writes
+          # with a fork in between. Never assert on it as one string.
+          if grep -qaE "Starting crond: OK" qemu-output.txt ||
+             grep -qaE "crond \(busybox [0-9.]+\) started" qemu-output.txt; then
               echo "PASS: ${{ matrix.machine }} kernel booted to userspace, no module-load regressions"
           else
-              fail_with "no 'Starting crond: OK' in QEMU output"
+              fail_with "boot never reached crond (no 'Starting crond: OK' and no crond startup banner)"
           fi
 
       - name: Upload QEMU output


### PR DESCRIPTION
Fixes #218.

## Confirmed the mechanism from the raw logs

`build.yml` asserted the boot reached userspace with one literal grep. The init
script prints `Starting crond: `, forks the daemon, then prints `OK`; busybox
`crond` writes its own banner to the same console from the forked child. Whether
that banner lands *between* the two writes is a write race.

Failing job [99857100601](https://github.com/OpenIPC/openhisilicon/actions/runs/33506265697/job/99857100601) — the boot is complete:

```
Starting dropbear: OK
Starting crond: crond[344]: crond (busybox 1.36.1) started, log level 8
OK
Starting majestic: OK
===CI:HISI_MOD_COUNT===0===
Welcome to OpenIPC
```

Passing job [99843767059](https://github.com/OpenIPC/openhisilicon/actions/runs/33504042825/job/99843767059), same image, same crond, same PID — banner just lands after the `OK`.

`hi3516av100_neo` has no `allow-failure`, so this gated every PR whenever the
race landed wrong. Three occurrences: main@001096ae (PID 263) and #217 twice
(PID 344).

## Fix

Accept crond's own banner as an alternative marker, per the suggestion in #218.
Kept as an OR rather than a swap: where syslogd swallows the banner, the
wrapper's `OK` is all we get (and in that case no race is possible either).

## Audit of the other assertions in the step

Per the issue's closing note. Only `Starting crond: OK` has the two-write shape
— `Error: There's something wrong`, `Cannot get chip id` and the `[err] os_mem`
line are each a single write and cannot split. But two of the *failure*
detectors were `^`-anchored, and the same interleave can prefix them with
another writer's output, silently dropping a real regression. Dropped the
anchors (and added `-a`), matching the reasoning the `HISI_MOD_COUNT` grep above
them already documents.

## Verification

Replayed the four real console captures through the modified check block
offline:

| capture | old | new |
|---|---|---|
| av100_neo #217 (interleave) | FAIL | **PASS** |
| av100_neo main@001096ae (interleave) | FAIL | **PASS** |
| av100_neo #216 (clean) | PASS | PASS |
| cv500 main (genuine stall, never reached crond) | FAIL | **FAIL** |

The last row matters: the fix does not paper over a boot that really didn't get
there. Also checked the unanchored `rmmod` detector against the real av100
(non-neo) capture that trips it — still matches all seven lines — and against a
synthetic interleaved line, which the anchored pattern misses and the unanchored
one catches.

## Separate finding, not fixed here

The cv500 row in that table is a **different** flake with the same error message.
On [job 99849843328](https://github.com/OpenIPC/openhisilicon/actions/runs/33505930645/job/99849843328) (main, after #216) init blocked in `S49ntp`:

```
adding dns 10.0.2.3
ntpd: timed out waiting for 185.234.20.134, reach 0x00, next query in 33s
qemu-system-arm: terminating on signal 15 (timeout)
```

The synchronous initial NTP sync stalls the whole init chain, so the boot never
reaches crond inside the 90 s budget. That is a real (if environmental) failure
and needs its own fix — worth a separate issue.